### PR TITLE
Added rdfs:label and dcterms:description in French and Germain 

### DIFF
--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -111,50 +111,83 @@ cc:licence rdf:type owl:AnnotationProperty .
 
 ###  http://purl.org/dc/elements/1.1/contributor
 dc:contributor rdf:type owl:AnnotationProperty ;
-               dcterms:description "An Agent who has participated in any phase of management of an Asset."@en ;
-               rdfs:label "Contributor"@en .
+               dcterms:description "An Agent who has participated in any phase of management of an Asset."@en ,
+                                   "Ein Agent, der in irgendeiner Phase der Verwaltung eines Assets mitgewirkt hat."@de ,
+                                   "Un agent qui a participé à une phase quelconque de la gestion d'un actif."@fr ;
+               rdfs:label "Beitragender"@de ,
+                          "Contributeur"@fr ,
+                          "Contributor"@en .
 
 
 ###  http://purl.org/dc/elements/1.1/creator
 dc:creator rdf:type owl:AnnotationProperty ;
-           dcterms:description "To identify the creator of an Asset."@en ;
-           rdfs:label "Creator"@en .
+           dcterms:description "Pour identifier le créateur d'un actif."@fr ,
+                               "So identifizieren Sie den Ersteller eines Assets."@de ,
+                               "To identify the creator of an Asset."@en ;
+           rdfs:label "Creator"@en ,
+                      "Créateur"@fr ,
+                      "Schöpfer"@de .
 
 
 ###  http://purl.org/dc/elements/1.1/date
 dc:date rdf:type owl:AnnotationProperty ;
-        dcterms:description "A date associated with an resource."@en ;
-        rdfs:label "Date"@en ;
+        dcterms:description "A date associated with an resource."@en ,
+                            "Ein Datum, das mit einer Ressource verbunden ist."@de ,
+                            "Une date associée à une ressource."@fr ;
+        rdfs:label "Date"@en ,
+                   "Date"@fr ,
+                   "Datum"@de ;
         rdfs:range xsd:date .
 
 
 ###  http://purl.org/dc/elements/1.1/description
 dc:description rdf:type owl:AnnotationProperty ;
-               dcterms:description "A description of an Asset."@en ;
-               rdfs:label "Description"@en .
+               dcterms:description "A description of an Asset."@en ,
+                                   "Eine Beschreibung eines Assets."@de ,
+                                   "Une description d'un actif."@fr ;
+               rdfs:label "Beschreibung"@de ,
+                          "Description"@en ,
+                          "Description"@fr .
 
 
 ###  http://purl.org/dc/elements/1.1/format
 dc:format rdf:type owl:AnnotationProperty ;
-          dcterms:description "Information about the Format of a Resource."@en ;
-          rdfs:label "Format"@en .
+          dcterms:description "Information about the Format of a Resource."@en ,
+                              "Informationen über das Format einer Ressource."@de ,
+                              "Informations sur le format d'une ressource."@fr ;
+          rdfs:label "Format"@de ,
+                     "Format"@en ,
+                     "Format"@fr .
 
 
 ###  http://purl.org/dc/elements/1.1/identifier
 dc:identifier rdf:type owl:AnnotationProperty ;
-              dcterms:description "To provide a simple not strongly structured identifier."@en ;
-              rdfs:label "Identifier"@en .
+              dcterms:description "Fournir un identifiant simple et non fortement structuré."@fr ,
+                                  "To provide a simple not strongly structured identifier."@en ,
+                                  "Um einen einfachen, nicht stark strukturierten Identifikator bereitzustellen."@de ;
+              rdfs:label "Identifiant"@fr ,
+                         "Identifier"@en ,
+                         "Kennung"@de .
 
 
 ###  http://purl.org/dc/elements/1.1/language
 dc:language rdf:type owl:AnnotationProperty ;
-            rdfs:label "To define languages associated with an Asset."@en .
+            dcterms:description "Pour définir les langues associées à une ressource."@fr ,
+                                "To define languages associated with an Asset."@en ,
+                                "Zur Definition von Sprachen, die mit einem Asset verbunden sind."@de ;
+            rdfs:label "Language"@en ,
+                       "Langue"@fr ,
+                       "Sprache"@de .
 
 
 ###  http://purl.org/dc/elements/1.1/publisher
 dc:publisher rdf:type owl:AnnotationProperty ;
-             dcterms:description "An Agent involved in the distribution of content."@en ;
-             rdfs:label "Publisher"@en .
+             dcterms:description "An Agent involved in the distribution of content."@en ,
+                                 "Ein Agent, der an der Verbreitung von Inhalten beteiligt ist."@de ,
+                                 "Un agent impliqué dans la distribution de contenu."@fr ;
+             rdfs:label "Editeur"@fr ,
+                        "Herausgeber"@de ,
+                        "Publisher"@en .
 
 
 ###  http://purl.org/dc/elements/1.1/rights
@@ -163,14 +196,22 @@ dc:rights rdf:type owl:AnnotationProperty .
 
 ###  http://purl.org/dc/elements/1.1/title
 dc:title rdf:type owl:AnnotationProperty ;
-         dcterms:description "The title by which a EditorialObject is known."@en ;
-         rdfs:label "Title"@en .
+         dcterms:description "Der Titel, unter dem ein EditorialObject bekannt ist."@de ,
+                             "Le titre par lequel un EditorialObject est connu."@fr ,
+                             "The title by which a EditorialObject is known."@en ;
+         rdfs:label "Titel"@de ,
+                    "Title"@en ,
+                    "Titre"@fr .
 
 
 ###  http://purl.org/dc/elements/1.1/type
 dc:type rdf:type owl:AnnotationProperty ;
-        dcterms:description "A concept associated with a resource."@en ;
-        rdfs:label "Type"@en .
+        dcterms:description "A concept associated with a resource."@en ,
+                            "Ein Konzept, das mit einer Ressource verbunden ist."@de ,
+                            "Un concept associé à une ressource."@fr ;
+        rdfs:label "Typ"@de ,
+                   "Type"@en ,
+                   "Type"@fr .
 
 
 ###  http://purl.org/dc/terms/description
@@ -183,6 +224,7 @@ vann:preferredNamespaceUri rdf:type owl:AnnotationProperty .
 
 ###  http://spinrdf.org/spin#imports
 spin:imports rdf:type owl:AnnotationProperty .
+
 
 
 ###  http://www.w3.org/2002/07/owl#maxQualifiedCardinality
@@ -223,862 +265,1308 @@ xsd:time rdf:type rdfs:Datatype .
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#accountingTo
 ebuccdm:accountingTo rdf:type owl:ObjectProperty ;
-                     dcterms:description "A Consumer Account for a particular Service."@en ;
-                     rdfs:label "Account"@en .
+                     dcterms:description "A Consumer Account for a particular Service."@en ,
+                                         "Ein Verbraucherkonto für einen bestimmten Dienst."@de ,
+                                         "Un compte de consommateur pour un service particulier."@fr ;
+                     rdfs:label "Account"@en ,
+                                "Compte"@fr ,
+                                "Konto"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#assetValueCurrency
 ebuccdm:assetValueCurrency rdf:type owl:ObjectProperty ;
-                           dcterms:description """To provide the currency in which the assetValue is
-      given."""@en ;
-                           rdfs:label "Asset value currency"@en .
+                           dcterms:description "Pour fournir la devise dans laquelle la valeur de l'actif est donnée."@fr ,
+                                               "To provide the currency in which the assetValue is given."@en ,
+                                               "Zur Angabe der Währung, in der der assetValue angegeben wird. gegeben ist."@de ;
+                           rdfs:label "Asset value currency"@en ,
+                                      "Devise de la valeur de l'actif"@fr ,
+                                      "Vermögenswert Währung"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#auditReportDate
 ebuccdm:auditReportDate rdf:type owl:ObjectProperty ;
-                        dcterms:description "The date of release of an AuditReport."@en ;
-                        rdfs:label "Audit report date"@en .
+                        dcterms:description "Das Datum der Veröffentlichung eines AuditReports."@de ,
+                                            "La date de publication d'un rapport d'audit."@fr ,
+                                            "The date of release of an AuditReport."@en ;
+                        rdfs:label "Audit report date"@en ,
+                                   "Date du rapport d'audit"@fr ,
+                                   "Datum des Prüfungsberichts"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#basedOn
 ebuccdm:basedOn rdf:type owl:ObjectProperty ;
-                dcterms:description """To identify the EditorialObject a ProductionJob relates
-      to."""@en ;
-                rdfs:label "Related Editorial Object"@en .
+                dcterms:description "Pour identifier l'EditorialObject auquel se rapporte un ProductionJob à."@fr ,
+                                    "So identifizieren Sie das EditorialObject, auf das sich ein ProductionJob bezieht zu."@de ,
+                                    "To identify the EditorialObject a ProductionJob relates to."@en ;
+                rdfs:label "Objet éditorial connexe"@fr ,
+                           "Related Editorial Object"@en ,
+                           "Verwandtes redaktionelles Objekt"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#belongsToAudience
 ebuccdm:belongsToAudience rdf:type owl:ObjectProperty ;
-                          dcterms:description """The parent Audience group to which a Consumer is a member
-      of."""@en ;
-                          rdfs:label "Parent audience"@en .
+                          dcterms:description "Die übergeordnete Hörergruppe, der ein Verbraucher angehört von."@de ,
+                                              "Le groupe d'audience parent auquel appartient un consommateur de."@fr ,
+                                              "The parent Audience group to which a Consumer is a member of."@en ;
+                          rdfs:label "Parent audience"@en ,
+                                     "Public de parents"@fr ,
+                                     "Publikum der Eltern"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#compilesResonanceEvents
 ebuccdm:compilesResonanceEvents rdf:type owl:ObjectProperty ;
-                                dcterms:description """One of the ResonanceEvents aggregated into a meaningfulf set of
-      Resonance data."""@en ;
-                                rdfs:label "Resonance"@en .
+                                dcterms:description "Eines der ResonanceEvents, die zu einem aussagekräftigen Satz von Resonanzdaten."@de ,
+                                                    "One of the ResonanceEvents aggregated into a meaningfulf set of Resonance data."@en ,
+                                                    "Un des ResonanceEvents agrégés en un ensemble significatif de données de résonance."@fr ;
+                                rdfs:label "Resonance"@en ,
+                                           "Resonanz"@de ,
+                                           "Résonance"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#compliesWith
 ebuccdm:compliesWith rdf:type owl:ObjectProperty ;
-                     dcterms:description "The profile a ConsumptionDevice complies with."@en ;
-                     rdfs:label "Device profile"@en .
+                     dcterms:description "Das Profil, dem ein ConsumptionDevice entspricht."@de ,
+                                         "Le profil auquel se conforme un ConsumptionDevice."@fr ,
+                                         "The profile a ConsumptionDevice complies with."@en ;
+                     rdfs:label "Device profile"@en ,
+                                "Geräteprofil"@de ,
+                                "Profil de l'appareil"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#consumesEssence
 ebuccdm:consumesEssence rdf:type owl:ObjectProperty ;
-                        dcterms:description """the Essence that has been consumed during a
-      ConsumptionEvent."""@en ;
-                        rdfs:label "Essence"@en .
+                        dcterms:description "die Essenz, die während eines ConsumptionEvent."@de ,
+                                            "l'Essence qui a été consommée lors d'un ConsumptionEvent."@fr ,
+                                            "the Essence that has been consumed during a ConsumptionEvent."@en ;
+                        rdfs:label "Essence"@en ,
+                                   "Essence"@fr ,
+                                   "Essenz"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#consumptionDeviceManufacturer
 ebuccdm:consumptionDeviceManufacturer rdf:type owl:ObjectProperty ;
-                                      dcterms:description "The manufacturer of a ConsumptionDevice."@en ;
-                                      rdfs:label "Consumption device manufacturer"@en .
+                                      dcterms:description "Der Hersteller eines ConsumptionDevice."@de ,
+                                                          "Le fabricant d'un ConsumptionDevice."@fr ,
+                                                          "The manufacturer of a ConsumptionDevice."@en ;
+                                      rdfs:label "Consumption device manufacturer"@en ,
+                                                 "Fabricant de dispositifs de consommation"@fr ,
+                                                 "Hersteller von Verbrauchsgeräten"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#consumptionEventResumePoint
 ebuccdm:consumptionEventResumePoint rdf:type owl:ObjectProperty ;
-                                    dcterms:description """The date and time point at which consumption has
-      resumed."""@en ;
-                                    rdfs:label "Consumption event resume point"@en .
+                                    dcterms:description "Das Datum und der Zeitpunkt, zu dem der Konsum wieder aufgenommen wurde wiederaufgenommen wurde."@de ,
+                                                        "La date et l'heure à laquelle la consommation a repris."@fr ,
+                                                        "The date and time point at which consumption has resumed."@en ;
+                                    rdfs:label "Consumption event resume point"@en ,
+                                               "Point de reprise de l'événement de consommation"@fr ,
+                                               "Punkt für die Fortsetzung des Verbrauchsereignisses"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#consumptionLicenceLink
 ebuccdm:consumptionLicenceLink rdf:type owl:ObjectProperty ;
-                               dcterms:description "A link to the terms of a ConsumptionLicence."@en ;
-                               rdfs:label "Consumption licence link"@en .
+                               dcterms:description "A link to the terms of a ConsumptionLicence."@en ,
+                                                   "Ein Link zu den Bedingungen einer ConsumptionLicence."@de ,
+                                                   "Un lien vers les conditions d'une licence de consommation."@fr ;
+                               rdfs:label "Consumption licence link"@en ,
+                                          "Lien vers le permis de consommation"@fr ,
+                                          "Link zur Verbrauchslizenz"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#contractCostAmountCurrency
 ebuccdm:contractCostAmountCurrency rdf:type owl:ObjectProperty ;
-                                   dcterms:description "The currency of the amount of the ContractCost."@en ;
-                                   rdfs:label "Cost currency"@en .
+                                   dcterms:description "Die Währung des Betrags der ContractCost."@de ,
+                                                       "La devise du montant du ContractCost."@fr ,
+                                                       "The currency of the amount of the ContractCost."@en ;
+                                   rdfs:label "Cost currency"@en ,
+                                              "Devise de coût"@fr ,
+                                              "Kostenwährung"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#contractLink
 ebuccdm:contractLink rdf:type owl:ObjectProperty ;
-                     dcterms:description """A link to a location where information can be found about a
-      Contract."""@en ;
-                     rdfs:label "Contract link"@en .
+                     dcterms:description "A link to a location where information can be found about a Contract."@en ,
+                                         "Ein Link zu einem Ort, an dem Sie Informationen über einen Vertrag."@de ,
+                                         "Un lien vers un emplacement où l'on peut trouver des informations sur un contrat."@fr ;
+                     rdfs:label "Contract link"@en ,
+                                "Lien vers le contrat"@fr ,
+                                "Vertrag Link"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#coversConsumptionDevice
 ebuccdm:coversConsumptionDevice rdf:type owl:ObjectProperty ;
-                                dcterms:description """To identify a device compatible with the
-      ConsumptionLicence."""@en ;
-                                rdfs:label "Compatible consumption device"@en .
+                                dcterms:description "Pour identifier un appareil compatible avec le licence de consommation."@fr ,
+                                                    "To identify a device compatible with the ConsumptionLicence."@en ,
+                                                    "Um ein Gerät zu identifizieren, das mit der ConsumptionLicence."@de ;
+                                rdfs:label "Compatible consumption device"@en ,
+                                           "Dispositif de consommation compatible"@fr ,
+                                           "Kompatibles Verbrauchsgerät"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#createsMetadata
 ebuccdm:createsMetadata rdf:type owl:ObjectProperty ;
-                        dcterms:description "Used where a production job, e.g. a face recognition service, yields information that can be described using the EditorialObject class."@en ;
-                        rdfs:label "creates metadata"@en .
+                        dcterms:description "Used where a production job, e.g. a face recognition service, yields information that can be described using the EditorialObject class."@en ,
+                                            "Utilisé lorsqu'un travail de production, par exemple un service de reconnaissance des visages, produit des informations qui peuvent être décrites à l'aide de la classe EditorialObject."@fr ,
+                                            "Wird verwendet, wenn ein Produktionsauftrag, z. B. ein Gesichtserkennungsdienst, Informationen liefert, die mit der Klasse EditorialObject beschrieben werden können."@de ;
+                        rdfs:label "creates metadata"@en ,
+                                   "crée des métadonnées"@fr ,
+                                   "erstellt Metadaten"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#excludesAudience
 ebuccdm:excludesAudience rdf:type owl:ObjectProperty ;
-                         dcterms:description "A defined audience group that is excluded from the audience"@en ;
-                         rdfs:label "Excludes audience"@en .
+                         dcterms:description "A defined audience group that is excluded from the audience"@en ,
+                                             "Eine bestimmte Zielgruppe, die von der Zielgruppe ausgeschlossen ist"@de ,
+                                             "Un groupe d'audience défini qui est exclu de l'audience"@fr ;
+                         rdfs:label "Excludes audience"@en ,
+                                    "Exclut le public"@fr ,
+                                    "Schließt Publikum aus"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#hasAgentOnStagePosition
 ebuccdm:hasAgentOnStagePosition rdf:type owl:ObjectProperty ;
-                                dcterms:description "To specify the position of an Agent on Stage."@en ;
-                                rdfs:label "On stage position"@en .
+                                dcterms:description "Pour spécifier la position d'un agent sur la scène."@fr ,
+                                                    "To specify the position of an Agent on Stage."@en ,
+                                                    "Zur Angabe der Position eines Agenten auf der Bühne."@de ;
+                                rdfs:label "On stage position"@en ,
+                                           "Position auf der Bühne"@de ,
+                                           "Position sur scène"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#hasAsset
 ebuccdm:hasAsset rdf:type owl:ObjectProperty ;
-                 dcterms:description "To identify the Assets related to a PublicationPlan."@en ;
-                 rdfs:label "Asset"@en .
+                 dcterms:description "Pour identifier les actifs liés à un PublicationPlan."@fr ,
+                                     "To identify the Assets related to a PublicationPlan."@en ,
+                                     "Um die Assets zu identifizieren, die mit einem PublicationPlan verbunden sind."@de ;
+                 rdfs:label "Actif"@fr ,
+                            "Asset"@en ,
+                            "Vermögenswert"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#hasAssetValue
 ebuccdm:hasAssetValue rdf:type owl:ObjectProperty ;
-                      dcterms:description "To associate an Asset with its AssetValue."@en ;
-                      rdfs:label "Asset value" .
+                      dcterms:description "Pour associer un actif à sa valeur d'actif."@fr ,
+                                          "So verknüpfen Sie ein Asset mit seinem AssetWert."@de ,
+                                          "To associate an Asset with its AssetValue."@en ;
+                      rdfs:label "Asset value"@en ,
+                                 "Valeur de l'actif"@fr ,
+                                 "Vermögenswert"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#hasAssociatedConsumer
 ebuccdm:hasAssociatedConsumer rdf:type owl:ObjectProperty ;
-                              dcterms:description "To associate a consumer with a ResonanceEvent."@en ;
-                              rdfs:label "Associated consumer"@en .
+                              dcterms:description "Pour associer un consommateur à un ResonanceEvent."@fr ,
+                                                  "To associate a consumer with a ResonanceEvent."@en ,
+                                                  "Um einen Verbraucher mit einem ResonanceEvent zu verknüpfen."@de ;
+                              rdfs:label "Associated consumer"@en ,
+                                         "Assoziierter Verbraucher"@de ,
+                                         "Consommateur associé"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#hasAssociatedConsumptionEvent
 ebuccdm:hasAssociatedConsumptionEvent rdf:type owl:ObjectProperty ;
-                                      dcterms:description """To identify ConsumptionEvents associated with a
-      Consumer."""@en ;
-                                      rdfs:label "Consumption event"@en .
+                                      dcterms:description "Pour identifier les ConsumptionEvents associés à un consommateur."@fr ,
+                                                          "To identify ConsumptionEvents associated with a Consumer."@en ,
+                                                          "Um ConsumptionEvents zu identifizieren, die mit einem Verbraucher."@de ;
+                                      rdfs:label "Consumption event"@en ,
+                                                 "Verbrauchsereignis"@de ,
+                                                 "Événement de consommation"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#hasAssociatedProductionJob
 ebuccdm:hasAssociatedProductionJob rdf:type owl:ObjectProperty ;
-                                   dcterms:description "To identify a ProductionJob associated with the realisation of an EditorialObject."@en ;
-                                   rdfs:label "Production job"@en .
+                                   dcterms:description "Pour identifier un ProductionJob associé à la réalisation d'un EditorialObject."@fr ,
+                                                       "To identify a ProductionJob associated with the realisation of an EditorialObject."@en ,
+                                                       "Um einen ProductionJob zu identifizieren, der mit der Realisierung eines EditorialObjects verbunden ist."@de ;
+                                   rdfs:label "Job in der Produktion"@de ,
+                                              "Poste de production"@fr ,
+                                              "Production job"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#hasAssociatedProductionOrder
 ebuccdm:hasAssociatedProductionOrder rdf:type owl:ObjectProperty ;
-                                     dcterms:description """To identify the productionOrders associated with
-      PublicationPan."""@en ;
-                                     rdfs:label "Production order"@en .
+                                     dcterms:description "Pour identifier les ProductionOrders associés à PublicationPan."@fr ,
+                                                         "To identify the productionOrders associated with PublicationPan."@en ,
+                                                         "Um die productionOrders zu identifizieren, die mit VeröffentlichungPan."@de ;
+                                     rdfs:label "Ordre de production"@fr ,
+                                                "Production order"@en ,
+                                                "Produktionsauftrag"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#hasAudience
 ebuccdm:hasAudience rdf:type owl:ObjectProperty ;
-                    rdfs:label "has audience"@en .
+                    rdfs:label "a un public"@fr ,
+                               "has audience"@en ,
+                               "hat Publikum"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#hasAuditJobRelatedAuditReport
 ebuccdm:hasAuditJobRelatedAuditReport rdf:type owl:ObjectProperty ;
-                                      dcterms:description "To associate an AuditReport with an AuditJob."@en ;
-                                      rdfs:label "Related audit report"@en .
+                                      dcterms:description "Pour associer un AuditReport à un AuditJob."@fr ,
+                                                          "So verknüpfen Sie einen AuditReport mit einem AuditJob."@de ,
+                                                          "To associate an AuditReport with an AuditJob."@en ;
+                                      rdfs:label "Rapport d'audit connexe"@fr ,
+                                                 "Related audit report"@en ,
+                                                 "Zugehöriger Prüfbericht"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#hasBusinessContract
 ebuccdm:hasBusinessContract rdf:type owl:ObjectProperty ;
-                            dcterms:description """To identify the Contracts associated with a
-      PublicationPlan."""@en ;
-                            rdfs:label "Business contract"@en .
+                            dcterms:description "Pour identifier les Contrats associés à un Plan de publication."@fr ,
+                                                "To identify the Contracts associated with a PublicationPlan."@en ,
+                                                "Zur Identifizierung der Verträge, die mit einem PublicationPlan."@de ;
+                            rdfs:label "Business contract"@en ,
+                                       "Contrat d'affaires"@fr ,
+                                       "Geschäftsvertrag"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#hasConsumptionContract
 ebuccdm:hasConsumptionContract rdf:type owl:ObjectProperty ;
-                               dcterms:description """To identify a ConsumptionContract related to an
-      Account."""@en ;
-                               rdfs:label "Consumption Contract"@en .
+                               dcterms:description "Pour identifier un ConsumptionContract lié à un compte."@fr ,
+                                                   "To identify a ConsumptionContract related to an Account."@en ,
+                                                   "Um einen ConsumptionContract zu identifizieren, der mit einem Konto."@de ;
+                               rdfs:label "Consumption Contract"@en ,
+                                          "Contrat de consommation"@fr ,
+                                          "Verbrauchsvertrag"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#hasConsumptionCount
 ebuccdm:hasConsumptionCount rdf:type owl:ObjectProperty ;
-                            dcterms:description "The count of and relation to the real audience."@en ;
-                            rdfs:label "has consumption count"@en .
+                            dcterms:description "Die Anzahl und der Bezug zum echten Publikum."@de ,
+                                                "Le nombre et la relation avec le public réel."@fr ,
+                                                "The count of and relation to the real audience."@en ;
+                            rdfs:label "a compte de la consommation"@fr ,
+                                       "has consumption count"@en ,
+                                       "hat den Verbrauch gezählt"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#hasConsumptionEvent
 ebuccdm:hasConsumptionEvent rdf:type owl:ObjectProperty ;
-                            dcterms:description """To identify a ConsumptionEvent related to a
-      PublicationEvent."""@en ;
-                            rdfs:label "Consumption event"@en .
+                            dcterms:description "Pour identifier un ConsumptionEvent lié à un PublicationEvent."@fr ,
+                                                "To identify a ConsumptionEvent related to a PublicationEvent."@en ,
+                                                "Um ein ConsumptionEvent zu identifizieren, das mit einem PublikationsEreignis."@de ;
+                            rdfs:label "Consumption event"@en ,
+                                       "Verbrauchsereignis"@de ,
+                                       "Événement de consommation"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#hasContractRelatedCost
 ebuccdm:hasContractRelatedCost rdf:type owl:ObjectProperty ;
-                               dcterms:description "To identify Contract related costs."@en ;
-                               rdfs:label "Contract related cost"@en .
+                               dcterms:description "Pour identifier les coûts liés au contrat."@fr ,
+                                                   "To identify Contract related costs."@en ,
+                                                   "Um vertragsbezogene Kosten zu ermitteln."@de ;
+                               rdfs:label "Contract related cost"@en ,
+                                          "Coût lié au contrat"@fr ,
+                                          "Vertragsbezogene Kosten"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#hasContractTemplate
 ebuccdm:hasContractTemplate rdf:type owl:ObjectProperty ;
-                            dcterms:description "A Contract used as a template for another Contract."@en ;
-                            rdfs:label "Contract template"@en .
+                            dcterms:description "A Contract used as a template for another Contract."@en ,
+                                                "Ein Vertrag, der als Vorlage für einen anderen Vertrag dient."@de ,
+                                                "Un contrat utilisé comme modèle pour un autre contrat."@fr ;
+                            rdfs:label "Contract template"@en ,
+                                       "Modèle de contrat"@fr ,
+                                       "Vertragsvorlage"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#hasContractualParty
 ebuccdm:hasContractualParty rdf:type owl:ObjectProperty ;
-                            dcterms:description """To identify the different parties involved mentioned in Contract
-      terms."""@en ;
-                            rdfs:label "Contract party"@en .
+                            dcterms:description "Identifier les différentes parties impliquées mentionnées dans le contrat termes."@fr ,
+                                                "Identifizierung der verschiedenen Parteien, die im Vertrag erwähnt werden Bedingungen."@de ,
+                                                "To identify the different parties involved mentioned in Contract terms."@en ;
+                            rdfs:label "Contract party"@en ,
+                                       "Partie contractante"@fr ,
+                                       "Vertragspartner"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#hasDevice
 ebuccdm:hasDevice rdf:type owl:ObjectProperty ;
-                  dcterms:description "The ConsumptionDevice used during a ConsumptionEvent."@en ;
-                  rdfs:label "has device"@en .
+                  dcterms:description "Das ConsumptionDevice, das während eines ConsumptionEvents verwendet wird."@de ,
+                                      "Le ConsumptionDevice utilisé pendant un ConsumptionEvent."@fr ,
+                                      "The ConsumptionDevice used during a ConsumptionEvent."@en ;
+                  rdfs:label "a un dispositif"@fr ,
+                             "has device"@en ,
+                             "hat Gerät"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#hasGeoLocation
 ebuccdm:hasGeoLocation rdf:type owl:ObjectProperty ;
-                       dcterms:description "The Location of a ConsumptionDevice."@en ;
-                       rdfs:label "Device location"@en .
+                       dcterms:description "Der Standort eines ConsumptionDevice."@de ,
+                                           "L'emplacement d'un ConsumptionDevice."@fr ,
+                                           "The Location of a ConsumptionDevice."@en ;
+                       rdfs:label "Device location"@en ,
+                                  "Emplacement du dispositif"@fr ,
+                                  "Standort des Geräts"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#hasInputMediaResource
 ebuccdm:hasInputMediaResource rdf:type owl:ObjectProperty ;
-                              dcterms:description """To identify a MediaResource used as an input to a ProductionJob /
-      process."""@en ;
-                              rdfs:label "Resource input"@en .
+                              dcterms:description "Pour identifier une MediaResource utilisée comme entrée d'un ProductionJob / processus."@fr ,
+                                                  "To identify a MediaResource used as an input to a ProductionJob / process."@en ,
+                                                  "Zur Identifizierung einer MediaResource, die als Input für einen ProductionJob / Prozess."@de ;
+                              rdfs:label "Entrée des ressources"@fr ,
+                                         "Resource input"@en ,
+                                         "Ressourceneinsatz"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#hasInputResonance
 ebuccdm:hasInputResonance rdf:type owl:ObjectProperty ;
-                          dcterms:description """A set of Resonance data used as input to influence the definition of
-      a better targeted Campaign."""@en ;
-                          rdfs:label "Input resonance"@en .
+                          dcterms:description "A set of Resonance data used as input to influence the definition of a better targeted Campaign."@en ,
+                                              "Ein Satz von Resonanzdaten, die als Input für die Definition einer einer besser ausgerichteten Kampagne."@de ,
+                                              "Un ensemble de données de résonance utilisé comme entrée pour influencer la définition d'une d'une campagne mieux ciblée."@fr ;
+                          rdfs:label "Eingangsresonanz"@de ,
+                                     "Input resonance"@en ,
+                                     "Résonance d'entrée"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#hasInputResource
 ebuccdm:hasInputResource rdf:type owl:ObjectProperty ;
-                         dcterms:description """To identify a Resource used as an input to a ProductionJob /
-      process."""@en ;
-                         rdfs:label "Resource input"@en .
+                         dcterms:description "Pour identifier une Ressource utilisée comme entrée d'un ProductionJob / processus."@fr ,
+                                             "To identify a Resource used as an input to a ProductionJob / process."@en ,
+                                             "Zur Identifizierung einer Ressource, die als Input für einen ProductionJob / Prozess verwendet wird."@de ;
+                         rdfs:label "Entrée des ressources"@fr ,
+                                    "Resource input"@en ,
+                                    "Ressourceneinsatz"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#hasMemberAudience
 ebuccdm:hasMemberAudience rdf:type owl:ObjectProperty ;
-                          dcterms:description """To identify an Audience member of (included in) the current an
-      Audience group."""@en ;
-                          rdfs:label "Member audience"@en .
+                          dcterms:description "Pour identifier un membre de l'audience de (inclus dans) l'actuel an groupe d'audience."@fr ,
+                                              "So identifizieren Sie ein Mitglied der (in der) aktuellen an Zuschauergruppe."@de ,
+                                              "To identify an Audience member of (included in) the current an Audience group."@en ;
+                          rdfs:label "Member audience"@en ,
+                                     "Mitglied Publikum"@de ,
+                                     "Public de membres"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#hasOutputEssence
 ebuccdm:hasOutputEssence rdf:type owl:ObjectProperty ;
-                         dcterms:description "To identify Essence resulting from a ProductionJob."@en ;
-                         rdfs:label "Output essence"@en .
+                         dcterms:description "Pour identifier l'Essence résultant d'un ProductionJob."@fr ,
+                                             "To identify Essence resulting from a ProductionJob."@en ,
+                                             "Um die aus einem ProductionJob resultierende Essenz zu identifizieren."@de ;
+                         rdfs:label "Ausgabe Essenz"@de ,
+                                    "Essence de sortie"@fr ,
+                                    "Output essence"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#hasOutputMediaResource
 ebuccdm:hasOutputMediaResource rdf:type owl:ObjectProperty ;
-                               dcterms:description """To identify a MediaResource resulting from a
-      ProductionJob."""@en ;
-                               rdfs:label "Output media resource"@en .
+                               dcterms:description "Pour identifier une MediaResource résultant d'un ProductionJob."@fr ,
+                                                   "So identifizieren Sie eine MediaResource, die aus einem ProductionJob."@de ,
+                                                   "To identify a MediaResource resulting from a ProductionJob."@en ;
+                               rdfs:label "Medienressource ausgeben"@de ,
+                                          "Output media resource"@en ,
+                                          "Ressource média de sortie"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#hasOutputResource
 ebuccdm:hasOutputResource rdf:type owl:ObjectProperty ;
-                          dcterms:description """To identify a Resource resulting from a
-      ProductionJob."""@en ;
-                          rdfs:label "Output resource"@en .
+                          dcterms:description "Pour identifier une ressource résultant d'un ProductionJob."@fr ,
+                                              "To identify a Resource resulting from a ProductionJob."@en ,
+                                              "Um eine Ressource zu identifizieren, die aus einem ProduktionsJob."@de ;
+                          rdfs:label "Output resource"@en ,
+                                     "Ressource ausgeben"@de ,
+                                     "Ressource de sortie"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#hasProductionContract
 ebuccdm:hasProductionContract rdf:type owl:ObjectProperty ;
-                              dcterms:description """To identify Contarcts associated witha
-      ProductionOrder."""@en ;
-                              rdfs:label "Contract"@en .
+                              dcterms:description "Pour identifier les Contarcts associés à un ordre de production."@fr ,
+                                                  "To identify Contarcts associated witha ProductionOrder."@en ,
+                                                  "Zur Identifizierung von Kontakten, die mit einem ProduktionsAuftrag."@de ;
+                              rdfs:label "Contract"@en ,
+                                         "Contrat"@fr ,
+                                         "Vertrag"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#hasProductionDevice
 ebuccdm:hasProductionDevice rdf:type owl:ObjectProperty ;
-                            dcterms:description """To identify a ProductionDevice associated with a
-      MediaResource."""@en ;
-                            rdfs:label "Production device"@en .
+                            dcterms:description "Pour identifier un ProductionDevice associé à une MediaResource."@fr ,
+                                                "To identify a ProductionDevice associated with a MediaResource."@en ,
+                                                "Um ein ProductionDevice zu identifizieren, das mit einer MediaResource."@de ;
+                            rdfs:label "Dispositif de production"@fr ,
+                                       "Production device"@en ,
+                                       "Produktionsgerät"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#hasProductionDeviceOnStagePosition
 ebuccdm:hasProductionDeviceOnStagePosition rdf:type owl:ObjectProperty ;
-                                           dcterms:description """To identify the OnStagePosition of a ProductionDevice on
-      Stage."""@en ;
-                                           rdfs:label "Production device"@en .
+                                           dcterms:description "Pour identifier la OnStagePosition d'un ProductionDevice sur la scène."@fr ,
+                                                               "So identifizieren Sie die OnStagePosition eines ProductionDevice auf Bühne."@de ,
+                                                               "To identify the OnStagePosition of a ProductionDevice on Stage."@en ;
+                                           rdfs:label "Dispositif de production"@fr ,
+                                                      "Production device"@en ,
+                                                      "Produktionsgerät"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#hasProductionJobEvent
 ebuccdm:hasProductionJobEvent rdf:type owl:ObjectProperty ;
-                              dcterms:description "To define an Event associated to a ProductionJob."@en ;
-                              rdfs:label "Production job event"@en .
+                              dcterms:description "Pour définir un événement associé à un ProductionJob."@fr ,
+                                                  "So definieren Sie ein Ereignis, das mit einem ProductionJob verbunden ist."@de ,
+                                                  "To define an Event associated to a ProductionJob."@en ;
+                              rdfs:label "Production job event"@en ,
+                                         "Produktion Job Event"@de ,
+                                         "Événement de travail de production"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#hasProductionJobLocation
 ebuccdm:hasProductionJobLocation rdf:type owl:ObjectProperty ;
-                                 dcterms:description """To define a Location where a ProductionJob has taken or is scheduled
-      to take place."""@en ;
-                                 rdfs:label "Production job location"@en .
+                                 dcterms:description "Pour définir un lieu où un ProductionJob a eu ou est prévu d'avoir lieu. de se dérouler."@fr ,
+                                                     "To define a Location where a ProductionJob has taken or is scheduled to take place."@en ,
+                                                     "Um einen Ort zu definieren, an dem ein ProductionJob stattgefunden hat oder geplant ist stattfinden soll."@de ;
+                                 rdfs:label "Arbeitsort Produktion"@de ,
+                                            "Lieu de travail de la production"@fr ,
+                                            "Production job location"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#hasPublicationPlan
 ebuccdm:hasPublicationPlan rdf:type owl:ObjectProperty ;
-                           dcterms:description "A PublicationPlan associated to a Campaign."@en ;
-                           rdfs:label "Publication plan"@en .
+                           dcterms:description "A PublicationPlan associated to a Campaign."@en ,
+                                               "Ein Publikationsplan, der mit einer Kampagne verknüpft ist."@de ,
+                                               "Un PublicationPlan associé à une campagne."@fr ;
+                           rdfs:label "Plan de publication"@fr ,
+                                      "Plan zur Veröffentlichung"@de ,
+                                      "Publication plan"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#hasRelatedAccount
 ebuccdm:hasRelatedAccount rdf:type owl:ObjectProperty ;
-                          dcterms:description "To link related Acounts."@en ;
-                          rdfs:label "Related account"@en .
+                          dcterms:description "Pour lier des comptes connexes."@fr ,
+                                              "To link related Acounts."@en ,
+                                              "Um verwandte Konten zu verknüpfen."@de ;
+                          rdfs:label "Compte connexe"@fr ,
+                                     "Related account"@en ,
+                                     "Verwandtes Konto"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#hasRelatedAsset
 ebuccdm:hasRelatedAsset rdf:type owl:ObjectProperty ;
-                        dcterms:description "To link related Assets."@en ;
-                        rdfs:label "Related asset"@en .
+                        dcterms:description "Pour lier les actifs connexes."@fr ,
+                                            "To link related Assets."@en ,
+                                            "Um verwandte Assets zu verlinken."@de ;
+                        rdfs:label "Bien connexe"@fr ,
+                                   "Related asset"@en ,
+                                   "Verwandter Vermögenswert"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#hasRelatedAuditJob
 ebuccdm:hasRelatedAuditJob rdf:type owl:ObjectProperty ;
-                           dcterms:description "To identify AuditJobs related to an AuditReport."@en ;
-                           rdfs:label "Audit job(s)"@en .
+                           dcterms:description "Pour identifier les AuditJobs liés à un AuditReport."@fr ,
+                                               "To identify AuditJobs related to an AuditReport."@en ,
+                                               "Um AuditJobs zu identifizieren, die mit einem AuditReport verbunden sind."@de ;
+                           rdfs:label "Audit job(s)"@en ,
+                                      "Audit-Auftrag(e)"@de ,
+                                      "Poste(s) d'audit"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#hasRelatedAuditReport
 ebuccdm:hasRelatedAuditReport rdf:type owl:ObjectProperty ;
-                              dcterms:description """To identify AuditReports associated with an Asset, EditorialObject
-      or Resource."""@en ;
-                              rdfs:label "Related audit report"@en .
+                              dcterms:description "Pour identifier les rapports d'audit associés à un actif, un objet éditorial ou une ressource."@fr ,
+                                                  "To identify AuditReports associated with an Asset, EditorialObject or Resource."@en ,
+                                                  "Um AuditReports zu identifizieren, die mit einem Asset, EditorialObject oder Ressource."@de ;
+                              rdfs:label "Rapport d'audit connexe"@fr ,
+                                         "Related audit report"@en ,
+                                         "Zugehöriger Prüfbericht"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#hasRelatedConsumptionEvent
 ebuccdm:hasRelatedConsumptionEvent rdf:type owl:ObjectProperty ;
-                                   dcterms:description "To identify related ConsumptionEvents."@en ;
-                                   rdfs:label "Related consumption event"@en .
+                                   dcterms:description "Pour identifier les ConsumptionEvents liés."@fr ,
+                                                       "To identify related ConsumptionEvents."@en ,
+                                                       "Um verwandte ConsumptionEvents zu identifizieren."@de ;
+                                   rdfs:label "Related consumption event"@en ,
+                                              "Veranstaltung zum Thema Konsum"@de ,
+                                              "Événement lié à la consommation"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#hasRelatedResonanceEvent
 ebuccdm:hasRelatedResonanceEvent rdf:type owl:ObjectProperty ;
-                                 dcterms:description """To associate a ResonanceEvent with an
-      EditorialObject."""@en ;
-                                 rdfs:label "Related resonance event"@en .
+                                 dcterms:description "Pour associer un ResonanceEvent à un EditorialObject."@fr ,
+                                                     "So verknüpfen Sie ein ResonanceEvent mit einem EditorialObject."@de ,
+                                                     "To associate a ResonanceEvent with an EditorialObject."@en ;
+                                 rdfs:label "Related resonance event"@en ,
+                                            "Ähnliches Resonanzereignis"@de ,
+                                            "Événement de résonance connexe"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#hasRelatedStage
 ebuccdm:hasRelatedStage rdf:type owl:ObjectProperty ;
-                        dcterms:description "To associate a stage with a position on stage."@en ;
-                        rdfs:label "Related stage"@en .
+                        dcterms:description "Pour associer une scène à une position sur la scène."@fr ,
+                                            "To associate a stage with a position on stage."@en ,
+                                            "Um eine Bühne mit einer Position auf der Bühne zu verbinden."@de ;
+                        rdfs:label "Related stage"@en ,
+                                   "Verwandte Etappe"@de ,
+                                   "Étape connexe"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#hasRestrictedAudience
 ebuccdm:hasRestrictedAudience rdf:type owl:ObjectProperty ;
-                              dcterms:description """To identify an Audience for which access is
-      restricted."""@en ;
-                              rdfs:label "Restricted audience"@en .
+                              dcterms:description "Pour identifier une audience pour laquelle l'accès est restreint."@fr ,
+                                                  "To identify an Audience for which access is restricted."@en ,
+                                                  "Um eine Zielgruppe zu identifizieren, für die der Zugriff eingeschränkt ist."@de ;
+                              rdfs:label "Eingeschränktes Publikum"@de ,
+                                         "Public restreint"@fr ,
+                                         "Restricted audience"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#hasStageLocation
 ebuccdm:hasStageLocation rdf:type owl:ObjectProperty ;
-                         dcterms:description "To associate a Location with a Stage."@en ;
-                         rdfs:label "Stage location"@en .
+                         dcterms:description "Pour associer un emplacement à une scène."@fr ,
+                                             "So verknüpfen Sie einen Ort mit einer Bühne."@de ,
+                                             "To associate a Location with a Stage."@en ;
+                         rdfs:label "Lieu de la scène"@fr ,
+                                    "Stage location"@en ,
+                                    "Standort der Bühne"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#hasStakeholder
 ebuccdm:hasStakeholder rdf:type owl:ObjectProperty ;
-                       dcterms:description "To identify Agents associated with a PublicationPan."@en ;
-                       rdfs:label "Stakeholder" .
+                       dcterms:description "Pour identifier les agents associés à un PublicationPan."@fr ,
+                                           "To identify Agents associated with a PublicationPan."@en ,
+                                           "Um Agenten zu identifizieren, die mit einem PublicationPan verbunden sind."@de ;
+                       rdfs:label "Parties prenantes"@fr ,
+                                  "Stakeholder"@de ,
+                                  "Stakeholder"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#hasSubJob
 ebuccdm:hasSubJob rdf:type owl:ObjectProperty ;
-                  dcterms:description """To identify a ProductionJob / process as part of a complex
-      ProductionJob."""@en ;
-                  rdfs:label "Production job"@en .
+                  dcterms:description "Pour identifier un ProductionJob / processus comme faisant partie d'un complexe ProductionJob."@fr ,
+                                      "So identifizieren Sie einen ProductionJob / Prozess als Teil eines komplexen ProduktionsJob."@de ,
+                                      "To identify a ProductionJob / process as part of a complex ProductionJob."@en ;
+                  rdfs:label "Job in der Produktion"@de ,
+                             "Poste de production"@fr ,
+                             "Production job"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#hasTargetAudience
 ebuccdm:hasTargetAudience rdf:type owl:ObjectProperty ;
-                          dcterms:description """To identify the target Audience associated with a
-      PublicationEvent."""@en ;
-                          rdfs:label "Target audience"@en .
+                          dcterms:description "Pour identifier le public cible associé à un PublicationEvent."@fr ,
+                                              "To identify the target Audience associated with a PublicationEvent."@en ,
+                                              "Um das Zielpublikum zu identifizieren, das mit einem PublikationsEreignis."@de ;
+                          rdfs:label "Public cible"@fr ,
+                                     "Target audience"@en ,
+                                     "Zielpublikum"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#hasUsageContract
 ebuccdm:hasUsageContract rdf:type owl:ObjectProperty ;
-                         dcterms:description """The contractual terms under which a ProductionDevice shall be
-      used."""@en ;
-                         rdfs:label "Usage contract"@en .
+                         dcterms:description "Die Vertragsbedingungen, unter denen ein ProductionDevice verwendet werden soll verwendet wird."@de ,
+                                             "Les conditions contractuelles selon lesquelles un ProductionDevice sera utilisé."@fr ,
+                                             "The contractual terms under which a ProductionDevice shall be used."@en ;
+                         rdfs:label "Contrat d'utilisation"@fr ,
+                                    "Nutzungsvertrag"@de ,
+                                    "Usage contract"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#holdsLicence
 ebuccdm:holdsLicence rdf:type owl:ObjectProperty ;
-                     dcterms:description """The terms of a ConsumptionLicence associated with a
-      Contract."""@en ;
-                     rdfs:label "Consumption Licence"@en .
+                     dcterms:description "Die Bedingungen einer ConsumptionLicence, die mit einem Vertrag."@de ,
+                                         "Les termes d'une ConsumptionLicence associée à un contrat."@fr ,
+                                         "The terms of a ConsumptionLicence associated with a Contract."@en ;
+                     rdfs:label "Consumption Licence"@en ,
+                                "Licence de consommation"@fr ,
+                                "Verbrauchslizenz"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#includesAudience
 ebuccdm:includesAudience rdf:type owl:ObjectProperty ;
-                         dcterms:description "A defined audience group that is included in the audience"@en ;
-                         rdfs:label "Includes audience"@en .
+                         dcterms:description "A defined audience group that is included in the audience"@en ,
+                                             "Eine definierte Zielgruppe, die in der Zielgruppe enthalten ist"@de ,
+                                             "Un groupe d'audience défini qui est inclus dans l'audience"@fr ;
+                         rdfs:label "Comprend le public"@fr ,
+                                    "Includes audience"@en ,
+                                    "Inklusive Publikum"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#isApprovedBy
 ebuccdm:isApprovedBy rdf:type owl:ObjectProperty ;
-                     dcterms:description "To identify an Agent who approved an AuditReport."@en ;
-                     rdfs:label "Approved by"@en .
+                     dcterms:description "Pour identifier un agent qui a approuvé un rapport d'audit."@fr ,
+                                         "To identify an Agent who approved an AuditReport."@en ,
+                                         "Um einen Agenten zu identifizieren, der einen AuditReport genehmigt hat."@de ;
+                     rdfs:label "Approuvé par"@fr ,
+                                "Approved by"@en ,
+                                "Genehmigt von"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#isCommissionedBy
 ebuccdm:isCommissionedBy rdf:type owl:ObjectProperty ;
-                         dcterms:description """The Contract through which an EditorialObject is
-      commissioned."""@en ;
-                         rdfs:label "Contract"@en .
+                         dcterms:description "Der Vertrag, durch den ein EditorialObject in Auftrag gegeben wird."@de ,
+                                             "Le contrat par lequel un objet éditorial est commissionné."@fr ,
+                                             "The Contract through which an EditorialObject is commissioned."@en ;
+                         rdfs:label "Contract"@en ,
+                                    "Contrat"@fr ,
+                                    "Vertrag"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#isDefinedBy
 ebuccdm:isDefinedBy rdf:type owl:ObjectProperty ;
-                    dcterms:description """To identify the Contract by which a Rule has been
-      defined."""@en ;
-                    rdfs:label "Related contract"@en .
+                    dcterms:description "Pour identifier le contrat par lequel une règle a été définie."@fr ,
+                                        "To identify the Contract by which a Rule has been defined."@en ,
+                                        "Um den Vertrag zu identifizieren, durch den eine Regel definiert wurde definiert wurde."@de ;
+                    rdfs:label "Contrat connexe"@fr ,
+                               "Related contract"@en ,
+                               "Verwandter Vertrag"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#isExtractOf
 ebuccdm:isExtractOf rdf:type owl:ObjectProperty ;
-                    dcterms:description """Used for representing an extract, i. e. the playout of a part or the whole of some archived material on the playout.
-For attributes  like duration and start, the data is placed in the instance representing the abstract. Other metadata is read from the original instance that is extracted."""@en ;
-                    rdfs:label "is extract of"@en .
+                    dcterms:description "Dient zur Darstellung eines Auszugs, d. h. der Wiedergabe eines Teils oder des gesamten archivierten Materials auf dem Abspielgerät. Für Attribute wie Dauer und Start werden die Daten in der Instanz platziert, die den Auszug darstellt. Andere Metadaten werden aus der Originalinstanz gelesen, die extrahiert wird."@de ,
+                                        "Used for representing an extract, i. e. the playout of a part or the whole of some archived material on the playout. For attributes like duration and start, the data is placed in the instance representing the abstract. Other metadata is read from the original instance that is extracted."@en ,
+                                        "Utilisé pour représenter un extrait, c'est-à-dire la diffusion d'une partie ou de la totalité d'un matériel archivé sur le playout. Pour les attributs tels que la durée et le début, les données sont placées dans l'instance représentant l'extrait. Les autres métadonnées sont lues à partir de l'instance originale qui est extraite."@fr ;
+                    rdfs:label "est un extrait de"@fr ,
+                               "is extract of"@en ,
+                               "ist ein Auszug aus"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#isMeasuredBy
 ebuccdm:isMeasuredBy rdf:type owl:ObjectProperty ;
-                     dcterms:description "The Agent who analyses data to define a Resonance."@en ;
-                     rdfs:label "Measured by"@en .
+                     dcterms:description "Der Agent, der Daten analysiert, um eine Resonanz zu definieren."@de ,
+                                         "L'agent qui analyse les données pour définir une résonance."@fr ,
+                                         "The Agent who analyses data to define a Resonance."@en ;
+                     rdfs:label "Gemessen an"@de ,
+                                "Measured by"@en ,
+                                "Mesuré par"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#isOrderedBy
 ebuccdm:isOrderedBy rdf:type owl:ObjectProperty ;
-                    dcterms:description """The Contract through which an ProductionJob is
-      ordered."""@en ;
-                    rdfs:label "Contract"@en .
+                    dcterms:description "Der Vertrag, über den ein ProductionJob bestellt wird bestellt wird."@de ,
+                                        "Le contrat par lequel un ProductionJob est commandée."@fr ,
+                                        "The Contract through which an ProductionJob is ordered."@en ;
+                    rdfs:label "Contract"@en ,
+                               "Contrat"@fr ,
+                               "Vertrag"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#isRegisteredAs
 ebuccdm:isRegisteredAs rdf:type owl:ObjectProperty ;
-                       dcterms:description """To provide the Account details of a registered
-      Consumer."""@en ;
-                       rdfs:label "Registration"@en .
+                       dcterms:description "Pour fournir les détails du compte d'un consommateur."@fr ,
+                                           "To provide the Account details of a registered Consumer."@en ,
+                                           "Zur Angabe der Kontodaten eines registrierten Verbrauchers."@de ;
+                       rdfs:label "Anmeldung"@de ,
+                                  "Inscription"@fr ,
+                                  "Registration"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#isResourceCommissionedBy
 ebuccdm:isResourceCommissionedBy rdf:type owl:ObjectProperty ;
-                                 dcterms:description """The Contract through which a Resource is
-      commissioned."""@en ;
-                                 rdfs:label "Contract"@en .
+                                 dcterms:description "Der Vertrag, durch den eine Ressource in Auftrag gegeben wird."@de ,
+                                                     "Le contrat par lequel une ressource est commandée."@fr ,
+                                                     "The Contract through which a Resource is commissioned."@en ;
+                                 rdfs:label "Contract"@en ,
+                                            "Contrat"@fr ,
+                                            "Vertrag"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#measureValueUnit
 ebuccdm:measureValueUnit rdf:type owl:ObjectProperty ;
-                         dcterms:description """To define the unit in which the value of a Measure is expressed,
-      when applicable."""@en ;
-                         rdfs:label "Measure unit"@en .
+                         dcterms:description "Pour définir l'unité dans laquelle la valeur d'une mesure est exprimée, le cas échéant."@fr ,
+                                             "To define the unit in which the value of a Measure is expressed, when applicable."@en ,
+                                             "Zur Festlegung der Einheit, in der der Wert einer Kennzahl ausgedrückt wird, falls zutreffend."@de ;
+                         rdfs:label "Einheit messen"@de ,
+                                    "Measure unit"@en ,
+                                    "Unité de mesure"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#measuresAgainstRule
 ebuccdm:measuresAgainstRule rdf:type owl:ObjectProperty ;
-                            dcterms:description "To associate a Rule with a Measure."@en ;
-                            rdfs:label "Related Rule"@en .
+                            dcterms:description "Pour associer une règle à une mesure."@fr ,
+                                                "So verknüpfen Sie eine Regel mit einer Kennzahl."@de ,
+                                                "To associate a Rule with a Measure."@en ;
+                            rdfs:label "Related Rule"@en ,
+                                       "Règle connexe"@fr ,
+                                       "Verwandte Regel"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#offers
 ebuccdm:offers rdf:type owl:ObjectProperty ;
-               dcterms:description """To identify the PublicationEvents available through a
-      Service."""@en ;
-               rdfs:label "Publication events"@en .
+               dcterms:description "Pour identifier les PublicationEvents disponibles via un service."@fr ,
+                                   "To identify the PublicationEvents available through a Service."@en ,
+                                   "Zur Identifizierung der PublicationEvents, die über einen Dienst."@de ;
+               rdfs:label "Publication events"@en ,
+                          "Veranstaltungen zur Veröffentlichung"@de ,
+                          "Événements de publication"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#offersService
 ebuccdm:offersService rdf:type owl:ObjectProperty ;
-                      rdfs:label "Offers service"@en .
+                      rdfs:label "Angebote Service"@de ,
+                                 "Offers service"@en ,
+                                 "Offres de service"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#originateFrom
 ebuccdm:originateFrom rdf:type owl:ObjectProperty ;
-                      dcterms:description "The Contract from which the Rights orginate."@en ;
-                      rdfs:label "Contract"@en .
+                      dcterms:description "Der Vertrag, aus dem die Rechte hervorgehen."@de ,
+                                          "Le contrat dont découlent les droits."@fr ,
+                                          "The Contract from which the Rights orginate."@en ;
+                      rdfs:label "Contract"@en ,
+                                 "Contrat"@fr ,
+                                 "Vertrag"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#previousRelatedProductionJob
 ebuccdm:previousRelatedProductionJob rdf:type owl:ObjectProperty ;
                                      rdfs:range ebuccdm:ProductionJob ;
-                                     dcterms:description "To identify a previous associated ProductionJob"@en ;
-                                     rdfs:label "Previous job"@en .
+                                     dcterms:description "Pour identifier un ProductionJob associé précédent"@fr ,
+                                                         "So identifizieren Sie einen früheren zugehörigen ProductionJob"@de ,
+                                                         "To identify a previous associated ProductionJob"@en ;
+                                     rdfs:label "Emploi précédent"@fr ,
+                                                "Previous job"@en ,
+                                                "Vorheriger Job"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#provenance
 ebuccdm:provenance rdf:type owl:ObjectProperty ;
                    rdfs:domain owl:Thing ;
                    rdfs:range ec:Agent ;
-                   dcterms:description "The person or company that is providing the metadata."@en ;
-                   rdfs:label "Provenance"@en .
+                   dcterms:description "Die Person oder Firma, die die Metadaten zur Verfügung stellt."@de ,
+                                       "La personne ou l'entreprise qui fournit les métadonnées."@fr ,
+                                       "The person or company that is providing the metadata."@en ;
+                   rdfs:label "Provenance"@en ,
+                              "Provenance"@fr ,
+                              "Provenienz"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#referencesRule
 ebuccdm:referencesRule rdf:type owl:ObjectProperty ;
-                       dcterms:description """To provide a reference to a Rule against which an AuditJob has been
-      performed through an associated Measure."""@en ;
-                       rdfs:label "Referenced Rule"@en .
+                       dcterms:description "Pour fournir une référence à une règle par rapport à laquelle un AuditJob a été effectué par le biais d'une mesure associée."@fr ,
+                                           "To provide a reference to a Rule against which an AuditJob has been performed through an associated Measure."@en ,
+                                           "Um einen Verweis auf eine Regel bereitzustellen, gegen die ein AuditJob durchgeführt wurde durch eine zugehörige Maßnahme durchgeführt wurde."@de ;
+                       rdfs:label "Referenced Rule"@en ,
+                                  "Referenzierte Regel"@de ,
+                                  "Règle référencée"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#renders
 ebuccdm:renders rdf:type owl:ObjectProperty ;
-                rdfs:label "renders"@en .
+                rdfs:label "Ruft  auf."@de ,
+                           "rend"@fr ,
+                           "renders"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#requiresLicence
 ebuccdm:requiresLicence rdf:type owl:ObjectProperty ;
-                        dcterms:description """To identify a ConsumptionLicence required by a
-      ConsumptionEvent."""@en ;
-                        rdfs:label "Required licence"@en .
+                        dcterms:description "Pour identifier une Licence de consommation requise par un ConsumptionEvent."@fr ,
+                                            "To identify a ConsumptionLicence required by a ConsumptionEvent."@en ,
+                                            "Zur Identifizierung einer ConsumptionLicence, die für ein VerbrauchsEreignis."@de ;
+                        rdfs:label "Erforderliche Lizenz"@de ,
+                                   "Licence requise"@fr ,
+                                   "Required licence"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#resultsIn
 ebuccdm:resultsIn rdf:type owl:ObjectProperty ;
-                  dcterms:description """A link between a ResonanceEvent and a
-      ConsumptionEvent."""@en ;
-                  rdfs:label "Resonance event"@en .
+                  dcterms:description "A link between a ResonanceEvent and a ConsumptionEvent."@en ,
+                                      "Eine Verbindung zwischen einem ResonanceEvent und einem VerbrauchsEreignis."@de ,
+                                      "Un lien entre un ResonanceEvent et un ConsumptionEvent."@fr ;
+                  rdfs:label "Resonance event"@en ,
+                             "Resonanz Ereignis"@de ,
+                             "Événement de résonance"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#rulePriority
 ebuccdm:rulePriority rdf:type owl:ObjectProperty ;
-                     dcterms:description "To define the priority associated to a Rule."@en ;
-                     rdfs:label "Rule priority"@en .
+                     dcterms:description "Pour définir la priorité associée à une règle."@fr ,
+                                         "To define the priority associated to a Rule."@en ,
+                                         "Um die Priorität einer Regel zu definieren."@de ;
+                     rdfs:label "Priorität der Regel"@de ,
+                                "Priorité de la règle"@fr ,
+                                "Rule priority"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#ruleReference
 ebuccdm:ruleReference rdf:type owl:ObjectProperty ;
-                      dcterms:description "To provide references to a Rule."@en ;
-                      rdfs:label "Rule reference"@en .
+                      dcterms:description "Pour fournir des références à une règle."@fr ,
+                                          "To provide references to a Rule."@en ,
+                                          "Um Hinweise auf eine Regel zu geben."@de ;
+                      rdfs:label "Regel-Referenz"@de ,
+                                 "Rule reference"@en ,
+                                 "Référence de la règle"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#supportsConsumptionDeviceProfile
 ebuccdm:supportsConsumptionDeviceProfile rdf:type owl:ObjectProperty ;
-                                         dcterms:description "To define the profile of a ConsumptionDevice."@en ;
-                                         rdfs:label "Device profile"@en .
+                                         dcterms:description "Pour définir le profil d'un ConsumptionDevice."@fr ,
+                                                             "So definieren Sie das Profil eines ConsumptionDevice."@de ,
+                                                             "To define the profile of a ConsumptionDevice."@en ;
+                                         rdfs:label "Device profile"@en ,
+                                                    "Geräteprofil"@de ,
+                                                    "Profil de l'appareil"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#usesConsumptionDevice
 ebuccdm:usesConsumptionDevice rdf:type owl:ObjectProperty ;
-                              dcterms:description "Range: string or ConsumptionDevice"@en ,
-                                                  """To identify the ConsumptionDevices used by a
-      Consumer."""@en ;
-                              rdfs:label "Consumption device"@en .
+                              dcterms:description "Bereich: string oder ConsumptionDevice"@de ,
+                                                  "Plage : chaîne ou ConsumptionDevice"@fr ,
+                                                  "To identify the ConsumptionDevices used by a Consumer. Range: string or ConsumptionDevice"@en ;
+                              rdfs:label "Consumption device"@en ,
+                                         "Dispositif de consommation"@fr ,
+                                         "Verbrauchsgerät"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#usesMeasure
 ebuccdm:usesMeasure rdf:type owl:ObjectProperty ;
-                    dcterms:description "To associate a Measure with an AuditJob."@en ;
-                    rdfs:label "Related measure"@en .
+                    dcterms:description "Pour associer une mesure à un AuditJob."@fr ,
+                                        "So verknüpfen Sie eine Maßnahme mit einem AuditJob."@de ,
+                                        "To associate a Measure with an AuditJob."@en ;
+                    rdfs:label "Mesure connexe"@fr ,
+                               "Related measure"@en ,
+                               "Verwandte Maßnahme"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#usesProductionDevice
 ebuccdm:usesProductionDevice rdf:type owl:ObjectProperty ;
-                             dcterms:description """To identify a ProductionDevice associated to a
-      ProductionJob."""@en ;
-                             rdfs:label "Production device"@en ,
-                                        "Uses production device"@en .
+                             dcterms:description "Pour identifier un ProductionDevice associé à un ProductionJob."@fr ,
+                                                 "To identify a ProductionDevice associated to a ProductionJob."@en ,
+                                                 "Um ein ProductionDevice zu identifizieren, das mit einem ProduktionsJob."@de ;
+                             rdfs:label "Dispositif de production"@fr ,
+                                        "Production device"@en ,
+                                        "Produktionsgerät"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#annotationCurationDateTime
 ec:annotationCurationDateTime rdf:type owl:ObjectProperty ;
                               rdfs:range time:Instant ;
-                              dcterms:description "To provide the date and time when an Annotation has been reviewed."@en ;
-                              rdfs:label "Annotation curation date & time"@en .
+                              dcterms:description "Pour fournir la date et l'heure auxquelles une Annotation a été révisée."@fr ,
+                                                  "To provide the date and time when an Annotation has been reviewed."@en ,
+                                                  "Um das Datum und die Uhrzeit anzugeben, zu der eine Anmerkung überprüft wurde."@de ;
+                              rdfs:label "Annotation curation date & time"@en ,
+                                         "Date et heure de la curation des annotations"@fr ,
+                                         "Datum und Uhrzeit der Kommentarkuration"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#appliesOutOf
 ec:appliesOutOf rdf:type owl:ObjectProperty ;
                 rdfs:range ec:CountryCode ;
-                dcterms:description "To define the Location (e.g. country, region) to which Rating and TargetAudience do NOT apply."@en ;
-                rdfs:label "Exclusion area"@en .
+                dcterms:description "Pour définir l'emplacement (par exemple, le pays, la région) auquel le classement et le public cible ne s'appliquent PAS."@fr ,
+                                    "To define the Location (e.g. country, region) to which Rating and TargetAudience do NOT apply."@en ,
+                                    "Zur Definition des Standorts (z.B. Land, Region), für den Rating und TargetAudience NICHT gelten."@de ;
+                rdfs:label "Ausschlussgebiet"@de ,
+                           "Exclusion area"@en ,
+                           "Zone d'exclusion"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#appliesTo
 ec:appliesTo rdf:type owl:ObjectProperty ;
              rdfs:range ec:Asset ;
-             dcterms:description "To identify the asset to which the Rating applies."@en ;
-             rdfs:label "applies to"@en .
+             dcterms:description "Identifier l'actif auquel le Rating s'applique."@fr ,
+                                 "To identify the asset to which the Rating applies."@en ,
+                                 "Um den Vermögenswert zu identifizieren, für den das Rating gilt."@de ;
+             rdfs:label "applies to"@en ,
+                        "gilt für"@de ,
+                        "s'applique à"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#applyTo
 ec:applyTo rdf:type owl:ObjectProperty ;
            rdfs:range ec:Asset ;
-           dcterms:description "The Asset to which Rights apply."@en ;
-           rdfs:label "Asset"@en .
+           dcterms:description "Das Asset, auf das sich die Rechte beziehen."@de ,
+                               "L'actif auquel les droits s'appliquent."@fr ,
+                               "The Asset to which Rights apply."@en ;
+           rdfs:label "Actif"@fr ,
+                      "Asset"@en ,
+                      "Vermögenswert"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#approvedBy
 ec:approvedBy rdf:type owl:ObjectProperty ;
               rdfs:range ec:Agent ;
-              dcterms:description """To identify the Agent who approved the EditorialObject for publishing.
-The property, when present, will act as an trigger for the publishing of the Editorial object."""@en ;
-              rdfs:label "Agent"@en .
+              dcterms:description "Pour identifier l'agent qui a approuvé la publication de l'objet EditorialObject. La propriété, lorsqu'elle est présente, servira de déclencheur pour la publication de l'objet Editorial."@fr ,
+                                  "To identify the Agent who approved the EditorialObject for publishing. The property, when present, will act as an trigger for the publishing of the Editorial object."@en ,
+                                  "Zur Identifizierung des Agenten, der das EditorialObject zur Veröffentlichung freigegeben hat. Wenn diese Eigenschaft vorhanden ist, dient sie als Auslöser für die Veröffentlichung des Redaktionsobjekts."@de ;
+              rdfs:label "Agent"@de ,
+                         "Agent"@en ,
+                         "Agent"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#artefactDateOfPurchase
 ec:artefactDateOfPurchase rdf:type owl:ObjectProperty ;
                           rdfs:subPropertyOf ec:date ;
                           rdfs:range time:Instant ;
-                          dcterms:description "The date when an Artefact was purchased. ."@en ;
-                          rdfs:label "Artefact date of purchase"@en .
+                          dcterms:description "Das Datum, an dem ein Artefakt gekauft wurde. ."@de ,
+                                              "La date à laquelle un artefact a été acheté. ."@fr ,
+                                              "The date when an Artefact was purchased. ."@en ;
+                          rdfs:label "Artefact date of purchase"@en ,
+                                     "Date d'achat de l'artefact"@fr ,
+                                     "Kaufdatum des Artefakts"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#artefactDateOfSell
 ec:artefactDateOfSell rdf:type owl:ObjectProperty ;
                       rdfs:subPropertyOf ec:date ;
                       rdfs:range time:Instant ;
-                      dcterms:description "The date when an Artefact was sold."@en ;
-                      rdfs:label "Artefact date of sell"@en .
+                      dcterms:description "Das Datum, an dem ein Artefakt verkauft wurde."@de ,
+                                          "La date à laquelle un artefact a été vendu."@fr ,
+                                          "The date when an Artefact was sold."@en ;
+                      rdfs:label "Artefact date of sell"@en ,
+                                 "Date de vente de l'artefact"@fr ,
+                                 "Verkaufsdatum des Artefakts"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#awardDate
 ec:awardDate rdf:type owl:ObjectProperty ;
              rdfs:subPropertyOf ec:date ;
              rdfs:range time:Instant ;
-             dcterms:description "To provide an date when an Award was delivered."@en ;
-             rdfs:label "Award date"@en .
+             dcterms:description "Pour fournir une date à laquelle un prix a été livré."@fr ,
+                                 "To provide an date when an Award was delivered."@en ,
+                                 "Zur Angabe des Datums, an dem ein Award zugestellt wurde."@de ;
+             rdfs:label "Award date"@en ,
+                        "Date d'attribution"@fr ,
+                        "Datum der Vergabe"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#bringsRights
 ec:bringsRights rdf:type owl:ObjectProperty ;
-                dcterms:description "The rights appear as a consequence of the engagement."@nb ;
-                rdfs:comment "brings rights"@nb .
+                dcterms:description "Die Rechte sind eine Folge des Engagements."@de ,
+                                    "Les droits apparaissent comme une conséquence de l'engagement."@fr ,
+                                    "The rights appear as a consequence of the engagement."@en ;
+                rdfs:label "Brings rights"@en ,
+                           "Bringt Rechte"@de ,
+                           "Donne des droits"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#canAccessPublicationChannel
 ec:canAccessPublicationChannel rdf:type owl:ObjectProperty ;
-                               rdfs:label "can accesspublication channel"@en .
+                               rdfs:label "can access
+publication channel"@en ,
+                                          "kann auf den Publikationskanal zugreifen"@de ,
+                                          "peut accéder au canal de publication"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#canAccessPublicationPlatform
 ec:canAccessPublicationPlatform rdf:type owl:ObjectProperty ;
-                                rdfs:label "canaccess publicationplatform"@en .
+                                rdfs:label "can
+access publication
+platform"@en ,
+                                           "kann auf die Publikationsplattform zugreifen"@de ,
+                                           "peut accéder à la plateforme de publication"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#clonedTo
 ec:clonedTo rdf:type owl:ObjectProperty ;
             owl:inverseOf ec:isClonedFrom ;
             rdfs:range ec:MediaResource ;
-            dcterms:description "Identifies relationship between a digital instantiation of a MediaResource and its direct copy, with no generational loss."@en ;
-            rdfs:label "Cloned to"@en .
+            dcterms:description "Identifie la relation entre une instanciation numérique d'une MediaResource et sa copie directe, sans perte de génération."@fr ,
+                                "Identifies relationship between a digital instantiation of a MediaResource and its direct copy, with no generational loss."@en ,
+                                "Identifiziert die Beziehung zwischen einer digitalen Instanziierung einer MediaResource und ihrer direkten Kopie, ohne Generationsverlust."@de ;
+            rdfs:label "Cloned to"@en ,
+                       "Cloné en"@fr ,
+                       "Geklont auf"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#coversEvent
 ec:coversEvent rdf:type owl:ObjectProperty ;
                rdfs:subPropertyOf ec:hasCoverage ;
                rdfs:range ec:Event ;
-               dcterms:description "A property to identify the Events, all real or fictional, covered by the EditorialObject"@en ;
-               rdfs:label "Covers event"@en .
+               dcterms:description "A property to identify the Events, all real or fictional, covered by the EditorialObject"@en ,
+                                   "Eine Eigenschaft zur Identifizierung der Ereignisse, alle real oder fiktiv, die vom EditorialObject abgedeckt werden"@de ,
+                                   "Une propriété pour identifier les événements, tous réels ou fictifs, couverts par l'EditorialObject."@fr ;
+               rdfs:label "Couvre l'événement"@fr ,
+                          "Covers event"@en ,
+                          "Deckt Ereignis"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#coversLocation
 ec:coversLocation rdf:type owl:ObjectProperty ;
                   rdfs:subPropertyOf ec:hasCoverage ;
                   rdfs:range ec:Location ;
-                  dcterms:description "A property to identify the Locations, all real or fictional, covered by the EditorialObject"@en ;
-                  rdfs:label "Covers location"@en .
+                  dcterms:description "A property to identify the Locations, all real or fictional, covered by the EditorialObject"@en ,
+                                      "Eine Eigenschaft zur Identifizierung der realen oder fiktiven Orte, die von dem EditorialObject abgedeckt werden."@de ,
+                                      "Une propriété pour identifier les lieux, tous réels ou fictifs, couverts par l'EditorialObject."@fr ;
+                  rdfs:label "Couvre l'emplacement"@fr ,
+                             "Covers location"@en ,
+                             "Deckt den Standort ab"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#date
 ec:date rdf:type owl:ObjectProperty ;
         rdfs:range time:Instant ;
         dc:description "Range: Litteral, on the instance level, this can be restricted to dateTime, date or another suitable format."@en ;
-        dcterms:description "A date associated to an Asset."@en ;
+        dcterms:description "A date associated to an Asset. Range: Litteral, on the instance level, this can be restricted to dateTime, date or another suitable format."@en ,
+                            "Ein Datum, das mit einem Asset verbunden ist. Range: Litteral, auf Instanzebene kann dies auf dateTime, Datum oder ein anderes geeignetes Format beschränkt werden."@de ,
+                            "Une date associée à un actif. Range : Litteral, au niveau de l'instance, cela peut être limité à dateTime, date ou un autre format approprié."@fr ;
         rdfs:isDefinedBy dc:date ;
-        rdfs:label "Date"@en .
+        rdfs:label "Date"@en ,
+                   "Date"@fr ,
+                   "Datum"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#dateArchived
 ec:dateArchived rdf:type owl:ObjectProperty ;
                 rdfs:subPropertyOf ec:date ;
                 rdfs:range time:Instant ;
-                dcterms:description "The date when the Asset was archived."@en ;
-                rdfs:label "Archiving date"@en .
+                dcterms:description "Das Datum, an dem das Asset archiviert wurde."@de ,
+                                    "La date à laquelle l'actif a été archivé."@fr ,
+                                    "The date when the Asset was archived."@en ;
+                rdfs:label "Archiving date"@en ,
+                           "Date d'archivage"@fr ,
+                           "Datum der Archivierung"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#dateBroadcast
 ec:dateBroadcast rdf:type owl:ObjectProperty ;
                  rdfs:subPropertyOf ec:date ;
                  rdfs:range time:Instant ;
-                 dcterms:description "The date when the Asset was first broadcast publicly on television or radio or via streaming."@en ;
-                 rdfs:label "Broadcast date"@en .
+                 dcterms:description "Das Datum, an dem der Asset zum ersten Mal öffentlich im Fernsehen, Radio oder per Streaming ausgestrahlt wurde."@de ,
+                                     "La date à laquelle l'actif a été diffusé pour la première fois en public à la télévision ou à la radio ou par streaming."@fr ,
+                                     "The date when the Asset was first broadcast publicly on television or radio or via streaming."@en ;
+                 rdfs:label "Broadcast date"@en ,
+                            "Date de diffusion"@fr ,
+                            "Datum der Ausstrahlung"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#dateCreated
 ec:dateCreated rdf:type owl:ObjectProperty ;
                rdfs:subPropertyOf ec:date ;
                rdfs:range time:Instant ;
-               dcterms:description "The date of creation of the Asset."@en ;
-               rdfs:label "Creation date/time"@en .
+               dcterms:description "Das Datum der Erstellung des Assets."@de ,
+                                   "La date de création de l'actif."@fr ,
+                                   "The date of creation of the Asset."@en ;
+               rdfs:label "Creation date/time"@en ,
+                          "Date/heure de création"@fr ,
+                          "Erstellungsdatum/-zeit"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#dateDeleted
 ec:dateDeleted rdf:type owl:ObjectProperty ;
                rdfs:subPropertyOf ec:date ;
                rdfs:range time:Instant ;
-               dcterms:description "The date when the Resource was deleted."@en ;
-               rdfs:label "Deletion date"@en .
+               dcterms:description "Das Datum, an dem die Ressource gelöscht wurde."@de ,
+                                   "La date à laquelle la ressource a été supprimée."@fr ,
+                                   "The date when the Resource was deleted."@en ;
+               rdfs:label "Date de suppression"@fr ,
+                          "Datum der Löschung"@de ,
+                          "Deletion date"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#dateDigitised
 ec:dateDigitised rdf:type owl:ObjectProperty ;
                  rdfs:subPropertyOf ec:date ;
                  rdfs:range time:Instant ;
-                 dcterms:description "The date when the Resource was digitised."@en ;
-                 rdfs:label "Digitisation date"@en .
+                 dcterms:description "Das Datum, an dem die Ressource digitalisiert wurde."@de ,
+                                     "La date à laquelle la ressource a été numérisée."@fr ,
+                                     "The date when the Resource was digitised."@en ;
+                 rdfs:label "Date de numérisation"@fr ,
+                            "Datum der Digitalisierung"@de ,
+                            "Digitisation date"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#dateDistributed
 ec:dateDistributed rdf:type owl:ObjectProperty ;
                    rdfs:subPropertyOf ec:date ;
                    rdfs:range time:Instant ;
-                   dcterms:description "The date when the Resource was first made available to the public for purchase, download, or online access."@en ;
-                   rdfs:label "Distribution date"@en .
+                   dcterms:description "Das Datum, an dem die Ressource erstmals der Öffentlichkeit zum Kauf, Download oder Online-Zugriff zur Verfügung gestellt wurde."@de ,
+                                       "La date à laquelle la ressource a été mise pour la première fois à la disposition du public pour l'achat, le téléchargement ou l'accès en ligne."@fr ,
+                                       "The date when the Resource was first made available to the public for purchase, download, or online access."@en ;
+                   rdfs:label "Date de distribution"@fr ,
+                              "Datum der Verteilung"@de ,
+                              "Distribution date"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#dateIngested
 ec:dateIngested rdf:type owl:ObjectProperty ;
                 rdfs:subPropertyOf ec:date ;
                 rdfs:range time:Instant ;
-                dcterms:description "The date when the Resource was ingested/acquired in institutional holdings."@en ;
-                rdfs:label "Ingest date"@en .
+                dcterms:description "Das Datum, an dem die Ressource in den institutionellen Bestand aufgenommen/erworben wurde."@de ,
+                                    "La date à laquelle la ressource a été ingérée/acquise dans les fonds institutionnels."@fr ,
+                                    "The date when the Resource was ingested/acquired in institutional holdings."@en ;
+                rdfs:label "Date d'ingestion"@fr ,
+                           "Ingest date"@en ,
+                           "Ingest-Datum"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#dateIssued
 ec:dateIssued rdf:type owl:ObjectProperty ;
               rdfs:subPropertyOf ec:date ;
               rdfs:range time:Instant ;
-              dcterms:description "The date when the Asset was issued."@en ;
-              rdfs:label "Date issued"@en .
+              dcterms:description "Das Datum, an dem das Asset ausgegeben wurde."@de ,
+                                  "La date à laquelle l'actif a été émis."@fr ,
+                                  "The date when the Asset was issued."@en ;
+              rdfs:label "Date d'émission"@fr ,
+                         "Date issued"@en ,
+                         "Datum der Ausstellung"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#dateLicenseEnd
 ec:dateLicenseEnd rdf:type owl:ObjectProperty ;
                   rdfs:subPropertyOf ec:date ;
                   rdfs:range time:Instant ;
-                  dcterms:description "The date when the licence for the Asset ends."@en ;
-                  rdfs:label "Licence end date"@en .
+                  dcterms:description "Das Datum, an dem die Lizenz für das Asset endet."@de ,
+                                      "La date à laquelle la licence de l'actif prend fin."@fr ,
+                                      "The date when the licence for the Asset ends."@en ;
+                  rdfs:label "Date de fin de licence"@fr ,
+                             "Enddatum der Lizenz"@de ,
+                             "Licence end date"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#dateMigrated
 ec:dateMigrated rdf:type owl:ObjectProperty ;
                 rdfs:subPropertyOf ec:date ;
                 rdfs:range time:Instant ;
-                dcterms:description "The date when the Resource was copied or converted from an obsolete or endangered original format to a more updated format for preservation."@en ;
-                rdfs:label "Migration date"@en .
+                dcterms:description "Das Datum, an dem die Ressource kopiert oder von einem veralteten oder gefährdeten Originalformat in ein aktuelleres Format zur Aufbewahrung konvertiert wurde."@de ,
+                                    "La date à laquelle la ressource a été copiée ou convertie d'un format original obsolète ou menacé à un format plus actualisé pour la conservation."@fr ,
+                                    "The date when the Resource was copied or converted from an obsolete or endangered original format to a more updated format for preservation."@en ;
+                rdfs:label "Date de migration"@fr ,
+                           "Datum der Migration"@de ,
+                           "Migration date"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#dateModified
 ec:dateModified rdf:type owl:ObjectProperty ;
                 rdfs:subPropertyOf ec:date ;
                 rdfs:range time:Instant ;
-                dcterms:description "To indicate the date at which the Asset has been modified."@en ;
-                rdfs:label "Modification date/time"@en .
+                dcterms:description "Pour indiquer la date à laquelle l'actif a été modifié."@fr ,
+                                    "To indicate the date at which the Asset has been modified."@en ,
+                                    "Zur Angabe des Datums, an dem das Asset geändert wurde."@de ;
+                rdfs:label "Date/heure de modification"@fr ,
+                           "Datum/Uhrzeit der Änderung"@de ,
+                           "Modification date/time"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#dateNormalized
 ec:dateNormalized rdf:type owl:ObjectProperty ;
                   rdfs:subPropertyOf ec:date ;
                   rdfs:range time:Instant ;
-                  dcterms:description "The date when the Resource was converted from its original format into a format pre-selected by the institution for preservation."@en ;
-                  rdfs:label "Normalization date"@en .
+                  dcterms:description "Das Datum, an dem die Ressource aus ihrem ursprünglichen Format in ein von der Institution für die Aufbewahrung ausgewähltes Format konvertiert wurde."@de ,
+                                      "La date à laquelle la ressource a été convertie de son format original en un format présélectionné par l'institution pour la préservation."@fr ,
+                                      "The date when the Resource was converted from its original format into a format pre-selected by the institution for preservation."@en ;
+                  rdfs:label "Date de normalisation"@fr ,
+                             "Datum der Normalisierung"@de ,
+                             "Normalization date"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#dateOfBirth
 ec:dateOfBirth rdf:type owl:ObjectProperty ;
                rdfs:subPropertyOf ec:date ;
                rdfs:range time:Instant ;
-               dcterms:description "The date when a Contact/Person is born."@en ;
-               rdfs:label "Date of birth"@en .
+               dcterms:description "Das Datum, an dem ein Kontakt/eine Person geboren wird."@de ,
+                                   "La date de naissance d'un contact/personne."@fr ,
+                                   "The date when a Contact/Person is born."@en ;
+               rdfs:label "Date de naissance"@fr ,
+                          "Date of birth"@en ,
+                          "Geburtsdatum"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#dateOfDeath
 ec:dateOfDeath rdf:type owl:ObjectProperty ;
                rdfs:subPropertyOf ec:date ;
                rdfs:range time:Instant ;
-               dcterms:description "The date when a Contact/Person has passed away."@en ;
-               rdfs:label "Date of death"@en .
+               dcterms:description "Das Datum, an dem ein Kontakt/eine Person verstorben ist."@de ,
+                                   "La date à laquelle un contact/personne est décédé."@fr ,
+                                   "The date when a Contact/Person has passed away."@en ;
+               rdfs:label "Date du décès"@fr ,
+                          "Date of death"@en ,
+                          "Datum des Todes"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#dateOfRetirement
 ec:dateOfRetirement rdf:type owl:ObjectProperty ;
                     rdfs:subPropertyOf ec:date ;
                     rdfs:range time:Instant ;
-                    dcterms:description "The date when a Contact/Person has retired."@en ;
-                    rdfs:label "Date of retirement"@en .
+                    dcterms:description "Das Datum, an dem ein Kontakt/eine Person in den Ruhestand getreten ist."@de ,
+                                        "La date à laquelle un contact/personne a pris sa retraite."@fr ,
+                                        "The date when a Contact/Person has retired."@en ;
+                    rdfs:label "Date de la retraite"@fr ,
+                               "Date of retirement"@en ,
+                               "Datum der Pensionierung"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#dateProduced
 ec:dateProduced rdf:type owl:ObjectProperty ;
                 rdfs:subPropertyOf ec:date ;
                 rdfs:range time:Instant ;
-                dcterms:description "The date of production of the Asset."@en ;
-                rdfs:label "production date"@en .
+                dcterms:description "Das Datum der Produktion des Assets."@de ,
+                                    "La date de production de l'actif."@fr ,
+                                    "The date of production of the Asset."@en ;
+                rdfs:label "Produktionsdatum"@de ,
+                           "date de production"@fr ,
+                           "production date"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#dateReleased
 ec:dateReleased rdf:type owl:ObjectProperty ;
                 rdfs:subPropertyOf ec:date ;
                 rdfs:range time:Instant ;
-                dcterms:description "The date when the Resource was first made available to the public for purchase, download, or online access."@en ;
-                rdfs:label "Release date"@en .
+                dcterms:description "Das Datum, an dem die Ressource erstmals der Öffentlichkeit zum Kauf, Download oder Online-Zugriff zur Verfügung gestellt wurde."@de ,
+                                    "La date à laquelle la ressource a été mise pour la première fois à la disposition du public pour l'achat, le téléchargement ou l'accès en ligne."@fr ,
+                                    "The date when the Resource was first made available to the public for purchase, download, or online access."@en ;
+                rdfs:label "Date de sortie"@fr ,
+                           "Datum der Veröffentlichung"@de ,
+                           "Release date"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#dateTransferred
 ec:dateTransferred rdf:type owl:ObjectProperty ;
                    rdfs:subPropertyOf ec:date ;
                    rdfs:range time:Instant ;
-                   dcterms:description "The date when the Asset was moved from one digital or physical location to another."@en ;
-                   rdfs:label "Transfer date"@en .
+                   dcterms:description "Das Datum, an dem das Asset von einem digitalen oder physischen Ort zu einem anderen verschoben wurde."@de ,
+                                       "La date à laquelle l'actif a été déplacé d'un emplacement numérique ou physique à un autre."@fr ,
+                                       "The date when the Asset was moved from one digital or physical location to another."@en ;
+                   rdfs:label "Date de transfert"@fr ,
+                              "Datum der Übertragung"@de ,
+                              "Transfer date"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#dateValidated
 ec:dateValidated rdf:type owl:ObjectProperty ;
                  rdfs:subPropertyOf ec:date ;
                  rdfs:range time:Instant ;
-                 dcterms:description "The most recent date when the Resource was confirmed to be valid through manual or digital QC."@en ;
-                 rdfs:label "Validation date"@en .
+                 dcterms:description "Das letzte Datum, an dem die Ressource durch manuelle oder digitale QC als gültig bestätigt wurde."@de ,
+                                     "La date la plus récente à laquelle la validité de la ressource a été confirmée par un CQ manuel ou numérique."@fr ,
+                                     "The most recent date when the Resource was confirmed to be valid through manual or digital QC."@en ;
+                 rdfs:label "Date de validation"@fr ,
+                            "Datum der Validierung"@de ,
+                            "Validation date"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#datelicensedStart
 ec:datelicensedStart rdf:type owl:ObjectProperty ;
                      rdfs:subPropertyOf ec:date ;
                      rdfs:range time:Instant ;
-                     dcterms:description "The date when the licence for the Asset begins."@en ;
-                     rdfs:label "Licence start date"@en .
+                     dcterms:description "Das Datum, an dem die Lizenz für das Asset beginnt."@de ,
+                                         "La date à laquelle la licence pour le bien commence."@fr ,
+                                         "The date when the licence for the Asset begins."@en ;
+                     rdfs:label "Date de début de la licence"@fr ,
+                                "Licence start date"@en ,
+                                "Startdatum der Lizenz"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#derivedTo
 ec:derivedTo rdf:type owl:ObjectProperty ;
              owl:inverseOf ec:isDerivedFrom ;
              rdfs:range ec:Asset ;
-             dcterms:description "To identify a new version derived from the original."@en ;
-             rdfs:label "Derivation target"@en .
+             dcterms:description "Pour identifier une nouvelle version dérivée de l'original."@fr ,
+                                 "To identify a new version derived from the original."@en ,
+                                 "Um eine neue, vom Original abgeleitete Version zu identifizieren."@de ;
+             rdfs:label "Ableitung Ziel"@de ,
+                        "Derivation target"@en ,
+                        "Objectif de dérivation"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#displayAspectRatio
 ec:displayAspectRatio rdf:type owl:ObjectProperty ;
                       rdfs:range ec:ActiveFormatDescriptorCode ;
-                      dcterms:description "The aspect ratio when displayed."@en ;
-                      rdfs:label "Display aspect ratio"@en .
+                      dcterms:description "Das Seitenverhältnis bei der Anzeige."@de ,
+                                          "Le rapport d'aspect lors de l'affichage."@fr ,
+                                          "The aspect ratio when displayed."@en ;
+                      rdfs:label "Display aspect ratio"@en ,
+                                 "Rapport d'aspect de l'écran"@fr ,
+                                 "Seitenverhältnis der Anzeige"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#dubbedTo
 ec:dubbedTo rdf:type owl:ObjectProperty ;
             owl:inverseOf ec:isDubbedFrom ;
             rdfs:range ec:MediaResource ;
-            dcterms:description "the resource have another languageversion"@en ;
-            rdfs:label "Dubbed to"@en .
+            dcterms:description "die Ressource eine andere Sprachversion hat"@de ,
+                                "la ressource a une autre version linguistique"@fr ,
+                                "the resource have another languageversion"@en ;
+            rdfs:label "Doublé à"@fr ,
+                       "Dubbed to"@en ,
+                       "Synchronisiert auf"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#duration
@@ -1095,578 +1583,886 @@ ec:end rdf:type owl:ObjectProperty ;
 ec:endDateTime rdf:type owl:ObjectProperty ;
                rdfs:subPropertyOf ec:date ;
                rdfs:range time:Instant ;
-               rdfs:comment "Describing an end of an interval"@en ,
-                            "End date time"@en .
+               dcterms:description "Das Ende eines Intervalls beschreiben"@de ,
+                                   "Describing an end of an interval"@en ,
+                                   "Décrit la fin d'un intervalle"@fr ;
+               rdfs:label "End date time"@en ,
+                          "Enddatum Uhrzeit"@de ,
+                          "Instant de fin"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#existsAs
 ec:existsAs rdf:type owl:ObjectProperty ;
-            dcterms:description "To identify alternative EditorialObjects in the form of which and EditorialObject may exists."@en ;
-            rdfs:label "Editorial object"@en .
+            dcterms:description "Identifier des objets éditoriaux alternatifs sous la forme desquels un objet éditorial peut exister."@fr ,
+                                "To identify alternative EditorialObjects in the form of which and EditorialObject may exists."@en ,
+                                "Um alternative EditorialObjects zu identifizieren, in deren Form und EditorialObject existieren können."@de ;
+            rdfs:label "Editorial object"@en ,
+                       "Objet de la rédaction"@fr ,
+                       "Redaktionelles Objekt"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#formatVersionId
 ec:formatVersionId rdf:type owl:ObjectProperty ;
                    rdfs:range ec:Identifier ;
-                   dcterms:description "A version identifier attributed to a Format."@en ;
-                   rdfs:label "Format version identifier"@en .
+                   dcterms:description "A version identifier attributed to a Format."@en ,
+                                       "Ein Versionsbezeichner, der einem Format zugeordnet ist."@de ,
+                                       "Un identifiant de version attribué à un format."@fr ;
+                   rdfs:label "Format version identifier"@en ,
+                              "Identifiant de la version du format"@fr ,
+                              "Kennung der Formatversion"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#geoBlockingBlacklist
 ec:geoBlockingBlacklist rdf:type owl:ObjectProperty ;
                         rdfs:range skos:Concept ;
-                        dcterms:description "checking a users IP-address against a blacklist"@en ;
-                        rdfs:label "geo-blocking blacklist"@en .
+                        dcterms:description "checking a users IP-address against a blacklist"@en ,
+                                            "vérification de l'adresse IP d'un utilisateur par rapport à une liste noire"@fr ,
+                                            "Überprüfung der IP-Adresse eines Benutzers anhand einer schwarzen Liste"@de ;
+                        rdfs:label "Schwarze Liste für Geoblockierung"@de ,
+                                   "geo-blocking blacklist"@en ,
+                                   "liste noire de géoblocage"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#geoBlockingWhitelist
 ec:geoBlockingWhitelist rdf:type owl:ObjectProperty ;
                         rdfs:range skos:Concept ;
-                        dcterms:description "checking a users IP-address against a whitelist"@en ;
-                        rdfs:label "geo-blocking whitelist"@en .
+                        dcterms:description "checking a users IP-address against a whitelist"@en ,
+                                            "vérification de l'adresse IP d'un utilisateur par rapport à une liste blanche"@fr ,
+                                            "Überprüfung der IP-Adresse eines Benutzers anhand einer Whitelist"@de ;
+                        rdfs:label "Geoblocking-Whitelist"@de ,
+                                   "geo-blocking whitelist"@en ,
+                                   "liste blanche de géo-blocage"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasAccessConditions
 ec:hasAccessConditions rdf:type owl:ObjectProperty ;
                        rdfs:subPropertyOf ec:isCoveredBy ;
                        rdfs:range ec:AccessConditions ;
-                       dcterms:description "To express access conditions/restrictions."@en ;
-                       rdfs:label "Access conditions"@en .
+                       dcterms:description "Pour exprimer les conditions/restrictions d'accès."@fr ,
+                                           "To express access conditions/restrictions."@en ,
+                                           "Um Zugangsbedingungen/Einschränkungen auszudrücken."@de ;
+                       rdfs:label "Access conditions"@en ,
+                                  "Conditions d'accès"@fr ,
+                                  "Zugangsbedingungen"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasAffiliation
 ec:hasAffiliation rdf:type owl:ObjectProperty ;
                   rdfs:range ec:Affiliation ;
-                  dcterms:description """A property to establish the relation between a
-            Contact/Person and an Organisation."""@en ;
-                  rdfs:label "Affiliation"@en .
+                  dcterms:description "A property to establish the relation between a Contact/Person and an Organisation."@en ,
+                                      "Eine Eigenschaft, die die Beziehung zwischen einem Kontakt/Person und einer Organisation."@de ,
+                                      "Une propriété permettant d'établir la relation entre un contact/personne et une organisation."@fr ;
+                  rdfs:label "Affiliation"@en ,
+                             "Affiliation"@fr ,
+                             "Zugehörigkeit"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasAgent
 ec:hasAgent rdf:type owl:ObjectProperty ;
-            rdfs:label "has agent"@en .
+            rdfs:label "a un agent"@fr ,
+                       "has agent"@en ,
+                       "hat Agent"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasAgentBiography
 ec:hasAgentBiography rdf:type owl:ObjectProperty ;
                      rdfs:range ec:Biography ;
-                     dcterms:description "To provide a biography of an Agent."@en ;
-                     rdfs:label "Biography"@en .
+                     dcterms:description "Fournir la biographie d'un agent."@fr ,
+                                         "To provide a biography of an Agent."@en ,
+                                         "Um eine Biographie eines Agenten zu erstellen."@de ;
+                     rdfs:label "Biographie"@de ,
+                                "Biographie"@fr ,
+                                "Biography"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasAgentCountryOfResidence
 ec:hasAgentCountryOfResidence rdf:type owl:ObjectProperty ;
                               rdfs:range ec:CountryCode ;
-                              dcterms:description "To indicate the place of residence of an Agent."@en ;
-                              rdfs:label "Country of residence"@en .
+                              dcterms:description "Pour indiquer le lieu de résidence d'un agent."@fr ,
+                                                  "To indicate the place of residence of an Agent."@en ,
+                                                  "Zur Angabe des Wohnsitzes eines Agenten."@de ;
+                              rdfs:label "Country of residence"@en ,
+                                         "Land des Wohnsitzes"@de ,
+                                         "Pays de résidence"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasAgentLanguage
 ec:hasAgentLanguage rdf:type owl:ObjectProperty ;
                     rdfs:range ec:Language ;
-                    dcterms:description "To provide the language(s) of a Contact/person."@en ;
-                    rdfs:label "Language"@en .
+                    dcterms:description "Pour fournir la ou les langues d'un contact/personne."@fr ,
+                                        "To provide the language(s) of a Contact/person."@en ,
+                                        "Zur Angabe der Sprache(n) eines Kontakts/einer Person."@de ;
+                    rdfs:label "Language"@en ,
+                               "Langue"@fr ,
+                               "Sprache"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasAgentMember
 ec:hasAgentMember rdf:type owl:ObjectProperty ;
                   rdfs:range ec:Agent ;
-                  dcterms:description "To associate an Agent to another Agent e.g. a Team."@en ;
-                  rdfs:label "Agent member"@en .
+                  dcterms:description "Pour associer un agent à un autre agent, par exemple une équipe."@fr ,
+                                      "So verknüpfen Sie einen Agenten mit einem anderen Agenten, z.B. einem Team."@de ,
+                                      "To associate an Agent to another Agent e.g. a Team."@en ;
+                  rdfs:label "Agent Mitglied"@de ,
+                             "Agent member"@en ,
+                             "Membre agent"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasAgentNationality
 ec:hasAgentNationality rdf:type owl:ObjectProperty ;
                        rdfs:range ec:CountryCode ;
-                       dcterms:description "To provide the nationality of an Agent."@en ;
-                       rdfs:label "Nationality"@en .
+                       dcterms:description "Pour fournir la nationalité d'un agent."@fr ,
+                                           "To provide the nationality of an Agent."@en ,
+                                           "Zur Angabe der Nationalität eines Agenten."@de ;
+                       rdfs:label "Nationality"@en ,
+                                  "Nationalität"@de ,
+                                  "Nationalité"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasAgentPlaceOfResidence
 ec:hasAgentPlaceOfResidence rdf:type owl:ObjectProperty ;
                             rdfs:range ec:Location ;
-                            dcterms:description "To indicate the place of residence of an Agent."@en ;
-                            rdfs:label "Place of residence"@en .
+                            dcterms:description "Pour indiquer le lieu de résidence d'un agent."@fr ,
+                                                "To indicate the place of residence of an Agent."@en ,
+                                                "Zur Angabe des Wohnsitzes eines Agenten."@de ;
+                            rdfs:label "Lieu de résidence"@fr ,
+                                       "Ort des Wohnsitzes"@de ,
+                                       "Place of residence"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasAlternativeTitle
 ec:hasAlternativeTitle rdf:type owl:ObjectProperty ;
-                       rdfs:label "has alternative title"@en .
+                       rdfs:label "a un titre alternatif"@fr ,
+                                  "has alternative title"@en ,
+                                  "hat einen alternativen Titel"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasAncillaryData
 ec:hasAncillaryData rdf:type owl:ObjectProperty ;
                     rdfs:range ec:AncillaryData ;
-                    dcterms:description "To identify ancillary data in the media resource."@en ;
-                    rdfs:label "Ancillary data"@en .
+                    dcterms:description "Pour identifier les données auxiliaires dans la ressource média."@fr ,
+                                        "To identify ancillary data in the media resource."@en ,
+                                        "Zur Identifizierung von Zusatzdaten in der Medienressource."@de ;
+                    rdfs:label "Ancillary data"@en ,
+                               "Données auxiliaires"@fr ,
+                               "Ergänzende Daten"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasAncillaryDataFormat
 ec:hasAncillaryDataFormat rdf:type owl:ObjectProperty ;
                           rdfs:subPropertyOf ec:hasFormat ;
                           rdfs:range ec:AncillaryDataFormat ;
-                          dcterms:description "the format of ancillary data."@en ;
-                          rdfs:label "Ancillary data format"@en .
+                          dcterms:description "das Format der Zusatzdaten."@de ,
+                                              "le format des données auxiliaires."@fr ,
+                                              "the format of ancillary data."@en ;
+                          rdfs:label "Ancillary data format"@en ,
+                                     "Format der Zusatzdaten"@de ,
+                                     "Format des données auxiliaires"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasAnimalBreedCode
 ec:hasAnimalBreedCode rdf:type owl:ObjectProperty ;
                       rdfs:range ec:AnimalBreedCode ;
-                      dcterms:description "To associate a breed code with an animal."@en ;
-                      rdfs:label "Animal breed code"@en .
+                      dcterms:description "Pour associer un code de race à un animal."@fr ,
+                                          "To associate a breed code with an animal."@en ,
+                                          "Um einen Rassencode mit einem Tier zu verknüpfen."@de ;
+                      rdfs:label "Animal breed code"@en ,
+                                 "Code de la race de l'animal"@fr ,
+                                 "Code der Tierrasse"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasAnimalColourCode
 ec:hasAnimalColourCode rdf:type owl:ObjectProperty ;
                        rdfs:range ec:AnimalColourCode ;
-                       dcterms:description "To associate a colour code with an animal."@en ;
-                       rdfs:label "Animal colour code"@en .
+                       dcterms:description "Pour associer un code de couleur à un animal."@fr ,
+                                           "To associate a colour code with an animal."@en ,
+                                           "Um einen Farbcode mit einem Tier zu verbinden."@de ;
+                       rdfs:label "Animal colour code"@en ,
+                                  "Code couleur des animaux"@fr ,
+                                  "Farbcode für Tiere"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasAnimalRole
 ec:hasAnimalRole rdf:type owl:ObjectProperty ;
                  rdfs:range ec:Role ;
-                 dcterms:description "To identify the role of an animal."@en ;
-                 rdfs:label "Animal role"@en .
+                 dcterms:description "Die Rolle eines Tieres zu identifizieren."@de ,
+                                     "Identifier le rôle d'un animal."@fr ,
+                                     "To identify the role of an animal."@en ;
+                 rdfs:label "Animal role"@en ,
+                            "Rôle des animaux"@fr ,
+                            "Tierische Rolle"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasAnnotationAgent
 ec:hasAnnotationAgent rdf:type owl:ObjectProperty ;
                       rdfs:range ec:Agent ;
-                      dcterms:description "To define the Annotation instance of an Agent."@en ;
-                      rdfs:label "Annotation agent"@en .
+                      dcterms:description "Pour définir l'instance d'annotation d'un agent."@fr ,
+                                          "So definieren Sie die Annotation-Instanz eines Agenten."@de ,
+                                          "To define the Annotation instance of an Agent."@en ;
+                      rdfs:label "Agent d'annotation"@fr ,
+                                 "Agent für Anmerkungen"@de ,
+                                 "Annotation agent"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasAnnotationTarget
 ec:hasAnnotationTarget rdf:type owl:ObjectProperty ;
                        rdfs:range owl:Thing ;
-                       dcterms:description "To define the target object to which the Annotation applies."@en ;
-                       rdfs:label "Annotation target"@en .
+                       dcterms:description "Pour définir l'objet cible auquel l'annotation s'applique."@fr ,
+                                           "To define the target object to which the Annotation applies."@en ,
+                                           "Zur Definition des Zielobjekts, auf das sich die Anmerkung bezieht."@de ;
+                       rdfs:label "Annotation target"@en ,
+                                  "Cible d'annotation"@fr ,
+                                  "Ziel der Annotation"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasArtefactBuyer
 ec:hasArtefactBuyer rdf:type owl:ObjectProperty ;
                     rdfs:range ec:Agent ;
-                    dcterms:description "The Agent who bought the Artefact."@en ;
-                    rdfs:label "Buyer"@en .
+                    dcterms:description "Der Agent, der das Artefakt gekauft hat."@de ,
+                                        "L'agent qui a acheté l'Artefact."@fr ,
+                                        "The Agent who bought the Artefact."@en ;
+                    rdfs:label "Acheteur"@fr ,
+                               "Buyer"@en ,
+                               "Käufer"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasArtefactOwner
 ec:hasArtefactOwner rdf:type owl:ObjectProperty ;
                     rdfs:range ec:Agent ;
-                    dcterms:description "To identify the owner of an Artefact."@en ;
-                    rdfs:label "Owner"@en .
+                    dcterms:description "Pour identifier le propriétaire d'un artefact."@fr ,
+                                        "To identify the owner of an Artefact."@en ,
+                                        "Um den Besitzer eines Artefakts zu identifizieren."@de ;
+                    rdfs:label "Eigentümer"@de ,
+                               "Owner"@en ,
+                               "Propriétaire"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasArtefactPriceCurrency
 ec:hasArtefactPriceCurrency rdf:type owl:ObjectProperty ;
                             rdfs:range ec:CurrencyCode ;
-                            dcterms:description "To specify the currency into which the price of an Artefact is expressed."@en ;
-                            rdfs:label "Artefact price currency"@en .
+                            dcterms:description "Pour spécifier la devise dans laquelle le prix d'un artefact est exprimé."@fr ,
+                                                "To specify the currency into which the price of an Artefact is expressed."@en ,
+                                                "Zur Angabe der Währung, in der der Preis eines Artefakts ausgedrückt wird."@de ;
+                            rdfs:label "Artefact price currency"@en ,
+                                       "Artefakt Preis Währung"@de ,
+                                       "Devise du prix de l'artefact"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasArtefactRelatedLocation
 ec:hasArtefactRelatedLocation rdf:type owl:ObjectProperty ;
                               rdfs:range ec:Location ;
-                              dcterms:description "To associate an Artefact/Prop or else with a Location."@en ;
-                              rdfs:label "Associated location"@en .
+                              dcterms:description "Pour associer un Artefact/Prop ou autre à un Lieu."@fr ,
+                                                  "To associate an Artefact/Prop or else with a Location."@en ,
+                                                  "Um ein Artefakt/eine Requisite oder einen anderen Ort zuzuordnen."@de ;
+                              rdfs:label "Associated location"@en ,
+                                         "Assoziierter Standort"@de ,
+                                         "Emplacement associé"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasArtefactRelatedPhysicalResource
 ec:hasArtefactRelatedPhysicalResource rdf:type owl:ObjectProperty ;
                                       rdfs:range ec:PhysicalResource ;
-                                      dcterms:description "To associate an Artefact/Prop or else with a physical resource."@en ;
-                                      rdfs:label "Associated physical resource"@en .
+                                      dcterms:description "Pour associer un Artefact/Prop ou autre à une ressource physique."@fr ,
+                                                          "To associate an Artefact/Prop or else with a physical resource."@en ,
+                                                          "Um ein Artefakt/Prop oder eine andere physische Ressource zu verknüpfen."@de ;
+                                      rdfs:label "Associated physical resource"@en ,
+                                                 "Assoziierte physische Ressource"@de ,
+                                                 "Ressource physique associée"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasArtefactRetailer
 ec:hasArtefactRetailer rdf:type owl:ObjectProperty ;
                        rdfs:range ec:Agent ;
-                       dcterms:description "To identify the retailer of an Artefact."@en ;
-                       rdfs:label "Retailer"@en .
+                       dcterms:description "Identifier le détaillant d'un artefact."@fr ,
+                                           "To identify the retailer of an Artefact."@en ,
+                                           "Zur Identifizierung des Händlers eines Artefakts."@de ;
+                       rdfs:label "Détaillant"@fr ,
+                                  "Einzelhändler"@de ,
+                                  "Retailer"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasArtefactSupplier
 ec:hasArtefactSupplier rdf:type owl:ObjectProperty ;
                        rdfs:range ec:Agent ;
-                       dcterms:description "To identify a supplier of an Artefact."@en ;
-                       rdfs:label "Supplier"@en .
+                       dcterms:description "Pour identifier le fournisseur d'un artefact."@fr ,
+                                           "To identify a supplier of an Artefact."@en ,
+                                           "Um einen Anbieter eines Artefakts zu identifizieren."@de ;
+                       rdfs:label "Anbieter"@de ,
+                                  "Fournisseur"@fr ,
+                                  "Supplier"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasArticle
 ec:hasArticle rdf:type owl:ObjectProperty ;
               rdfs:range ec:Article ;
-              rdfs:label "has article"@en .
+              rdfs:label "a article"@fr ,
+                         "has article"@en ,
+                         "hat Artikel"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasAssociatedArtefact
 ec:hasAssociatedArtefact rdf:type owl:ObjectProperty ;
                          rdfs:range ec:Artefact ;
-                         dcterms:description "An Artefact related to an Agent."@en ;
-                         rdfs:label "Related Artefact"@en .
+                         dcterms:description "An Artefact related to an Agent."@en ,
+                                             "Ein Artefakt, das mit einem Agent verbunden ist."@de ,
+                                             "Un artefact lié à un agent."@fr ;
+                         rdfs:label "Artefact connexe"@fr ,
+                                    "Related Artefact"@en ,
+                                    "Verwandtes Artefakt"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasAssociatedRelation
 ec:hasAssociatedRelation rdf:type owl:ObjectProperty ;
                          rdfs:range ec:Relation ;
-                         dcterms:description "To define a Relation."@en ;
-                         rdfs:label "Relation"@en .
+                         dcterms:description "Pour définir une Relation."@fr ,
+                                             "To define a Relation."@en ,
+                                             "Um eine Relation zu definieren."@de ;
+                         rdfs:label "Beziehung"@de ,
+                                    "Relation"@en ,
+                                    "Relation"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasAudienceScoreRecordingTechnique
 ec:hasAudienceScoreRecordingTechnique rdf:type owl:ObjectProperty ;
                                       rdfs:range skos:Concept ;
-                                      dcterms:description "To identify the technique used to measure an audience."@en ;
-                                      rdfs:label "Audience score recording technique"@en .
+                                      dcterms:description "Die Technik zu identifizieren, die zur Messung eines Publikums verwendet wird."@de ,
+                                                          "Identifier la technique utilisée pour mesurer une audience."@fr ,
+                                                          "To identify the technique used to measure an audience."@en ;
+                                      rdfs:label "Audience score recording technique"@en ,
+                                                 "Aufnahmetechnik für Publikumspartituren"@de ,
+                                                 "Technique d'enregistrement des partitions d'audience"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasAudioCodec
 ec:hasAudioCodec rdf:type owl:ObjectProperty ;
                  rdfs:subPropertyOf ec:hasCodec ;
                  rdfs:range ec:AudioCodec ;
-                 dcterms:description "To identify the audio Codec"@en ;
-                 rdfs:label "Audio codec"@en .
+                 dcterms:description "Pour identifier le Codec audio"@fr ,
+                                     "So identifizieren Sie den Audio Codec"@de ,
+                                     "To identify the audio Codec"@en ;
+                 rdfs:label "Audio Codec"@de ,
+                            "Audio codec"@en ,
+                            "Codec audio"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasAudioDescription
 ec:hasAudioDescription rdf:type owl:ObjectProperty ;
                        rdfs:range ec:AudioDescription ;
-                       dcterms:description "To signal the presence of AudioDescription."@en ;
-                       rdfs:label "Audio description"@en .
+                       dcterms:description "Pour signaler la présence de l'AudioDescription."@fr ,
+                                           "To signal the presence of AudioDescription."@en ,
+                                           "Um das Vorhandensein von AudioDescription zu signalisieren."@de ;
+                       rdfs:label "Audio description"@en ,
+                                  "Audio-Beschreibung"@de ,
+                                  "Description audio"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasAudioEncodingFormat
 ec:hasAudioEncodingFormat rdf:type owl:ObjectProperty ;
                           rdfs:subPropertyOf ec:hasFormat ;
                           rdfs:range ec:AudioEncodingFormat ;
-                          dcterms:description "To specify the audio encoding format."@en ;
-                          rdfs:label "Audio encoding format"@en .
+                          dcterms:description "Pour spécifier le format d'encodage audio."@fr ,
+                                              "To specify the audio encoding format."@en ,
+                                              "Zur Angabe des Audio-Codierungsformats."@de ;
+                          rdfs:label "Audio encoding format"@en ,
+                                     "Format d'encodage audio"@fr ,
+                                     "Format der Audiokodierung"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasAudioTrack
 ec:hasAudioTrack rdf:type owl:ObjectProperty ;
                  rdfs:range ec:AudioTrack ;
-                 dcterms:description "To identify AudioTracks in the Resource."@en ;
-                 rdfs:label "Audio track"@en .
+                 dcterms:description "Pour identifier les AudioTracks dans la ressource."@fr ,
+                                     "So identifizieren Sie Audiospuren in der Ressource."@de ,
+                                     "To identify AudioTracks in the Resource."@en ;
+                 rdfs:label "Audio track"@en ,
+                            "Audiospur"@de ,
+                            "Piste audio"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasBeenAwarded
 ec:hasBeenAwarded rdf:type owl:ObjectProperty ;
                   rdfs:range ec:Award ;
-                  dcterms:description "The Award gievn to an Agent"@en ;
-                  rdfs:label "Agent"@en .
+                  dcterms:description "Der an einen Agenten verliehene Preis"@de ,
+                                      "Le prix décerné à un agent"@fr ,
+                                      "The Award gievn to an Agent"@en ;
+                  rdfs:label "Agent"@de ,
+                             "Agent"@en ,
+                             "Agent"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasCaptioning
 ec:hasCaptioning rdf:type owl:ObjectProperty ;
                  rdfs:range ec:Captioning ;
-                 dcterms:description """To signal the presence of
-            Captioning."""@en ;
-                 rdfs:label "Captioning"@en .
+                 dcterms:description "Pour signaler la présence de sous-titres."@fr ,
+                                     "To signal the presence of Captioning."@en ,
+                                     "Zum Signalisieren der Anwesenheit von Untertitel."@de ;
+                 rdfs:label "Captioning"@en ,
+                            "Sous-titrage"@fr ,
+                            "Untertitel"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasCaptioningFormat
 ec:hasCaptioningFormat rdf:type owl:ObjectProperty ;
                        rdfs:subPropertyOf ec:hasFormat ;
                        rdfs:range ec:CaptioningFormat ;
-                       dcterms:description "The format of Captioning."@en ;
-                       rdfs:label "Captioning format"@en .
+                       dcterms:description "Das Format der Untertitelung."@de ,
+                                           "Le format du sous-titrage."@fr ,
+                                           "The format of Captioning."@en ;
+                       rdfs:label "Captioning format"@en ,
+                                  "Format de sous-titrage"@fr ,
+                                  "Format der Untertitel"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasCaptioningSource
 ec:hasCaptioningSource rdf:type owl:ObjectProperty ;
                        rdfs:range ec:Agent ;
-                       dcterms:description "To provide information on the source of Captioning."@en ;
-                       rdfs:label "Captioning source"@en .
+                       dcterms:description "Fournir des informations sur la source du sous-titrage."@fr ,
+                                           "To provide information on the source of Captioning."@en ,
+                                           "Um Informationen über die Quelle der Untertitelung bereitzustellen."@de ;
+                       rdfs:label "Captioning source"@en ,
+                                  "Quelle für Untertitel"@de ,
+                                  "Source de sous-titrage"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasCastMember
 ec:hasCastMember rdf:type owl:ObjectProperty ;
                  rdfs:range ec:CastMember ;
-                 dcterms:description "A member of the cast."@en ;
-                 rdfs:label "Cast member"@en .
+                 dcterms:description "A member of the cast."@en ,
+                                     "Ein Mitglied der Besetzung."@de ,
+                                     "Un membre de la distribution."@fr ;
+                 rdfs:label "Cast member"@en ,
+                            "Membre de la distribution"@fr ,
+                            "Mitglied der Besetzung"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasCharacter
 ec:hasCharacter rdf:type owl:ObjectProperty ;
                 rdfs:range ec:Character ;
-                dcterms:description "To list characters in a fiction."@en ;
-                rdfs:label "Character"@en .
+                dcterms:description "Pour énumérer les personnages d'une fiction."@fr ,
+                                    "To list characters in a fiction."@en ,
+                                    "Zum Auflisten von Figuren in einer Fiktion."@de ;
+                rdfs:label "Caractère"@fr ,
+                           "Character"@en ,
+                           "Charakter"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasClip
 ec:hasClip rdf:type owl:ObjectProperty ;
-           rdfs:label "has clip"@en .
+           rdfs:label "a un clip"@fr ,
+                      "has clip"@en ,
+                      "hat Clip"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasCodec
 ec:hasCodec rdf:type owl:ObjectProperty ;
             rdfs:range ec:Codec ;
-            dcterms:description "To identify a Codec used to create a resource."@en ;
-            rdfs:label "Codec"@en .
+            dcterms:description "Pour identifier un Codec utilisé pour créer une ressource."@fr ,
+                                "To identify a Codec used to create a resource."@en ,
+                                "Um einen Codec zu identifizieren, der zur Erstellung einer Ressource verwendet wird."@de ;
+            rdfs:label "Codec"@de ,
+                       "Codec"@en ,
+                       "Codec"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasCodecVendor
 ec:hasCodecVendor rdf:type owl:ObjectProperty ;
                   rdfs:range ec:Agent ;
-                  dcterms:description "To provide a name for the vendor of the Codec."@en ;
-                  rdfs:label "Codec vendor"@en .
+                  dcterms:description "Pour fournir un nom pour le vendeur du Codec."@fr ,
+                                      "To provide a name for the vendor of the Codec."@en ,
+                                      "Um einen Namen für den Anbieter des Codecs anzugeben."@de ;
+                  rdfs:label "Codec vendor"@en ,
+                             "Codec-Anbieter"@de ,
+                             "Fournisseur de codecs"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasColourSpace
 ec:hasColourSpace rdf:type owl:ObjectProperty ;
                   rdfs:subPropertyOf ec:hasFormat ;
                   rdfs:range ec:ColourSpace ;
-                  dcterms:description "To describe the colour space."@en ;
-                  rdfs:label "Colour space"@en .
+                  dcterms:description "Pour décrire l'espace couleur."@fr ,
+                                      "To describe the colour space."@en ,
+                                      "Zur Beschreibung des Farbraums."@de ;
+                  rdfs:label "Colour space"@en ,
+                             "Espace couleur"@fr ,
+                             "Farbraum"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasContact
 ec:hasContact rdf:type owl:ObjectProperty ;
               rdfs:range ec:Contact ;
-              dcterms:description """To provide information on a Contact for an
-            Organisation or a physical person (e.g. the agent of an actor)."""@en ;
-              rdfs:label "Contact"@en .
+              dcterms:description "Pour fournir des informations sur un contact pour une Organisation ou une personne physique (par exemple, l'agent d'un acteur)."@fr ,
+                                  "To provide information on a Contact for an Organisation or a physical person (e.g. the agent of an actor)."@en ,
+                                  "Zur Bereitstellung von Informationen über einen Kontakt für eine Organisation oder eine natürliche Person (z.B. den Agenten eines Schauspielers)."@de ;
+              rdfs:label "Contact"@en ,
+                         "Contact"@fr ,
+                         "Kontakt"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasContainerCodec
 ec:hasContainerCodec rdf:type owl:ObjectProperty ;
                      rdfs:subPropertyOf ec:hasCodec ;
                      rdfs:range ec:ContainerCodec ;
-                     dcterms:description "To identify a container codec."@en ;
-                     rdfs:label "Container codec"@en .
+                     dcterms:description "Pour identifier un codec de conteneur."@fr ,
+                                         "To identify a container codec."@en ,
+                                         "Um einen Container-Codec zu identifizieren."@de ;
+                     rdfs:label "Codec de conteneur"@fr ,
+                                "Container Codec"@de ,
+                                "Container codec"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasContainerEncodingFormat
 ec:hasContainerEncodingFormat rdf:type owl:ObjectProperty ;
                               rdfs:subPropertyOf ec:hasFormat ;
                               rdfs:range ec:ContainerEncodingFormat ;
-                              dcterms:description "To describe the container encoding format."@en ;
-                              rdfs:label "Container encoding format"@en .
+                              dcterms:description "Pour décrire le format d'encodage du conteneur."@fr ,
+                                                  "To describe the container encoding format."@en ,
+                                                  "Zur Beschreibung des Container-Kodierungsformats."@de ;
+                              rdfs:label "Container encoding format"@en ,
+                                         "Container-Kodierungsformat"@de ,
+                                         "Format d'encodage du conteneur"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasContainerMimeType
 ec:hasContainerMimeType rdf:type owl:ObjectProperty ;
                         rdfs:subPropertyOf ec:hasFormat ;
                         rdfs:range ec:MimeType ;
-                        dcterms:description "To provide the Mime type of the Resource."@en ;
-                        rdfs:label "Mime type"@en .
+                        dcterms:description "Pour fournir le type Mime de la ressource."@fr ,
+                                            "To provide the Mime type of the Resource."@en ,
+                                            "Zur Angabe des Mime-Typs der Ressource."@de ;
+                        rdfs:label "Mime type"@en ,
+                                   "Mime-Typ"@de ,
+                                   "Type Mime"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasContentEditorialFormat
 ec:hasContentEditorialFormat rdf:type owl:ObjectProperty ;
                              rdfs:range ec:ContentEditorialFormat ;
-                             dcterms:description "To define a content editorial format e.g. magazine."@en ;
-                             rdfs:label "Editorial format"@en .
+                             dcterms:description "Pour définir un format éditorial de contenu, par exemple un magazine."@fr ,
+                                                 "To define a content editorial format e.g. magazine."@en ,
+                                                 "Um ein redaktionelles Format zu definieren, z. B. ein Magazin."@de ;
+                             rdfs:label "Editorial format"@en ,
+                                        "Format rédactionnel"@fr ,
+                                        "Redaktionelles Format"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasContributor
 ec:hasContributor rdf:type owl:ObjectProperty ;
                   rdfs:range ec:Role ;
-                  dcterms:description "To identify a contributor to a Resource, a EditorialObject, an Event..."@en ;
-                  rdfs:label "Contributor"@en .
+                  dcterms:description "Pour identifier un contributeur à une Ressource, un EditorialObject, un Événement..."@fr ,
+                                      "To identify a contributor to a Resource, a EditorialObject, an Event..."@en ,
+                                      "Zur Identifizierung eines Mitwirkenden an einer Ressource, einem Redaktionsobjekt, einem Ereignis..."@de ;
+                  rdfs:label "Beitragender"@de ,
+                             "Contributeur"@fr ,
+                             "Contributor"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasCopyright
 ec:hasCopyright rdf:type owl:ObjectProperty ;
                 rdfs:subPropertyOf ec:isCoveredBy ;
                 rdfs:range ec:Copyright ;
-                dcterms:description "To express copyright."@en ;
-                rdfs:label "Copyright"@en .
+                dcterms:description "Pour exprimer le droit d'auteur."@fr ,
+                                    "To express copyright."@en ,
+                                    "Um das Urheberrecht auszudrücken."@de ;
+                rdfs:label "Copyright"@de ,
+                           "Copyright"@en ,
+                           "Copyright"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasCountryOfBirth
 ec:hasCountryOfBirth rdf:type owl:ObjectProperty ;
                      rdfs:range ec:CountryCode ;
-                     dcterms:description "The country where a person is born."@en ;
-                     rdfs:label "Country of birth"@en .
+                     dcterms:description "Das Land, in dem eine Person geboren ist."@de ,
+                                         "Le pays où une personne est née."@fr ,
+                                         "The country where a person is born."@en ;
+                     rdfs:label "Country of birth"@en ,
+                                "Land der Geburt"@de ,
+                                "Pays de naissance"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasCountryOfDeath
 ec:hasCountryOfDeath rdf:type owl:ObjectProperty ;
                      rdfs:range ec:CountryCode ;
-                     dcterms:description "The country where the person died"@en ;
-                     rdfs:label "Country of death"@en .
+                     dcterms:description "Das Land, in dem die Person gestorben ist"@de ,
+                                         "Le pays où la personne est décédée"@fr ,
+                                         "The country where the person died"@en ;
+                     rdfs:label "Country of death"@en ,
+                                "Land des Todes"@de ,
+                                "Pays de décès"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasCoverage
 ec:hasCoverage rdf:type owl:ObjectProperty ;
-               dcterms:description "To provide coverage information."@en ;
-               rdfs:label "Coverage"@en .
+               dcterms:description "Pour fournir des informations sur la couverture."@fr ,
+                                   "To provide coverage information."@en ,
+                                   "Zur Bereitstellung von Informationen zum Versicherungsschutz."@de ;
+               rdfs:label "Couverture"@fr ,
+                          "Coverage"@en ,
+                          "Erfassungsbereich"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasCoverageRestrictions
 ec:hasCoverageRestrictions rdf:type owl:ObjectProperty ;
                            rdfs:subPropertyOf ec:isCoveredBy ;
                            rdfs:range ec:CoverageRestrictions ;
-                           dcterms:description "To express coverage restrictions."@en ;
-                           rdfs:label "Coverage restrictions"@en .
+                           dcterms:description "Pour exprimer les restrictions de couverture."@fr ,
+                                               "To express coverage restrictions."@en ,
+                                               "Um Einschränkungen der Deckung auszudrücken."@de ;
+                           rdfs:label "Coverage restrictions"@en ,
+                                      "Einschränkungen der Deckung"@de ,
+                                      "Restrictions de couverture"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasCreativeCommons
 ec:hasCreativeCommons rdf:type owl:ObjectProperty ;
                       rdfs:subPropertyOf ec:isCoveredBy ;
                       rdfs:range ec:CreativeCommons ;
-                      dcterms:description "To express Creative Commons."@en ;
-                      rdfs:label "Creative Commons"@en .
+                      dcterms:description "Pour exprimer Creative Commons."@fr ,
+                                          "To express Creative Commons."@en ,
+                                          "Um Creative Commons auszudrücken."@de ;
+                      rdfs:label "Creative Commons"@de ,
+                                 "Creative Commons"@en ,
+                                 "Creative Commons"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasCreator
 ec:hasCreator rdf:type owl:ObjectProperty ;
               rdfs:range ec:Role ;
-              dcterms:description "To identify an Agent involved in the creation of the Resource or EditorialObject."@en ;
-              rdfs:label "Creator"@en .
+              dcterms:description "Pour identifier un agent impliqué dans la création de la ressource ou de l'objet éditorial."@fr ,
+                                  "To identify an Agent involved in the creation of the Resource or EditorialObject."@en ,
+                                  "Zur Identifizierung eines Agenten, der an der Erstellung der Ressource oder des Redaktionsobjekts beteiligt war."@de ;
+              rdfs:label "Creator"@en ,
+                         "Créateur"@fr ,
+                         "Schöpfer"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasCrewMember
 ec:hasCrewMember rdf:type owl:ObjectProperty ;
                  rdfs:range ec:CrewMember ;
-                 dcterms:description "A member of the crew."@en ;
-                 rdfs:label "Crew member"@en .
+                 dcterms:description "A member of the crew."@en ,
+                                     "Ein Mitglied der Besatzung."@de ,
+                                     "Un membre de l'équipage."@fr ;
+                 rdfs:label "Besatzungsmitglied"@de ,
+                            "Crew member"@en ,
+                            "Membre de l'équipage"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasCuisineOrigin
 ec:hasCuisineOrigin rdf:type owl:ObjectProperty ;
                     rdfs:range ec:CountryCode ;
-                    dcterms:description "The country/region of origin of the cuisine"@en ;
-                    rdfs:label "Cuisine origin"@en .
+                    dcterms:description "Das Land/die Region, aus dem/der die Küche stammt"@de ,
+                                        "Le pays/la région d'origine de la cuisine"@fr ,
+                                        "The country/region of origin of the cuisine"@en ;
+                    rdfs:label "Cuisine origin"@en ,
+                               "Herkunft der Küche"@de ,
+                               "Origine de la cuisine"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasCuisineStyle
 ec:hasCuisineStyle rdf:type owl:ObjectProperty ;
                    rdfs:range ec:CuisineStyle ;
-                   dcterms:description "The style of the cuisine"@en ;
-                   rdfs:label "Cuisine style"@en .
+                   dcterms:description "Der Stil der Küche"@de ,
+                                       "Le style de la cuisine"@fr ,
+                                       "The style of the cuisine"@en ;
+                   rdfs:label "Cuisine style"@en ,
+                              "Stil der Küche"@de ,
+                              "Style de cuisine"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasDataFormat
 ec:hasDataFormat rdf:type owl:ObjectProperty ;
                  rdfs:subPropertyOf ec:hasFormat ;
                  rdfs:range ec:DataFormat ;
-                 dcterms:description "To describe the format of data carried in a resource."@en ;
-                 rdfs:label "Data format"@en .
+                 dcterms:description "Pour décrire le format des données transportées dans une ressource."@fr ,
+                                     "To describe the format of data carried in a resource."@en ,
+                                     "Zur Beschreibung des Formats der in einer Ressource enthaltenen Daten."@de ;
+                 rdfs:label "Data format"@en ,
+                            "Datenformat"@de ,
+                            "Format des données"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasDataTrack
 ec:hasDataTrack rdf:type owl:ObjectProperty ;
                 rdfs:range ec:DataTrack ;
-                dcterms:description "To identify DataTracks in the Resource."@en ;
-                rdfs:label "Data track"@en .
+                dcterms:description "Pour identifier les DataTracks dans la ressource."@fr ,
+                                    "To identify DataTracks in the Resource."@en ,
+                                    "Um DataTracks in der Ressource zu identifizieren."@de ;
+                rdfs:label "Data track"@en ,
+                           "Daten verfolgen"@de ,
+                           "Suivi des données"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasDepartment
 ec:hasDepartment rdf:type owl:ObjectProperty ;
                  rdfs:range ec:Department ;
-                 dcterms:description "To identify a department in an organisation."@en ;
-                 rdfs:label "Department"@en .
+                 dcterms:description "Pour identifier un département dans une organisation."@fr ,
+                                     "To identify a department in an organisation."@en ,
+                                     "Zur Identifizierung einer Abteilung in einer Organisation."@de ;
+                 rdfs:label "Abteilung"@de ,
+                            "Department"@en ,
+                            "Département"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasDisclaimer
 ec:hasDisclaimer rdf:type owl:ObjectProperty ;
                  rdfs:subPropertyOf ec:isCoveredBy ;
                  rdfs:range ec:Disclaimer ;
-                 dcterms:description "To express Disclaimer."@en ;
-                 rdfs:label "Disclaimer"@en .
+                 dcterms:description "Pour exprimer le désistement."@fr ,
+                                     "To express Disclaimer."@en ,
+                                     "Zum Ausdruck bringen Disclaimer."@de ;
+                 rdfs:label "Avis de non-responsabilité"@fr ,
+                            "Disclaimer"@en ,
+                            "Haftungsausschluss"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasDocumentFormat
 ec:hasDocumentFormat rdf:type owl:ObjectProperty ;
                      rdfs:subPropertyOf ec:hasFormat ;
                      rdfs:range ec:DocumentFormat ;
-                     dcterms:description "To describe the format of a Document."@en ;
-                     rdfs:label "Document format"@en .
+                     dcterms:description "Pour décrire le format d'un document."@fr ,
+                                         "To describe the format of a Document."@en ,
+                                         "Zur Beschreibung des Formats eines Dokuments."@de ;
+                     rdfs:label "Document format"@en ,
+                                "Format des Dokuments"@de ,
+                                "Format du document"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasDopesheet
 ec:hasDopesheet rdf:type owl:ObjectProperty ;
                 rdfs:range ec:Dopesheet ;
-                dcterms:description "The dopesheet of a NewsItem."@en ;
-                rdfs:label "Dopesheet"@en .
+                dcterms:description "Das Dossier eines NewsItems."@de ,
+                                    "La feuille de dopage d'un NewsItem."@fr ,
+                                    "The dopesheet of a NewsItem."@en ;
+                rdfs:label "Dopesheet"@de ,
+                           "Dopesheet"@en ,
+                           "Dopesheet"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasDubbedLanguage
 ec:hasDubbedLanguage rdf:type owl:ObjectProperty ;
                      rdfs:subPropertyOf ec:hasLanguage ;
                      rdfs:range ec:Language ;
-                     dcterms:description "To identify available dubbed languages."@en ;
-                     rdfs:label "Dubbed language"@en .
+                     dcterms:description "Pour identifier les langues doublées disponibles."@fr ,
+                                         "To identify available dubbed languages."@en ,
+                                         "Um die verfügbaren Synchronsprachen zu identifizieren."@de ;
+                     rdfs:label "Dubbed language"@en ,
+                                "Langue doublée"@fr ,
+                                "Synchronisierte Sprache"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasEditorialGroup
 ec:hasEditorialGroup rdf:type owl:ObjectProperty ;
                      rdfs:subPropertyOf ec:isMemberOf ;
-                     rdfs:label "has editorial group"@en .
+                     rdfs:label "a groupe de rédaction"@fr ,
+                                "has editorial group"@en ,
+                                "hat eine Redaktionsgruppe"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasEditorialWork
 ec:hasEditorialWork rdf:type owl:ObjectProperty ;
                     rdfs:subPropertyOf ec:isMemberOf ;
-                    rdfs:label "has editorial work"@en .
+                    rdfs:label "a un travail éditorial"@fr ,
+                               "has editorial work"@en ,
+                               "hat redaktionelle Arbeit"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasEncodingFormat
 ec:hasEncodingFormat rdf:type owl:ObjectProperty ;
                      rdfs:subPropertyOf ec:hasFormat ;
                      rdfs:range ec:EncodingFormat ;
-                     dcterms:description "To describe any encoding format use to produce content."@en ;
-                     rdfs:label "Encoding format"@en .
+                     dcterms:description "Pour décrire tout format d'encodage utilisé pour produire du contenu."@fr ,
+                                         "To describe any encoding format use to produce content."@en ,
+                                         "Zur Beschreibung eines beliebigen Kodierungsformats, das zur Erstellung von Inhalten verwendet wird."@de ;
+                     rdfs:label "Encoding format"@en ,
+                                "Format de codage"@fr ,
+                                "Format der Kodierung"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasEpisode
 ec:hasEpisode rdf:type owl:ObjectProperty ;
               rdfs:range ec:Programme ;
-              dcterms:description "To identify Episodes in a Series"@en ;
-              rdfs:label "Episode"@en .
+              dcterms:description "Pour identifier les épisodes d'une série"@fr ,
+                                  "So identifizieren Sie Episoden einer Serie"@de ,
+                                  "To identify Episodes in a Series"@en ;
+              rdfs:label "Episode"@de ,
+                         "Episode"@en ,
+                         "Episode"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasExploitationIssues
 ec:hasExploitationIssues rdf:type owl:ObjectProperty ;
                          rdfs:subPropertyOf ec:isCoveredBy ;
                          rdfs:range ec:ExploitationIssues ;
-                         dcterms:description "To express Exploitation Issues."@en ;
-                         rdfs:label "Exploitation Issues"@en .
+                         dcterms:description "Pour exprimer les problèmes d'exploitation."@fr ,
+                                             "To express Exploitation Issues."@en ,
+                                             "Zum Ausdruck bringen von Ausbeutungsproblemen."@de ;
+                         rdfs:label "Exploitation Issues"@en ,
+                                    "Fragen der Ausbeutung"@de ,
+                                    "Problèmes d'exploitation"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasFileFormat
 ec:hasFileFormat rdf:type owl:ObjectProperty ;
                  rdfs:range ec:FileFormat ;
-                 dcterms:description "The format of a file."@en ;
-                 rdfs:label "File format"@en .
+                 dcterms:description "Das Format einer Datei."@de ,
+                                     "Le format d'un fichier."@fr ,
+                                     "The format of a file."@en ;
+                 rdfs:label "Dateiformat"@de ,
+                            "File format"@en ,
+                            "Format de fichier"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasFoodStyle
 ec:hasFoodStyle rdf:type owl:ObjectProperty ;
                 rdfs:range ec:FoodStyle ;
-                dcterms:description "The style of Food."@en ;
-                rdfs:label "Food style"@en .
+                dcterms:description "Der Stil des Essens."@de ,
+                                    "Le style de la nourriture."@fr ,
+                                    "The style of Food."@en ;
+                rdfs:label "Essen Stil"@de ,
+                           "Food style"@en ,
+                           "Style alimentaire"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasFormat
 ec:hasFormat rdf:type owl:ObjectProperty ;
              rdfs:range ec:Format ;
-             dcterms:description "To identify a Format"@en ;
-             rdfs:label "Format"@en .
+             dcterms:description "Pour identifier un format"@fr ,
+                                 "So identifizieren Sie ein Format"@de ,
+                                 "To identify a Format"@en ;
+             rdfs:label "Format"@de ,
+                        "Format"@en ,
+                        "Format"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasFormatId
 ec:hasFormatId rdf:type owl:ObjectProperty ;
                rdfs:range ec:Identifier ;
-               dcterms:description "An identifier attributed to a Format."@en ;
-               rdfs:label "Format identifier"@en .
+               dcterms:description "An identifier attributed to a Format."@en ,
+                                   "Ein Identifikator, der einem Format zugeordnet ist."@de ,
+                                   "Un identifiant attribué à un format."@fr ;
+               rdfs:label "Format Kennung"@de ,
+                          "Format identifier"@en ,
+                          "Identificateur de format"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasGeneration
 ec:hasGeneration rdf:type owl:ObjectProperty ;
                  rdfs:range ec:MediaResource ;
-                 dcterms:description """Identifies the generation of a version of a resource, i.e. master,
-      edit master, distribution copy, etc."""@en ;
-                 rdfs:label "Generation"@en .
+                 dcterms:description "Identifie la génération d'une version d'une ressource, c'est-à-dire master, maître de modification, copie de distribution, etc."@fr ,
+                                     "Identifies the generation of a version of a resource, i.e. master, edit master, distribution copy, etc."@en ,
+                                     "Identifiziert die Erzeugung einer Version einer Ressource, d.h. Master, Master bearbeiten, Verteilungskopie, etc."@de ;
+                 rdfs:label "Generation"@de ,
+                            "Generation"@en ,
+                            "Génération"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasGenre
 ec:hasGenre rdf:type owl:ObjectProperty ;
-            dcterms:description "To define a Genre/category associated to the EditorialObject."@en ;
-            rdfs:label "Genre"@en .
+            dcterms:description "Pour définir un Genre/catégorie associé à l'objet EditorialObject."@fr ,
+                                "To define a Genre/category associated to the EditorialObject."@en ,
+                                "Um ein Genre/eine Kategorie zu definieren, das/die dem EditorialObject zugeordnet ist."@de ;
+            rdfs:label "Genre"@de ,
+                       "Genre"@en ,
+                       "Genre"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasGroupMember
@@ -1677,264 +2473,392 @@ ec:hasGroupMember rdf:type owl:ObjectProperty .
 ec:hasIPRRestrictions rdf:type owl:ObjectProperty ;
                       rdfs:subPropertyOf ec:isCoveredBy ;
                       rdfs:range ec:IPRRestrictions ;
-                      dcterms:description "To express IPR Restrictions."@en ;
-                      rdfs:label "IPR restrictions"@en .
+                      dcterms:description "Pour exprimer les restrictions en matière de DPI."@fr ,
+                                          "To express IPR Restrictions."@en ,
+                                          "Um IPR-Einschränkungen auszudrücken."@de ;
+                      rdfs:label "IPR restrictions"@en ,
+                                 "IPR-Beschränkungen"@de ,
+                                 "Restrictions DPI"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasIdPicture
 ec:hasIdPicture rdf:type owl:ObjectProperty ;
                 rdfs:range ec:Picture ;
-                dcterms:description "To provide a link to an identification picture."@en ;
-                rdfs:label "Identification picture"@en .
+                dcterms:description "Fournir un lien vers une photo d'identification."@fr ,
+                                    "To provide a link to an identification picture."@en ,
+                                    "Um einen Link zu einem Identifikationsbild bereitzustellen."@de ;
+                rdfs:label "Bild zur Identifizierung"@de ,
+                           "Identification picture"@en ,
+                           "Photo d'identification"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasIdentifier
 ec:hasIdentifier rdf:type owl:ObjectProperty ;
                  rdfs:range ec:Identifier ;
-                 dcterms:description "To associate an Identifier with an Asset."@en ;
-                 rdfs:label "Identifier"@en .
+                 dcterms:description "Pour associer un identifiant à un bien."@fr ,
+                                     "So verknüpfen Sie einen Identifier mit einem Asset."@de ,
+                                     "To associate an Identifier with an Asset."@en ;
+                 rdfs:label "Identifiant"@fr ,
+                            "Identifier"@en ,
+                            "Kennung"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasImageCodec
 ec:hasImageCodec rdf:type owl:ObjectProperty ;
                  rdfs:range ec:ImageCodec ;
-                 dcterms:description "To specify the codec of an Image."@en ;
-                 rdfs:label "Image codec"@en .
+                 dcterms:description "Pour spécifier le codec d'une image."@fr ,
+                                     "To specify the codec of an Image."@en ,
+                                     "Um den Codec eines Bildes anzugeben."@de ;
+                 rdfs:label "Bild-Codec"@de ,
+                            "Codec d'image"@fr ,
+                            "Image codec"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasImageFormat
 ec:hasImageFormat rdf:type owl:ObjectProperty ;
                   rdfs:range ec:ImageFormat ;
-                  dcterms:description "To specify the format of an Image."@en ;
-                  rdfs:label "Image format"@en .
+                  dcterms:description "Pour spécifier le format d'une image."@fr ,
+                                      "To specify the format of an Image."@en ,
+                                      "Um das Format eines Bildes festzulegen."@de ;
+                  rdfs:label "Bildformat"@de ,
+                             "Format d'image"@fr ,
+                             "Image format"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasKeyCareerEvent
 ec:hasKeyCareerEvent rdf:type owl:ObjectProperty ;
                      rdfs:range ec:KeyCareerEvent ;
-                     dcterms:description "To identify the key career events of a Person."@en ;
-                     rdfs:label "Career event"@en .
+                     dcterms:description "Die wichtigsten Karriereereignisse einer Person zu identifizieren."@de ,
+                                         "Identifier les événements clés de la carrière d'une personne."@fr ,
+                                         "To identify the key career events of a Person."@en ;
+                     rdfs:label "Career event"@en ,
+                                "Karriere-Veranstaltung"@de ,
+                                "Événement de carrière"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasKeyPersonalEvent
 ec:hasKeyPersonalEvent rdf:type owl:ObjectProperty ;
                        rdfs:range ec:KeyPersonalEvent ;
-                       dcterms:description "To identify the key personal events of a Person."@en ;
-                       rdfs:label "Personal event"@en .
+                       dcterms:description "Identifier les événements personnels clés d'une personne."@fr ,
+                                           "To identify the key personal events of a Person."@en ,
+                                           "Um die wichtigsten persönlichen Ereignisse einer Person zu identifizieren."@de ;
+                       rdfs:label "Personal event"@en ,
+                                  "Persönliches Ereignis"@de ,
+                                  "Événement personnel"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasKeyword
 ec:hasKeyword rdf:type owl:ObjectProperty ;
               rdfs:subPropertyOf ec:hasSubject ;
               rdfs:range ec:Keyword ;
-              dcterms:description "To associate a concept, descriptive phrase or Keyword that specifies the topic of the EditorialObject."@en ;
-              rdfs:label "Keyword"@en .
+              dcterms:description "Pour associer un concept, une phrase descriptive ou un mot-clé qui spécifie le sujet de l'EditorialObject."@fr ,
+                                  "To associate a concept, descriptive phrase or Keyword that specifies the topic of the EditorialObject."@en ,
+                                  "Um ein Konzept, eine beschreibende Phrase oder ein Schlüsselwort zuzuordnen, das das Thema des EditorialObjects angibt."@de ;
+              rdfs:label "Keyword"@en ,
+                         "Mot-clé"@fr ,
+                         "Schlüsselwort"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasLanguage
 ec:hasLanguage rdf:type owl:ObjectProperty ;
                rdfs:range ec:Language ;
-               dcterms:description """To associate a Language to an Asset. A controlled vocabulary based on BCP 47 is recommended. This
-            property can also be used to identify the presence of sign language (RFC 5646). By
-            inheritance, the hasLanguage property applies indifferently at the MediaResource /
-            Fragment / Track levels at which the usage is being defined. Best practice recommends to
-            use to best possible level of granularity fo describe the usage of language within a
-            MediaResource including at Fragment and Track levels."""@en ;
-               rdfs:label "Language"@en .
+               dcterms:description "Pour associer une langue à un actif. Un vocabulaire contrôlé basé sur le BCP 47 est recommandé. Cette propriété peut également être utilisée pour identifier la présence d'une langue des signes (RFC 5646). Par héritage, la propriété hasLanguage s'applique indifféremment aux niveaux MediaResource / Fragment / Piste aux niveaux desquels l'usage est défini. Les meilleures pratiques recommandent de d'utiliser le meilleur niveau de granularité possible pour décrire l'utilisation de la langue dans une ressource multimédia, y compris au niveau des fragments. MediaResource, y compris aux niveaux Fragment et Track."@fr ,
+                                   "So verknüpfen Sie eine Sprache mit einem Asset. Es wird ein kontrolliertes Vokabular auf der Grundlage von BCP 47 empfohlen. Diese Eigenschaft kann auch verwendet werden, um das Vorhandensein von Zeichensprache zu identifizieren (RFC 5646). Durch Vererbung gilt die Eigenschaft hasLanguage gleichgültig auf den Ebenen MediaResource / Fragment / Track-Ebene, auf der die Verwendung definiert wird. Die beste Praxis empfiehlt, dass die bestmögliche Granularität zu verwenden, um die Verwendung der Sprache innerhalb einer MediaResource zu beschreiben, auch auf Fragment- und Trackebene."@de ,
+                                   "To associate a Language to an Asset. A controlled vocabulary based on BCP 47 is recommended. This property can also be used to identify the presence of sign language (RFC 5646). By inheritance, the hasLanguage property applies indifferently at the MediaResource / Fragment / Track levels at which the usage is being defined. Best practice recommends to use to best possible level of granularity fo describe the usage of language within a MediaResource including at Fragment and Track levels."@en ;
+               rdfs:label "Language"@en ,
+                          "Langue"@fr ,
+                          "Sprache"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasLicensing
 ec:hasLicensing rdf:type owl:ObjectProperty ;
                 rdfs:subPropertyOf ec:isCoveredBy ;
                 rdfs:range ec:Licensing ;
-                dcterms:description "To express Licensing."@en ;
-                rdfs:label "Licensing"@en .
+                dcterms:description "Pour exprimer l'autorisation."@fr ,
+                                    "To express Licensing."@en ,
+                                    "Um die Lizenzierung auszudrücken."@de ;
+                rdfs:label "Licences"@fr ,
+                           "Licensing"@en ,
+                           "Lizenzierung"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasLocation
 ec:hasLocation rdf:type owl:ObjectProperty ;
                rdfs:range ec:Location ;
-               dcterms:description "A location assosiated with the object or consept"@en ;
-               rdfs:label "Location"@en ;
-               skos:example "The Location where content has been captured."@en .
+               dcterms:description "A location assosiated with the object or consept"@en ,
+                                   "Ein Ort, der mit dem Objekt oder Gegenstand verbunden ist"@de ,
+                                   "Un emplacement associé à l'objet ou au consept."@fr ;
+               rdfs:example "The Location where content has been captured."@en ;
+               rdfs:label "Emplacement"@fr ,
+                          "Location"@en ,
+                          "Standort"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasLocationCode
 ec:hasLocationCode rdf:type owl:ObjectProperty ;
                    rdfs:range ec:LocationCode ;
-                   dcterms:description "To give the code of a Location."@en ;
-                   rdfs:label "Locationcode"@en .
+                   dcterms:description "Pour donner le code d'un emplacement."@fr ,
+                                       "To give the code of a Location."@en ,
+                                       "Um den Code eines Ortes anzugeben."@de ;
+                   rdfs:label "Code de localisation"@fr ,
+                              "Locationcode"@en ,
+                              "Standortcode"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasLocationPicture
 ec:hasLocationPicture rdf:type owl:ObjectProperty ;
                       rdfs:range ec:Picture ;
-                      dcterms:description "A picture associated with a Location."@en ;
-                      rdfs:label "Picture"@en .
+                      dcterms:description "A picture associated with a Location."@en ,
+                                          "Ein Bild, das mit einem Ort verbunden ist."@de ,
+                                          "Une image associée à un emplacement."@fr ;
+                      rdfs:label "Bild"@de ,
+                                 "Photo"@fr ,
+                                 "Picture"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasLocator
 ec:hasLocator rdf:type owl:ObjectProperty ;
               rdfs:range ec:Locator ;
-              dcterms:description "A locator from where the Resource can be accessed."@en ;
-              rdfs:label "Locator"@en .
+              dcterms:description "A locator from where the Resource can be accessed."@en ,
+                                  "Ein Locator, von dem aus auf die Ressource zugegriffen werden kann."@de ,
+                                  "Un localisateur à partir duquel la ressource est accessible."@fr ;
+              rdfs:label "Localisateur"@fr ,
+                         "Locator"@de ,
+                         "Locator"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasLogo
 ec:hasLogo rdf:type owl:ObjectProperty ;
            rdfs:range ec:Logo ;
-           dcterms:description """Logos can be used in a variety of contexts.
-            Logo can be associated with an Organisation or a Service or a PublicationChannel."""@en ;
-           rdfs:label "Logo"@en .
+           dcterms:description "Les logos peuvent être utilisés dans une variété de contextes. Le logo peut être associé à une organisation, un service ou un canal de publication."@fr ,
+                               "Logos can be used in a variety of contexts. Logo can be associated with an Organisation or a Service or a PublicationChannel."@en ,
+                               "Logos können in einer Vielzahl von Kontexten verwendet werden. Ein Logo kann mit einer Organisation, einem Dienst oder einem Publikationskanal verbunden sein."@de ;
+           rdfs:label "Logo"@de ,
+                      "Logo"@en ,
+                      "Logo"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasManifestation
 ec:hasManifestation rdf:type owl:ObjectProperty ;
                     rdfs:range ec:Resource ;
-                    dcterms:description "A manifestation is the physical embodiment of work e.g. a tape, a file..."@en ;
-                    rdfs:label "Manifestation"@en .
+                    dcterms:description "A manifestation is the physical embodiment of work e.g. a tape, a file..."@en ,
+                                        "Eine Manifestation ist die physische Verkörperung der Arbeit, z. B. ein Band, eine Datei..."@de ,
+                                        "Une manifestation est l'incarnation physique du travail, par exemple une bande, un fichier..."@fr ;
+                    rdfs:label "Manifestation"@de ,
+                               "Manifestation"@en ,
+                               "Manifestation"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasMaster
 ec:hasMaster rdf:type owl:ObjectProperty ;
              rdfs:range ec:MediaResource ;
-             dcterms:description "To identify the master of a Resource"@en ;
-             rdfs:label "Master"@en .
+             dcterms:description "Pour identifier le maître d'une ressource"@fr ,
+                                 "So identifizieren Sie den Master einer Ressource"@de ,
+                                 "To identify the master of a Resource"@en ;
+             rdfs:label "Master"@en ,
+                        "Maître"@fr ,
+                        "Meister"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasMediaFragment
 ec:hasMediaFragment rdf:type owl:ObjectProperty ;
                     owl:inverseOf ec:isMediaFragmentOf ;
                     rdfs:range ec:MediaFragment ;
-                    dcterms:description """To define relation to MediaFragments
-            withiin a MediaResource."""@en ;
-                    rdfs:label "Fragment"@en .
+                    dcterms:description "Pour définir la relation avec les MediaFragments au sein d'une MediaResource."@fr ,
+                                        "So definieren Sie die Beziehung zu MediaFragmenten innerhalb einer MediaResource zu definieren."@de ,
+                                        "To define relation to MediaFragments withiin a MediaResource."@en ;
+                    rdfs:label "Fragment"@de ,
+                               "Fragment"@en ,
+                               "Fragment"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasMedium
 ec:hasMedium rdf:type owl:ObjectProperty ;
              rdfs:subPropertyOf ec:hasFormat ;
              rdfs:range ec:Medium ;
-             dcterms:description "To specify the medium on which the Resource is available."@en ;
-             rdfs:label "Medium"@en .
+             dcterms:description "Pour spécifier le support sur lequel la ressource est disponible."@fr ,
+                                 "To specify the medium on which the Resource is available."@en ,
+                                 "Zur Angabe des Mediums, auf dem die Ressource verfügbar ist."@de ;
+             rdfs:label "Medium"@de ,
+                        "Medium"@en ,
+                        "Moyen"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasMember
 ec:hasMember rdf:type owl:ObjectProperty ;
              owl:inverseOf ec:isMemberOf ;
              rdfs:range ec:EditorialObject ;
-             dcterms:description "To establish group/collection relationship between EditorialObjects."@en ;
-             rdfs:label "Member."@en .
+             dcterms:description "Pour établir une relation de groupe/collection entre les EditorialObjects."@fr ,
+                                 "To establish group/collection relationship between EditorialObjects."@en ,
+                                 "Um eine Gruppen-/Sammlungsbeziehung zwischen EditorialObjects herzustellen."@de ;
+             rdfs:label "Member."@en ,
+                        "Membre."@fr ,
+                        "Mitglied."@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasMetadataTrack
 ec:hasMetadataTrack rdf:type owl:ObjectProperty ;
                     rdfs:range ec:MetadataTrack ;
-                    dcterms:description "To identify MetadataTracks in the Resource."@en ;
-                    rdfs:label "Metadata track"@en .
+                    dcterms:description "Pour identifier les MetadataTracks dans la ressource."@fr ,
+                                        "So identifizieren Sie MetadataTracks in der Ressource."@de ,
+                                        "To identify MetadataTracks in the Resource."@en ;
+                    rdfs:label "Metadata track"@en ,
+                               "Metadaten Spur"@de ,
+                               "Piste de métadonnées"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasMimeType
 ec:hasMimeType rdf:type owl:ObjectProperty ;
                rdfs:subPropertyOf ec:hasFormat ;
                rdfs:range ec:MimeType ;
-               dcterms:description "To specify the Mime type of a Resource."@en ;
-               rdfs:label "Mime type"@en .
+               dcterms:description "Pour spécifier le type Mime d'une ressource."@fr ,
+                                   "To specify the Mime type of a Resource."@en ,
+                                   "Um den Mime-Typ einer Ressource anzugeben."@de ;
+               rdfs:label "Mime type"@en ,
+                          "Mime-Typ"@de ,
+                          "Type Mime"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasOrganisationStaff
 ec:hasOrganisationStaff rdf:type owl:ObjectProperty ;
                         rdfs:range ec:StaffMember ;
-                        dcterms:description "To identify Staff members in an Organisation."@en ;
-                        rdfs:label "Staff"@en .
+                        dcterms:description "Pour identifier les membres du personnel d'une organisation."@fr ,
+                                            "To identify Staff members in an Organisation."@en ,
+                                            "Zur Identifizierung von Mitarbeitern in einer Organisation."@de ;
+                        rdfs:label "Personal"@de ,
+                                   "Personnel"@fr ,
+                                   "Staff"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasOriginalLanguage
 ec:hasOriginalLanguage rdf:type owl:ObjectProperty ;
                        rdfs:subPropertyOf ec:hasLanguage ;
                        rdfs:range ec:Language ;
-                       dcterms:description "To define the original language of an Asset."@en ;
-                       rdfs:label "Original language"@en .
+                       dcterms:description "Pour définir la langue d'origine d'un actif."@fr ,
+                                           "So definieren Sie die Originalsprache eines Assets."@de ,
+                                           "To define the original language of an Asset."@en ;
+                       rdfs:label "Langue originale"@fr ,
+                                  "Original language"@en ,
+                                  "Originalsprache"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasParentEditorialObject
 ec:hasParentEditorialObject rdf:type owl:ObjectProperty ;
                             rdfs:range ec:EditorialObject ;
-                            dcterms:description "To link a EditorialOject to a parent."@en ;
-                            rdfs:label "Parent editorial object"@en .
+                            dcterms:description "Pour lier un ÉditorialOject à un parent."@fr ,
+                                                "To link a EditorialOject to a parent."@en ,
+                                                "Um ein EditorialOject mit einem Parent zu verknüpfen."@de ;
+                            rdfs:label "Objet éditorial parent"@fr ,
+                                       "Parent editorial object"@en ,
+                                       "Übergeordnetes redaktionelles Objekt"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasParentEditorialSegment
 ec:hasParentEditorialSegment rdf:type owl:ObjectProperty ;
-                             rdfs:label "has parent editorial segment"@en .
+                             rdfs:label "a un segment éditorial parent"@fr ,
+                                        "has parent editorial segment"@en ,
+                                        "hat ein übergeordnetes redaktionelles Segment"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasParentMediaResource
 ec:hasParentMediaResource rdf:type owl:ObjectProperty ;
                           rdfs:range ec:MediaResource ;
-                          dcterms:description "To link a MediaResource to a parent."@en ;
-                          rdfs:label "Parent resource"@en .
+                          dcterms:description "Pour lier une MediaResource à un parent."@fr ,
+                                              "To link a MediaResource to a parent."@en ,
+                                              "Um eine MediaResource mit einer übergeordneten Ressource zu verknüpfen."@de ;
+                          rdfs:label "Parent resource"@en ,
+                                     "Ressource für Eltern"@de ,
+                                     "Ressource pour les parents"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasPart
 ec:hasPart rdf:type owl:ObjectProperty ;
            owl:inverseOf ec:isPartOf ;
            rdfs:range ec:EditorialSegment ;
-           dcterms:description """To define Parts (segments, fragments, shots, etc.)
-            within an EditorialObject."""@en ;
-           rdfs:label "Part"@en .
+           dcterms:description "Pour définir des parties (segments, fragments, plans, etc.) au sein d'un EditorialObject."@fr ,
+                               "To define Parts (segments, fragments, shots, etc.) within an EditorialObject."@en ,
+                               "Zur Definition von Teilen (Segmente, Fragmente, Aufnahmen usw.) innerhalb eines EditorialObjects."@de ;
+           rdfs:label "Part"@en ,
+                      "Partie"@fr ,
+                      "Teil"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasParticipatingAgent
 ec:hasParticipatingAgent rdf:type owl:ObjectProperty ;
                          rdfs:range ec:Agent ;
-                         dcterms:description "To identify participating Agents."@en ;
-                         rdfs:label "Participating agent"@en .
+                         dcterms:description "Pour identifier les agents participants."@fr ,
+                                             "To identify participating Agents."@en ,
+                                             "Um teilnehmende Agenten zu identifizieren."@de ;
+                         rdfs:label "Agent participant"@fr ,
+                                    "Beteiligter Agent"@de ,
+                                    "Participating agent"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasPictogram
 ec:hasPictogram rdf:type owl:ObjectProperty ;
                 rdfs:range ec:Picture ;
-                dcterms:description "To provide a visual representation of  a Rating / AufdienceRating / AudienceLevel."@en ;
-                rdfs:label "Pictogram"@en .
+                dcterms:description "Für eine visuelle Darstellung eines Ratings / AufdienceRating / AudienceLevel."@de ,
+                                    "Pour fournir une représentation visuelle d'un Rating / AufdienceRating / AudienceLevel."@fr ,
+                                    "To provide a visual representation of a Rating / AufdienceRating / AudienceLevel."@en ;
+                rdfs:label "Pictogram"@en ,
+                           "Pictogramme"@fr ,
+                           "Piktogramm"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasPlaceOfBirth
 ec:hasPlaceOfBirth rdf:type owl:ObjectProperty ;
                    rdfs:range ec:Location ;
-                   dcterms:description "To identify the place of birth."@en ;
-                   rdfs:label "Birth place"@en .
+                   dcterms:description "Pour identifier le lieu de naissance."@fr ,
+                                       "To identify the place of birth."@en ,
+                                       "Zur Identifizierung des Geburtsortes."@de ;
+                   rdfs:label "Birth place"@en ,
+                              "Geburtsort"@de ,
+                              "Lieu de naissance"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasPlaceOfDeath
 ec:hasPlaceOfDeath rdf:type owl:ObjectProperty ;
                    rdfs:range ec:Location ;
-                   dcterms:description "To identify the place of death."@en ;
-                   rdfs:label "Death place"@en .
+                   dcterms:description "Pour identifier le lieu du décès."@fr ,
+                                       "To identify the place of death."@en ,
+                                       "Um den Ort des Todes zu identifizieren."@de ;
+                   rdfs:label "Death place"@en ,
+                              "Lieu de décès"@fr ,
+                              "Ort des Todes"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasPost
 ec:hasPost rdf:type owl:ObjectProperty ;
            rdfs:range ec:Post ;
-           rdfs:label "has post"@en .
+           rdfs:label "a poste"@fr ,
+                      "has post"@en ,
+                      "hat Post"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasProducer
 ec:hasProducer rdf:type owl:ObjectProperty ;
                rdfs:range ec:Agent ;
-               dcterms:description "To identify an Agent involved in the production of the Resource or EditorialObject."@en ;
-               rdfs:label "Producer"@en .
+               dcterms:description "Pour identifier un agent impliqué dans la production de la ressource ou de l'objet éditorial."@fr ,
+                                   "To identify an Agent involved in the production of the Resource or EditorialObject."@en ,
+                                   "Zur Identifizierung eines Agenten, der an der Produktion der Ressource oder des Redaktionsobjekts beteiligt ist."@de ;
+               rdfs:label "Producer"@en ,
+                          "Producteur"@fr ,
+                          "Produzent"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasProgramme
 ec:hasProgramme rdf:type owl:ObjectProperty ;
                 rdfs:range ec:Programme ;
-                rdfs:label "has programme"@en .
+                rdfs:label "a programme"@fr ,
+                           "has programme"@en ,
+                           "hat Programm"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasPromotion
 ec:hasPromotion rdf:type owl:ObjectProperty ;
-                rdfs:label "has promotion"@en .
+                rdfs:label "a la promotion"@fr ,
+                           "has promotion"@en ,
+                           "hat Förderung"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasProvenance
@@ -1942,931 +2866,1437 @@ ec:hasProvenance rdf:type owl:ObjectProperty ;
                  owl:inverseOf ec:hasProvenanceTarget ;
                  rdfs:domain owl:Thing ;
                  rdfs:range ec:Provenance ;
-                 dcterms:description "Range: string, anyURI or Concept."@en ,
-                                     "To associate information on Provenance to an EBUCore class."@en ;
-                 rdfs:label "Provenance"@en .
+                 dcterms:description "Bereich: String, anyURI oder Konzept."@de ,
+                                     "Plage : chaîne, anyURI ou Concept."@fr ,
+                                     "To associate information on Provenance to an EBUCore class. Range: string, anyURI or Concept."@en ;
+                 rdfs:label "Provenance"@en ,
+                            "Provenance"@fr ,
+                            "Provenienz"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasProvenanceTarget
 ec:hasProvenanceTarget rdf:type owl:ObjectProperty ;
                        rdfs:range owl:Thing ;
-                       dcterms:description "The instance of an object sourced by the Provenance."@en ;
-                       rdfs:label "Provenance target"@en .
+                       dcterms:description "Die Instanz eines Objekts, das von der Provenance bezogen wird."@de ,
+                                           "L'instance d'un objet sourcé par la Provenance."@fr ,
+                                           "The instance of an object sourced by the Provenance."@en ;
+                       rdfs:label "Cible de provenance"@fr ,
+                                  "Provenance target"@en ,
+                                  "Ziel Provenienz"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasPublicationChannel
 ec:hasPublicationChannel rdf:type owl:ObjectProperty ;
-                         rdfs:label "haspublicationchannel"@en .
+                         rdfs:label "a un canal de publication"@fr ,
+                                    "has
+publication
+channel"@en ,
+                                    "hat Publikationskanal"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasPublicationEvent
 ec:hasPublicationEvent rdf:type owl:ObjectProperty ;
                        rdfs:range ec:PublicationEvent ;
-                       dcterms:description """To associate PublicationEvents with
-            PublicationChannels or as elements of a PublicationHistory or PublicationPlanning."""@en ;
-                       rdfs:label "Publication event"@en .
+                       dcterms:description "Pour associer les PublicationEvents à canaux de publication ou en tant qu'éléments d'une PublicationHistory ou d'une PublicationPlanning."@fr ,
+                                           "To associate PublicationEvents with PublicationChannels or as elements of a PublicationHistory or PublicationPlanning."@en ,
+                                           "Um PublicationEvents zu verknüpfen mit PublicationChannels oder als Elemente einer PublicationHistory oder PublicationPlanning."@de ;
+                       rdfs:label "Ereignis der Veröffentlichung"@de ,
+                                  "Publication event"@en ,
+                                  "Événement de publication"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasPublicationHistory
 ec:hasPublicationHistory rdf:type owl:ObjectProperty ;
                          rdfs:range ec:PublicationHistory ;
-                         dcterms:description "To provide the history of publication of an EditorailObject or MediaResource."@en ;
-                         rdfs:label "Publication history"@en .
+                         dcterms:description "Pour fournir l'historique de publication d'un EditorailObject ou d'un MediaResource."@fr ,
+                                             "To provide the history of publication of an EditorailObject or MediaResource."@en ,
+                                             "Um den Verlauf der Veröffentlichung eines EditorailObjects oder einer MediaResource anzuzeigen."@de ;
+                         rdfs:label "Geschichte der Veröffentlichung"@de ,
+                                    "Historique de la publication"@fr ,
+                                    "Publication history"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasPublicationMedium
 ec:hasPublicationMedium rdf:type owl:ObjectProperty ;
                         rdfs:range ec:PublicationMedium ;
-                        dcterms:description "To identify the publication medium."@en ;
-                        rdfs:label "Publication medium"@en .
+                        dcterms:description "Pour identifier le support de publication."@fr ,
+                                            "To identify the publication medium."@en ,
+                                            "Um das Publikationsmedium zu identifizieren."@de ;
+                        rdfs:label "Medium der Veröffentlichung"@de ,
+                                   "Publication medium"@en ,
+                                   "Support de publication"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasPublicationPlanMember
 ec:hasPublicationPlanMember rdf:type owl:ObjectProperty ;
                             rdfs:range ec:PublicationPlan ;
-                            dcterms:description "To identify a subplan of a publication plan."@en ;
-                            rdfs:label "Publication plan member."@en .
+                            dcterms:description "Pour identifier un sous-plan d'un plan de publication."@fr ,
+                                                "To identify a subplan of a publication plan."@en ,
+                                                "Um einen Teilplan eines Veröffentlichungsplans zu identifizieren."@de ;
+                            rdfs:label "Mitglied des Veröffentlichungsplans."@de ,
+                                       "Participant au plan de publication."@fr ,
+                                       "Publication plan member."@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasPublicationRegion
 ec:hasPublicationRegion rdf:type owl:ObjectProperty ;
                         rdfs:range ec:Location ;
-                        dcterms:description "The region where the publication takes place."@en ;
-                        rdfs:label "Publication region"@en .
+                        dcterms:description "Die Region, in der die Veröffentlichung stattfindet."@de ,
+                                            "La région où la publication a lieu."@fr ,
+                                            "The region where the publication takes place."@en ;
+                        rdfs:label "Publication region"@en ,
+                                   "Region der Veröffentlichung"@de ,
+                                   "Région de publication"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasPublisher
 ec:hasPublisher rdf:type owl:ObjectProperty ;
                 rdfs:range ec:Role ;
-                dcterms:description "To identify an Agent involved in the publication of the EditorialObject."@en ;
-                rdfs:label "Publisher"@en .
+                dcterms:description "Pour identifier un agent impliqué dans la publication de l'EditorialObject."@fr ,
+                                    "To identify an Agent involved in the publication of the EditorialObject."@en ,
+                                    "Zur Identifizierung eines Agenten, der an der Veröffentlichung des EditorialObjects beteiligt ist."@de ;
+                rdfs:label "Editeur"@fr ,
+                           "Herausgeber"@de ,
+                           "Publisher"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasRating
 ec:hasRating rdf:type owl:ObjectProperty ;
              rdfs:range ec:Rating ;
-             dcterms:description "To identify the presence of Rating attributed to a EditorialObject."@en ;
-             rdfs:label "Rating"@en .
+             dcterms:description "Pour identifier la présence de Rating attribué à un EditorialObject."@fr ,
+                                 "To identify the presence of Rating attributed to a EditorialObject."@en ,
+                                 "Um das Vorhandensein von Bewertungen zu identifizieren, die einem EditorialObject zugeordnet sind."@de ;
+             rdfs:label "Bewertung"@de ,
+                        "Classement"@fr ,
+                        "Rating"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasRatingProvider
 ec:hasRatingProvider rdf:type owl:ObjectProperty ;
                      rdfs:range ec:Agent ;
-                     dcterms:description "To identify an Agent who has provided a Rating."@en ;
-                     rdfs:label "Rating source / agent"@en .
+                     dcterms:description "Pour identifier un agent qui a fourni un classement."@fr ,
+                                         "To identify an Agent who has provided a Rating."@en ,
+                                         "Zur Identifizierung eines Agenten, der eine Bewertung abgegeben hat."@de ;
+                     rdfs:label "Quelle der Bewertung / Agent"@de ,
+                                "Rating source / agent"@en ,
+                                "Source de notation / agent"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasRelatedAgent
 ec:hasRelatedAgent rdf:type owl:ObjectProperty ;
                    rdfs:range ec:Agent ;
-                   dcterms:description "To associate a concept with an Agent (e.g. Person or Character)."@en ;
-                   rdfs:label "Related agent"@en .
+                   dcterms:description "Pour associer un concept à un agent (par exemple, une personne ou un personnage)."@fr ,
+                                       "To associate a concept with an Agent (e.g. Person or Character)."@en ,
+                                       "Um ein Konzept mit einem Agenten (z.B. einer Person oder einem Charakter) zu verknüpfen."@de ;
+                   rdfs:label "Agent connexe"@fr ,
+                              "Related agent"@en ,
+                              "Verwandter Agent"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasRelatedAnimal
 ec:hasRelatedAnimal rdf:type owl:ObjectProperty ;
                     rdfs:range ec:Animal ;
-                    dcterms:description "To identify animals associate with a concept"@en ;
-                    rdfs:label "Related animal"@en .
+                    dcterms:description "Identifier les animaux associés à un concept"@fr ,
+                                        "Tiere identifizieren, die mit einem Konzept verbunden sind"@de ,
+                                        "To identify animals associate with a concept"@en ;
+                    rdfs:label "Animal apparenté"@fr ,
+                               "Related animal"@en ,
+                               "Verwandtes Tier"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasRelatedArtefact
 ec:hasRelatedArtefact rdf:type owl:ObjectProperty ;
                       rdfs:range ec:Artefact ;
-                      dcterms:description "To identify and Artefact related to EditorialObject or a concept"@en ;
-                      rdfs:label "Related artefact"@en .
+                      dcterms:description "Identifier un artefact lié à EditorialObject ou à un concept."@fr ,
+                                          "Identifizieren eines Artefakts mit Bezug zu einem EditorialObject oder einem Konzept"@de ,
+                                          "To identify and Artefact related to EditorialObject or a concept"@en ;
+                      rdfs:label "Artéfact connexe"@fr ,
+                                 "Related artefact"@en ,
+                                 "Verwandtes Artefakt"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasRelatedAsset
 ec:hasRelatedAsset rdf:type owl:ObjectProperty ;
                    rdfs:range ec:Asset ;
-                   dcterms:description "To identify related Assets."@en ;
-                   rdfs:label "Related asset"@en .
+                   dcterms:description "Pour identifier les actifs connexes."@fr ,
+                                       "To identify related Assets."@en ,
+                                       "Um verwandte Assets zu identifizieren."@de ;
+                   rdfs:label "Bien connexe"@fr ,
+                              "Related asset"@en ,
+                              "Verwandter Vermögenswert"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasRelatedAudioContent
 ec:hasRelatedAudioContent rdf:type owl:ObjectProperty ;
                           rdfs:range ec:AudioContent ;
-                          dcterms:description "To identify related Audio Content"@en ;
-                          rdfs:label "Audio content"@en .
+                          dcterms:description "Pour identifier le contenu audio associé"@fr ,
+                                              "So identifizieren Sie verwandte Audioinhalte"@de ,
+                                              "To identify related Audio Content"@en ;
+                          rdfs:label "Audio content"@en ,
+                                     "Audio-Inhalt"@de ,
+                                     "Contenu audio"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasRelatedAudioObject
 ec:hasRelatedAudioObject rdf:type owl:ObjectProperty ;
                          rdfs:range ec:AudioObject ;
-                         dcterms:description "To identify related Audio Objects"@en ;
-                         rdfs:label "Audio object"@en .
+                         dcterms:description "Pour identifier les objets audio associés"@fr ,
+                                             "To identify related Audio Objects"@en ,
+                                             "Um verwandte Audio-Objekte zu identifizieren"@de ;
+                         rdfs:label "Audio object"@en ,
+                                    "Audio-Objekt"@de ,
+                                    "Objet audio"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasRelatedAudioProgramme
 ec:hasRelatedAudioProgramme rdf:type owl:ObjectProperty ;
                             rdfs:range ec:AudioProgramme ;
-                            dcterms:description "A related audio programme"@en ;
-                            rdfs:label "Audio programme"@en .
+                            dcterms:description "A related audio programme"@en ,
+                                                "Ein entsprechendes Audioprogramm"@de ,
+                                                "Un programme audio connexe"@fr ;
+                            rdfs:label "Audio Programm"@de ,
+                                       "Audio programme"@en ,
+                                       "Programme audio"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasRelatedAudioTrack
 ec:hasRelatedAudioTrack rdf:type owl:ObjectProperty ;
                         rdfs:range ec:AudioTrack ;
-                        dcterms:description "To identify related Audio Tracks"@en ;
-                        rdfs:label "Audio track"@en .
+                        dcterms:description "Pour identifier les pistes audio liées"@fr ,
+                                            "So identifizieren Sie verwandte Audiospuren"@de ,
+                                            "To identify related Audio Tracks"@en ;
+                        rdfs:label "Audio track"@en ,
+                                   "Audiospur"@de ,
+                                   "Piste audio"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasRelatedAward
 ec:hasRelatedAward rdf:type owl:ObjectProperty ;
                    rdfs:range ec:Award ;
-                   dcterms:description "To identify an Award related to EditorialObject."@en ;
-                   rdfs:label "Related award"@en .
+                   dcterms:description "Pour identifier une récompense liée à EditorialObject."@fr ,
+                                       "To identify an Award related to EditorialObject."@en ,
+                                       "Um einen Award zu identifizieren, der sich auf EditorialObject bezieht."@de ;
+                   rdfs:label "Prix connexe"@fr ,
+                              "Related award"@en ,
+                              "Verwandter Preis"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasRelatedCharacter
 ec:hasRelatedCharacter rdf:type owl:ObjectProperty ;
                        rdfs:range ec:Character ;
-                       dcterms:description "To identify a Character related to a concept"@en ;
-                       rdfs:label "Related character"@en .
+                       dcterms:description "Pour identifier un caractère lié à un concept"@fr ,
+                                           "So identifizieren Sie ein Zeichen, das mit einem Konzept verbunden ist"@de ,
+                                           "To identify a Character related to a concept"@en ;
+                       rdfs:label "Caractère apparenté"@fr ,
+                                  "Related character"@en ,
+                                  "Verwandter Charakter"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasRelatedEditorialObject
 ec:hasRelatedEditorialObject rdf:type owl:ObjectProperty ;
                              rdfs:range ec:EditorialObject ;
-                             dcterms:description "To identify related EditorialObjects."@en ;
-                             rdfs:label "Related editorial object"@en .
+                             dcterms:description "Pour identifier les EditorialObjects connexes."@fr ,
+                                                 "To identify related EditorialObjects."@en ,
+                                                 "Um verwandte EditorialObjects zu identifizieren."@de ;
+                             rdfs:label "Objet éditorial connexe"@fr ,
+                                        "Related editorial object"@en ,
+                                        "Zugehöriges redaktionelles Objekt"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasRelatedEssence
 ec:hasRelatedEssence rdf:type owl:ObjectProperty ;
                      rdfs:range ec:Essence ;
-                     dcterms:description "To establish a relation between a MediaResource and an Essence."@en ;
-                     rdfs:label "Related essence"@en .
+                     dcterms:description "Pour établir une relation entre une MediaResource et une Essence."@fr ,
+                                         "To establish a relation between a MediaResource and an Essence."@en ,
+                                         "Um eine Beziehung zwischen einer MediaResource und einer Essenz herzustellen."@de ;
+                     rdfs:label "Essence apparentée"@fr ,
+                                "Related essence"@en ,
+                                "Verwandte Essenz"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasRelatedEvent
 ec:hasRelatedEvent rdf:type owl:ObjectProperty ,
                             owl:IrreflexiveProperty ;
-                   dcterms:description "an event associated with the concept"@en ;
-                   rdfs:label "related event"@en .
+                   dcterms:description "an event associated with the concept"@en ,
+                                       "ein mit dem Konzept verbundenes Ereignis"@de ,
+                                       "un événement associé au concept"@fr ;
+                   rdfs:label "related event"@en ,
+                              "verwandtes Ereignis"@de ,
+                              "événement connexe"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasRelatedMediaFragment
 ec:hasRelatedMediaFragment rdf:type owl:ObjectProperty ;
                            rdfs:range ec:MediaFragment ;
-                           dcterms:description "To associate a Part of an Editorial Object with a MediaFragment within the association MediaResource instantiating the Editrial Object."@en ;
-                           rdfs:label "Media fragment"@en .
+                           dcterms:description "Pour associer une partie d'un objet éditorial à un MediaFragment au sein de l'association MediaResource instanciant l'objet éditorial."@fr ,
+                                               "So verknüpfen Sie einen Teil eines Redaktionsobjekts mit einem MediaFragment innerhalb der Assoziation MediaResource, die das Redaktionsobjekt instanziiert."@de ,
+                                               "To associate a Part of an Editorial Object with a MediaFragment within the association MediaResource instantiating the Editrial Object."@en ;
+                           rdfs:label "Fragment de média"@fr ,
+                                      "Media fragment"@en ,
+                                      "Medienfragment"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasRelatedMediaResource
 ec:hasRelatedMediaResource rdf:type owl:ObjectProperty ;
                            rdfs:range ec:MediaResource ;
-                           dcterms:description "To identify a MediaResource associated with a concept"@en ;
-                           rdfs:label "Related media resource"@en .
+                           dcterms:description "Pour identifier une MediaResource associée à un concept"@fr ,
+                                               "So identifizieren Sie eine mit einem Konzept verbundene MediaResource"@de ,
+                                               "To identify a MediaResource associated with a concept"@en ;
+                           rdfs:label "Related media resource"@en ,
+                                      "Ressource médiatique connexe"@fr ,
+                                      "Verwandte Medienressourcen"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasRelatedPicture
 ec:hasRelatedPicture rdf:type owl:ObjectProperty ;
                      rdfs:range ec:Picture ;
-                     dcterms:description "To associate a Picture with an EditorialObject"@en ;
-                     rdfs:label "Picture"@en .
+                     dcterms:description "Pour associer une image à un EditorialObject"@fr ,
+                                         "So verknüpfen Sie ein Bild mit einem EditorialObject"@de ,
+                                         "To associate a Picture with an EditorialObject"@en ;
+                     rdfs:label "Bild"@de ,
+                                "Photo"@fr ,
+                                "Picture"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasRelatedPublicationChannel
 ec:hasRelatedPublicationChannel rdf:type owl:ObjectProperty ;
                                 rdfs:range ec:PublicationChannel ;
-                                dcterms:description "To identify a Publication Channel"@en ;
-                                rdfs:label "Publication channel"@en .
+                                dcterms:description "Pour identifier un canal de publication"@fr ,
+                                                    "So identifizieren Sie einen Publikationskanal"@de ,
+                                                    "To identify a Publication Channel"@en ;
+                                rdfs:label "Canal de publication"@fr ,
+                                           "Publication channel"@en ,
+                                           "Publikationskanal"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasRelatedPublicationEvent
 ec:hasRelatedPublicationEvent rdf:type owl:ObjectProperty ;
                               rdfs:range ec:PublicationEvent ;
-                              dcterms:description "To identify the PublicationEvent associated with a MediaResource (manifestation of an EditorialObject)."@en ;
-                              rdfs:label "Publication event"@en .
+                              dcterms:description "Pour identifier le PublicationEvent associé à une MediaResource (manifestation d'un EditorialObject)."@fr ,
+                                                  "To identify the PublicationEvent associated with a MediaResource (manifestation of an EditorialObject)."@en ,
+                                                  "Zur Identifizierung des mit einer MediaResource verbundenen PublicationEvent (Manifestation eines EditorialObjects)."@de ;
+                              rdfs:label "Ereignis der Veröffentlichung"@de ,
+                                         "Publication event"@en ,
+                                         "Événement de publication"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasRelatedPublicationService
 ec:hasRelatedPublicationService rdf:type owl:ObjectProperty ;
                                 rdfs:range ec:PublicationService ;
-                                dcterms:description "To establish a relation to publication services."@en ;
-                                rdfs:label "Related publication service"@en .
+                                dcterms:description "To establish a relation to publication services."@en ,
+                                                    "Um eine Beziehung zu den Publikationsdiensten herzustellen."@de ,
+                                                    "Établir une relation avec les services de publication."@fr ;
+                                rdfs:label "Related publication service"@en ,
+                                           "Service de publication connexe"@fr ,
+                                           "Service für verwandte Publikationen"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasRelatedRecord
 ec:hasRelatedRecord rdf:type owl:ObjectProperty ;
                     rdfs:range ec:Record ;
-                    dcterms:description "To associate a Record with an Asset."@en ;
-                    rdfs:label "Related record"@en .
+                    dcterms:description "Pour associer un Enregistrement à un Bien."@fr ,
+                                        "So verknüpfen Sie einen Datensatz mit einem Asset."@de ,
+                                        "To associate a Record with an Asset."@en ;
+                    rdfs:label "Dossier connexe"@fr ,
+                               "Related record"@en ,
+                               "Verwandter Datensatz"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasRelatedResource
 ec:hasRelatedResource rdf:type owl:ObjectProperty ;
                       rdfs:range ec:Resource ;
-                      dcterms:description "To identify a Resource associated with an Asset or an EditorialObject or a PublicationEvent or another Resource."@en ;
-                      rdfs:label "Related resource"@en .
+                      dcterms:description "Pour identifier une ressource associée à un actif ou un EditorialObject ou un PublicationEvent ou une autre ressource."@fr ,
+                                          "To identify a Resource associated with an Asset or an EditorialObject or a PublicationEvent or another Resource."@en ,
+                                          "Um eine Ressource zu identifizieren, die mit einem Asset oder einem EditorialObject oder einem PublicationEvent oder einer anderen Ressource verbunden ist."@de ;
+                      rdfs:label "Related resource"@en ,
+                                 "Ressource connexe"@fr ,
+                                 "Verwandte Ressource"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasRelatedScene
 ec:hasRelatedScene rdf:type owl:ObjectProperty ;
                    rdfs:range ec:Scene ;
-                   dcterms:description "To associate a concept with a Scene"@en ;
-                   rdfs:label "Related scene"@en .
+                   dcterms:description "Pour associer un concept à une Scène"@fr ,
+                                       "So verknüpfen Sie ein Konzept mit einer Szene"@de ,
+                                       "To associate a concept with a Scene"@en ;
+                   rdfs:label "Related scene"@en ,
+                              "Scène connexe"@fr ,
+                              "Verwandte Szene"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasRelatedTextLine
 ec:hasRelatedTextLine rdf:type owl:ObjectProperty ;
                       rdfs:range ec:TextLine ;
-                      dcterms:description "A TextLine or free text related to an EditorialObject."@en ;
-                      rdfs:label "Related text line"@en .
+                      dcterms:description "A TextLine or free text related to an EditorialObject."@en ,
+                                          "Eine Textzeile oder ein freier Text, der sich auf ein EditorialObject bezieht."@de ,
+                                          "Une TextLine ou un texte libre lié à un EditorialObject."@fr ;
+                      rdfs:label "Ligne de texte associée"@fr ,
+                                 "Related text line"@en ,
+                                 "Zugehörige Textzeile"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasRelationSource
 ec:hasRelationSource rdf:type owl:ObjectProperty ;
                      rdfs:range ec:Agent ;
-                     dcterms:description "To define source of a Relation."@en ;
-                     rdfs:label "Relation source"@en .
+                     dcterms:description "Pour définir la source d'une Relation."@fr ,
+                                         "To define source of a Relation."@en ,
+                                         "Um die Quelle einer Relation zu definieren."@de ;
+                     rdfs:label "Relation Quelle"@de ,
+                                "Relation source"@en ,
+                                "Source de la relation"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasReview
 ec:hasReview rdf:type owl:ObjectProperty ;
              rdfs:range ec:Review ;
-             dcterms:description "To provide a review."@en ;
-             rdfs:label "Review"@en .
+             dcterms:description "Pour fournir une revue."@fr ,
+                                 "To provide a review."@en ,
+                                 "Um einen Überblick zu geben."@de ;
+             rdfs:label "Consulter"@fr ,
+                        "Review"@en ,
+                        "Überprüfung"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasRightsClearance
 ec:hasRightsClearance rdf:type owl:ObjectProperty ;
                       rdfs:subPropertyOf ec:isCoveredBy ;
                       rdfs:range ec:RightsClearance ;
-                      dcterms:description "To express Rights Clearance."@en ;
-                      rdfs:label "Rights clearance"@en .
+                      dcterms:description "Pour exprimer l'autorisation des droits."@fr ,
+                                          "To express Rights Clearance."@en ,
+                                          "Zum Ausdruck bringen Rechte Clearance."@de ;
+                      rdfs:label "Apurement des droits"@fr ,
+                                 "Rechteklärung"@de ,
+                                 "Rights clearance"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasRightsHolder
 ec:hasRightsHolder rdf:type owl:ObjectProperty ;
                    rdfs:range ec:Agent ;
-                   dcterms:description """To identify an Agent (Contact/person or
-            Organisation) having/managing Rights."""@en ;
-                   rdfs:label "Rights holder"@en .
+                   dcterms:description "Pour identifier un agent (contact/personne ou Organisation) ayant/gérant des droits."@fr ,
+                                       "To identify an Agent (Contact/person or Organisation) having/managing Rights."@en ,
+                                       "Zur Identifizierung eines Agenten (Kontaktperson/Person oder Organisation), der Rechte besitzt/verwaltet."@de ;
+                   rdfs:label "Rechteinhaber"@de ,
+                              "Rights holder"@en ,
+                              "Titulaire des droits"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasRightsTargetService
 ec:hasRightsTargetService rdf:type owl:ObjectProperty ;
                           rdfs:range ec:PublicationService ;
-                          dcterms:description "To identify a Service associated to Rights."@en ;
-                          rdfs:label "Target service"@en .
+                          dcterms:description "Pour identifier un service associé à des droits."@fr ,
+                                              "To identify a Service associated to Rights."@en ,
+                                              "Um einen mit Rechten verbundenen Service zu identifizieren."@de ;
+                          rdfs:label "Service cible"@fr ,
+                                     "Target service"@en ,
+                                     "Zielservice"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasRole
 ec:hasRole rdf:type owl:ObjectProperty ;
            rdfs:range ec:Role ;
-           dcterms:description """To define the role of an Agent (Contact/person
-            or Organisation). The association in a particular context is made by e.g. declaring the hasCastRole or hasCrewRole  associated with the EditorialObject."""@en ;
-           rdfs:label "Role"@en .
+           dcterms:description "Pour définir le rôle d'un agent (Contact/personne ou Organisation). L'association dans un contexte particulier se fait en déclarant, par exemple, le hasCastRole ou le hasCrewRole associé à l'EditorialObject."@fr ,
+                               "So definieren Sie die Rolle eines Agenten (Kontakt/Person oder Organisation). Die Assoziation in einem bestimmten Kontext erfolgt z.B. durch die Angabe von hasCastRole oder hasCrewRole in Verbindung mit dem EditorialObject."@de ,
+                               "To define the role of an Agent (Contact/person or Organisation). The association in a particular context is made by e.g. declaring the hasCastRole or hasCrewRole associated with the EditorialObject."@en ;
+           rdfs:label "Role"@en ,
+                      "Rolle"@de ,
+                      "Rôle"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasScene
 ec:hasScene rdf:type owl:ObjectProperty ;
             rdfs:subPropertyOf ec:hasPart ;
-            rdfs:label "has scene"@en .
+            rdfs:label "a scène"@fr ,
+                       "has scene"@en ,
+                       "hat Szene"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasSeason
 ec:hasSeason rdf:type owl:ObjectProperty ;
              rdfs:range ec:Season ;
-             dcterms:description "To identiify Seasons in a Series."@en ;
-             rdfs:label "Season"@en .
+             dcterms:description "Pour identifier les saisons d'une série."@fr ,
+                                 "To identiify Seasons in a Series."@en ,
+                                 "Zur Identifizierung von Jahreszeiten in einer Serie."@de ;
+             rdfs:label "Saison"@de ,
+                        "Saison"@fr ,
+                        "Season"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasSerial
 ec:hasSerial rdf:type owl:ObjectProperty ;
-             rdfs:label "has serial"@en .
+             rdfs:label "a une série"@fr ,
+                        "has serial"@en ,
+                        "hat serielle"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasServiceGenre
 ec:hasServiceGenre rdf:type owl:ObjectProperty ;
                    rdfs:range ec:Genre ;
-                   dcterms:description "The genre of content associated with the Service."@en ;
-                   rdfs:label "Service genre"@en .
+                   dcterms:description "Das Genre des mit dem Dienst verbundenen Inhalts."@de ,
+                                       "Le genre de contenu associé au service."@fr ,
+                                       "The genre of content associated with the Service."@en ;
+                   rdfs:label "Genre Dienstleistung"@de ,
+                              "Genre de service"@fr ,
+                              "Service genre"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasShot
 ec:hasShot rdf:type owl:ObjectProperty ;
            rdfs:subPropertyOf ec:hasPart ;
-           rdfs:label "has shot"@en .
+           rdfs:label "a tiré"@fr ,
+                      "has shot"@en ,
+                      "hat geschossen"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasSigning
 ec:hasSigning rdf:type owl:ObjectProperty ;
               rdfs:range ec:Signing ;
-              dcterms:description "To identify the presence of Signing associated to the EditorialObject."@en ;
-              rdfs:label "Accessibility - signing"@en .
+              dcterms:description "Pour identifier la présence d'une signature associée à l'EditorialObject."@fr ,
+                                  "To identify the presence of Signing associated to the EditorialObject."@en ,
+                                  "Um das Vorhandensein von Signaturen im Zusammenhang mit dem EditorialObject festzustellen."@de ;
+              rdfs:label "Accessibility - signing"@en ,
+                         "Accessibilité - signature"@fr ,
+                         "Zugänglichkeit - Beschilderung"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasSigningFormat
 ec:hasSigningFormat rdf:type owl:ObjectProperty ;
                     rdfs:range ec:SigningFormat ;
-                    dcterms:description "To specify the format used for signing."@en ;
-                    rdfs:label "Signing format"@en .
+                    dcterms:description "Pour spécifier le format utilisé pour la signature."@fr ,
+                                        "To specify the format used for signing."@en ,
+                                        "Zur Angabe des für die Unterzeichnung verwendeten Formats."@de ;
+                    rdfs:label "Format de signature"@fr ,
+                               "Format der Unterschrift"@de ,
+                               "Signing format"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasSigningSource
 ec:hasSigningSource rdf:type owl:ObjectProperty ;
                     rdfs:range ec:Agent ;
-                    dcterms:description "To specify the source of signing."@en ;
-                    rdfs:label "Signing source"@en .
+                    dcterms:description "Pour spécifier la source de la signature."@fr ,
+                                        "So geben Sie die Quelle der Signierung an."@de ,
+                                        "To specify the source of signing."@en ;
+                    rdfs:label "Quelle der Signierung"@de ,
+                               "Signing source"@en ,
+                               "Source de signature"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasSource
 ec:hasSource rdf:type owl:ObjectProperty ;
              rdfs:range ec:MediaResource ;
-             dcterms:description "To identify the source of a MediaResource."@en ;
-             rdfs:label "Source"@en .
+             dcterms:description "Pour identifier la source d'une MediaResource."@fr ,
+                                 "To identify the source of a MediaResource."@en ,
+                                 "Um die Quelle einer MediaResource zu identifizieren."@de ;
+             rdfs:label "Quelle"@de ,
+                        "Source"@en ,
+                        "Source :"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasStaffMember
 ec:hasStaffMember rdf:type owl:ObjectProperty ;
                   rdfs:range ec:StaffMember ;
-                  dcterms:description "To identify members of staff in an organisation."@en ;
-                  rdfs:label "member of Staff"@en .
+                  dcterms:description "Pour identifier les membres du personnel d'une organisation."@fr ,
+                                      "To identify members of staff in an organisation."@en ,
+                                      "Zur Identifizierung von Mitarbeitern in einer Organisation."@de ;
+                  rdfs:label "Mitglied des Personals"@de ,
+                             "member of Staff"@en ,
+                             "membre du personnel"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasStakeholder
 ec:hasStakeholder rdf:type owl:ObjectProperty ;
                   rdfs:range ec:Agent ;
-                  dcterms:description "An Agent related to the PublicationPlan."@en ;
-                  rdfs:label "Publication plan stakeholder"@en .
+                  dcterms:description "An Agent related to the PublicationPlan."@en ,
+                                      "Ein Agent, der sich auf den PublicationPlan bezieht."@de ,
+                                      "Un agent lié au PublicationPlan."@fr ;
+                  rdfs:label "Intervenant du plan de publication"@fr ,
+                             "Publication plan stakeholder"@en ,
+                             "Publikationsplan Stakeholder"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasStandard
 ec:hasStandard rdf:type owl:ObjectProperty ;
                rdfs:subPropertyOf ec:hasFormat ;
                rdfs:range ec:Standard ;
-               dcterms:description "Identifies the technical video standard of a MediaResource, i.e. NTSC or PAL."@en ;
-               rdfs:label "Standard"@en .
+               dcterms:description "Identifie la norme vidéo technique d'une MediaResource, c'est-à-dire NTSC ou PAL."@fr ,
+                                   "Identifies the technical video standard of a MediaResource, i.e. NTSC or PAL."@en ,
+                                   "Identifiziert den technischen Videostandard einer MediaResource, d.h. NTSC oder PAL."@de ;
+               rdfs:label "Standard"@de ,
+                          "Standard"@en ,
+                          "Standard"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasStorageId
 ec:hasStorageId rdf:type owl:ObjectProperty ;
                 rdfs:range ec:Identifier ;
-                dcterms:description "To identify storage associated with a locator from which a Resource can be accessed or can be retrieved."@en ;
-                rdfs:label "Storage identifier"@en .
+                dcterms:description "Identifier le stockage associé à un localisateur à partir duquel une ressource peut être accédée ou peut être récupérée."@fr ,
+                                    "To identify storage associated with a locator from which a Resource can be accessed or can be retrieved."@en ,
+                                    "Zur Identifizierung des mit einem Locator verbundenen Speichers, von dem aus auf eine Ressource zugegriffen werden kann oder die abgerufen werden kann."@de ;
+                rdfs:label "Identifiant de stockage"@fr ,
+                           "Kennung des Speichers"@de ,
+                           "Storage identifier"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasStorageType
 ec:hasStorageType rdf:type owl:ObjectProperty ;
                   rdfs:range ec:Storage_Type ;
-                  dcterms:description "To define a type of storage associated with a locator from which a Resource can be accessed or can be retrieved."@en ;
-                  rdfs:label "Storage type"@en .
+                  dcterms:description "Définir un type de stockage associé à un localisateur à partir duquel une ressource peut être accédée ou peut être récupérée."@fr ,
+                                      "To define a type of storage associated with a locator from which a Resource can be accessed or can be retrieved."@en ,
+                                      "Zur Definition eines Speichertyps, der mit einem Locator verknüpft ist, von dem aus auf eine Ressource zugegriffen werden kann oder die abgerufen werden kann."@de ;
+                  rdfs:label "Art der Lagerung"@de ,
+                             "Storage type"@en ,
+                             "Type de stockage"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasSubject
 ec:hasSubject rdf:type owl:ObjectProperty ;
               rdfs:range ec:Subject ;
-              dcterms:description "This property enables to associate an Asset with a subject which can be a string or a URI pointing to a term from a controlled vocabulary."@en ;
-              rdfs:label "Subject"@en .
+              dcterms:description "Cette propriété permet d'associer un actif à un sujet qui peut être une chaîne ou une URI pointant vers un terme d'un vocabulaire contrôlé."@fr ,
+                                  "Diese Eigenschaft ermöglicht es, ein Asset mit einem Betreff zu verknüpfen, der eine Zeichenkette oder ein URI sein kann, der auf einen Begriff aus einem kontrollierten Vokabular verweist."@de ,
+                                  "This property enables to associate an Asset with a subject which can be a string or a URI pointing to a term from a controlled vocabulary."@en ;
+              rdfs:label "Subject"@en ,
+                         "Sujet"@fr ,
+                         "Thema"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasSubtitling
 ec:hasSubtitling rdf:type owl:ObjectProperty ;
                  rdfs:range ec:Subtitling ;
-                 dcterms:description "To identify existing subtitling."@en ;
-                 rdfs:label "Subtitling"@en .
+                 dcterms:description "Pour identifier le sous-titrage existant."@fr ,
+                                     "To identify existing subtitling."@en ,
+                                     "Um vorhandene Untertitel zu identifizieren."@de ;
+                 rdfs:label "Sous-titrage"@fr ,
+                            "Subtitling"@en ,
+                            "Untertitelung"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasSubtitlingFormat
 ec:hasSubtitlingFormat rdf:type owl:ObjectProperty ;
                        rdfs:subPropertyOf ec:hasFormat ;
                        rdfs:range ec:SubtitlingFormat ;
-                       dcterms:description "The format of Subtitling."@en ;
-                       rdfs:label "Subtitling format"@en .
+                       dcterms:description "Das Format der Untertitelung."@de ,
+                                           "Le format du sous-titrage."@fr ,
+                                           "The format of Subtitling."@en ;
+                       rdfs:label "Format de sous-titrage"@fr ,
+                                  "Format der Untertitelung"@de ,
+                                  "Subtitling format"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasSubtitlingSource
 ec:hasSubtitlingSource rdf:type owl:ObjectProperty ;
                        rdfs:range ec:Agent ;
-                       dcterms:description """To identify the source of the Subtitling
-            resource."""@en ;
-                       rdfs:label "Subtitling source"@en .
+                       dcterms:description "Pour identifier la source du sous-titrage de la ressource."@fr ,
+                                           "To identify the source of the Subtitling resource."@en ,
+                                           "Um die Quelle der Untertitelung zu identifizieren Ressource."@de ;
+                       rdfs:label "Quelle für die Untertitelung"@de ,
+                                  "Source de sous-titrage"@fr ,
+                                  "Subtitling source"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasTake
 ec:hasTake rdf:type owl:ObjectProperty ;
            rdfs:subPropertyOf ec:hasPart ;
-           rdfs:label "has take"@en .
+           rdfs:label "a pris"@fr ,
+                      "has take"@en ,
+                      "hat angenommen"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasTargetAudience
 ec:hasTargetAudience rdf:type owl:ObjectProperty ;
-                     dcterms:description "To associate a TargetAudience (e.g. for parental guiddance or targeting a particular social group) with a EditorialObject"@en ;
-                     rdfs:label "Target audience"@en .
+                     dcterms:description "Pour associer une TargetAudience (par exemple, pour l'orientation parentale ou le ciblage d'un groupe social particulier) à un EditorialObject."@fr ,
+                                         "To associate a TargetAudience (e.g. for parental guiddance or targeting a particular social group) with a EditorialObject"@en ,
+                                         "Um ein TargetAudience (z.B. für elterliche Ratschläge oder für eine bestimmte soziale Gruppe) mit einem EditorialObject zu verbinden"@de ;
+                     rdfs:label "Public cible"@fr ,
+                                "Target audience"@en ,
+                                "Zielpublikum"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasTargetPlatform
 ec:hasTargetPlatform rdf:type owl:ObjectProperty ;
                      rdfs:range ec:PublicationPlatform ;
-                     dcterms:description "To specify a target platform."@en ;
-                     rdfs:label "Target platform"@en .
+                     dcterms:description "Pour spécifier une plate-forme cible."@fr ,
+                                         "To specify a target platform."@en ,
+                                         "Um eine Zielplattform anzugeben."@de ;
+                     rdfs:label "Plate-forme cible"@fr ,
+                                "Target platform"@en ,
+                                "Ziel-Plattform"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasTeamMember
 ec:hasTeamMember rdf:type owl:ObjectProperty ;
                  rdfs:range ec:Person ;
-                 dcterms:description "To identify the members of a Team"@en ;
-                 rdfs:label "Team member"@en .
+                 dcterms:description "Pour identifier les membres d'une équipe"@fr ,
+                                     "So identifizieren Sie die Mitglieder eines Teams"@de ,
+                                     "To identify the members of a Team"@en ;
+                 rdfs:label "Membre de l'équipe"@fr ,
+                            "Team member"@en ,
+                            "Teammitglied"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasTextLineSource
 ec:hasTextLineSource rdf:type owl:ObjectProperty ;
                      rdfs:range ec:Agent ;
-                     dcterms:description "To identify the source of a TextLine."@en ;
-                     rdfs:label "Text line source"@en .
+                     dcterms:description "Pour identifier la source d'un TextLine."@fr ,
+                                         "So identifizieren Sie die Quelle einer Textzeile."@de ,
+                                         "To identify the source of a TextLine."@en ;
+                     rdfs:label "Quelle der Textzeile"@de ,
+                                "Source de la ligne de texte"@fr ,
+                                "Text line source"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasTheme
 ec:hasTheme rdf:type owl:ObjectProperty ;
             rdfs:subPropertyOf ec:hasSubject ;
             rdfs:range ec:Theme ;
-            dcterms:description "This property enables to associate an Asset with a theme which can be a string or a URI pointing to a term from a controlled vocabulary. A typical example is the Eurostats NACE classification."@en ;
-            rdfs:label "Theme"@en .
+            dcterms:description "Cette propriété permet d'associer un actif à un thème qui peut être une chaîne ou un URI pointant vers un terme d'un vocabulaire contrôlé. Un exemple typique est la classification NACE d'Eurostats."@fr ,
+                                "Diese Eigenschaft ermöglicht es, ein Asset mit einem Thema zu verknüpfen, das eine Zeichenkette oder ein URI sein kann, der auf einen Begriff aus einem kontrollierten Vokabular verweist. Ein typisches Beispiel ist die NACE-Klassifizierung von Eurostats."@de ,
+                                "This property enables to associate an Asset with a theme which can be a string or a URI pointing to a term from a controlled vocabulary. A typical example is the Eurostats NACE classification."@en ;
+            rdfs:label "Thema"@de ,
+                       "Theme"@en ,
+                       "Thème"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasTimecodeTrack
 ec:hasTimecodeTrack rdf:type owl:ObjectProperty ;
                     rdfs:range ec:TimecodeTrack ;
-                    dcterms:description "To identify a timecode track with a MediaResource."@en ;
-                    rdfs:label "Timecode track"@en .
+                    dcterms:description "Pour identifier une piste de timecode avec une MediaResource."@fr ,
+                                        "So identifizieren Sie eine Timecode-Spur mit einer MediaResource."@de ,
+                                        "To identify a timecode track with a MediaResource."@en ;
+                    rdfs:label "Piste de timecode"@fr ,
+                               "Timecode track"@en ,
+                               "Timecode-Spur"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasTimelineTrack
 ec:hasTimelineTrack rdf:type owl:ObjectProperty ;
                     rdfs:range ec:TimelineTrack ;
-                    dcterms:description "To associate a TimelineTrack with an EditorialObject"@en ;
-                    rdfs:label "Timeline track"@en .
+                    dcterms:description "Pour associer un TimelineTrack à un EditorialObject"@fr ,
+                                        "So verknüpfen Sie einen TimelineTrack mit einem EditorialObject"@de ,
+                                        "To associate a TimelineTrack with an EditorialObject"@en ;
+                    rdfs:label "Piste chronologique"@fr ,
+                               "Timeline track"@en ,
+                               "Zeitleiste Spur"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasTimelineTrackPart
 ec:hasTimelineTrackPart rdf:type owl:ObjectProperty ;
                         rdfs:range ec:EditorialObject ;
-                        dcterms:description "To associate an EditorialObject to a TimelineTrack as an TimelineTrackpart"@en ;
-                        rdfs:label "Timeline track part"@en .
+                        dcterms:description "Pour associer un EditorialObject à une TimelineTrack en tant que TimelineTrackpart"@fr ,
+                                            "So verknüpfen Sie ein EditorialObject mit einem TimelineTrack als TimelineTrackpart"@de ,
+                                            "To associate an EditorialObject to a TimelineTrack as an TimelineTrackpart"@en ;
+                        rdfs:label "Partie de la piste de la ligne de temps"@fr ,
+                                   "Teil der Zeitleiste"@de ,
+                                   "Timeline track part"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasTopic
 ec:hasTopic rdf:type owl:ObjectProperty ;
             rdfs:subPropertyOf ec:hasSubject ;
-            dcterms:description "This property enables to associate an Asset with a topic which can be a string or a URI pointing to a term from a controlled vocabulary. A typical example is to make use of the IPTC Media Topics defined at http://cv.iptc.org/newscodes/mediatopic/."@en ;
-            rdfs:label "Topic"@en .
+            dcterms:description "Cette propriété permet d'associer un actif à un sujet qui peut être une chaîne ou une URI pointant vers un terme d'un vocabulaire contrôlé. Un exemple typique est l'utilisation des sujets IPTC Media Topics définis sur http://cv.iptc.org/newscodes/mediatopic/."@fr ,
+                                "Mit dieser Eigenschaft können Sie ein Asset mit einem Thema verknüpfen, das eine Zeichenkette oder ein URI sein kann, der auf einen Begriff aus einem kontrollierten Vokabular verweist. Ein typisches Beispiel ist die Verwendung der IPTC-Medienthemen, die unter http://cv.iptc.org/newscodes/mediatopic/ definiert sind."@de ,
+                                "This property enables to associate an Asset with a topic which can be a string or a URI pointing to a term from a controlled vocabulary. A typical example is to make use of the IPTC Media Topics defined at http://cv.iptc.org/newscodes/mediatopic/."@en ;
+            rdfs:label "Sujet"@fr ,
+                       "Thema"@de ,
+                       "Topic"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasTrack
 ec:hasTrack rdf:type owl:ObjectProperty ;
             rdfs:range ec:Track ;
-            dcterms:description "To associate audio/data/video tracks with a MediaResource."@en ;
-            rdfs:label "Track"@en .
+            dcterms:description "Pour associer des pistes audio/données/vidéo à une MediaResource."@fr ,
+                                "So verknüpfen Sie Audio-/Daten-/Videotracks mit einer MediaResource."@de ,
+                                "To associate audio/data/video tracks with a MediaResource."@en ;
+            rdfs:label "Piste"@fr ,
+                       "Spur"@de ,
+                       "Track"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasTrackPart
 ec:hasTrackPart rdf:type owl:ObjectProperty ;
                 rdfs:range ec:MediaResource ;
-                dcterms:description "An element to identify a part of a track by a title, a start time and an end time in both the media source and media destinationn."@en ;
-                rdfs:label "Track part source"@en .
+                dcterms:description "An element to identify a part of a track by a title, a start time and an end time in both the media source and media destinationn."@en ,
+                                    "Ein Element zur Identifizierung eines Teils eines Titels durch einen Titel, eine Startzeit und eine Endzeit sowohl in der Medienquelle als auch im Medienziel."@de ,
+                                    "Un élément pour identifier une partie d'une piste par un titre, une heure de début et une heure de fin dans la source du média et la destination du médian."@fr ;
+                rdfs:label "Quelle des Trackings"@de ,
+                           "Source de la partie de la voie"@fr ,
+                           "Track part source"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasTrackPurpose
 ec:hasTrackPurpose rdf:type owl:ObjectProperty ;
                    rdfs:range ec:TrackPurpose ;
-                   dcterms:description "The purpose for which the Track is provided."@en ;
-                   rdfs:label "Track purpose"@en .
+                   dcterms:description "Der Zweck, für den der Track bereitgestellt wird."@de ,
+                                       "Le but pour lequel la piste est fournie."@fr ,
+                                       "The purpose for which the Track is provided."@en ;
+                   rdfs:label "Objectif de la voie"@fr ,
+                              "Track purpose"@en ,
+                              "Zweck der Spur"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasTrackType
 ec:hasTrackType rdf:type owl:ObjectProperty ;
                 rdfs:range ec:Track_Type ;
-                dcterms:description "The type attributed to a Track."@en ;
-                rdfs:label "Track name"@en .
+                dcterms:description "Der Typ, der einem Track zugeordnet ist."@de ,
+                                    "Le type attribué à une piste."@fr ,
+                                    "The type attributed to a Track."@en ;
+                rdfs:label "Name der Spur"@de ,
+                           "Nom de la piste"@fr ,
+                           "Track name"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasUsageRestrictions
 ec:hasUsageRestrictions rdf:type owl:ObjectProperty ;
                         rdfs:subPropertyOf ec:isCoveredBy ;
                         rdfs:range ec:UsageRestrictions ;
-                        dcterms:description "To express usage restrictions."@en ;
-                        rdfs:label "Usage restrictions"@en .
+                        dcterms:description "Pour exprimer des restrictions d'utilisation."@fr ,
+                                            "To express usage restrictions."@en ,
+                                            "Um Nutzungseinschränkungen auszudrücken."@de ;
+                        rdfs:label "Einschränkungen bei der Verwendung"@de ,
+                                   "Restrictions d'utilisation"@fr ,
+                                   "Usage restrictions"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasUsageRights
 ec:hasUsageRights rdf:type owl:ObjectProperty ;
                   rdfs:subPropertyOf ec:isCoveredBy ;
                   rdfs:range ec:UsageRights ;
-                  dcterms:description "To express usage rights."@en ;
-                  rdfs:label "Usage rights"@en .
+                  dcterms:description "Pour exprimer les droits d'utilisation."@fr ,
+                                      "To express usage rights."@en ,
+                                      "Um Nutzungsrechte auszudrücken."@de ;
+                  rdfs:label "Droits d'utilisation"@fr ,
+                             "Nutzungsrechte"@de ,
+                             "Usage rights"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasVersion
 ec:hasVersion rdf:type owl:ObjectProperty ;
               owl:inverseOf ec:isVersionOf ;
               rdfs:range ec:EditorialObject ;
-              dcterms:description "To identify another version of an Asset, EditorialObject or Resource."@en ;
-              rdfs:label "Version"@en .
+              dcterms:description "Pour identifier une autre version d'un actif, d'un objet éditorial ou d'une ressource."@fr ,
+                                  "To identify another version of an Asset, EditorialObject or Resource."@en ,
+                                  "Um eine andere Version eines Assets, Redaktionsobjekts oder einer Ressource zu identifizieren."@de ;
+              rdfs:label "Version"@de ,
+                         "Version"@en ,
+                         "Version"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasVideoCodec
 ec:hasVideoCodec rdf:type owl:ObjectProperty ;
                  rdfs:subPropertyOf ec:hasCodec ;
                  rdfs:range ec:VideoCodec ;
-                 dcterms:description "To identify a video codec"@en ;
-                 rdfs:label "Video codec"@en .
+                 dcterms:description "Pour identifier un codec vidéo"@fr ,
+                                     "So identifizieren Sie einen Videocodec"@de ,
+                                     "To identify a video codec"@en ;
+                 rdfs:label "Codec vidéo"@fr ,
+                            "Video Codec"@de ,
+                            "Video codec"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasVideoEncodingFormat
 ec:hasVideoEncodingFormat rdf:type owl:ObjectProperty ;
                           rdfs:subPropertyOf ec:hasFormat ;
                           rdfs:range ec:VideoEncodingFormat ;
-                          dcterms:description "To specify the video encoding format."@en ;
-                          rdfs:label "Audio encoding format"@en .
+                          dcterms:description "Pour spécifier le format d'encodage vidéo."@fr ,
+                                              "To specify the video encoding format."@en ,
+                                              "Zur Angabe des Videocodierungsformats."@de ;
+                          rdfs:label "Audio encoding format"@en ,
+                                     "Format d'encodage audio"@fr ,
+                                     "Format der Audiokodierung"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasVideoTrack
 ec:hasVideoTrack rdf:type owl:ObjectProperty ;
                  rdfs:range ec:VideoTrack ;
-                 dcterms:description "To identify VideoTracks in the Resource."@en ;
-                 rdfs:label "Video track"@en .
+                 dcterms:description "Pour identifier les VideoTracks dans la ressource."@fr ,
+                                     "So identifizieren Sie Videospuren in der Ressource."@de ,
+                                     "To identify VideoTracks in the Resource."@en ;
+                 rdfs:label "Piste vidéo"@fr ,
+                            "Video track"@en ,
+                            "Video-Spur"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasWrappingType
 ec:hasWrappingType rdf:type owl:ObjectProperty ;
                    rdfs:range ec:WrappingType ;
-                   dcterms:description "To specify the type of wrapping."@en ;
-                   rdfs:label "Wrapping type"@en .
+                   dcterms:description "Pour spécifier le type d'emballage."@fr ,
+                                       "To specify the type of wrapping."@en ,
+                                       "Um die Art der Umhüllung festzulegen."@de ;
+                   rdfs:label "Art der Umhüllung"@de ,
+                              "Type d'emballage"@fr ,
+                              "Wrapping type"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#instantiates
 ec:instantiates rdf:type owl:ObjectProperty ;
                 owl:inverseOf ec:isInstantiatedBy ;
                 rdfs:range ec:EditorialObject ;
-                dcterms:description "To link a particular manifestation of an EditorialObject to the corresponding Resource."@en ;
-                rdfs:label "Editorial object"@en .
+                dcterms:description "Pour lier une manifestation particulière d'un objet éditorial à la ressource correspondante."@fr ,
+                                    "To link a particular manifestation of an EditorialObject to the corresponding Resource."@en ,
+                                    "Um eine bestimmte Manifestation eines EditorialObjects mit der entsprechenden Ressource zu verknüpfen."@de ;
+                rdfs:label "Editorial object"@en ,
+                           "Objet de la rédaction"@fr ,
+                           "Redaktionelles Objekt"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#isAffiliatedTo
 ec:isAffiliatedTo rdf:type owl:ObjectProperty ;
                   rdfs:range ec:Organisation ;
-                  dcterms:description "Relation to the organisation the affiliation represents"@en ;
-                  rdfs:label "is affiliated to"@en .
+                  dcterms:description "Beziehung zu der Organisation, die der Verband vertritt"@de ,
+                                      "Relation avec l'organisation que l'affiliation représente"@fr ,
+                                      "Relation to the organisation the affiliation represents"@en ;
+                  rdfs:label "est affilié à"@fr ,
+                             "is affiliated to"@en ,
+                             "ist angegliedert an"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#isAgent
 ec:isAgent rdf:type owl:ObjectProperty ,
                     owl:IrreflexiveProperty ;
            rdfs:range ec:Agent ;
-           dcterms:description "Range: string or Agent."@en ,
-                               "To identify a related Agent. I.e. a person related to a call for a function on a production plan."@en .
+           dcterms:description "Pour identifier un agent lié. C'est-à-dire une personne liée à un appel pour une fonction sur un plan de production. Plage : chaîne de caractères ou agent."@fr ,
+                               "To identify a related Agent. I.e. a person related to a call for a function on a production plan. Range: string or Agent."@en ,
+                               "Um einen verwandten Agenten zu identifizieren. D.h. eine Person, die mit einem Anruf für eine Funktion in einem Produktionsplan verbunden ist. Bereich: String oder Agent."@de ;
+           rdfs:label "Est Agent"@fr ,
+                      "isAgent"@en ,
+                      "ist Agent"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#isAnimalGroom
 ec:isAnimalGroom rdf:type owl:ObjectProperty ;
                  rdfs:range ec:Agent ;
-                 dcterms:description "To identify the groom / care taker of an animal."@en ;
-                 rdfs:label "Animal groom"@en .
+                 dcterms:description "Identifier le palefrenier / le soigneur d'un animal."@fr ,
+                                     "To identify the groom / care taker of an animal."@en ,
+                                     "Zur Identifizierung des Pflegers / Betreuers eines Tieres."@de ;
+                 rdfs:label "Animal groom"@en ,
+                            "Tierpfleger"@de ,
+                            "Toilette pour animaux"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#isAnimalOwner
 ec:isAnimalOwner rdf:type owl:ObjectProperty ;
                  rdfs:range ec:Agent ;
-                 dcterms:description "To identify the owner of an animal."@en ;
-                 rdfs:label "Animal owner"@en .
+                 dcterms:description "Pour identifier le propriétaire d'un animal."@fr ,
+                                     "To identify the owner of an animal."@en ,
+                                     "Um den Besitzer eines Tieres zu identifizieren."@de ;
+                 rdfs:label "Animal owner"@en ,
+                            "Propriétaire d'animaux"@fr ,
+                            "Tierhalter"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#isAnimatedBy
 ec:isAnimatedBy rdf:type owl:ObjectProperty ;
                 rdfs:range ec:Person ;
-                dcterms:description "Character, animated by a persion using an artifact"@en ;
-                rdfs:label "is animated by"@en .
+                dcterms:description "Character, animated by a persion using an artifact"@en ,
+                                    "Charakter, der von einer Persion mit Hilfe eines Artefakts animiert wird"@de ,
+                                    "Personnage, animé par une persion utilisant un artefact"@fr ;
+                rdfs:label "est animé par"@fr ,
+                           "is animated by"@en ,
+                           "wird animiert von"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#isAnnotatedMediaResource
 ec:isAnnotatedMediaResource rdf:type owl:ObjectProperty ;
                             rdfs:range ec:MediaResource ;
-                            dcterms:description "To link an Annotation to a MediaResource."@en ;
-                            rdfs:label "Media resource"@en .
+                            dcterms:description "Pour lier une Annotation à une MediaResource."@fr ,
+                                                "So verknüpfen Sie eine Anmerkung mit einer MediaResource."@de ,
+                                                "To link an Annotation to a MediaResource."@en ;
+                            rdfs:label "Media resource"@en ,
+                                       "Medienressource"@de ,
+                                       "Ressource médiatique"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#isAnnotationBy
 ec:isAnnotationBy rdf:type owl:ObjectProperty ;
                   rdfs:range ec:Agent ;
-                  dcterms:description "To link an Annotation to an Agent who created it."@en ;
-                  rdfs:label "Agent"@en .
+                  dcterms:description "Pour lier une annotation à l'agent qui l'a créée."@fr ,
+                                      "So verknüpfen Sie eine Anmerkung mit einem Agenten, der sie erstellt hat."@de ,
+                                      "To link an Annotation to an Agent who created it."@en ;
+                  rdfs:label "Agent"@de ,
+                             "Agent"@en ,
+                             "Agent"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#isAttributedTo
 ec:isAttributedTo rdf:type owl:ObjectProperty ;
                   rdfs:range ec:Agent ;
-                  dcterms:description "To associate an Agent with a Provenance instance."@en ;
-                  rdfs:label "Provenance target"@en .
+                  dcterms:description "Pour associer un agent à une instance de Provenance."@fr ,
+                                      "So verknüpfen Sie einen Agenten mit einer Provenance-Instanz."@de ,
+                                      "To associate an Agent with a Provenance instance."@en ;
+                  rdfs:label "Cible de provenance"@fr ,
+                             "Provenance target"@en ,
+                             "Ziel Provenienz"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#isBrand
 ec:isBrand rdf:type owl:ObjectProperty ;
            rdfs:range ec:Brand ;
-           dcterms:description "To identify a Brand."@en ;
-           rdfs:label "Brand"@en .
+           dcterms:description "Pour identifier une Marque."@fr ,
+                               "To identify a Brand."@en ,
+                               "Um eine Marke zu identifizieren."@de ;
+           rdfs:label "Brand"@en ,
+                      "Marke"@de ,
+                      "Marque"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#isCharacter
 ec:isCharacter rdf:type owl:ObjectProperty ;
                rdfs:range ec:Character ;
-               dcterms:description "To identify a character."@en ;
-               rdfs:label "Fictional character."@en .
+               dcterms:description "Pour identifier un personnage."@fr ,
+                                   "To identify a character."@en ,
+                                   "Um einen Charakter zu identifizieren."@de ;
+               rdfs:label "Fictional character."@en ,
+                          "Fiktiver Charakter."@de ,
+                          "Personnage fictif."@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#isChildOf
 ec:isChildOf rdf:type owl:ObjectProperty ;
              owl:inverseOf ec:isParentOf ;
              rdfs:range ec:Asset ;
-             dcterms:description "To link a concept to a parent."@en ;
-             rdfs:label "Parent"@en .
+             dcterms:description "Pour lier un concept à un parent."@fr ,
+                                 "To link a concept to a parent."@en ,
+                                 "Um ein Konzept mit einem übergeordneten Konzept zu verknüpfen."@de ;
+             rdfs:label "Eltern"@de ,
+                        "Parent"@en ,
+                        "Parent"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#isClonedFrom
 ec:isClonedFrom rdf:type owl:ObjectProperty ;
                 rdfs:range ec:MediaResource ;
-                dcterms:description "To identify the source of a clone MediaResource"@en ;
-                rdfs:label "Clone source"@en .
+                dcterms:description "Pour identifier la source d'une MediaResource clonée"@fr ,
+                                    "So identifizieren Sie die Quelle einer geklonten MediaResource"@de ,
+                                    "To identify the source of a clone MediaResource"@en ;
+                rdfs:label "Clone source"@en ,
+                           "Cloner la source"@fr ,
+                           "Quelle klonen"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#isComposedOf
 ec:isComposedOf rdf:type owl:ObjectProperty ;
                 rdfs:range ec:MediaResource ;
-                dcterms:description "To identify mediaResources used to compose an Essence."@en ;
-                rdfs:label "Media Resource"@en .
+                dcterms:description "Identifier les mediaRessources utilisées pour composer une Essence."@fr ,
+                                    "To identify mediaResources used to compose an Essence."@en ,
+                                    "Zur Identifizierung von MedienRessourcen, die zur Erstellung einer Essenz verwendet werden."@de ;
+                rdfs:label "Media Resource"@en ,
+                           "Medien Ressource"@de ,
+                           "Ressource médiatique"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#isCoveredBy
 ec:isCoveredBy rdf:type owl:ObjectProperty ;
-               rdfs:range ec:Rights .
+               rdfs:range ec:Rights ;
+               rdfs:label "Est couvert par"@fr ,
+                          "Is covered by"@en ,
+                          "Wird abgedeckt durch"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#isDerivedFrom
 ec:isDerivedFrom rdf:type owl:ObjectProperty ;
                  rdfs:range ec:Asset ;
-                 dcterms:description "Identifies a content-based relationship between two resources."@en ;
-                 rdfs:label "Derived from"@en .
+                 dcterms:description "Identifie une relation basée sur le contenu entre deux ressources."@fr ,
+                                     "Identifies a content-based relationship between two resources."@en ,
+                                     "Identifiziert eine inhaltsbezogene Beziehung zwischen zwei Ressourcen."@de ;
+                 rdfs:label "Abgeleitet von"@de ,
+                            "Derived from"@en ,
+                            "Dérivé de"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#isDistributedOn
 ec:isDistributedOn rdf:type owl:ObjectProperty ;
                    rdfs:range ec:PublicationService ;
-                   dcterms:description "To identify the platform on which content is distributed."@en ;
-                   rdfs:label "Platform/Service/PublicationChannel"@en .
+                   dcterms:description "Pour identifier la plateforme sur laquelle le contenu est distribué."@fr ,
+                                       "To identify the platform on which content is distributed."@en ,
+                                       "Um die Plattform zu identifizieren, auf der die Inhalte verbreitet werden."@de ;
+                   rdfs:label "Plate-forme/Service/Canal de publication"@fr ,
+                              "Platform/Service/PublicationChannel"@en ,
+                              "Plattform/Dienstleistung/Veröffentlichungskanal"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#isDubbedFrom
 ec:isDubbedFrom rdf:type owl:ObjectProperty ;
                 rdfs:range ec:MediaResource ;
-                dcterms:description "the origin of a dubbed MediaResource."@en ;
-                rdfs:label "Dubbed from"@en .
+                dcterms:description "die Herkunft einer überspielten MediaResource."@de ,
+                                    "l'origine d'une MediaResource doublée."@fr ,
+                                    "the origin of a dubbed MediaResource."@en ;
+                rdfs:label "Doublé de"@fr ,
+                           "Dubbed from"@en ,
+                           "Synchronisiert von"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#isEditorialFormatOf
 ec:isEditorialFormatOf rdf:type owl:ObjectProperty ;
                        rdfs:range ec:EditorialObject ;
-                       dcterms:description "To identify an Editorial Object based on the same Editorial format"@en ;
+                       dcterms:description "Pour identifier un objet éditorial basé sur le même format éditorial"@fr ,
+                                           "So identifizieren Sie ein redaktionelles Objekt, das auf demselben redaktionellen Format basiert"@de ,
+                                           "To identify an Editorial Object based on the same Editorial format"@en ;
                        rdfs:comment "*** Bad description ***"@en ;
-                       rdfs:label "Same editorial format"@en .
+                       rdfs:label "Gleiches redaktionelles Format"@de ,
+                                  "Même format éditorial"@fr ,
+                                  "Same editorial format"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#isEmbodiedBy
 ec:isEmbodiedBy rdf:type owl:ObjectProperty ;
                 rdfs:range ec:Artefact ;
-                dcterms:description "Character depicted by an Artifact"@en ;
-                rdfs:label "is embodied by"@en .
+                dcterms:description "Character depicted by an Artifact"@en ,
+                                    "Personnage représenté par un artefact"@fr ,
+                                    "Von einem Artefakt dargestellter Charakter"@de ;
+                rdfs:label "est incarné par"@fr ,
+                           "is embodied by"@en ,
+                           "wird verkörpert durch"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#isEpisodeOf
 ec:isEpisodeOf rdf:type owl:ObjectProperty ;
                rdfs:range ec:EditorialGroup ;
-               dcterms:description "The Episode of a Series or a Season."@en ;
-               rdfs:label "Parent season / series"@en .
+               dcterms:description "Die Episode einer Serie oder einer Saison."@de ,
+                                   "L'épisode d'une série ou d'une saison."@fr ,
+                                   "The Episode of a Series or a Season."@en ;
+               rdfs:label "Parent season / series"@en ,
+                          "Saison / série parentale"@fr ,
+                          "Übergeordnete Saison / Serie"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#isEpisodeOfSeason
 ec:isEpisodeOfSeason rdf:type owl:ObjectProperty ;
                      rdfs:range ec:Season ;
-                     dcterms:description "The Episode of a Season."@en ;
-                     rdfs:label "Parent season"@en .
+                     dcterms:description "Die Episode einer Saison."@de ,
+                                         "L'épisode d'une saison."@fr ,
+                                         "The Episode of a Season."@en ;
+                     rdfs:label "Parent season"@en ,
+                                "Saison der Eltern"@de ,
+                                "Saison des parents"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#isEpisodeOfSerial
 ec:isEpisodeOfSerial rdf:type owl:ObjectProperty ;
-                     rdfs:label "is episode of serial"@en .
+                     rdfs:label "est un épisode de la série"@fr ,
+                                "is episode of serial"@en ,
+                                "ist eine Folge der Serie"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#isEpisodeOfSeries
 ec:isEpisodeOfSeries rdf:type owl:ObjectProperty ;
                      rdfs:range ec:Series ;
-                     dcterms:description "The Episode of a Series."@en ;
-                     rdfs:label "Parent series"@en .
+                     dcterms:description "Die Episode einer Serie."@de ,
+                                         "L'épisode d'une série."@fr ,
+                                         "The Episode of a Series."@en ;
+                     rdfs:label "Eltern-Serie"@de ,
+                                "Parent series"@en ,
+                                "Série sur les parents"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#isFictitiousPerson
 ec:isFictitiousPerson rdf:type owl:ObjectProperty ;
                       rdfs:range ec:Person ;
-                      dcterms:description "To identify a Contact/Person being fictitious."@en ;
-                      rdfs:label "Fictitious contact"@en .
+                      dcterms:description "Pour identifier un contact/personne fictive."@fr ,
+                                          "To identify a Contact/Person being fictitious."@en ,
+                                          "Um einen Kontakt/eine Person als fiktiv zu identifizieren."@de ;
+                      rdfs:label "Contact fictif"@fr ,
+                                 "Fictitious contact"@en ,
+                                 "Fiktiver Kontakt"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#isInstantiatedBy
 ec:isInstantiatedBy rdf:type owl:ObjectProperty ;
                     rdfs:range ec:MediaResource ;
-                    dcterms:description "To identify a MediaResource instantiating an EditorialObject."@en ;
-                    rdfs:label "Media Resource"@en .
+                    dcterms:description "Pour identifier une MediaResource instanciant un EditorialObject."@fr ,
+                                        "To identify a MediaResource instantiating an EditorialObject."@en ,
+                                        "Um eine MediaResource zu identifizieren, die ein EditorialObject instanziiert."@de ;
+                    rdfs:label "Media Resource"@en ,
+                               "Medien Ressource"@de ,
+                               "Ressource médiatique"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#isIssuedBy
 ec:isIssuedBy rdf:type owl:ObjectProperty ;
               rdfs:range ec:Agent ;
-              dcterms:description "To identify the issuer of an identifier."@en ;
-              rdfs:label "Issuer"@en .
+              dcterms:description "Pour identifier l'émetteur d'un identifiant."@fr ,
+                                  "To identify the issuer of an identifier."@en ,
+                                  "Zur Identifizierung des Ausstellers eines Identifikators."@de ;
+              rdfs:label "Emittent"@de ,
+                         "Issuer"@en ,
+                         "Émetteur"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#isMasterOf
 ec:isMasterOf rdf:type owl:ObjectProperty ;
               rdfs:range ec:MediaResource ;
-              dcterms:description "To identify the master of a derived media resource."@en ;
-              rdfs:label "Derived media resource"@en .
+              dcterms:description "Pour identifier le maître d'une ressource média dérivée."@fr ,
+                                  "To identify the master of a derived media resource."@en ,
+                                  "Um den Master einer abgeleiteten Medienressource zu identifizieren."@de ;
+              rdfs:label "Abgeleitete Medienressource"@de ,
+                         "Derived media resource"@en ,
+                         "Ressource média dérivée"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#isMediaFragmentOf
 ec:isMediaFragmentOf rdf:type owl:ObjectProperty ;
                      rdfs:range ec:MediaResource ;
-                     dcterms:description "To identify the Media Resource to which a Media Fragment belongs to"@en ;
-                     rdfs:label "Media fragment source"@en .
+                     dcterms:description "Pour identifier la ressource média à laquelle appartient un fragment de média"@fr ,
+                                         "So identifizieren Sie die Medienressource, zu der ein Medienfragment gehört"@de ,
+                                         "To identify the Media Resource to which a Media Fragment belongs to"@en ;
+                     rdfs:label "Media fragment source"@en ,
+                                "Quelle des Medienfragments"@de ,
+                                "Source du fragment de média"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#isMemberOf
 ec:isMemberOf rdf:type owl:ObjectProperty ;
               rdfs:range ec:EditorialGroup ;
-              dcterms:description "To identify a Group to which an EditorialObject is a member of."@en ;
-              rdfs:label "Member of"@en .
+              dcterms:description "Pour identifier un groupe dont un objet éditorial est membre."@fr ,
+                                  "To identify a Group to which an EditorialObject is a member of."@en ,
+                                  "Um eine Gruppe zu identifizieren, in der ein EditorialObject Mitglied ist."@de ;
+              rdfs:label "Member of"@en ,
+                         "Membre de"@fr ,
+                         "Mitglied von"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#isMemberOfPublicationPlan
 ec:isMemberOfPublicationPlan rdf:type owl:ObjectProperty ;
                              rdfs:range ec:PublicationPlan ;
-                             dcterms:description "To identify a parent Publication Plan"@en ;
-                             rdfs:label "Parent publication  plan"@en .
+                             dcterms:description "Identifier un parent Plan de publication"@fr ,
+                                                 "So identifizieren Sie einen übergeordneten Veröffentlichungsplan"@de ,
+                                                 "To identify a parent Publication Plan"@en ;
+                             rdfs:label "Parent publication  plan"@en ,
+                                        "Plan de publication des parents"@fr ,
+                                        "Veröffentlichungsplan der Eltern"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#isNextInSequence
 ec:isNextInSequence rdf:type owl:ObjectProperty ;
                     owl:inverseOf ec:isPreviousInSequence ;
                     rdfs:range ec:EditorialObject ;
-                    dcterms:description "A link to an Editorial Object following the current Editorial Object in an ordered sequence."@en ;
-                    rdfs:label "Next"@en .
+                    dcterms:description "A link to an Editorial Object following the current Editorial Object in an ordered sequence."@en ,
+                                        "Ein Link zu einem redaktionellen Objekt, das dem aktuellen redaktionellen Objekt in einer geordneten Reihenfolge folgt."@de ,
+                                        "Un lien vers un objet éditorial suivant l'objet éditorial actuel dans une séquence ordonnée."@fr ;
+                    rdfs:label "Next"@en ,
+                               "Nächste"@de ,
+                               "Suivant"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#isOperatedBy
 ec:isOperatedBy rdf:type owl:ObjectProperty ;
                 rdfs:range ec:PublicationService ;
-                dcterms:description """To identify the Service that operates the
-            PublicationChannel."""@en ;
-                rdfs:label "Operator, owner"@en .
+                dcterms:description "Pour identifier le service qui exploite le canal de publication."@fr ,
+                                    "To identify the Service that operates the PublicationChannel."@en ,
+                                    "Um den Dienst zu identifizieren, der den PublicationChannel."@de ;
+                rdfs:label "Betreiber, Eigentümer"@de ,
+                           "Operator, owner"@en ,
+                           "Opérateur, propriétaire"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#isOwnedBy
 ec:isOwnedBy rdf:type owl:ObjectProperty ;
              rdfs:range ec:Agent ;
-             dcterms:description """To identify the Agent (Contact/person or
-            Organisation) who owns a Service operating a PublicationChannel."""@en ;
-             rdfs:label "Owner"@en .
+             dcterms:description "Pour identifier l'agent (contact/personne ou Organisation) qui possède un Service exploitant un PublicationChannel."@fr ,
+                                 "To identify the Agent (Contact/person or Organisation) who owns a Service operating a PublicationChannel."@en ,
+                                 "Zur Identifizierung des Agenten (Kontakt/Person oder Organisation), der Eigentümer eines Dienstes ist, der einen PublicationChannel betreibt."@de ;
+             rdfs:label "Eigentümer"@de ,
+                        "Owner"@en ,
+                        "Propriétaire"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#isParentOf
 ec:isParentOf rdf:type owl:ObjectProperty ;
               rdfs:range ec:Asset ;
-              dcterms:description "To link a Asset to a parent Asset."@en ;
-              rdfs:label "Child"@en .
+              dcterms:description "Pour lier un actif à un actif parent."@fr ,
+                                  "So verknüpfen Sie ein Asset mit einem übergeordneten Asset."@de ,
+                                  "To link a Asset to a parent Asset."@en ;
+              rdfs:label "Child"@en ,
+                         "Enfant"@fr ,
+                         "Kind"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#isPartOf
 ec:isPartOf rdf:type owl:ObjectProperty ;
             rdfs:range ec:EditorialObject ;
-            dcterms:description "To identify the editorial object to which belongs a part."@en ;
-            rdfs:label "Editorial object"@en .
+            dcterms:description "Pour identifier l'objet éditorial auquel appartient une partie."@fr ,
+                                "To identify the editorial object to which belongs a part."@en ,
+                                "Um das redaktionelle Objekt zu identifizieren, zu dem ein Teil gehört."@de ;
+            rdfs:label "Editorial object"@en ,
+                       "Objet de la rédaction"@fr ,
+                       "Redaktionelles Objekt"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#isPlayedBy
 ec:isPlayedBy rdf:type owl:ObjectProperty ;
               rdfs:range ec:Agent ;
               owl:propertyDisjointWith ec:isPortrayedBy ;
-              dcterms:description "Relationship between a fictional character and the actor playing the part."@en ;
-              rdfs:label "is played by"@en .
+              dcterms:description "Beziehung zwischen einer fiktiven Figur und dem Schauspieler, der die Rolle spielt."@de ,
+                                  "Relation entre un personnage fictif et l'acteur qui joue le rôle."@fr ,
+                                  "Relationship between a fictional character and the actor playing the part."@en ;
+              rdfs:label "est joué par"@fr ,
+                         "is played by"@en ,
+                         "wird gespielt von"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#isPortrayedBy
 ec:isPortrayedBy rdf:type owl:ObjectProperty ;
                  owl:inverseOf ec:portrays ;
                  rdfs:range ec:Animal ;
-                 dcterms:description "Relationship between a fictional character and the animal that is depicted in the scene."@en ;
-                 rdfs:label "is portrayed by"@en .
+                 dcterms:description "Beziehung zwischen einer fiktiven Figur und dem Tier, das in der Szene abgebildet ist."@de ,
+                                     "Relation entre un personnage fictif et l'animal qui est représenté dans la scène."@fr ,
+                                     "Relationship between a fictional character and the animal that is depicted in the scene."@en ;
+                 rdfs:label "est dépeint par"@fr ,
+                            "is portrayed by"@en ,
+                            "wird porträtiert von"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#isPreviousInSequence
 ec:isPreviousInSequence rdf:type owl:ObjectProperty ;
                         rdfs:range ec:EditorialObject ;
-                        dcterms:description "A link to an Editorial Object precedinging the current Editorial Object in an ordered sequence."@en ;
-                        rdfs:label "Preceding"@en .
+                        dcterms:description "A link to an Editorial Object precedinging the current Editorial Object in an ordered sequence."@en ,
+                                            "Ein Link zu einem redaktionellen Objekt, das dem aktuellen redaktionellen Objekt in einer geordneten Reihenfolge vorausgeht."@de ,
+                                            "Un lien vers un objet éditorial précédant l'objet éditorial actuel dans une séquence ordonnée."@fr ;
+                        rdfs:label "Preceding"@en ,
+                                   "Précédant"@fr ,
+                                   "Vorangehend"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#isReferencedBy
 ec:isReferencedBy rdf:type owl:ObjectProperty ;
                   owl:inverseOf ec:references ;
-                  dcterms:description "To described references between a source and a editorial or bibliografical object"@en ;
-                  rdfs:label "Reference source"@en .
+                  dcterms:description "Décrire les références entre une source et un objet éditorial ou bibliographique"@fr ,
+                                      "To described references between a source and a editorial or bibliografical object"@en ,
+                                      "Zur Beschreibung von Referenzen zwischen einer Quelle und einem redaktionellen oder bibliografischen Objekt"@de ;
+                  rdfs:label "Reference source"@en ,
+                             "Referenzquelle"@de ,
+                             "Source de référence"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#isReleasedBy
 ec:isReleasedBy rdf:type owl:ObjectProperty ;
                 rdfs:range ec:PublicationService ;
-                dcterms:description "To identify a Service assocoated to a PublicationEvent."@en ;
-                rdfs:label "Service"@en .
+                dcterms:description "Pour identifier un service associé à un PublicationEvent."@fr ,
+                                    "To identify a Service assocoated to a PublicationEvent."@en ,
+                                    "Um einen Dienst zu identifizieren, der einem PublicationEvent zugeordnet ist."@de ;
+                rdfs:label "Service"@de ,
+                           "Service"@en ,
+                           "Service"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#isReplacedBy
 ec:isReplacedBy rdf:type owl:ObjectProperty ;
                 owl:inverseOf ec:replaces ;
                 rdfs:range ec:Asset ;
-                dcterms:description "To identify substitutions."@en ;
-                rdfs:label "Replacement"@en .
+                dcterms:description "Pour identifier les substitutions."@fr ,
+                                    "To identify substitutions."@en ,
+                                    "Um Substitutionen zu identifizieren."@de ;
+                rdfs:label "Ersatz"@de ,
+                           "Remplacement"@fr ,
+                           "Replacement"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#isRequiredBy
 ec:isRequiredBy rdf:type owl:ObjectProperty ;
                 owl:inverseOf ec:requires ;
-                dcterms:description "To express strong relations between EditorialObjects"@en ;
-                rdfs:label "Required"@en .
+                dcterms:description "Pour exprimer des relations fortes entre les EditorialObjects"@fr ,
+                                    "To express strong relations between EditorialObjects"@en ,
+                                    "Um starke Beziehungen zwischen EditorialObjects auszudrücken"@de ;
+                rdfs:label "Erforderlich"@de ,
+                           "Required"@en ,
+                           "Requis"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#isScheduledOn
 ec:isScheduledOn rdf:type owl:ObjectProperty ;
                  owl:inverseOf ec:publishes ;
                  rdfs:range ec:PublicationEvent ;
-                 dcterms:description "To associatre a PublicationEvent with an EditorialObject."@en ;
-                 rdfs:label "Publication event"@en .
+                 dcterms:description "Pour associer un PublicationEvent à un EditorialObject."@fr ,
+                                     "So assoziieren Sie ein PublicationEvent mit einem EditorialObject."@de ,
+                                     "To associatre a PublicationEvent with an EditorialObject."@en ;
+                 rdfs:label "Ereignis der Veröffentlichung"@de ,
+                            "Publication event"@en ,
+                            "Événement de publication"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#isSeasonOf
 ec:isSeasonOf rdf:type owl:ObjectProperty ;
               rdfs:range ec:Series ;
-              dcterms:description "To assoicate a Season with a Series."@en ;
-              rdfs:label "Series"@en .
+              dcterms:description "Pour associer une Saison à une Série."@fr ,
+                                  "So ordnen Sie eine Saison einer Serie zu."@de ,
+                                  "To assoicate a Season with a Series."@en ;
+              rdfs:label "Serie"@de ,
+                         "Series"@en ,
+                         "Série"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#isSeriesOf
 ec:isSeriesOf rdf:type owl:ObjectProperty ;
               rdfs:range ec:Brand ;
-              dcterms:description "To associate a Series with a Brand."@en ;
-              rdfs:label "Brand"@en .
+              dcterms:description "Pour associer une série à une marque."@fr ,
+                                  "So verknüpfen Sie eine Serie mit einer Marke."@de ,
+                                  "To associate a Series with a Brand."@en ;
+              rdfs:label "Brand"@en ,
+                         "Marke"@de ,
+                         "Marque"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#isTimelineTrackPartOf
 ec:isTimelineTrackPartOf rdf:type owl:ObjectProperty ;
                          rdfs:range ec:TimelineTrack ;
-                         dcterms:description "To associate an EditorialObject with a part of the TimelineTrack."@en ;
-                         rdfs:label "Editorial Object"@en .
+                         dcterms:description "Pour associer un EditorialObject à une partie de la TimelineTrack."@fr ,
+                                             "So verknüpfen Sie ein EditorialObject mit einem Teil der TimelineTrack."@de ,
+                                             "To associate an EditorialObject with a part of the TimelineTrack."@en ;
+                         rdfs:label "Editorial Object"@en ,
+                                    "Objet de la rédaction"@fr ,
+                                    "Redaktionelles Objekt"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#isTrackPartOf
 ec:isTrackPartOf rdf:type owl:ObjectProperty ;
                  rdfs:range ec:Track ;
-                 dcterms:description "An element to identify a part of a track by a title, a start time and an end time in both the media source and media destination."@en ;
-                 rdfs:label "Track part source"@en .
+                 dcterms:description "An element to identify a part of a track by a title, a start time and an end time in both the media source and media destination."@en ,
+                                     "Ein Element zur Identifizierung eines Teils eines Titels durch einen Titel, eine Startzeit und eine Endzeit sowohl in der Medienquelle als auch im Medienziel."@de ,
+                                     "Un élément pour identifier une partie d'une piste par un titre, une heure de début et une heure de fin dans la source et la destination du média."@fr ;
+                 rdfs:label "Quelle des Trackings"@de ,
+                            "Source de la partie de la voie"@fr ,
+                            "Track part source"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#isVersionOf
 ec:isVersionOf rdf:type owl:ObjectProperty ;
                rdfs:range ec:EditorialObject ;
-               dcterms:description "To identify related versions."@en ;
-               rdfs:label "Version of"@en .
+               dcterms:description "Pour identifier les versions connexes."@fr ,
+                                   "To identify related versions."@en ,
+                                   "Um verwandte Versionen zu identifizieren."@de ;
+               rdfs:label "Version de"@fr ,
+                          "Version of"@en ,
+                          "Version von"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#linkToLogo
 ec:linkToLogo rdf:type owl:ObjectProperty ;
               rdfs:range ec:Logo ;
-              dcterms:description "To provide a link to a Logo"@en ;
-              rdfs:label "Link to logo"@en .
+              dcterms:description "Pour fournir un lien vers un logo"@fr ,
+                                  "So erstellen Sie einen Link zu einem Logo"@de ,
+                                  "To provide a link to a Logo"@en ;
+              rdfs:label "Lien vers le logo"@fr ,
+                         "Link to logo"@en ,
+                         "Link zum Logo"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#linkToSticker
 ec:linkToSticker rdf:type owl:ObjectProperty ;
                  rdfs:range ec:Sticker ;
-                 dcterms:description "To provide a link to a Sticker"@en ;
-                 rdfs:label "Link to Sticker"@en .
+                 dcterms:description "Pour fournir un lien vers un autocollant"@fr ,
+                                     "So erstellen Sie einen Link zu einem Sticker"@de ,
+                                     "To provide a link to a Sticker"@en ;
+                 rdfs:label "Lien vers l'autocollant"@fr ,
+                            "Link to Sticker"@en ,
+                            "Link zum Aufkleber"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#locationRegion
 ec:locationRegion rdf:type owl:ObjectProperty ;
                   rdfs:range ec:RegionCode ;
-                  dcterms:description "To provide a description of a particular region assocoated to the Location."@en ;
-                  rdfs:label "Region"@en .
+                  dcterms:description "Eine Beschreibung einer bestimmten Region, die mit dem Ort verbunden ist."@de ,
+                                      "Fournir une description d'une région particulière associée à l'emplacement."@fr ,
+                                      "To provide a description of a particular region assocoated to the Location."@en ;
+                  rdfs:label "Region"@de ,
+                             "Region"@en ,
+                             "Région"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#loggsPublicationEvent
@@ -2878,187 +4308,299 @@ ec:loggsPublicationEvent rdf:type owl:ObjectProperty ;
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#objectType
 ec:objectType rdf:type owl:ObjectProperty ;
               rdfs:range skos:Concept ;
-              dcterms:description "The kind or genre of the resource."@en ;
-              rdfs:label "type"@en .
+              dcterms:description "Die Art oder das Genre der Ressource."@de ,
+                                  "Le type ou le genre de la ressource."@fr ,
+                                  "The kind or genre of the resource."@en ;
+              rdfs:label "Typ"@de ,
+                         "type"@en ,
+                         "type"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#playsCharacter
 ec:playsCharacter rdf:type owl:ObjectProperty ;
                   rdfs:range ec:Character ;
-                  dcterms:description "A character played by a person. The relationship implies that the person has intellectual rights to the performance of the character."@en ;
-                  rdfs:label "plays character"@en .
+                  dcterms:description "A character played by a person. The relationship implies that the person has intellectual rights to the performance of the character."@en ,
+                                      "Eine Figur, die von einer Person gespielt wird. Die Beziehung impliziert, dass die Person die geistigen Rechte an der Darstellung der Figur hat."@de ,
+                                      "Un personnage joué par une personne. La relation implique que la personne a des droits intellectuels sur l'interprétation du personnage."@fr ;
+                  rdfs:label "joue un personnage"@fr ,
+                             "plays character"@en ,
+                             "spielt Charakter"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#playsOut
 ec:playsOut rdf:type owl:ObjectProperty ;
             rdfs:range ec:Essence ;
-            dcterms:description "To identify the Essence used in a PublicationEvent"@en ;
-            rdfs:label "Essence"@en .
+            dcterms:description "Pour identifier l'essence utilisée dans un PublicationEvent"@fr ,
+                                "So identifizieren Sie die in einem PublicationEvent verwendete Essenz"@de ,
+                                "To identify the Essence used in a PublicationEvent"@en ;
+            rdfs:label "Essence"@en ,
+                       "Essence"@fr ,
+                       "Essenz"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#portrays
 ec:portrays rdf:type owl:ObjectProperty ;
-            dcterms:description "An animal that appears as a character other than itself."@en ;
-            rdfs:label "portrays"@en .
+            dcterms:description "An animal that appears as a character other than itself."@en ,
+                                "Ein Tier, das als eine andere Figur als sich selbst erscheint."@de ,
+                                "Un animal qui apparaît comme un personnage autre que lui-même."@fr ;
+            rdfs:label "dépeint"@fr ,
+                       "portrays"@en ,
+                       "porträtiert"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#promotes
 ec:promotes rdf:type owl:ObjectProperty ;
-            dcterms:description "The content promotes some other content"@en ;
-            rdfs:label "promotes"@en .
+            dcterms:description "Der Inhalt wirbt für einen anderen Inhalt"@de ,
+                                "Le contenu fait la promotion d'un autre contenu"@fr ,
+                                "The content promotes some other content"@en ;
+            rdfs:label "favorise"@fr ,
+                       "fördert"@de ,
+                       "promotes"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#publicationPlanStatus
 ec:publicationPlanStatus rdf:type owl:ObjectProperty ;
                          rdfs:range skos:Concept ;
-                         dcterms:description "To provide a status regarding the PublicationPlan."@en ;
-                         rdfs:label "PublicationPlan status"@en .
+                         dcterms:description "Pour fournir un statut concernant le PublicationPlan."@fr ,
+                                             "To provide a status regarding the PublicationPlan."@en ,
+                                             "Um einen Status bezüglich des PublicationPlan zu liefern."@de ;
+                         rdfs:label "PublicationPlan status"@en ,
+                                    "Statut du plan de publication"@fr ,
+                                    "VeröffentlichungPlan Status"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#publicationScheduleDate
 ec:publicationScheduleDate rdf:type owl:ObjectProperty ;
                            rdfs:range time:Instant ;
-                           dcterms:description "To express specifically the schedule date to which a PublicationEvent is related in particular if the broacdast time is after midnight. For example, the schedule date would be May 29th and the programme is published at 1 am on May 30th, while still associated in the schedule with the night of May 29th."@en ;
-                           rdfs:label "Schedule date"@en .
+                           dcterms:description "Pour exprimer spécifiquement la date d'horaire à laquelle un PublicationEvent est associé en particulier si l'heure de broacdast est après minuit. Par exemple, la date du planning serait le 29 mai et le programme est publié à 1 heure du matin le 30 mai, tout en restant associé dans le planning à la nuit du 29 mai."@fr ,
+                                               "To express specifically the schedule date to which a PublicationEvent is related in particular if the broacdast time is after midnight. For example, the schedule date would be May 29th and the programme is published at 1 am on May 30th, while still associated in the schedule with the night of May 29th."@en ,
+                                               "Zur Angabe des spezifischen Termindatums, auf das sich ein PublicationEvent bezieht, insbesondere wenn die Broacdast-Zeit nach Mitternacht liegt. Zum Beispiel wäre das Programmdatum der 29. Mai und die Sendung wird um 1 Uhr morgens am 30. Mai veröffentlicht, während sie im Programm noch mit der Nacht des 29. Mai verbunden ist."@de ;
+                           rdfs:label "Date du calendrier"@fr ,
+                                      "Schedule date"@en ,
+                                      "Zeitplan Datum"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#publishes
 ec:publishes rdf:type owl:ObjectProperty ;
              rdfs:range ec:EditorialObject ;
-             dcterms:description "The editorial object associated to a PublicationEvent."@en ;
-             rdfs:label "Editorial object"@en .
+             dcterms:description "Das redaktionelle Objekt, das mit einem PublicationEvent verbunden ist."@de ,
+                                 "L'objet éditorial associé à un PublicationEvent."@fr ,
+                                 "The editorial object associated to a PublicationEvent."@en ;
+             rdfs:label "Editorial object"@en ,
+                        "Objet de la rédaction"@fr ,
+                        "Redaktionelles Objekt"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#references
 ec:references rdf:type owl:ObjectProperty ;
-              dcterms:description "To express a reference between an editorial or bibliographical object and its source"@en ;
-              rdfs:label "References"@en .
+              dcterms:description "Pour exprimer une référence entre un objet éditorial ou bibliographique et sa source"@fr ,
+                                  "To express a reference between an editorial or bibliographical object and its source"@en ,
+                                  "Um eine Referenz zwischen einem redaktionellen oder bibliografischen Objekt und seiner Quelle auszudrücken"@de ;
+              rdfs:label "References"@en ,
+                         "Referenzen"@de ,
+                         "Références"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#relationLink
 ec:relationLink rdf:type owl:ObjectProperty ;
                 rdfs:range owl:Thing ;
-                dcterms:description "To define a link in a Relation."@en ;
-                rdfs:label "Link"@en .
+                dcterms:description "Pour définir un lien dans une Relation."@fr ,
+                                    "So definieren Sie eine Verknüpfung in einer Relation."@de ,
+                                    "To define a link in a Relation."@en ;
+                rdfs:label "Lien"@fr ,
+                           "Link"@de ,
+                           "Link"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#replaces
 ec:replaces rdf:type owl:ObjectProperty ;
             rdfs:range ec:Asset ;
-            dcterms:description "To identify substitution."@en ;
-            rdfs:label "Replaces"@en .
+            dcterms:description "Pour identifier la substitution."@fr ,
+                                "To identify substitution."@en ,
+                                "Um die Substitution zu identifizieren."@de ;
+            rdfs:label "Ersetzt"@de ,
+                       "Remplace"@fr ,
+                       "Replaces"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#represents
 ec:represents rdf:type owl:ObjectProperty ;
               rdfs:range ec:Asset ;
-              dcterms:description "To establish a relation between an EditorialObject and an Asset."@en ;
-              rdfs:label "Related asset"@en .
+              dcterms:description "Pour établir une relation entre un EditorialObject et un Asset."@fr ,
+                                  "To establish a relation between an EditorialObject and an Asset."@en ,
+                                  "Um eine Beziehung zwischen einem EditorialObject und einem Asset herzustellen."@de ;
+              rdfs:label "Bien connexe"@fr ,
+                         "Related asset"@en ,
+                         "Verwandter Vermögenswert"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#requires
 ec:requires rdf:type owl:ObjectProperty ;
-            dcterms:description "To express dependency."@en ;
-            rdfs:label "Requires"@en .
+            dcterms:description "Pour exprimer la dépendance."@fr ,
+                                "To express dependency."@en ,
+                                "Um eine Abhängigkeit auszudrücken."@de ;
+            rdfs:label "Benötigt"@de ,
+                       "Nécessite"@fr ,
+                       "Requires"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#resourceOffset
 ec:resourceOffset rdf:type owl:ObjectProperty ;
                   rdfs:range ec:TimelinePoint ;
-                  dcterms:description "The start offset within a Resource."@en ;
-                  rdfs:label "Resource offset"@en .
+                  dcterms:description "Der Start-Offset innerhalb einer Ressource."@de ,
+                                      "Le décalage de départ dans une ressource."@fr ,
+                                      "The start offset within a Resource."@en ;
+                  rdfs:label "Compensation des ressources"@fr ,
+                             "Resource offset"@en ,
+                             "Ressourcenausgleich"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#rightsTerritoryExcludes
 ec:rightsTerritoryExcludes rdf:type owl:ObjectProperty ;
                            rdfs:range ec:CountryCode ;
-                           dcterms:description "A list of country or region codes to which Rights do not apply."@en ;
-                           rdfs:label "Excluded territories"@en .
+                           dcterms:description "A list of country or region codes to which Rights do not apply."@en ,
+                                               "Eine Liste von Länder- oder Regionencodes, für die die Rechte nicht gelten."@de ,
+                                               "Une liste de codes de pays ou de régions auxquels les droits ne s'appliquent pas."@fr ;
+                           rdfs:label "Ausgeschlossene Territorien"@de ,
+                                      "Excluded territories"@en ,
+                                      "Territoires exclus"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#rightsTerritoryIncludes
 ec:rightsTerritoryIncludes rdf:type owl:ObjectProperty ;
                            rdfs:range ec:CountryCode ;
-                           dcterms:description "A list of country or region codes to which Rights apply."@en ;
-                           rdfs:label "Included territories"@en .
+                           dcterms:description "A list of country or region codes to which Rights apply."@en ,
+                                               "Eine Liste der Länder- oder Regionencodes, für die Rechte gelten."@de ,
+                                               "Une liste des codes de pays ou de région auxquels les droits s'appliquent."@fr ;
+                           rdfs:label "Enthaltene Territorien"@de ,
+                                      "Included territories"@en ,
+                                      "Territoires inclus"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#start
 ec:start rdf:type owl:ObjectProperty ;
-         rdfs:range ec:TimelinePoint .
+         rdfs:range ec:TimelinePoint ;
+         rdfs:label "Début"@fr ,
+                    "Start"@de ,
+                    "Start"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#startDateTime
 ec:startDateTime rdf:type owl:ObjectProperty ;
                  rdfs:subPropertyOf ec:date ;
                  rdfs:range time:Instant ;
-                 rdfs:comment "A point of time or start of an interval"@en ,
-                              "Start date time"@en .
+                 dcterms:description "A point of time or start of an interval"@en ,
+                                     "Ein Zeitpunkt oder der Beginn eines Intervalls"@de ,
+                                     "Un instant ou l'nstant de départ d'un intervalle"@fr ;
+                 rdfs:label "Date de début"@fr ,
+                            "Start date time"@en ,
+                            "Startdatum Uhrzeit"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#transports
 ec:transports rdf:type owl:ObjectProperty ;
-              rdfs:label "Transports"@en .
+              rdfs:label "Transporte"@de ,
+                         "Transports"@en ,
+                         "Transports"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#versionType
 ec:versionType rdf:type owl:ObjectProperty ;
-               dcterms:description "To specify a type of version for an EditorialObject."@en ;
-               rdfs:label "Version type"@en .
+               dcterms:description "Pour spécifier un type de version pour un EditorialObject."@fr ,
+                                   "To specify a type of version for an EditorialObject."@en ,
+                                   "Um eine Art von Version für ein EditorialObject anzugeben."@de ;
+               rdfs:label "Type de version"@fr ,
+                          "Version Typ"@de ,
+                          "Version type"@en .
+
+
+###  http://www.w3.org/2000/01/rdf-schema#related
+rdfs:related rdf:type owl:ObjectProperty .
 
 
 ###  http://www.w3.org/2006/time#hasTRS
 time:hasTRS rdf:type owl:ObjectProperty ;
-            dcterms:description "The temporal reference system used by a temporal position or extent description."@en ;
-            rdfs:label "Has TRS"@en .
+            dcterms:description "Das zeitliche Referenzsystem, das von einer zeitlichen Positions- oder Ausdehnungsbeschreibung verwendet wird."@de ,
+                                "Le système de référence temporel utilisé par une description de position ou d'étendue temporelle."@fr ,
+                                "The temporal reference system used by a temporal position or extent description."@en ;
+            rdfs:label "A un TRS"@fr ,
+                       "Has TRS"@en ,
+                       "Hat TRS"@de .
+
+
+###  http://www.w3.org/ns/ma-ont#hasPermissions
+<http://www.w3.org/ns/ma-ont#hasPermissions> rdf:type owl:ObjectProperty ;
+                                             dcterms:description "Pour définir les autorisations telles que définies dans l'ontologie des médias du W3C (ma-ont)"@fr ,
+                                                                 "To set permissions as defined in the W3C Media Ontology (ma-ont)."@en ,
+                                                                 "Zur Definition von Berechtigungen, wie sie in der W3C-Medien-Ontologie (ma-ont) definiert sind"@de ;
+                                             rdfs:label "Berechtigungen"@de ,
+                                                        "Permissions"@en ,
+                                                        "Permissions"@fr ;
+                                             rdfs:prefLabel "Permissions"^^xsd:string .
 
 
 ###  https://rdf-vocabulary.ddialliance.org/xkos/after
 xkos:after rdf:type owl:ObjectProperty ;
            rdfs:subPropertyOf xkos:temporal ;
-           rdfs:label "after"@en .
+           rdfs:label "after"@en ,
+                      "après"@fr ,
+                      "nach"@de .
 
 
 ###  https://rdf-vocabulary.ddialliance.org/xkos/before
 xkos:before rdf:type owl:ObjectProperty ;
             rdfs:subPropertyOf xkos:temporal ;
-            rdfs:label "before"@en .
+            rdfs:label "avant"@fr ,
+                       "before"@en ,
+                       "vor"@de .
 
 
 ###  https://rdf-vocabulary.ddialliance.org/xkos/next
 xkos:next rdf:type owl:ObjectProperty ;
           rdfs:subPropertyOf xkos:succeeds ;
-          rdfs:label "next"@en .
+          rdfs:label "next"@en ,
+                     "nächste"@de ,
+                     "suivant"@fr .
 
 
 ###  https://rdf-vocabulary.ddialliance.org/xkos/precedes
 xkos:precedes rdf:type owl:ObjectProperty ;
               rdfs:subPropertyOf xkos:sequential ;
-              rdfs:label "precedes"@en .
+              rdfs:label "precedes"@en ,
+                         "précède"@fr ,
+                         "steht vor"@de .
 
 
 ###  https://rdf-vocabulary.ddialliance.org/xkos/previous
 xkos:previous rdf:type owl:ObjectProperty ;
               rdfs:subPropertyOf xkos:precedes ;
-              rdfs:label "previous"@en .
+              rdfs:label "previous"@en ,
+                         "précédent"@fr ,
+                         "vorherige"@de .
 
 
 ###  https://rdf-vocabulary.ddialliance.org/xkos/sequential
 xkos:sequential rdf:type owl:ObjectProperty ;
                 rdfs:subPropertyOf skos:related ;
-                rdfs:label "sequential"@en .
+                rdfs:label "sequential"@en ,
+                           "sequenziell"@de ,
+                           "séquentiel"@fr .
 
 
 ###  https://rdf-vocabulary.ddialliance.org/xkos/succeeds
 xkos:succeeds rdf:type owl:ObjectProperty ;
               rdfs:subPropertyOf xkos:sequential ;
-              rdfs:label "succeeds"@en .
+              rdfs:label "folgt auf"@de ,
+                         "réussit"@fr ,
+                         "succeeds"@en .
 
 
 ###  https://rdf-vocabulary.ddialliance.org/xkos/temporal
 xkos:temporal rdf:type owl:ObjectProperty ;
               rdfs:subPropertyOf xkos:sequential ;
-              rdfs:label "temporal"@en .
+              rdfs:label "Zeitliche"@de ,
+                         "temporal"@en ,
+                         "temporel"@fr .
 
 
 #################################################################
@@ -3068,81 +4610,132 @@ xkos:temporal rdf:type owl:ObjectProperty ;
 ###  http://purl.org/dc/elements/1.1/source
 dc:source rdf:type owl:DatatypeProperty ;
           rdfs:range rdfs:Literal ;
-          dcterms:description "To identify a Resource as the source of another Resource."@en ;
-          rdfs:label "Source"@en .
+          dcterms:description "Pour identifier une ressource comme étant la source d'une autre ressource."@fr ,
+                              "To identify a Resource as the source of another Resource."@en ,
+                              "Um eine Ressource als Quelle einer anderen Ressource zu identifizieren."@de ;
+          rdfs:label "Quelle"@de ,
+                     "Source"@en ,
+                     "Source :"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#assetValue
 ebuccdm:assetValue rdf:type owl:DatatypeProperty ;
-                   dcterms:description "To provide an estimated or actual value of an Asset."@en ;
-                   rdfs:label "Asset value"@en .
+                   dcterms:description "Donne la valeur estimée ou réelle d'un actif."@fr ,
+                                       "To provide an estimated or actual value of an Asset."@en ,
+                                       "Um einen geschätzten oder tatsächlichen Wert eines Assets anzugeben."@de ;
+                   rdfs:label "Asset value"@en ,
+                              "Valeur de l'actif"@fr ,
+                              "Vermögenswert"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#audienceAgeHigh
 ebuccdm:audienceAgeHigh rdf:type owl:DatatypeProperty ;
-                        dcterms:description "The maximum age of an Audience."@en ;
-                        rdfs:label "Audience age high"@en .
+                        dcterms:description "Das maximale Alter eines Publikums."@de ,
+                                            "L'âge maximum d'une audience."@fr ,
+                                            "The maximum age of an Audience."@en ;
+                        rdfs:label "Age maximum du public visé"@fr ,
+                                   "Alter des Publikums hoch"@de ,
+                                   "Audience age high"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#audienceAgeLow
 ebuccdm:audienceAgeLow rdf:type owl:DatatypeProperty ;
-                       dcterms:description "The minimum age of an Audience."@en ;
-                       rdfs:label "Audience age low"@en .
+                       dcterms:description "Das Mindestalter eines Zuschauers."@de ,
+                                           "L'âge minimum d'une audience."@fr ,
+                                           "The minimum age of an Audience."@en ;
+                       rdfs:label "Alter des Publikums niedrig"@de ,
+                                  "Audience age low"@en ,
+                                  "Âge minimum du public visé."@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#audienceCount
 ebuccdm:audienceCount rdf:type owl:DatatypeProperty ;
-                      dcterms:description "The Audience reach in numbers or percent."@en ;
-                      rdfs:label "Audience number"@en .
+                      dcterms:description "Die Reichweite des Publikums in Zahlen oder Prozent."@de ,
+                                          "La portée de l'audience en nombre ou en pourcentage."@fr ,
+                                          "The Audience reach in numbers or percent."@en ;
+                      rdfs:label "Anzahl der Zuhörer"@de ,
+                                 "Audience number"@en ,
+                                 "Valeur d'audience"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#audienceInterest
 ebuccdm:audienceInterest rdf:type owl:DatatypeProperty ;
-                         dcterms:description "The points of interest of an Audience."@en ;
-                         rdfs:label "Audience interest"@en .
+                         dcterms:description "Die Punkte, die für ein Publikum von Interesse sind."@de ,
+                                             "Les points d'intérêt d'une audience."@fr ,
+                                             "The points of interest of an Audience."@en ;
+                         rdfs:label "Audience interest"@en ,
+                                    "Interesse des Publikums"@de ,
+                                    "Intérêt du public"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#auditReportResults
 ebuccdm:auditReportResults rdf:type owl:DatatypeProperty ;
-                           dcterms:description """To express the combined results of one or more
-      AuditJobs."""@en ;
-                           rdfs:label "Audit report results"@en .
+                           dcterms:description "Pour exprimer les résultats combinés d'un ou plusieurs AuditJobs."@fr ,
+                                               "To express the combined results of one or more AuditJobs."@en ,
+                                               "Um die kombinierten Ergebnisse von einem oder mehreren AuditJobs."@de ;
+                           rdfs:label "Audit report results"@en ,
+                                      "Ergebnisse des Auditberichts"@de ,
+                                      "Résultats du rapport d'audit"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#consumptionDeviceBrand
 ebuccdm:consumptionDeviceBrand rdf:type owl:DatatypeProperty ;
-                               dcterms:description "The brand of a ConsumptionDevice."@en ;
-                               rdfs:label "Consumption device brand"@en .
+                               dcterms:description "Die Marke eines ConsumptionDevice."@de ,
+                                                   "La marque d'un ConsumptionDevice."@fr ,
+                                                   "The brand of a ConsumptionDevice."@en ;
+                               rdfs:label "Consumption device brand"@en ,
+                                          "Marke des Verbrauchsgeräts"@de ,
+                                          "Marque du dispositif de consommation"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#consumptionDeviceBrowser
 ebuccdm:consumptionDeviceBrowser rdf:type owl:DatatypeProperty ;
-                                 dcterms:description "The browser compatible with a ConsumptionDevice."@en ;
-                                 rdfs:label "Consumption device browser"@en .
+                                 dcterms:description "Der Browser, der mit einem ConsumptionDevice kompatibel ist."@de ,
+                                                     "Le navigateur compatible avec un ConsumptionDevice."@fr ,
+                                                     "The browser compatible with a ConsumptionDevice."@en ;
+                                 rdfs:label "Browser für Verbrauchsgeräte"@de ,
+                                            "Consumption device browser"@en ,
+                                            "Navigateur du dispositif de consommation"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#consumptionDeviceModel
 ebuccdm:consumptionDeviceModel rdf:type owl:DatatypeProperty ;
-                               dcterms:description "The model of a ConsumptionDevice."@en ;
-                               rdfs:label "Consumption device model"@en .
+                               dcterms:description "Das Modell eines ConsumptionDevice."@de ,
+                                                   "Le modèle d'un ConsumptionDevice."@fr ,
+                                                   "The model of a ConsumptionDevice."@en ;
+                               rdfs:label "Consumption device model"@en ,
+                                          "Modèle de dispositif de consommation"@fr ,
+                                          "Verbrauchsgerät Modell"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#consumptionDeviceOS
 ebuccdm:consumptionDeviceOS rdf:type owl:DatatypeProperty ;
-                            dcterms:description "The operating system of a ConsumptionDevice."@en ;
-                            rdfs:label "Consumption device OS"@en .
+                            dcterms:description "Das Betriebssystem eines ConsumptionDevice."@de ,
+                                                "Le système d'exploitation d'un ConsumptionDevice."@fr ,
+                                                "The operating system of a ConsumptionDevice."@en ;
+                            rdfs:label "Consumption device OS"@en ,
+                                       "Os du dispositif de consommation"@fr ,
+                                       "Verbrauchsgerät OS"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#consumptionLicenceText
 ebuccdm:consumptionLicenceText rdf:type owl:DatatypeProperty ;
-                               dcterms:description "The terms of a ConsumptionLicence."@en ;
-                               rdfs:label "Consumption licence"@en .
+                               dcterms:description "Die Bedingungen für eine Verbrauchslizenz."@de ,
+                                                   "Les conditions d'une licence de consommation."@fr ,
+                                                   "The terms of a ConsumptionLicence."@en ;
+                               rdfs:label "Consumption licence"@en ,
+                                          "Licence de consommation"@fr ,
+                                          "Verbrauchslizenz"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#contractCostAmount
 ebuccdm:contractCostAmount rdf:type owl:DatatypeProperty ;
-                           dcterms:description "The amount of the ContractCost."@en ;
-                           rdfs:label "Cost amount"@en .
+                           dcterms:description "Der Betrag der ContractCost."@de ,
+                                               "Le montant du ContractCost."@fr ,
+                                               "The amount of the ContractCost."@en ;
+                           rdfs:label "Cost amount"@en ,
+                                      "Kostenbetrag"@de ,
+                                      "Montant du coût"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#formatId
@@ -3152,1366 +4745,2020 @@ ebuccdm:formatId rdf:type owl:DatatypeProperty ;
                                             xsd:string
                                           )
                             ] ;
-                 dcterms:description "An Id attributed to a Format."@en ;
-                 rdfs:label "Format Id"@en .
+                 dcterms:description "An Id attributed to a Format."@en ,
+                                     "Eine Id, die einem Format zugeordnet ist."@de ,
+                                     "Un Id attribué à un Format."@fr ;
+                 rdfs:label "Format Id"@de ,
+                            "Format Id"@en ,
+                            "Id du format"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#internetConnectivity
 ebuccdm:internetConnectivity rdf:type owl:DatatypeProperty ,
                                       owl:FunctionalProperty ;
-                             dcterms:description """To indicate if the Service requires Internet
-      connectivity."""@en ;
-                             rdfs:label "Internet connectivity"@en .
+                             dcterms:description "Pour indiquer si le service nécessite une connection Internet."@fr ,
+                                                 "To indicate if the Service requires Internet connectivity."@en ,
+                                                 "Zur Angabe, ob der Dienst eine Internetverbindung erfordert Konnektivität erfordert."@de ;
+                             rdfs:label "Connectivité Internet"@fr ,
+                                        "Internet connectivity"@en ,
+                                        "Internet-Verbindung"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#measureValue
 ebuccdm:measureValue rdf:type owl:DatatypeProperty ;
-                     dcterms:description "To provide the value of a Measure."@en ;
+                     dcterms:description "Pour fournir la valeur d'une mesure."@fr ,
+                                         "To provide the value of a Measure."@en ,
+                                         "Um den Wert einer Maßnahme anzugeben."@de ;
                      rdfs:comment "The range is Literal. A more specific range can be used for a specific measurement."@en ;
-                     rdfs:label "Measure value"@en .
+                     rdfs:label "Measure value"@en ,
+                                "Valeur de mesure"@fr ,
+                                "Wert messen"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#measureValueMax
 ebuccdm:measureValueMax rdf:type owl:DatatypeProperty ;
-                        dcterms:description """To define the maximum value of a Measure when
-      applicable."""@en ;
-                        rdfs:label "Measure maximum value"@en .
+                        dcterms:description "Pour définir la valeur maximale d'une mesure lorsque applicable."@fr ,
+                                            "To define the maximum value of a Measure when applicable."@en ,
+                                            "Um den maximalen Wert einer Kennzahl zu definieren, wenn gilt."@de ;
+                        rdfs:label "Maximalwert messen"@de ,
+                                   "Measure maximum value"@en ,
+                                   "Mesure de la valeur maximale"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#measureValueMin
 ebuccdm:measureValueMin rdf:type owl:DatatypeProperty ;
-                        dcterms:description """To define the minimum value of a Measure when
-      applicable."""@en ;
-                        rdfs:label "Measure minimum value"@en .
+                        dcterms:description "Pour définir la valeur minimale d'une mesure lorsque applicable."@fr ,
+                                            "To define the minimum value of a Measure when applicable."@en ,
+                                            "Um den Mindestwert einer Maßnahme zu definieren, wenn gilt."@de ;
+                        rdfs:label "Measure minimum value"@en ,
+                                   "Mesure de la valeur minimale"@fr ,
+                                   "Minimalwert messen"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#microphone
 ebuccdm:microphone rdf:type owl:DatatypeProperty ,
                             owl:FunctionalProperty ;
-                   dcterms:description "To indicate if the Service requires a microphone."@en ;
-                   rdfs:label "Microphone"@en .
+                   dcterms:description "Pour indiquer si le service nécessite un microphone."@fr ,
+                                       "To indicate if the Service requires a microphone."@en ,
+                                       "Um anzugeben, ob der Service ein Mikrofon benötigt."@de ;
+                   rdfs:label "Microphone"@en ,
+                              "Microphone"@fr ,
+                              "Mikrofon"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#onStagePositionCoordinateX
 ebuccdm:onStagePositionCoordinateX rdf:type owl:DatatypeProperty ;
-                                   dcterms:description """The x coordinates within a 3 axis spatial coordinates
-      space."""@en ;
-                                   rdfs:label "X coordinate"@en .
+                                   dcterms:description "Die x-Koordinaten innerhalb eines 3-Achsen-Raumkoordinaten Raum."@de ,
+                                                       "Les coordonnées x dans un espace à 3 axes"@fr ,
+                                                       "The x coordinates within a 3 axis spatial coordinates space."@en ;
+                                   rdfs:label "Coordonnée X"@fr ,
+                                              "X coordinate"@en ,
+                                              "X-Koordinate"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#onStagePositionCoordinateY
 ebuccdm:onStagePositionCoordinateY rdf:type owl:DatatypeProperty ;
-                                   dcterms:description """The y coordinates within a 3 axis spatial coordinates
-      space."""@en ;
-                                   rdfs:label "Y coordinate"@en .
+                                   dcterms:description "Die y-Koordinaten innerhalb eines 3-Achsen-Raumkoordinaten Raum."@de ,
+                                                       "Les coordonnées y dans un espace à 3 axes."@fr ,
+                                                       "The y coordinates within a 3 axis spatial coordinates space."@en ;
+                                   rdfs:label "Coordonnée Y"@fr ,
+                                              "Y coordinate"@en ,
+                                              "Y-Koordinate"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#onStagePositionCoordinateZ
 ebuccdm:onStagePositionCoordinateZ rdf:type owl:DatatypeProperty ;
-                                   dcterms:description """The z coordinates within a 3 axis spatial coordinates
-      space."""@en ;
-                                   rdfs:label "Z coordinate"@en .
+                                   dcterms:description "Die z-Koordinaten innerhalb eines 3-Achsen-Raumkoordinaten Raum."@de ,
+                                                       "Les coordonnées z dans un espace à 3 axes."@fr ,
+                                                       "The z coordinates within a 3 axis spatial coordinates space."@en ;
+                                   rdfs:label "Coordonnée Z"@fr ,
+                                              "Z coordinate"@en ,
+                                              "Z-Koordinate"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#onStagePositionCoordinatesReferencePoint
 ebuccdm:onStagePositionCoordinatesReferencePoint rdf:type owl:DatatypeProperty ;
-                                                 dcterms:description """To define a reference point for a set of coordinates defining a
-      position on stage."""@en ;
-                                                 rdfs:label "On stage position coordinates reference point"@en .
+                                                 dcterms:description "Pour définir un point de référence pour un ensemble de coordonnées définissant une position sur la scène."@fr ,
+                                                                     "To define a reference point for a set of coordinates defining a position on stage."@en ,
+                                                                     "Um einen Referenzpunkt für einen Satz von Koordinaten zu definieren, der eine Position auf der Bühne definiert."@de ;
+                                                 rdfs:label "On stage position coordinates reference point"@en ,
+                                                            "Point de référence des coordonnées de la position sur scène"@fr ,
+                                                            "Position auf der Bühne Koordinaten Referenzpunkt"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#orderedFlag
 ebuccdm:orderedFlag rdf:type owl:DatatypeProperty ,
                              owl:FunctionalProperty ;
-                    dcterms:description """A flag to signal that a Collection/Group of EditorialObject, itself
-      an EditorialObject, is ordered."""@en ;
-                    rdfs:label "Ordered"@en .
+                    dcterms:description "A flag to signal that a Collection/Group of EditorialObject, itself an EditorialObject, is ordered."@en ,
+                                        "Ein Flag, das signalisiert, dass eine Sammlung/Gruppe von EditorialObject, selbst ein EditorialObject, geordnet ist."@de ,
+                                        "Un indicateur pour signaler qu'une Collection/Groupe d'EditorialObject, lui même un EditorialObject, est commandé."@fr ;
+                    rdfs:label "Bestellt"@de ,
+                               "Commandé"@fr ,
+                               "Ordered"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#radioTuner
 ebuccdm:radioTuner rdf:type owl:DatatypeProperty ,
                             owl:FunctionalProperty ;
-                   dcterms:description "To indicate if the Service requires a radio tuner."@en ;
-                   rdfs:label "Radio tuner"@en .
+                   dcterms:description "Pour indiquer si le service nécessite un tuner radio."@fr ,
+                                       "To indicate if the Service requires a radio tuner."@en ,
+                                       "Zur Angabe, ob der Service einen Radiotuner benötigt."@de ;
+                   rdfs:label "Radio tuner"@en ,
+                              "Radio-Tuner"@de ,
+                              "Tuner radio"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#readyForPublication
 ebuccdm:readyForPublication rdf:type owl:DatatypeProperty ;
                             rdfs:range xsd:boolean ;
-                            dcterms:description """A flag to indicate that the resource/essence is ready for
-      publication."""@en ;
-                            rdfs:label "Ready for publication"@en .
+                            dcterms:description "A flag to indicate that the resource/essence is ready for publication."@en ,
+                                                "Ein Kennzeichen, das anzeigt, dass die Ressource/Essenz zur Veröffentlichung bereit ist. Veröffentlichung."@de ,
+                                                "Un drapeau pour indiquer que la ressource/essence est prête à être publiée."@fr ;
+                            rdfs:label "Bereit zur Veröffentlichung"@de ,
+                                       "Prêt pour la publication"@fr ,
+                                       "Ready for publication"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#rightsUsageRestrictions
 ebuccdm:rightsUsageRestrictions rdf:type owl:DatatypeProperty ;
-                                dcterms:description "To specify a set of UsageRestrictions."@en ;
-                                rdfs:label "Usage restrictions"@en .
+                                dcterms:description "Pour spécifier un ensemble de UsageRestrictions."@fr ,
+                                                    "To specify a set of UsageRestrictions."@en ,
+                                                    "Um eine Reihe von Nutzungseinschränkungen anzugeben."@de ;
+                                rdfs:label "Einschränkungen bei der Verwendung"@de ,
+                                           "Restrictions d'utilisation"@fr ,
+                                           "Usage restrictions"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#ruleStatement
 ebuccdm:ruleStatement rdf:type owl:DatatypeProperty ;
-                      dcterms:description "To express a statement related to a Rule."@en ;
-                      rdfs:label "Rule statement"@en .
+                      dcterms:description "Pour exprimer une déclaration relative à une règle."@fr ,
+                                          "To express a statement related to a Rule."@en ,
+                                          "Um eine Aussage in Bezug auf eine Regel zu machen."@de ;
+                      rdfs:label "Erklärung zur Regel"@de ,
+                                 "Rule statement"@en ,
+                                 "Énoncé de la règle"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#soundOutput
 ebuccdm:soundOutput rdf:type owl:DatatypeProperty ,
                              owl:FunctionalProperty ;
-                    dcterms:description """A flag to indicate if the Service requires a sound
-      output."""@en ;
-                    rdfs:label "Sound output"@en .
+                    dcterms:description "A flag to indicate if the Service requires a sound output."@en ,
+                                        "Drapeau pour indiquer si le service exige une sortie son."@fr ,
+                                        "Ein Flag, das anzeigt, ob der Dienst eine Tonausgabe benötigt Ausgabe."@de ;
+                    rdfs:label "Sortie sonore"@fr ,
+                               "Sound output"@en ,
+                               "Tonausgabe"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#textInput
 ebuccdm:textInput rdf:type owl:DatatypeProperty ,
                            owl:FunctionalProperty ;
-                  dcterms:description """To indicate if the Service requires text input
-      capability."""@en ;
-                  rdfs:label "Text input capability"@en .
+                  dcterms:description "Pour indiquer si le service nécessite une functionnalité de saisie de texte."@fr ,
+                                      "To indicate if the Service requires text input capability."@en ,
+                                      "Zur Angabe, ob der Service eine Texteingabe erfordert Fähigkeit."@de ;
+                  rdfs:label "Capacité de saisie de texte"@fr ,
+                             "Text input capability"@en ,
+                             "Texteingabefähigkeit"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#timeshift
 ebuccdm:timeshift rdf:type owl:DatatypeProperty ,
                            owl:FunctionalProperty ;
-                  dcterms:description """A flag to indicate if the Service requires timeshift
-      support."""@en ;
-                  rdfs:label "Timeshift support"@en .
+                  dcterms:description "A flag to indicate if the Service requires timeshift support."@en ,
+                                      "Ein Kennzeichen, das angibt, ob der Dienst die Unterstützung von Zeitverschiebungen benötigt. Unterstützung benötigt."@de ,
+                                      "Un drapeau pour indiquer si le service a besoin d'une équipe de travail en horaires décalés. soutien."@fr ;
+                  rdfs:label "Soutien aux horaires décalés"@fr ,
+                             "Timeshift support"@en ,
+                             "Unterstützung für Timeshift"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#videoDisplay
 ebuccdm:videoDisplay rdf:type owl:DatatypeProperty ,
                               owl:FunctionalProperty ;
-                     dcterms:description """A flag to indicate if the Service requires a video
-      display."""@en ;
-                     rdfs:label "Video display"@en .
+                     dcterms:description "A flag to indicate if the Service requires a video display."@en ,
+                                         "Eine Markierung, die anzeigt, ob der Dienst eine Videoanzeige benötigt. Anzeige benötigt."@de ,
+                                         "Un drapeau pour indiquer si le service exige un affichage vidéo."@fr ;
+                     rdfs:label "Affichage vidéo"@fr ,
+                                "Video display"@en ,
+                                "Videoanzeige"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#webcam
 ebuccdm:webcam rdf:type owl:DatatypeProperty ,
                         owl:FunctionalProperty ;
-               dcterms:description "A flag to indicate if the Service requires a webcam."@en ;
-               rdfs:label "Webcam"@en .
+               dcterms:description "A flag to indicate if the Service requires a webcam."@en ,
+                                   "Eine Markierung, die anzeigt, ob der Dienst eine Webcam benötigt."@de ,
+                                   "Un drapeau pour indiquer si le service nécessite une webcam."@fr ;
+               rdfs:label "Webcam"@de ,
+                          "Webcam"@en ,
+                          "Webcam"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#DID
 ec:DID rdf:type owl:DatatypeProperty ;
        rdfs:range xsd:integer ;
-       dcterms:description """The Data Identifier word (along with the SDID,
-            if used), indicates the type of ancillary data that the packet corresponds
-            to."""@en ;
-       rdfs:label "DID"@en .
+       dcterms:description "Das Data Identifier Wort (zusammen mit der SDID, falls verwendet), gibt die Art der Zusatzdaten an, denen das Paket entspricht entspricht."@de ,
+                           "Le mot Data Identifier (ainsi que le SDID, s'il est utilisé), indique le type de données auxiliaires auquel correspond le paquet au paquet."@fr ,
+                           "The Data Identifier word (along with the SDID, if used), indicates the type of ancillary data that the packet corresponds to."@en ;
+       rdfs:label "DID"@de ,
+                  "DID"@en ,
+                  "DID"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#SDID
 ec:SDID rdf:type owl:DatatypeProperty ;
         rdfs:range xsd:integer ;
-        dcterms:description "Secondary data identification word for ancillary data. Send mode identifier. An identifier which indicates the transmission timing for closed caption data."@en ;
-        rdfs:label "SDID"@en .
+        dcterms:description "Mot d'identification de données secondaires pour les données auxiliaires. Identificateur de mode d'envoi. Un identificateur qui indique le moment de la transmission pour les données de sous-titres codés."@fr ,
+                            "Secondary data identification word for ancillary data. Send mode identifier. An identifier which indicates the transmission timing for closed caption data."@en ,
+                            "Sekundärdaten-Kennwort für Zusatzdaten. Kennung für den Sendemodus. Eine Kennung, die den Übertragungszeitpunkt für Untertiteldaten angibt."@de ;
+        rdfs:label "SDID"@de ,
+                   "SDID"@en ,
+                   "SDID"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#abstract
 ec:abstract rdf:type owl:DatatypeProperty ;
             rdfs:subPropertyOf ec:contentDescription ;
             rdfs:range rdfs:Literal ;
-            dcterms:description "To provide an abstract."@en ;
-            rdfs:label "Abstract"@en .
+            dcterms:description "Pour fournir un résumé."@fr ,
+                                "To provide an abstract."@en ,
+                                "Um eine Zusammenfassung zu erstellen."@de ;
+            rdfs:label "Abstract"@en ,
+                       "Abstrakt"@de ,
+                       "Résumé"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#age
 ec:age rdf:type owl:DatatypeProperty ;
        rdfs:range xsd:integer ;
-       dcterms:description "The age in years of a Contact/Person."@en ;
-       rdfs:label "Age"@en .
+       dcterms:description "Das Alter eines Kontakts/einer Person in Jahren."@de ,
+                           "L'âge en années d'un contact/personne."@fr ,
+                           "The age in years of a Contact/Person."@en ;
+       rdfs:label "Age"@en ,
+                  "Alter"@de ,
+                  "Âge"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#agentDbpedia
 ec:agentDbpedia rdf:type owl:DatatypeProperty ;
                 rdfs:subPropertyOf ec:agentLinkedData ;
                 rdfs:range xsd:anyURI ;
-                dcterms:description "A link to a DBPedia page."@en ;
-                rdfs:label "DBPedia" .
+                dcterms:description "A link to a DBPedia page."@en ,
+                                    "Ein Link zu einer DBPedia-Seite."@de ,
+                                    "Un lien vers une page DBPedia."@fr ;
+                rdfs:label "DBPedia"@de ,
+                           "DBPedia"@en ,
+                           "DBPedia"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#agentEmailAddress
 ec:agentEmailAddress rdf:type owl:DatatypeProperty ;
                      rdfs:range xsd:string ;
-                     dcterms:description "To provide an email address."@en ;
-                     rdfs:label "email"@en .
+                     dcterms:description "Pour fournir une adresse e-mail."@fr ,
+                                         "To provide an email address."@en ,
+                                         "Um eine E-Mail-Adresse anzugeben."@de ;
+                     rdfs:label "E-Mail"@de ,
+                                "e-mail"@fr ,
+                                "email"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#agentFacebook
 ec:agentFacebook rdf:type owl:DatatypeProperty ;
                  rdfs:subPropertyOf ec:agentSocialMedia ;
                  rdfs:range xsd:anyURI ;
-                 rdfs:label "Facebook"@en .
+                 rdfs:label "Facebook"@de ,
+                            "Facebook"@en ,
+                            "Facebook"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#agentFee
 ec:agentFee rdf:type owl:DatatypeProperty ;
             rdfs:range rdfs:Literal ;
-            dcterms:description "The fee of an Agent."@en ;
-            rdfs:label "Agent fee"@en .
+            dcterms:description "Das Honorar eines Agenten."@de ,
+                                "Les honoraires d'un agent."@fr ,
+                                "The fee of an Agent."@en ;
+            rdfs:label "Agent fee"@en ,
+                       "Agenturgebühr"@de ,
+                       "Frais d'agent"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#agentFlickr
 ec:agentFlickr rdf:type owl:DatatypeProperty ;
                rdfs:subPropertyOf ec:agentSocialMedia ;
                rdfs:range xsd:anyURI ;
-               rdfs:label "Flickr"@en .
+               rdfs:label "Flickr"@de ,
+                          "Flickr"@en ,
+                          "Flickr"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#agentImdb
 ec:agentImdb rdf:type owl:DatatypeProperty ;
              rdfs:subPropertyOf ec:agentLinkedData ;
              rdfs:range xsd:anyURI ;
-             dcterms:description "A link to an imdb page."@en ;
-             rdfs:label "Wikidata" .
+             dcterms:description "A link to an imdb page."@en ,
+                                 "Ein Link zu einer imdb-Seite."@de ,
+                                 "Un lien vers une page imdb."@fr ;
+             rdfs:label "IMDB"@de ,
+                        "IMDB"@en ,
+                        "IMDB"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#agentInstagram
 ec:agentInstagram rdf:type owl:DatatypeProperty ;
                   rdfs:subPropertyOf ec:agentSocialMedia ;
                   rdfs:range xsd:anyURI ;
-                  rdfs:label "Instagram"@en .
+                  rdfs:label "Instagram"@de ,
+                             "Instagram"@en ,
+                             "Instagram"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#agentLinkedData
 ec:agentLinkedData rdf:type owl:DatatypeProperty ;
                    rdfs:range xsd:anyURI ;
-                   dcterms:description "Range: a URL or URI."@en ,
-                                       "To provide a hook to linked data."@en ;
-                   rdfs:label "Agent linked data"@en .
+                   dcterms:description "Einen Haken für verknüpfte Daten bereitstellen. Bereich: eine URL oder URI."@de ,
+                                       "Pour fournir un lien avec les données liées. Range: une URL ou une URI."@fr ,
+                                       "To provide a hook to linked data. Range: a URL or URI."@en ;
+                   rdfs:label "Agent linked data"@en ,
+                              "Données liées à l'agent"@fr ,
+                              "Verknüpfte Daten des Agenten"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#agentLinkedIn
 ec:agentLinkedIn rdf:type owl:DatatypeProperty ;
                  rdfs:subPropertyOf ec:agentSocialMedia ;
                  rdfs:range xsd:anyURI ;
-                 rdfs:label "LinkedIn"@en .
+                 rdfs:label "LinkedIn"@de ,
+                            "LinkedIn"@en ,
+                            "LinkedIn"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#agentMobileTelephoneNumber
 ec:agentMobileTelephoneNumber rdf:type owl:DatatypeProperty ;
                               rdfs:subPropertyOf ec:agentTelephoneNumber ;
                               rdfs:range xsd:string ;
-                              dcterms:description """To provide the mobile telephone number of an
-            Agent (Contact/Person or organisation)"""@en ;
-                              rdfs:label "Mobile"@en .
+                              dcterms:description "Pour fournir le numéro de téléphone mobile d'un Agent (Contact/Personne ou organisation)"@fr ,
+                                                  "To provide the mobile telephone number of an Agent (Contact/Person or organisation)"@en ,
+                                                  "Zur Angabe der Mobiltelefonnummer eines Agenten (Kontaktperson/Person oder Organisation)"@de ;
+                              rdfs:label "Mobil"@de ,
+                                         "Mobile"@en ,
+                                         "Mobile"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#agentPreviousName
 ec:agentPreviousName rdf:type owl:DatatypeProperty ;
                      rdfs:range rdfs:Literal ;
-                     dcterms:description "To provide the previous name of a Contact/Person."@en ;
-                     rdfs:label "Previous name"@en .
+                     dcterms:description "Pour fournir le nom précédent d'un contact/personne."@fr ,
+                                         "To provide the previous name of a Contact/Person."@en ,
+                                         "Um den früheren Namen eines Kontakts/einer Person anzugeben."@de ;
+                     rdfs:label "Nom précédent"@fr ,
+                                "Previous name"@en ,
+                                "Vorheriger Name"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#agentRelatedInformationLink
 ec:agentRelatedInformationLink rdf:type owl:DatatypeProperty ;
                                rdfs:subPropertyOf ec:agentRelatedLink ;
                                rdfs:range xsd:anyURI ;
-                               dcterms:description """To provide a link to a web resource containing
-            information related to an Agent (Contact/Person or Organisation)."""@en ;
-                               rdfs:label "Related information link"@en .
+                               dcterms:description "Bereitstellung eines Links zu einer Webressource mit Informationen zu einem Agenten (Kontakt/Person oder Organisation) enthält."@de ,
+                                                   "Pour fournir un lien vers une ressource web contenant des informations relatives à un agent (contact/personne ou organisation)."@fr ,
+                                                   "To provide a link to a web resource containing information related to an Agent (Contact/Person or Organisation)."@en ;
+                               rdfs:label "Lien d'information connexe"@fr ,
+                                          "Related information link"@en ,
+                                          "Verwandte Informationen Link"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#agentRelatedLink
 ec:agentRelatedLink rdf:type owl:DatatypeProperty ;
                     rdfs:range xsd:anyURI ;
-                    dcterms:description "To provide a link to e.g. a web resource related to an Agent."@en ;
-                    rdfs:label "Related link"@en .
+                    dcterms:description "Fournir un lien vers, par exemple, une ressource Web liée à un agent."@fr ,
+                                        "To provide a link to e.g. a web resource related to an Agent."@en ,
+                                        "Um einen Link z.B. zu einer Web-Ressource im Zusammenhang mit einem Agent bereitzustellen."@de ;
+                    rdfs:label "Lien connexe"@fr ,
+                               "Related link"@en ,
+                               "Verwandter Link"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#agentRelatedPressLink
 ec:agentRelatedPressLink rdf:type owl:DatatypeProperty ;
                          rdfs:subPropertyOf ec:agentRelatedLink ;
                          rdfs:range xsd:anyURI ;
-                         dcterms:description """To provide a link to a web resource containing
-            information related to an Agent (Contact/Person or Organisation)."""@en ;
-                         rdfs:label "Related press link"@en .
+                         dcterms:description "Bereitstellung eines Links zu einer Webressource mit Informationen zu einem Agenten (Kontakt/Person oder Organisation) enthält."@de ,
+                                             "Pour fournir un lien vers une ressource web contenant des informations relatives à un agent (contact/personne ou organisation)."@fr ,
+                                             "To provide a link to a web resource containing information related to an Agent (Contact/Person or Organisation)."@en ;
+                         rdfs:label "Lien presse connexe"@fr ,
+                                    "Link zur Presse"@de ,
+                                    "Related press link"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#agentSocialMedia
 ec:agentSocialMedia rdf:type owl:DatatypeProperty ;
                     rdfs:range xsd:anyURI ;
-                    dcterms:description "Links to an Agent's social media."@en ;
-                    rdfs:label "Socail media"@en .
+                    dcterms:description "Liens vers les médias sociaux d'un agent."@fr ,
+                                        "Links to an Agent's social media."@en ,
+                                        "Links zu den sozialen Medien eines Agenten."@de ;
+                    rdfs:label "Médias sociaux"@fr ,
+                               "Social media"@en ,
+                               "Soziale Medien"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#agentTelephoneNumber
 ec:agentTelephoneNumber rdf:type owl:DatatypeProperty ;
                         rdfs:range xsd:string ;
-                        dcterms:description """To provide the telephone number of an Agent
-            (Contact/Person or Organisation)."""@en ;
-                        rdfs:label "Telephone"@en .
+                        dcterms:description "Pour fournir le numéro de téléphone d'un agent (Contact/Personne ou Organisation)."@fr ,
+                                            "To provide the telephone number of an Agent (Contact/Person or Organisation)."@en ,
+                                            "Zur Angabe der Telefonnummer eines Agenten (Kontaktperson/Person oder Organisation)."@de ;
+                        rdfs:label "Telefon"@de ,
+                                   "Telephone"@en ,
+                                   "Téléphone"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#agentTwitter
 ec:agentTwitter rdf:type owl:DatatypeProperty ;
                 rdfs:subPropertyOf ec:agentSocialMedia ;
                 rdfs:range xsd:anyURI ;
-                rdfs:label "Twitter"@en .
+                rdfs:label "Twitter"@de ,
+                           "Twitter"@en ,
+                           "Twitter"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#agentWebHomepage
 ec:agentWebHomepage rdf:type owl:DatatypeProperty ;
                     rdfs:range xsd:anyURI ;
-                    dcterms:description """To provide the address of the webpage of an
-            Agent (Contact/Person or Organisation)."""@en ;
-                    rdfs:label "Homepage"@en .
+                    dcterms:description "Pour fournir l'adresse de la page web d'un agent (contact/personne ou organisation)."@fr ,
+                                        "To provide the address of the webpage of an Agent (Contact/Person or Organisation)."@en ,
+                                        "Zur Angabe der Adresse der Webseite eines Agenten (Kontaktperson/Person oder Organisation)."@de ;
+                    rdfs:label "Homepage"@de ,
+                               "Homepage"@en ,
+                               "Page d'accueil"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#agentWikidata
 ec:agentWikidata rdf:type owl:DatatypeProperty ;
                  rdfs:subPropertyOf ec:agentLinkedData ;
                  rdfs:range xsd:anyURI ;
-                 dcterms:description "A link to a wikidata page."@en ;
-                 rdfs:label "Wikidata" .
+                 dcterms:description "A link to a wikidata page."@en ,
+                                     "Ein Link zu einer wikidata-Seite."@de ,
+                                     "Un lien vers une page de wikidata."@fr ;
+                 rdfs:label "Wikidata"@de ,
+                            "Wikidata"@en ,
+                            "Wikidata"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#agentWikipedia
 ec:agentWikipedia rdf:type owl:DatatypeProperty ;
                   rdfs:subPropertyOf ec:agentSocialMedia ;
                   rdfs:range xsd:anyURI ;
-                  rdfs:label "Wikipedia"@en .
+                  rdfs:label "Wikipedia"@de ,
+                             "Wikipedia"@en ,
+                             "Wikipedia"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#animalCharacterName
 ec:animalCharacterName rdf:type owl:DatatypeProperty ;
                        rdfs:range rdfs:Literal ;
-                       dcterms:description "To associate a fictitious character name with an animal."@en ;
-                       rdfs:label "Animal character name"@en .
+                       dcterms:description "Pour associer le nom d'un personnage fictif à un animal."@fr ,
+                                           "To associate a fictitious character name with an animal."@en ,
+                                           "Um einen fiktiven Charakternamen mit einem Tier zu verbinden."@de ;
+                       rdfs:label "Animal character name"@en ,
+                                  "Name der Tierfigur"@de ,
+                                  "Nom du personnage animal"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#animalCode
 ec:animalCode rdf:type owl:DatatypeProperty ;
               rdfs:range rdfs:Literal ;
-              dcterms:description "To associate a code with an animal."@en ;
-              rdfs:label "Animal code"@en .
+              dcterms:description "Pour associer un code à un animal."@fr ,
+                                  "To associate a code with an animal."@en ,
+                                  "Um einen Code mit einem Tier zu verbinden."@de ;
+              rdfs:label "Animal code"@en ,
+                         "Code animal"@fr ,
+                         "Tiercode"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#animalPassport
 ec:animalPassport rdf:type owl:DatatypeProperty ;
                   rdfs:range rdfs:Literal ;
-                  dcterms:description "To replicate the passport of an animal."@en ;
-                  rdfs:label "Animal passport"@en .
+                  dcterms:description "Passeport d'un animal."@fr ,
+                                      "To replicate the passport of an animal."@en ,
+                                      "Um den Pass eines Tieres zu replizieren."@de ;
+                  rdfs:label "Animal passport"@en ,
+                             "Passeport pour animaux"@fr ,
+                             "Tierpass"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#annotationConfidence
 ec:annotationConfidence rdf:type owl:DatatypeProperty ;
                         rdfs:range rdfs:Literal ;
-                        dcterms:description "To estimate the confidence in an Annotation."@en ;
-                        rdfs:label "Annotation confidence"@en .
+                        dcterms:description "Pour estimer la confiance dans une Annotation."@fr ,
+                                            "So schätzen Sie das Vertrauen in eine Anmerkung ein."@de ,
+                                            "To estimate the confidence in an Annotation."@en ;
+                        rdfs:label "Annotation confidence"@en ,
+                                   "Niveau de confiance dans l'annotation"@fr ,
+                                   "Vertrauen in die Kommentierung"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#annotationPurpose
 ec:annotationPurpose rdf:type owl:DatatypeProperty ;
                      rdfs:range rdfs:Literal ;
-                     dcterms:description "To define the purpose of an Annotation."@en ;
-                     rdfs:label "Annotation confidence"@en .
+                     dcterms:description "Définir l'objectif d'une annotation."@fr ,
+                                         "To define the purpose of an Annotation."@en ,
+                                         "Um den Zweck einer Anmerkung zu definieren."@de ;
+                     rdfs:label "Annotation purpose"@en ,
+                                "Objectif de l'annotation"@fr ,
+                                "Vertrauen in die Kommentierung"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#annotationSaliency
 ec:annotationSaliency rdf:type owl:DatatypeProperty ;
                       rdfs:range rdfs:Literal ;
-                      dcterms:description "To estimate the saliency of an Annotation."@en ;
-                      rdfs:label "Annotation saliency"@en .
+                      dcterms:description "Pour estimer la saillance d'une Annotation."@fr ,
+                                          "So schätzen Sie die Bedeutung einer Anmerkung ein."@de ,
+                                          "To estimate the saliency of an Annotation."@en ;
+                      rdfs:label "Annotation saliency"@en ,
+                                 "Bedeutung von Kommentaren"@de ,
+                                 "Saillance des annotations"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#artefactAvailability
 ec:artefactAvailability rdf:type owl:DatatypeProperty ;
                         rdfs:range xsd:boolean ;
-                        dcterms:description "To flag the availability of an Artefact."@en ;
-                        rdfs:label "Artefact availability flag"@en .
+                        dcterms:description "Pour signaler la disponibilité d'un artefact."@fr ,
+                                            "To flag the availability of an Artefact."@en ,
+                                            "Zur Kennzeichnung der Verfügbarkeit eines Artefakts."@de ;
+                        rdfs:label "Artefact availability flag"@en ,
+                                   "Flagge für die Verfügbarkeit von Artefakten"@de ,
+                                   "Indicateur de disponibilité de l'artefact"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#artefactBoxHeight
 ec:artefactBoxHeight rdf:type owl:DatatypeProperty ;
                      rdfs:range xsd:nonNegativeInteger ;
-                     dcterms:description "The height of the box containing the Artefact."@en ;
-                     rdfs:label "Artefact box height."@en .
+                     dcterms:description "Die Höhe der Box, die das Artefakt enthält."@de ,
+                                         "La hauteur de la boîte contenant l'artefact."@fr ,
+                                         "The height of the box containing the Artefact."@en ;
+                     rdfs:label "Artefact box height."@en ,
+                                "Hauteur de la boîte à artefacts."@fr ,
+                                "Höhe der Artefaktbox."@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#artefactBoxTopLeftCornerLineNumber
 ec:artefactBoxTopLeftCornerLineNumber rdf:type owl:DatatypeProperty ;
                                       rdfs:range xsd:nonNegativeInteger ;
-                                      dcterms:description "The coordinates on a vertical axis of the position of the top left corner of the box containing the Artefact."@en ;
-                                      rdfs:label "Artefact box top left corner Y position."@en .
+                                      dcterms:description "Die Koordinaten auf einer vertikalen Achse für die Position der linken oberen Ecke der Box, die das Artefakt enthält."@de ,
+                                                          "Les coordonnées sur un axe vertical de la position du coin supérieur gauche de la boîte contenant l'Artefact."@fr ,
+                                                          "The coordinates on a vertical axis of the position of the top left corner of the box containing the Artefact."@en ;
+                                      rdfs:label "Artefact box top left corner Y position."@en ,
+                                                 "Artefaktbox obere linke Ecke Y-Position."@de ,
+                                                 "Boîte d'artefact coin supérieur gauche position Y."@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#artefactBoxTopLeftCornerPixelNumber
 ec:artefactBoxTopLeftCornerPixelNumber rdf:type owl:DatatypeProperty ;
                                        rdfs:range xsd:nonNegativeInteger ;
-                                       dcterms:description "The coordinates on an horizontal axis of the position of the top left corner of the box containing the Artefact."@en ;
-                                       rdfs:label "Artefact box top left corner X position."@en .
+                                       dcterms:description "Die Koordinaten auf einer horizontalen Achse für die Position der linken oberen Ecke der Box, die das Artefakt enthält."@de ,
+                                                           "Les coordonnées sur un axe horizontal de la position du coin supérieur gauche de la boîte contenant l'Artefact."@fr ,
+                                                           "The coordinates on an horizontal axis of the position of the top left corner of the box containing the Artefact."@en ;
+                                       rdfs:label "Artefact box top left corner X position."@en ,
+                                                  "Artefaktbox obere linke Ecke X-Position."@de ,
+                                                  "Boîte d'artefact coin supérieur gauche position X."@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#artefactBoxWidth
 ec:artefactBoxWidth rdf:type owl:DatatypeProperty ;
                     rdfs:range xsd:nonNegativeInteger ;
-                    dcterms:description "The width of the box containing the Artefact."@en ;
-                    rdfs:label "Artefact box width."@en .
+                    dcterms:description "Die Breite des Feldes, das das Artefakt enthält."@de ,
+                                        "La largeur de la boîte contenant l'artefact."@fr ,
+                                        "The width of the box containing the Artefact."@en ;
+                    rdfs:label "Artefact box width."@en ,
+                               "Breite des Artefaktkastens."@de ,
+                               "Largeur de la boîte à artefacts."@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#artefactBrand
 ec:artefactBrand rdf:type owl:DatatypeProperty ;
                  rdfs:range rdfs:Literal ;
-                 dcterms:description "To specify the brand of an Artefact."@en ;
-                 rdfs:label "Artefact brand"@en .
+                 dcterms:description "Pour spécifier la marque d'un artefact."@fr ,
+                                     "To specify the brand of an Artefact."@en ,
+                                     "Zur Angabe der Marke eines Artefakts."@de ;
+                 rdfs:label "Artefact brand"@en ,
+                            "Marke Artefact"@de ,
+                            "Marque d'un artefact"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#artefactColour
 ec:artefactColour rdf:type owl:DatatypeProperty ;
                   rdfs:range rdfs:Literal ;
-                  dcterms:description "To provide the clour(s) of an Artefact."@en ;
-                  rdfs:label "Artefact colour(s)"@en .
+                  dcterms:description "Pour ournir le(s) clouleur(s) d'un artefact."@fr ,
+                                      "To provide the colour(s) of an Artefact."@en ,
+                                      "Um den/die Geruch(e) eines Artefakts bereitzustellen."@de ;
+                  rdfs:label "Artefact colour(s)"@en ,
+                             "Couleur(s) de l'artefact"@fr ,
+                             "Farbe(n) des Artefakts"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#artefactComment
 ec:artefactComment rdf:type owl:DatatypeProperty ;
                    rdfs:range rdfs:Literal ;
-                   dcterms:description "To provide a contextual comment about an Artefact."@en ;
-                   rdfs:label "Artefact comment"@en .
+                   dcterms:description "Pour fournir un commentaire contextuel sur un artefact."@fr ,
+                                       "To provide a contextual comment about an Artefact."@en ,
+                                       "Um einen kontextbezogenen Kommentar zu einem Artefakt abzugeben."@de ;
+                   rdfs:label "Artefact comment"@en ,
+                              "Artefakt-Kommentar"@de ,
+                              "Commentaire sur l'artefact"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#artefactModel
 ec:artefactModel rdf:type owl:DatatypeProperty ;
                  rdfs:range rdfs:Literal ;
-                 dcterms:description "To specify a model of an Artefact."@en ;
-                 rdfs:label "Artefact model"@en .
+                 dcterms:description "Pour spécifier un modèle d'un artefact."@fr ,
+                                     "To specify a model of an Artefact."@en ,
+                                     "Um ein Modell eines Artefakts anzugeben."@de ;
+                 rdfs:label "Artefact model"@en ,
+                            "Artefakt-Modell"@de ,
+                            "Modèle d'artefact"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#artefactPeriod
 ec:artefactPeriod rdf:type owl:DatatypeProperty ;
                   rdfs:range rdfs:Literal ;
-                  dcterms:description "To specify the period associated with an Artefact."@en ;
-                  rdfs:label "Artefact period"@en .
+                  dcterms:description "Pour spécifier la période associée à un artefact."@fr ,
+                                      "To specify the period associated with an Artefact."@en ,
+                                      "Zur Angabe des Zeitraums, der mit einem Artefakt verbunden ist."@de ;
+                  rdfs:label "Artefact period"@en ,
+                             "Artefakt Zeitraum"@de ,
+                             "Période de l'artefact"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#artefactPriceAmount
 ec:artefactPriceAmount rdf:type owl:DatatypeProperty ;
                        rdfs:range rdfs:Literal ;
-                       dcterms:description "To specifythe price of an Artefact."@en ;
-                       rdfs:label "Artefact price"@en .
+                       dcterms:description "Pour préciser le prix d'un artefact."@fr ,
+                                           "To specifythe price of an Artefact."@en ,
+                                           "Um den Preis eines Artefakts anzugeben."@de ;
+                       rdfs:label "Artefact price"@en ,
+                                  "Artefakt Preis"@de ,
+                                  "Prix de l'artefact"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#artefactReference
 ec:artefactReference rdf:type owl:DatatypeProperty ;
                      rdfs:range xsd:anyURI ;
-                     dcterms:description "To specify a reference of an Artefact."@en ;
-                     rdfs:label "Artefact reference"@en .
+                     dcterms:description "Pour spécifier une référence d'un Artefact."@fr ,
+                                         "To specify a reference of an Artefact."@en ,
+                                         "Um eine Referenz eines Artefakts anzugeben."@de ;
+                     rdfs:label "Artefact reference"@en ,
+                                "Artefakt-Referenz"@de ,
+                                "Référence de l'artefact"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#artefactStyle
 ec:artefactStyle rdf:type owl:DatatypeProperty ;
                  rdfs:range rdfs:Literal ;
-                 dcterms:description "To specify the style associated with an Artefact."@en ;
-                 rdfs:label "Artefact style"@en .
+                 dcterms:description "Pour spécifier le style associé à un artefact."@fr ,
+                                     "To specify the style associated with an Artefact."@en ,
+                                     "Um den mit einem Artefakt verbundenen Stil festzulegen."@de ;
+                 rdfs:label "Artefact style"@en ,
+                            "Artefakt-Stil"@de ,
+                            "Style de l'artefact"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#artefactUsageHistory
 ec:artefactUsageHistory rdf:type owl:DatatypeProperty ;
                         rdfs:range rdfs:Literal ;
-                        dcterms:description "To provide information on the usage history of an Artefact."@en ;
-                        rdfs:label "Artefact usage history"@en .
+                        dcterms:description "Pour fournir des informations sur l'historique d'utilisation d'un artefact."@fr ,
+                                            "To provide information on the usage history of an Artefact."@en ,
+                                            "Um Informationen über die Nutzungshistorie eines Artefakts bereitzustellen."@de ;
+                        rdfs:label "Artefact usage history"@en ,
+                                   "Geschichte der Artefaktnutzung"@de ,
+                                   "Historique de l'utilisation de l'artefact"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#artefactWebsite
 ec:artefactWebsite rdf:type owl:DatatypeProperty ;
                    rdfs:range xsd:anyURI ;
-                   dcterms:description "To specify a website where more 	information can be found on the Artefact."@en ;
-                   rdfs:label "Artefact website"@en .
+                   dcterms:description "Pour indiquer un site web où l'on peut trouver plus d'informations sur l'artefact."@fr ,
+                                       "To specify a website where more information can be found on the Artefact."@en ,
+                                       "Zur Angabe einer Website, auf der Sie weitere Informationen über das Artefakt finden können."@de ;
+                   rdfs:label "Artefact Website"@de ,
+                              "Artefact website"@en ,
+                              "Site web d'Artefact"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#aspectRatio
 ec:aspectRatio rdf:type owl:DatatypeProperty ;
                rdfs:range xsd:string ;
-               dcterms:description "To specify the aspect ratio."@en ;
-               rdfs:label "Aspect ratio"@en .
+               dcterms:description "Pour spécifier le rapport d'aspect."@fr ,
+                                   "To specify the aspect ratio."@en ,
+                                   "Um das Seitenverhältnis festzulegen."@de ;
+               rdfs:label "Aspect ratio"@en ,
+                          "Bildseitenverhältnis"@de ,
+                          "Rapport d'aspect"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#audioBitRate
 ec:audioBitRate rdf:type owl:DatatypeProperty ;
                 rdfs:range xsd:nonNegativeInteger ;
-                dcterms:description "The audio bitrate."@en ;
-                rdfs:label "Audio bitrate"@en .
+                dcterms:description "Die Audio-Bitrate."@de ,
+                                    "Le débit binaire audio."@fr ,
+                                    "The audio bitrate."@en ;
+                rdfs:label "Audio bitrate"@en ,
+                           "Audio-Bitrate"@de ,
+                           "Débit binaire audio"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#audioBitRateMax
 ec:audioBitRateMax rdf:type owl:DatatypeProperty ;
                    rdfs:range xsd:nonNegativeInteger ;
-                   dcterms:description "The max audio bitrate."@en ;
-                   rdfs:label "Audio bitrate max"@en .
+                   dcterms:description "Die maximale Audio-Bitrate."@de ,
+                                       "Le débit binaire audio maximal."@fr ,
+                                       "The max audio bitrate."@en ;
+                   rdfs:label "Audio bitrate max"@en ,
+                              "Audio-Bitrate max."@de ,
+                              "Débit binaire audio max."@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#audioBitRateMode
 ec:audioBitRateMode rdf:type owl:DatatypeProperty ;
                     rdfs:range rdfs:Literal ;
-                    dcterms:description "The audio bitrate mode."@en ;
-                    rdfs:label "Audio bitrate mode"@en .
+                    dcterms:description "Der Modus für die Audio-Bitrate."@de ,
+                                        "Le mode de débit binaire audio."@fr ,
+                                        "The audio bitrate mode."@en ;
+                    rdfs:label "Audio bitrate mode"@en ,
+                               "Audio-Bitrate-Modus"@de ,
+                               "Mode de débit binaire audio"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#audioChannelNumber
 ec:audioChannelNumber rdf:type owl:DatatypeProperty ;
                       rdfs:range xsd:nonNegativeInteger ;
-                      dcterms:description """The total number of audio channels contained in
-            the MediaResource."""@en ;
-                      rdfs:label "Audio channel number"@en .
+                      dcterms:description "Die Gesamtzahl der Audiokanäle, die in der der MediaResource."@de ,
+                                          "Le nombre total de canaux audio contenus dans la MediaResource."@fr ,
+                                          "The total number of audio channels contained in the MediaResource."@en ;
+                      rdfs:label "Nombre de canal audio"@fr ,
+                                 "Number of audio channel"@en ,
+                                 "Nummer des Audiokanals"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#audioEncodingLevel
 ec:audioEncodingLevel rdf:type owl:DatatypeProperty ;
                       rdfs:subPropertyOf ec:encodingLevel ;
                       rdfs:range rdfs:Literal ;
-                      dcterms:description "The encoding level as defined in specifications."@en ;
-                      rdfs:label "Audio encoding level"@en .
+                      dcterms:description "Die Kodierungsebene, wie sie in den Spezifikationen definiert ist."@de ,
+                                          "Le niveau de codage tel que défini dans les spécifications."@fr ,
+                                          "The encoding level as defined in specifications."@en ;
+                      rdfs:label "Audio encoding level"@en ,
+                                 "Niveau d'encodage audio"@fr ,
+                                 "Pegel der Audiokodierung"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#audioEncodingProfile
 ec:audioEncodingProfile rdf:type owl:DatatypeProperty ;
                         rdfs:subPropertyOf ec:encodingProfile ;
                         rdfs:range rdfs:Literal ;
-                        dcterms:description "The encoding profile as defined in specifications."@en ;
-                        rdfs:label "Audio encoding profile"@en .
+                        dcterms:description "Das Kodierungsprofil, wie in den Spezifikationen definiert."@de ,
+                                            "Le profil de codage tel que défini dans les spécifications."@fr ,
+                                            "The encoding profile as defined in specifications."@en ;
+                        rdfs:label "Audio encoding profile"@en ,
+                                   "Audio-Kodierungsprofil"@de ,
+                                   "Profil d'encodage audio"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#audioTrackConfiguration
 ec:audioTrackConfiguration rdf:type owl:DatatypeProperty ;
                            rdfs:range rdfs:Literal ;
-                           dcterms:description """The configuration of audio tracks contained in
-            the MediaResource."""@en ;
-                           rdfs:label "Audio track configuration"@en .
+                           dcterms:description "Die Konfiguration der Audiospuren, die in der der MediaResource."@de ,
+                                               "La configuration des pistes audio contenues dans la MediaResource."@fr ,
+                                               "The configuration of audio tracks contained in the MediaResource."@en ;
+                           rdfs:label "Audio track configuration"@en ,
+                                      "Configuration des pistes audio"@fr ,
+                                      "Konfiguration der Audiospur"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#audioTrackNumber
 ec:audioTrackNumber rdf:type owl:DatatypeProperty ;
                     rdfs:range xsd:nonNegativeInteger ;
-                    dcterms:description """The total number of audio tracks contained in
-            the MediaResource."""@en ;
-                    rdfs:label "Audio track number"@en .
+                    dcterms:description "Die Gesamtzahl der Audiospuren, die in der der MediaResource."@de ,
+                                        "Le nombre total de pistes audio contenues dans la MediaResource."@fr ,
+                                        "The total number of audio tracks contained in the MediaResource."@en ;
+                    rdfs:label "Nombre de pistes audio"@fr ,
+                               "Number of audio track"@en ,
+                               "Nummer der Audiospur"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#awardCeremony
 ec:awardCeremony rdf:type owl:DatatypeProperty ;
                  rdfs:range rdfs:Literal ;
-                 dcterms:description "To provide an Award ceremony name."@en ;
-                 rdfs:label "Award ceremony"@en .
+                 dcterms:description "Pour fournir un nom de cérémonie de remise de prix."@fr ,
+                                     "To provide an Award ceremony name."@en ,
+                                     "Um einen Namen für die Preisverleihung anzugeben."@de ;
+                 rdfs:label "Award ceremony"@en ,
+                            "Cérémonie de remise des prix"@fr ,
+                            "Preisverleihung"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#bitDepth
 ec:bitDepth rdf:type owl:DatatypeProperty ;
             rdfs:range xsd:nonNegativeInteger ;
-            dcterms:description """To provide the bitdepth at which the
-            MediaResource has been encoded."""@en ;
-            rdfs:label "Bit depth"@en .
+            dcterms:description "Pour fournir le nombre bit à laquelle lz MediaResource a été encodée."@fr ,
+                                "To provide the bitdepth at which the MediaResource has been encoded."@en ,
+                                "Zur Angabe der Bit-Tiefe, mit der die MediaResource kodiert wurde."@de ;
+            rdfs:label "Bit depth"@en ,
+                       "Bit-Tiefe"@de ,
+                       "Profondeur de bit"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#bitRate
 ec:bitRate rdf:type owl:DatatypeProperty ;
            rdfs:range xsd:nonNegativeInteger ;
-           dcterms:description """To provide the bitrate at which the
-            MediaResource can be played in bits/second. Current bitrate if constant, and average bitrate if variable."""@en ;
-           rdfs:label "Bitrate"@en .
+           dcterms:description "Pour fournir le débit binaire auquel la MediaResource peut être lue en bits/seconde. Débit binaire réel si constant, et débit binaire moyen si variable."@fr ,
+                               "To provide the bitrate at which the MediaResource can be played in bits/second. Current bitrate if constant, and average bitrate if variable."@en ,
+                               "Zur Angabe der Bitrate, mit der die MediaResource abgespielt werden kann, in Bits/Sekunde. Aktuelle Bitrate, wenn konstant, und durchschnittliche Bitrate, wenn variabel."@de ;
+           rdfs:label "Bitrate"@de ,
+                      "Bitrate"@en ,
+                      "Bitrate"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#bitRateMax
 ec:bitRateMax rdf:type owl:DatatypeProperty ;
               rdfs:range xsd:nonNegativeInteger ;
-              dcterms:description "The maximum bitrate when variable, in bits per second."@en ;
-              rdfs:label "Maximum bitrate"@en .
+              dcterms:description "Die maximale Bitrate, wenn variabel, in Bits pro Sekunde."@de ,
+                                  "Le débit maximal lorsqu'il est variable, en bits par seconde."@fr ,
+                                  "The maximum bitrate when variable, in bits per second."@en ;
+              rdfs:label "Débit binaire maximal"@fr ,
+                         "Maximale Bitrate"@de ,
+                         "Maximum bitrate"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#bitRateMode
 ec:bitRateMode rdf:type owl:DatatypeProperty ;
                rdfs:range rdfs:Literal ;
-               dcterms:description """A flag to indicate if the bit rate is fixed or
-            variable."""@en ;
-               rdfs:label "Bitrate mode"@en .
+               dcterms:description "A flag to indicate if the bit rate is fixed or variable."@en ,
+                                   "Ein Flag, das anzeigt, ob die Bitrate fest oder variabel ist. variabel ist."@de ,
+                                   "Un drapeau pour indiquer si le débit binaire est fixe ou variable."@fr ;
+               rdfs:label "Bitrate mode"@en ,
+                          "Mode de débit binaire"@fr ,
+                          "Modus Bitrate"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#bitRateOverall
 ec:bitRateOverall rdf:type owl:DatatypeProperty ;
                   rdfs:range xsd:nonNegativeInteger ;
-                  dcterms:description """To provide the overall bitrate at which the
-            MediaResource can be played in bits/second. Current bitrate if constant, and average bitrate if variable."""@en ;
-                  rdfs:label "Overall bitrate"@en .
+                  dcterms:description "Pour fournir le débit binaire global auquel la MediaResource peut être lue en bits/seconde. Débit binaire réel si constant, et débit binaire moyen si variable."@fr ,
+                                      "To provide the overall bitrate at which the MediaResource can be played in bits/second. Current bitrate if constant, and average bitrate if variable."@en ,
+                                      "Zur Angabe der Gesamtbitrate, mit der die MediaResource abgespielt werden kann, in Bits/Sekunde. Aktuelle Bitrate, wenn konstant, und durchschnittliche Bitrate, wenn variabel."@de ;
+                  rdfs:label "Débit binaire global"@fr ,
+                             "Gesamt-Bitrate"@de ,
+                             "Overall bitrate"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#bookmark
 ec:bookmark rdf:type owl:DatatypeProperty ;
             rdfs:subPropertyOf ec:contentDescription ;
             rdfs:range rdfs:Literal ;
-            dcterms:description "To provide a bookmark."@en ;
-            rdfs:label "Bookmark"@en .
+            dcterms:description "Pour fournir un signet."@fr ,
+                                "To provide a bookmark."@en ,
+                                "Um ein Lesezeichen zu setzen."@de ;
+            rdfs:label "Bookmark"@en ,
+                       "Bookmark"@fr ,
+                       "Lesezeichen"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#characterEndIndex
 ec:characterEndIndex rdf:type owl:DatatypeProperty ;
                      rdfs:range xsd:integer ;
-                     dcterms:description "To identify the end character index of the portion of text to which the Annotation applies."@en ;
-                     rdfs:label "Annotation character start index"@en .
+                     dcterms:description "Pour identifier l'indice de caractère de fin de la portion de texte à laquelle s'applique l'annotation."@fr ,
+                                         "To identify the end character index of the portion of text to which the Annotation applies."@en ,
+                                         "Zur Ermittlung des Endzeichenindexes des Textabschnitts, auf den sich die Anmerkung bezieht."@de ;
+                     rdfs:label "Annotation character start index"@en ,
+                                "Index de début de caractère d'annotation"@fr ,
+                                "Index für den Beginn der Annotationszeichen"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#characterStartIndex
 ec:characterStartIndex rdf:type owl:DatatypeProperty ;
                        rdfs:range xsd:integer ;
-                       dcterms:description "To identify the start character index of the portion of text to which the Annotation applies."@en ;
-                       rdfs:label "Annotation text character start index"@en .
+                       dcterms:description "Pour identifier l'indice de caractère de début de la portion de texte à laquelle l'annotation s'applique."@fr ,
+                                           "To identify the start character index of the portion of text to which the Annotation applies."@en ,
+                                           "Um den Index des Anfangszeichens des Textabschnitts zu ermitteln, auf den sich die Anmerkung bezieht."@de ;
+                       rdfs:label "Annotation text character start index"@en ,
+                                  "Indice du début du caractère du texte annoté"@fr ,
+                                  "Zeichenindex für den Beginn des Kommentartextes"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#codecFamily
 ec:codecFamily rdf:type owl:DatatypeProperty ;
                rdfs:range rdfs:Literal ;
-               dcterms:description "To provide information on the product family of the Codec."@en ;
-               rdfs:label "Codec family"@en .
+               dcterms:description "Pour fournir des informations sur la famille de produits du Codec."@fr ,
+                                   "To provide information on the product family of the Codec."@en ,
+                                   "Zur Bereitstellung von Informationen über die Produktfamilie des Codec."@de ;
+               rdfs:label "Codec family"@en ,
+                          "Codec-Familie"@de ,
+                          "Famille de codecs"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#codecVersion
 ec:codecVersion rdf:type owl:DatatypeProperty ;
                 rdfs:range rdfs:Literal ;
-                dcterms:description "To provide information on the version of the Codec."@en ;
-                rdfs:label "Codec version"@en .
+                dcterms:description "Pour fournir des informations sur la version du Codec."@fr ,
+                                    "To provide information on the version of the Codec."@en ,
+                                    "Um Informationen über die Version des Codec bereitzustellen."@de ;
+                rdfs:label "Codec Version"@de ,
+                           "Codec version"@en ,
+                           "Version du codec"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#comments
 ec:comments rdf:type owl:DatatypeProperty ;
             rdfs:subPropertyOf ec:contentDescription ;
             rdfs:range rdfs:Literal ;
-            dcterms:description "To provide a comment."@en ;
-            rdfs:label "Comments"@en .
+            dcterms:description "Pour fournir un commentaire."@fr ,
+                                "To provide a comment."@en ,
+                                "Um einen Kommentar abzugeben."@de ;
+            rdfs:label "Commentaires"@fr ,
+                       "Comments"@en ,
+                       "Kommentare"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#contentDescription
 ec:contentDescription rdf:type owl:DatatypeProperty ;
                       rdfs:range rdfs:Literal ;
-                      dcterms:description """This can be specialised by using sub-properties
-            like defined in http://www.ebu.ch/metadata/cs/web/ebu_DescriptionTypeCodeCS_p.xml.htm
-            implemented as examples as e.g. 'summary' or
-            'script'."""@en ;
+                      dcterms:description "Ceci peut être spécialisé en utilisant des sous-propriétés comme celles définies dans http://www.ebu.ch/metadata/cs/web/ebu_DescriptionTypeCodeCS_p.xml.htm mises en œuvre à titre d'exemple, comme par exemple \"summary\" ou \"script\"."@fr ,
+                                          "Dies kann durch die Verwendung von Untereigenschaften spezialisiert werden wie in http://www.ebu.ch/metadata/cs/web/ebu_DescriptionTypeCodeCS_p.xml.htm definiert als Beispiele implementiert sind, wie z.B. 'summary' oder 'Skript'."@de ,
+                                          "This can be specialised by using sub-properties like defined in http://www.ebu.ch/metadata/cs/web/ebu_DescriptionTypeCodeCS_p.xml.htm implemented as examples as e.g. 'summary' or 'script'."@en ;
                       rdfs:isDefinedBy <dc:description> ;
-                      rdfs:label "Content description"@en .
+                      rdfs:label "Beschreibung des Inhalts"@de ,
+                                 "Content description"@en ,
+                                 "Description du contenu"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#costumeSizeInformation
 ec:costumeSizeInformation rdf:type owl:DatatypeProperty ;
                           rdfs:range rdfs:Literal ;
-                          dcterms:description "To collect all information available useful to determine the size of a Costume."@en ;
-                          rdfs:label "Costume size information"@en .
+                          dcterms:description "Recueillir toutes les informations disponibles utiles pour déterminer la taille d'un Costume."@fr ,
+                                              "To collect all information available useful to determine the size of a Costume."@en ,
+                                              "Um alle verfügbaren Informationen zu sammeln, die nützlich sind, um die Größe eines Kostüms zu bestimmen."@de ;
+                          rdfs:label "Costume size information"@en ,
+                                     "Informationen zur Kostümgröße"@de ,
+                                     "Informations sur la taille des costumes"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#costumeTexture
 ec:costumeTexture rdf:type owl:DatatypeProperty ;
                   rdfs:range rdfs:Literal ;
-                  dcterms:description "Range: a string or a Concept code from a vocabulary, e.g. Getty"@en ,
-                                      "To define the texture of a Costume."@en ;
-                  rdfs:label "Costume texture"@en .
+                  dcterms:description "Bereich: eine Zeichenkette oder ein Konzeptcode aus einem Vokabular, z.B. Getty"@de ,
+                                      "Gamme : une chaîne de caractères ou un code de concept d'un vocabulaire, par exemple Getty"@fr ,
+                                      "Range: a string or a Concept code from a vocabulary, e.g. Getty To define the texture of a Costume."@en ;
+                  rdfs:label "Costume texture"@en ,
+                             "Textur des Kostüms"@de ,
+                             "Texture du costume"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#day
 ec:day rdf:type owl:DatatypeProperty ;
        rdfs:range xsd:integer ;
-       rdfs:label "Day"@en .
+       rdfs:label "Day"@en ,
+                  "Jour"@fr ,
+                  "Tag"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#description
 ec:description rdf:type owl:DatatypeProperty ;
                rdfs:range rdfs:Literal ;
-               dcterms:description "A summary of the resource."@en ;
-               rdfs:label "Description"@en .
+               dcterms:description "A summary of the resource."@en ,
+                                   "Eine Zusammenfassung der Ressource."@de ,
+                                   "Un résumé de la ressource."@fr ;
+               rdfs:label "Beschreibung"@de ,
+                          "Description"@en ,
+                          "Description"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#dimensions
 ec:dimensions rdf:type owl:DatatypeProperty ;
               rdfs:range rdfs:Literal ;
-              dcterms:description "Describes the physical dimensions of a MediaResource, with units of measure concatenated to become part of the value."@en ;
-              rdfs:label "Dimensions"@en .
+              dcterms:description "Beschreibt die physischen Abmessungen einer MediaResource, wobei die Maßeinheiten als Teil des Wertes verkettet werden."@de ,
+                                  "Describes the physical dimensions of a MediaResource, with units of measure concatenated to become part of the value."@en ,
+                                  "Décrit les dimensions physiques d'une MediaResource, les unités de mesure étant concaténées pour faire partie de la valeur."@fr ;
+              rdfs:label "Abmessungen"@de ,
+                         "Dimensions"@en ,
+                         "Dimensions"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#displayOrder
 ec:displayOrder rdf:type owl:DatatypeProperty ;
                 rdfs:range rdfs:Literal ;
-                dcterms:description "The order in which an Agent appears in a scene."@en ;
-                rdfs:label "Display order"@en .
+                dcterms:description "Die Reihenfolge, in der ein Agent in einer Szene erscheint."@de ,
+                                    "L'ordre dans lequel un agent apparaît dans une scène."@fr ,
+                                    "The order in which an Agent appears in a scene."@en ;
+                rdfs:label "Bestellung anzeigen"@de ,
+                           "Display order"@en ,
+                           "Ordre d'affichage"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#editUnit
 ec:editUnit rdf:type owl:DatatypeProperty ;
             rdfs:range xsd:long ;
-            dcterms:description """The edit unit is e.g. the inverse of the audio
-            sample rate or video frame rate."""@en ;
-            rdfs:label "Edit unit"@en .
+            dcterms:description "Die Bearbeitungseinheit ist z.B. der Kehrwert der Audio Sample-Rate oder Video-Frame-Rate."@de ,
+                                "L'unité de montage est par exemple l'inverse du taux d'échantillonnage audio ou de la fréquence d'images vidéo."@fr ,
+                                "The edit unit is e.g. the inverse of the audio sample rate or video frame rate."@en ;
+            rdfs:label "Edit unit"@en ,
+                       "Einheit bearbeiten"@de ,
+                       "Unité d'édition"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#editUnitNumbering
 ec:editUnitNumbering rdf:type owl:DatatypeProperty ;
                      rdfs:range xsd:long ;
-                     dc:description "Time expressed as the number of editunits or samples."@en ;
-                     rdfs:label "Edit unit numbering"@en .
+                     dcterms:description "Temps exprimé en nombre d'unités de montage ou d'échantillons."@fr ,
+                                         "Time expressed as the number of editunits or samples."@en ,
+                                         "Zeit, ausgedrückt in der Anzahl der Bearbeitungseinheiten oder Stichproben."@de ;
+                     rdfs:label "Edit unit numbering"@en ,
+                                "Edite la numérotation des unités"@fr ,
+                                "Nummerierung der Einheiten bearbeiten"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#education
 ec:education rdf:type owl:DatatypeProperty ;
              rdfs:range rdfs:Literal ;
-             dcterms:description "To provide information on the education."@en ;
-             rdfs:label "Education"@en .
+             dcterms:description "Informationen über die Ausbildung zu liefern."@de ,
+                                 "Pour fournir des informations sur l'éducation."@fr ,
+                                 "To provide information on the education."@en ;
+             rdfs:label "Bildung"@de ,
+                        "Education"@en ,
+                        "Éducation"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#encodingLevel
 ec:encodingLevel rdf:type owl:DatatypeProperty ;
                  rdfs:range rdfs:Literal ;
-                 dcterms:description "To define an encoding level."@en ;
-                 rdfs:label "Encoding level"@en .
+                 dcterms:description "Pour définir un niveau d'encodage."@fr ,
+                                     "To define an encoding level."@en ,
+                                     "Um eine Kodierungsebene zu definieren."@de ;
+                 rdfs:label "Encoding level"@en ,
+                            "Kodierungsebene"@de ,
+                            "Niveau de codage"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#encodingProfile
 ec:encodingProfile rdf:type owl:DatatypeProperty ;
                    rdfs:range rdfs:Literal ;
-                   dcterms:description "The encoding profile as defined in specifications."@en ;
-                   rdfs:label "Encoding profile"@en .
+                   dcterms:description "Das Kodierungsprofil, wie in den Spezifikationen definiert."@de ,
+                                       "Le profil de codage tel que défini dans les spécifications."@fr ,
+                                       "The encoding profile as defined in specifications."@en ;
+                   rdfs:label "Encoding profile"@en ,
+                              "Kodierungsprofil"@de ,
+                              "Profil d'encodage"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#episodeNumber
 ec:episodeNumber rdf:type owl:DatatypeProperty ;
                  rdfs:range xsd:integer ;
-                 dcterms:description "The Episode Number"@en ;
-                 rdfs:label "Episode number"@en .
+                 dcterms:description "Die Episodennummer"@de ,
+                                     "Le numéro de l'épisode"@fr ,
+                                     "The Episode Number"@en ;
+                 rdfs:label "Episode number"@en ,
+                            "Folge Nummer"@de ,
+                            "Numéro d'épisode"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#episodeNumberInSeason
 ec:episodeNumberInSeason rdf:type owl:DatatypeProperty ;
                          rdfs:range xsd:integer ;
-                         dcterms:description "The Episode Number in a season"@en ;
-                         rdfs:label "Episode number in season"@en .
+                         dcterms:description "Die Episodennummer in einer Staffel"@de ,
+                                             "Le numéro d'épisode dans une saison"@fr ,
+                                             "The Episode Number in a season"@en ;
+                         rdfs:label "Episode number in season"@en ,
+                                    "Nummer der Episode in der Staffel"@de ,
+                                    "Numéro d'épisode dans la saison"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#episodeNumberInSerial
 ec:episodeNumberInSerial rdf:type owl:DatatypeProperty ;
-                         rdfs:label "episode number of serial"@en .
+                         rdfs:label "Episodennummer der Serie"@de ,
+                                    "episode number of serial"@en ,
+                                    "numéro d'épisode de la série"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#episodeNumberInSeries
 ec:episodeNumberInSeries rdf:type owl:DatatypeProperty ;
                          rdfs:range xsd:integer ;
-                         dcterms:description "The Episode Number in a series"@en ;
-                         rdfs:label "Episode number in series"@en .
+                         dcterms:description "Die Episodennummer in einer Serie"@de ,
+                                             "Le numéro de l'épisode dans une série"@fr ,
+                                             "The Episode Number in a series"@en ;
+                         rdfs:label "Episode number in series"@en ,
+                                    "Nummer der Episode in der Serie"@de ,
+                                    "Numéro d'épisode dans la série"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#equivalentTime
 ec:equivalentTime rdf:type owl:DatatypeProperty ;
                   rdfs:range xsd:float ;
                   dc:description "Notation of time in seconds compares different ways to denote time, like timecode or sample count."@en ;
-                  rdfs:label "equivalent time"@en .
+                  rdfs:label "entsprechende Zeit"@de ,
+                             "equivalent time"@en ,
+                             "temps équivalent"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#familyInformation
 ec:familyInformation rdf:type owl:DatatypeProperty ;
                      rdfs:range rdfs:Literal ;
-                     dcterms:description "To provide information on the family of a Person."@en ;
-                     rdfs:label "Family information"@en .
+                     dcterms:description "Pour fournir des informations sur la famille d'une personne."@fr ,
+                                         "To provide information on the family of a Person."@en ,
+                                         "Um Informationen über die Familie einer Person bereitzustellen."@de ;
+                     rdfs:label "Family information"@en ,
+                                "Informationen zur Familie"@de ,
+                                "Informations sur la famille"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#familyName
 ec:familyName rdf:type owl:DatatypeProperty ;
               rdfs:range rdfs:Literal ;
-              dcterms:description "The family name of a Person."@en ;
-              rdfs:label "Family name"@en .
+              dcterms:description "Der Familienname einer Person."@de ,
+                                  "Le nom de famille d'une personne."@fr ,
+                                  "The family name of a Person."@en ;
+              rdfs:label "Familienname"@de ,
+                         "Family name"@en ,
+                         "Nom de famille"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#fileName
 ec:fileName rdf:type owl:DatatypeProperty ,
                      owl:FunctionalProperty ;
             rdfs:range xsd:string ;
-            dcterms:description "The name of the file containing the Resource."@en ;
-            rdfs:label "File name"@en .
+            dcterms:description "Der Name der Datei, die die Ressource enthält."@de ,
+                                "Le nom du fichier contenant la ressource."@fr ,
+                                "The name of the file containing the Resource."@en ;
+            rdfs:label "Dateiname"@de ,
+                       "File name"@en ,
+                       "Nom du fichier"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#fileSize
 ec:fileSize rdf:type owl:DatatypeProperty ;
             rdfs:range xsd:double ;
-            dcterms:description "Provides the size of a Resource in bytes."@en ;
-            rdfs:label "File size"@en .
+            dcterms:description "Fournit la taille d'une ressource en octets."@fr ,
+                                "Gibt die Größe einer Ressource in Bytes an."@de ,
+                                "Provides the size of a Resource in bytes."@en ;
+            rdfs:label "Dateigröße"@de ,
+                       "File size"@en ,
+                       "Taille du fichier"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#firstShowing
 ec:firstShowing rdf:type owl:DatatypeProperty ,
                          owl:FunctionalProperty ;
                 rdfs:range xsd:boolean ;
-                dcterms:description "To flag this is a first showing PublicationEvent."@en ;
-                rdfs:label "First showing flag"@en .
+                dcterms:description "Pour signaler qu'il s'agit d'une première présentation PublicationEvent."@fr ,
+                                    "To flag this is a first showing PublicationEvent."@en ,
+                                    "Um dies zu kennzeichnen, muss zuerst ein PublicationEvent angezeigt werden."@de ;
+                rdfs:label "Erste Flagge zeigen"@de ,
+                           "First showing flag"@en ,
+                           "Premier drapeau d'exposition"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#firstShowingThisService
 ec:firstShowingThisService rdf:type owl:DatatypeProperty ,
                                     owl:FunctionalProperty ;
                            rdfs:range xsd:boolean ;
-                           dcterms:description "To falg this is a first showing  PublicationEvent on this service."@en ;
-                           rdfs:label "First showing on service flag"@en .
+                           dcterms:description "Für falg ist dies das erste PublicationEvent, das in diesem Dienst angezeigt wird."@de ,
+                                               "Pour notifier, il s'agit d'un premier événement de publication sur ce service."@fr ,
+                                               "To falg this is a first showing PublicationEvent on this service."@en ;
+                           rdfs:label "Drapeau pour la première apparition en service"@fr ,
+                                      "Erste Anzeige auf der Serviceflagge"@de ,
+                                      "First showing on service flag"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#folksonomy
 ec:folksonomy rdf:type owl:DatatypeProperty ;
               rdfs:range rdfs:Literal ;
-              dcterms:description "Provides a user/audience-generated description, tag, or label for resource content."@en ;
-              rdfs:label "Folksonomy"@en .
+              dcterms:description "Bietet eine vom Benutzer/Zuschauer generierte Beschreibung, Markierung oder Bezeichnung für Ressourceninhalte."@de ,
+                                  "Fournit une description, une balise ou une étiquette générée par l'utilisateur/audience pour le contenu de la ressource."@fr ,
+                                  "Provides a user/audience-generated description, tag, or label for resource content."@en ;
+              rdfs:label "Folksonomie"@fr ,
+                         "Folksonomy"@de ,
+                         "Folksonomy"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#foodCategory
 ec:foodCategory rdf:type owl:DatatypeProperty ;
                 rdfs:range rdfs:Literal ;
-                dcterms:description "To define a category of Food."@en ;
-                rdfs:label "Food category"@en .
+                dcterms:description "Pour définir une catégorie d'aliments."@fr ,
+                                    "To define a category of Food."@en ,
+                                    "Um eine Kategorie von Lebensmitteln zu definieren."@de ;
+                rdfs:label "Catégorie d'aliments"@fr ,
+                           "Food category"@en ,
+                           "Kategorie Lebensmittel"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#foodIngredient
 ec:foodIngredient rdf:type owl:DatatypeProperty ;
                   rdfs:range rdfs:Literal ;
-                  dcterms:description "The Food ingredients or Food items."@en ;
-                  rdfs:label "Food ingredient"@en .
+                  dcterms:description "Die Lebensmittelzutaten oder Lebensmittelartikel."@de ,
+                                      "Les ingrédients alimentaires ou les produits alimentaires."@fr ,
+                                      "The Food ingredients or Food items."@en ;
+                  rdfs:label "Food ingredient"@en ,
+                             "Ingrédient alimentaire"@fr ,
+                             "Lebensmittelzutat"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#frameHeight
 ec:frameHeight rdf:type owl:DatatypeProperty ;
                rdfs:subPropertyOf ec:height ;
                rdfs:range xsd:integer ;
-               dcterms:description "The height of a video frame."@en ;
-               rdfs:label "Frame height"@en .
+               dcterms:description "Die Höhe eines Videobildes."@de ,
+                                   "La hauteur d'une image vidéo."@fr ,
+                                   "The height of a video frame."@en ;
+               rdfs:label "Frame height"@en ,
+                          "Hauteur du cadre"@fr ,
+                          "Rahmenhöhe"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#frameHeightUnit
 ec:frameHeightUnit rdf:type owl:DatatypeProperty ;
                    rdfs:subPropertyOf ec:heightUnit ;
                    rdfs:range rdfs:Literal ;
-                   dcterms:description "The unit used to measure the height of a frame."@en ;
-                   rdfs:label "Frame height unit"@en .
+                   dcterms:description "Die Einheit, die zur Messung der Höhe eines Rahmens verwendet wird."@de ,
+                                       "L'unité utilisée pour mesurer la hauteur d'un cadre."@fr ,
+                                       "The unit used to measure the height of a frame."@en ;
+                   rdfs:label "Einheit Rahmenhöhe"@de ,
+                              "Frame height unit"@en ,
+                              "Unité de hauteur du cadre"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#frameRate
 ec:frameRate rdf:type owl:DatatypeProperty ;
              rdfs:range rdfs:Literal ;
-             dcterms:description "The unit used to express the frame rate of a MediaResource in frames/second."@en ;
-             rdfs:label "Frame rate"@en .
+             dcterms:description "Die Einheit, mit der die Bildrate einer MediaResource in Bildern/Sekunde ausgedrückt wird."@de ,
+                                 "L'unité utilisée pour exprimer la fréquence d'images d'une MediaResource en images/seconde."@fr ,
+                                 "The unit used to express the frame rate of a MediaResource in frames/second."@en ;
+             rdfs:label "Bildrate"@de ,
+                        "Frame rate"@en ,
+                        "Fréquence d'images"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#frameSizeUnit
 ec:frameSizeUnit rdf:type owl:DatatypeProperty ;
                  rdfs:range rdfs:Literal ;
-                 dcterms:description """The unit used to express the frame width or
-            height. The unit by default is 'pixel'."""@en ;
-                 rdfs:label "Frame size unit"@en .
+                 dcterms:description "Die Einheit, die verwendet wird, um die Breite oder Höhe des Rahmens auszudrücken. Höhe. Die Einheit ist standardmäßig 'Pixel'."@de ,
+                                     "L'unité utilisée pour exprimer la largeur ou la hauteur. L'unité par défaut est le \"pixel\"."@fr ,
+                                     "The unit used to express the frame width or height. The unit by default is 'pixel'."@en ;
+                 rdfs:label "Frame size unit"@en ,
+                            "Rahmengröße Einheit"@de ,
+                            "Unité de taille de cadre"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#frameWidth
 ec:frameWidth rdf:type owl:DatatypeProperty ;
               rdfs:subPropertyOf ec:width ;
               rdfs:range xsd:integer ;
-              dcterms:description "The width of a video frame."@en ;
-              rdfs:label "Frame width"@en .
+              dcterms:description "Die Breite eines Videobildes."@de ,
+                                  "La largeur d'une image vidéo."@fr ,
+                                  "The width of a video frame."@en ;
+              rdfs:label "Frame width"@en ,
+                         "Largeur du cadre"@fr ,
+                         "Rahmenbreite"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#frameWidthUnit
 ec:frameWidthUnit rdf:type owl:DatatypeProperty ;
                   rdfs:subPropertyOf ec:widthUnit ;
                   rdfs:range rdfs:Literal ;
-                  dcterms:description "The unit used to measure the width of a frame."@en ;
-                  rdfs:label "Frame width unit"@en .
+                  dcterms:description "Die Einheit, die zur Messung der Breite eines Rahmens verwendet wird."@de ,
+                                      "L'unité utilisée pour mesurer la largeur d'un cadre."@fr ,
+                                      "The unit used to measure the width of a frame."@en ;
+                  rdfs:label "Einheit Rahmenbreite"@de ,
+                             "Frame width unit"@en ,
+                             "Unité de largeur du cadre"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#free
 ec:free rdf:type owl:DatatypeProperty ,
                  owl:FunctionalProperty ;
         rdfs:range xsd:boolean ;
-        dcterms:description "A flag to indicate that the access to the PublicationEvent is 'free'."@en ;
-        rdfs:label "Free access"@en .
+        dcterms:description "A flag to indicate that the access to the PublicationEvent is 'free'."@en ,
+                            "Ein Flag, das anzeigt, dass der Zugriff auf das PublicationEvent 'frei' ist."@de ,
+                            "Un drapeau pour indiquer que l'accès au PublicationEvent est \"libre\"."@fr ;
+        rdfs:label "Accès gratuit"@fr ,
+                   "Free access"@en ,
+                   "Freier Zugang"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#gender
 ec:gender rdf:type owl:DatatypeProperty ;
           rdfs:range rdfs:Literal ;
-          dcterms:description "The gender of a Person e.g. male or female."@en ;
-          rdfs:label "Gender"@en .
+          dcterms:description "Das Geschlecht einer Person, z.B. männlich oder weiblich."@de ,
+                              "Le genre d'une personne, par exemple, homme ou femme."@fr ,
+                              "The gender of a Person e.g. male or female."@en ;
+          rdfs:label "Gender"@en ,
+                     "Genre"@fr ,
+                     "Geschlecht"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#givenName
 ec:givenName rdf:type owl:DatatypeProperty ;
              rdfs:range rdfs:Literal ;
-             dcterms:description "The given name of a Person."@en ;
-             rdfs:label "Given name"@en .
+             dcterms:description "Der Vorname einer Person."@de ,
+                                 "Le prénom d'une personne."@fr ,
+                                 "The given name of a Person."@en ;
+             rdfs:label "Given name"@en ,
+                        "Nom de famille"@fr ,
+                        "Vorname"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hashValue
 ec:hashValue rdf:type owl:DatatypeProperty ;
              rdfs:range xsd:string ;
-             dcterms:description """The hash value associated to a Resource. There
-            are different methods / algorithms to calculate hash values, which can be defined as
-            subproperties."""@en ;
-             rdfs:label "Hash code"@en .
+             dcterms:description "Der Hash-Wert, der einer Ressource zugeordnet ist. Es gibt es verschiedene Methoden / Algorithmen zur Berechnung von Hash-Werten, die als Untereigenschaften definiert werden können. Unter-Eigenschaften."@de ,
+                                 "La valeur de hachage associée à une ressource. Il existe différentes méthodes / algorithmes pour calculer les valeurs de hachage, qui peuvent être définies en tant que sous-propriétés."@fr ,
+                                 "The hash value associated to a Resource. There are different methods / algorithms to calculate hash values, which can be defined as subproperties."@en ;
+             rdfs:label "Code de hachage"@fr ,
+                        "Hash code"@en ,
+                        "Hash-Code"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#height
 ec:height rdf:type owl:DatatypeProperty ;
           rdfs:range xsd:integer ;
-          dcterms:description """The height of e.g. a video frame typically
-            expressed as a number of lines or the height of a picture/image expressed in millimeters
-            or else."""@en ;
-          rdfs:label "Height"@en .
+          dcterms:description "Die Höhe z.B. eines Videobildes wird normalerweise ausgedrückt als Anzahl von Zeilen oder die Höhe eines Bildes/Bildes, ausgedrückt in Millimetern oder anders."@de ,
+                              "La hauteur d'une image vidéo, par exemple, généralement exprimée en nombre de lignes ou la hauteur d'une photo/image exprimée en millimètres ou autre unité."@fr ,
+                              "The height of e.g. a video frame typically expressed as a number of lines or the height of a picture/image expressed in millimeters or else."@en ;
+          rdfs:label "Hauteur"@fr ,
+                     "Height"@en ,
+                     "Höhe"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#heightUnit
 ec:heightUnit rdf:type owl:DatatypeProperty ;
               rdfs:range rdfs:Literal ;
-              dcterms:description "To specify a unit to express height."@en ;
-              rdfs:label "Height unit"@en .
+              dcterms:description "Pour spécifier une unité pour exprimer la hauteur."@fr ,
+                                  "To specify a unit to express height."@en ,
+                                  "Um eine Einheit für die Höhe anzugeben."@de ;
+              rdfs:label "Height unit"@en ,
+                         "Höheneinheit"@de ,
+                         "Unité de hauteur"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#highlights
 ec:highlights rdf:type owl:DatatypeProperty ;
               rdfs:subPropertyOf ec:contentDescription ;
               rdfs:range rdfs:Literal ;
-              dcterms:description "To provide highlights."@en ;
-              rdfs:label "Highlights"@en .
+              dcterms:description "Pour fournir des points forts."@fr ,
+                                  "To provide highlights."@en ,
+                                  "Um Highlights zu bieten."@de ;
+              rdfs:label "Highlights"@en ,
+                         "Höhepunkte"@de ,
+                         "Points forts"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hobbies
 ec:hobbies rdf:type owl:DatatypeProperty ;
            rdfs:range rdfs:Literal ;
-           dcterms:description "The hobbies of a Person."@en ;
-           rdfs:label "Hobbies"@en .
+           dcterms:description "Die Hobbys einer Person."@de ,
+                               "Les loisirs d'une personne."@fr ,
+                               "The hobbies of a Person."@en ;
+           rdfs:label "Hobbies"@en ,
+                      "Hobbys"@de ,
+                      "Passe-temps"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#iFrameSize
 ec:iFrameSize rdf:type owl:DatatypeProperty ;
               rdfs:range xsd:int ;
-              dcterms:description "The distance between 2 I-frames also known as the gop size."@en ;
-              rdfs:label "I-frame/Gop size"@en .
+              dcterms:description "Der Abstand zwischen 2 I-Frames wird auch als Gop-Größe bezeichnet."@de ,
+                                  "La distance entre 2 I-frames également connue comme la taille du gap."@fr ,
+                                  "The distance between 2 I-frames also known as the gop size."@en ;
+              rdfs:label "I-Frame/Gop-Größe"@de ,
+                         "I-frame/Gop size"@en ,
+                         "Taille I-frame/Gap"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#identifierValue
 ec:identifierValue rdf:type owl:DatatypeProperty ;
                    rdfs:range rdfs:Literal ;
-                   dcterms:description "Range: string or anyURI."@en ,
-                                       "To provide the value attribued to an Identifier."@en ;
-                   rdfs:label "Identifier value"@en .
+                   dcterms:description "Bereich: String oder anyURI."@de ,
+                                       "Plage : chaîne de caractères ou anyURI."@fr ,
+                                       "To provide the value attribued to an Identifier. Range: string or anyURI."@en ;
+                   rdfs:label "Identifier value"@en ,
+                              "Valeur d'identification"@fr ,
+                              "Wert der Kennung"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#inchesPerSecond
 ec:inchesPerSecond rdf:type owl:DatatypeProperty ;
                    rdfs:subPropertyOf ec:playbackSpeed ;
                    rdfs:range xsd:double ;
-                   dcterms:description "Identifies the inches per second at which an analog audio tape should be played back for human consumption."@en ;
-                   rdfs:label "Inches per second"@en .
+                   dcterms:description "Gibt die Zoll pro Sekunde an, mit der ein analoges Audioband für den menschlichen Verzehr wiedergegeben werden sollte."@de ,
+                                       "Identifie les pouces par seconde auxquels une bande audio analogique doit être lue pour la consommation humaine."@fr ,
+                                       "Identifies the inches per second at which an analog audio tape should be played back for human consumption."@en ;
+                   rdfs:label "Inches per second"@en ,
+                              "Pouces par seconde"@fr ,
+                              "Zentimeter pro Sekunde"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#isoDuration
 ec:isoDuration rdf:type owl:DatatypeProperty ;
                rdfs:range xsd:string ;
-               dcterms:description "a duration expressed as a string formated as ISO8601 ie PT3M23S"@en ;
-               rdfs:label "ISO duration"@en .
+               dcterms:description "a duration expressed as a string formated as ISO8601 ie PT3M23S"@en ,
+                                   "eine Dauer, ausgedrückt als Zeichenkette im Format ISO8601, also PT3M23S"@de ,
+                                   "une durée exprimée sous la forme d'une chaîne de caractères au format ISO8601 : PT3M23S"@fr ;
+               rdfs:label "Durée ISO"@fr ,
+                          "ISO duration"@en ,
+                          "ISO-Dauer"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#lineNumber
 ec:lineNumber rdf:type owl:DatatypeProperty ;
               rdfs:range xsd:integer ;
-              dcterms:description """To provide the number of the line on which
-            ancillary data is being carried and the equivalent in the digital domain."""@en ;
-              rdfs:label "Line number"@en .
+              dcterms:description "Ppur fournir le numéro de la ligne sur laquelle les données auxiliaires sont transportées et l'équivalent dans le domaine numérique."@fr ,
+                                  "To provide the number of the line on which ancillary data is being carried and the equivalent in the digital domain."@en ,
+                                  "Zur Angabe der Nummer der Leitung, auf der Zusatzdaten übertragen werden, und die Entsprechung im digitalen Bereich."@de ;
+              rdfs:label "Line number"@en ,
+                         "Numéro de ligne"@fr ,
+                         "Zeilennummer"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#live
 ec:live rdf:type owl:DatatypeProperty ,
                  owl:FunctionalProperty ;
         rdfs:range xsd:boolean ;
-        dcterms:description "A flag to signal that content is live"@en ;
-        rdfs:label "Live"@en .
+        dcterms:description "A flag to signal that content is live"@en ,
+                            "Ein Flag, das signalisiert, dass der Inhalt live ist"@de ,
+                            "Un drapeau pour signaler que le contenu est en direct"@fr ;
+        rdfs:label "En direct"@fr ,
+                   "Live"@de ,
+                   "Live"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#locationAddressAppartmentNumber
 ec:locationAddressAppartmentNumber rdf:type owl:DatatypeProperty ;
                                    rdfs:range xsd:string ;
-                                   dcterms:description "The number identifying an apartment in a house."@en ;
-                                   rdfs:label "appartment number"@en .
+                                   dcterms:description "Die Nummer, die eine Wohnung in einem Haus identifiziert."@de ,
+                                                       "Le numéro identifiant un appartement dans une maison."@fr ,
+                                                       "The number identifying an apartment in a house."@en ;
+                                   rdfs:label "Appartmentnummer"@de ,
+                                              "appartment number"@en ,
+                                              "numéro de l'appartement"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#locationAddressArea
 ec:locationAddressArea rdf:type owl:DatatypeProperty ;
                        rdfs:range rdfs:Literal ;
-                       dcterms:description """To provide the Area part of an
-            Adrress."""@en ;
-                       rdfs:label "Area"@en .
+                       dcterms:description "Pour fournir la partie Zone d'une adresse."@fr ,
+                                           "To provide the Area part of an Adrress."@en ,
+                                           "Um den Bereich Teil einer Adresse."@de ;
+                       rdfs:label "Area"@en ,
+                                  "Bereich"@de ,
+                                  "Zone"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#locationAddressCountry
 ec:locationAddressCountry rdf:type owl:DatatypeProperty ;
                           rdfs:range rdfs:Literal ;
-                          dcterms:description """To provide the country name and or country
-            code."""@en ;
-                          rdfs:label "Country"@en .
+                          dcterms:description "Pour fournir le nom du pays et ou le code du pays."@fr ,
+                                              "To provide the country name and or country code."@en ,
+                                              "Zur Angabe des Ländernamens und/oder des Ländercodes Code."@de ;
+                          rdfs:label "Country"@en ,
+                                     "Land"@de ,
+                                     "Pays"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#locationAddressHouseNumber
 ec:locationAddressHouseNumber rdf:type owl:DatatypeProperty ;
                               rdfs:range xsd:string ;
-                              dcterms:description "The number given to the house or an entrance in a street"@en ;
-                              rdfs:label "house number"@en .
+                              dcterms:description "Die Nummer, die einem Haus oder einem Eingang in einer Straße gegeben wird"@de ,
+                                                  "Le numéro donné à la maison ou à une entrée dans une rue"@fr ,
+                                                  "The number given to the house or an entrance in a street"@en ;
+                              rdfs:label "Hausnummer"@de ,
+                                         "house number"@en ,
+                                         "numéro de maison"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#locationAddressMunicipality
 ec:locationAddressMunicipality rdf:type owl:DatatypeProperty ;
                                rdfs:range rdfs:Literal ;
-                               dcterms:description """To provide the name of a city, village,
-            etc."""@en ;
-                               rdfs:label "municipality"@en .
+                               dcterms:description "Pour fournir le nom d'une ville, d'un village, etc."@fr ,
+                                                   "To provide the name of a city, village, etc."@en ,
+                                                   "Zur Angabe des Namens einer Stadt, eines Dorfes, usw."@de ;
+                               rdfs:label "Gemeinde"@de ,
+                                          "municipality"@en ,
+                                          "municipalité"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#locationAddressPostalCode
 ec:locationAddressPostalCode rdf:type owl:DatatypeProperty ;
                              rdfs:range rdfs:Literal ;
-                             dcterms:description """To provide an address postal
-            code."""@en ;
-                             rdfs:label "Postal code"@en .
+                             dcterms:description "Pour fournir le code de l' adresse postale ."@fr ,
+                                                 "To provide an address postal code."@en ,
+                                                 "Zur Angabe einer Postleitzahl für die Adresse code."@de ;
+                             rdfs:label "Code postal"@fr ,
+                                        "Postal code"@en ,
+                                        "Postleitzahl"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#locationAddressStreetName
 ec:locationAddressStreetName rdf:type owl:DatatypeProperty ;
                              rdfs:range rdfs:Literal ;
-                             dcterms:description "The name of the street, square or block in a adress"@en ;
-                             rdfs:label "street name"@en .
+                             dcterms:description "Der Name der Straße, des Platzes oder des Blocks in einer Adresse"@de ,
+                                                 "Le nom de la rue, de la place ou du bloc dans une adresse"@fr ,
+                                                 "The name of the street, square or block in a adress"@en ;
+                             rdfs:label "Straßenname"@de ,
+                                        "nom de la rue"@fr ,
+                                        "street name"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#locationAltitude
 ec:locationAltitude rdf:type owl:DatatypeProperty ;
                     rdfs:range xsd:float ;
-                    dcterms:description """To define the altitude of a Location in
-            meters."""@en ;
-                    rdfs:label "Altitude"@en .
+                    dcterms:description "Pour définir l'altitude d'un emplacement en mètres."@fr ,
+                                        "So definieren Sie die Höhe eines Ortes in Metern."@de ,
+                                        "To define the altitude of a Location in meters."@en ;
+                    rdfs:label "Altitude"@en ,
+                               "Altitude"@fr ,
+                               "Höhenlage"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#locationCoordinateSystemName
 ec:locationCoordinateSystemName rdf:type owl:DatatypeProperty ;
                                 rdfs:range rdfs:Literal ;
-                                dcterms:description """To specify the name of the gps coordinate
-            system used for the Location."""@en ;
-                                rdfs:label "Coordinate system"@en .
+                                dcterms:description "Pour spécifier le nom du système de coordonnées gps utilisé pour l'emplacement."@fr ,
+                                                    "To specify the name of the gps coordinate system used for the Location."@en ,
+                                                    "Zur Angabe des Namens des GPS-Koordinatensystems Systems, das für den Standort verwendet wird."@de ;
+                                rdfs:label "Coordinate system"@en ,
+                                           "Koordinatensystem"@de ,
+                                           "Système de coordonnées"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#locationLatitude
 ec:locationLatitude rdf:type owl:DatatypeProperty ;
                     rdfs:range xsd:float ;
-                    dcterms:description "The latitude of the Location."@en ;
-                    rdfs:label "Latitude"@en .
+                    dcterms:description "Der Breitengrad des Ortes."@de ,
+                                        "La latitude de l'emplacement."@fr ,
+                                        "The latitude of the Location."@en ;
+                    rdfs:label "Breitengrad"@de ,
+                               "Latitude"@en ,
+                               "Latitude"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#locationLongitude
 ec:locationLongitude rdf:type owl:DatatypeProperty ;
                      rdfs:range xsd:float ;
-                     dcterms:description """To define the longitude of the
-            Location."""@en ;
-                     rdfs:label "Longitude"@en .
+                     dcterms:description "Pour définir la longitude de la emplacement."@fr ,
+                                         "So definieren Sie den Längengrad des Standortes."@de ,
+                                         "To define the longitude of the Location."@en ;
+                     rdfs:label "Longitude"@en ,
+                                "Longitude"@fr ,
+                                "Längengrad"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#locatorTargetInformation
 ec:locatorTargetInformation rdf:type owl:DatatypeProperty ;
                             rdfs:range rdfs:Literal ;
-                            dcterms:description "Information on the locator target."@en ;
-                            rdfs:label "Locator target information"@en .
+                            dcterms:description "Information on the locator target."@en ,
+                                                "Informationen über das Ortungsziel."@de ,
+                                                "Informations sur la cible du localisateur."@fr ;
+                            rdfs:label "Informationen zum Ziel des Locators"@de ,
+                                       "Informations sur la cible du localisateur"@fr ,
+                                       "Locator target information"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#log
 ec:log rdf:type owl:DatatypeProperty ;
        rdfs:subPropertyOf ec:contentDescription ;
        rdfs:range rdfs:Literal ;
-       dcterms:description "To log everything in the content following predefined rules and criterias, as a neutral sequence of (possibly timed) textual descriptions."@en ;
-       rdfs:label "Log"@en .
+       dcterms:description "Pour enregistrer tout le contenu selon des règles et des critères prédéfinis, sous la forme d'une séquence neutre de descriptions textuelles (éventuellement minutées)."@fr ,
+                           "To log everything in the content following predefined rules and criterias, as a neutral sequence of (possibly timed) textual descriptions."@en ,
+                           "Um alles im Inhalt nach vordefinierten Regeln und Kriterien als neutrale Abfolge von (möglicherweise zeitlich begrenzten) Textbeschreibungen zu protokollieren."@de ;
+       rdfs:label "Journal de bord"@fr ,
+                  "Log"@en ,
+                  "Protokoll"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#loudnessIntegratedLoudness
 ec:loudnessIntegratedLoudness rdf:type owl:DatatypeProperty ;
                               rdfs:range xsd:float ;
-                              dcterms:description "The value for integrated loudness measured at AudioProgramme or AudioContent level."@en ;
-                              rdfs:label "Integrated loudness"@en .
+                              dcterms:description "Der Wert für die integrierte Lautheit, gemessen auf AudioProgramme- oder AudioContent-Ebene."@de ,
+                                                  "La valeur de l'intensité sonore intégrée mesurée au niveau de l'AudioProgramme ou de l'AudioContent."@fr ,
+                                                  "The value for integrated loudness measured at AudioProgramme or AudioContent level."@en ;
+                              rdfs:label "Integrated loudness"@en ,
+                                         "Integrierte Lautstärke"@de ,
+                                         "loudness intégré"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#loudnessMaxMomentary
 ec:loudnessMaxMomentary rdf:type owl:DatatypeProperty ;
                         rdfs:range xsd:float ;
-                        dcterms:description "The value for maximum momentary loudness measured at AudioProgramme or AudioContent level."@en ;
-                        rdfs:label "Max momentary loudness"@en .
+                        dcterms:description "Der Wert für die maximale momentane Lautstärke, gemessen auf AudioProgramme- oder AudioContent-Ebene."@de ,
+                                            "La valeur de l'intensité sonore maximale momentanée mesurée au niveau de l'AudioProgramme ou de l'AudioContent."@fr ,
+                                            "The value for maximum momentary loudness measured at AudioProgramme or AudioContent level."@en ;
+                        rdfs:label "Intensité sonore maximale momentanée"@fr ,
+                                   "Max momentary loudness"@en ,
+                                   "Maximale momentane Lautstärke"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#loudnessMaxShortTerm
 ec:loudnessMaxShortTerm rdf:type owl:DatatypeProperty ;
                         rdfs:range xsd:float ;
-                        dcterms:description "The value for maximum max short term loudness measured at AudioProgramme or AudioContent level."@en ;
-                        rdfs:label "Max short term loudness"@en .
+                        dcterms:description "Der Wert für die maximale kurzfristige Lautstärke, gemessen auf der Ebene des AudioProgramms oder AudioContents."@de ,
+                                            "La valeur de l'intensité sonore maximale à court terme mesurée au niveau de l'AudioProgramme ou de l'AudioContent."@fr ,
+                                            "The value for maximum max short term loudness measured at AudioProgramme or AudioContent level."@en ;
+                        rdfs:label "Max short term loudness"@en ,
+                                   "Maximale Kurzzeit-Lautstärke"@de ,
+                                   "Sonie maximale à court terme"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#loudnessMaxTruepeak
 ec:loudnessMaxTruepeak rdf:type owl:DatatypeProperty ;
                        rdfs:range xsd:float ;
-                       dcterms:description "The value for maximum true peak loudness measured at AudioProgramme or AudioContent level."@en ;
-                       rdfs:label "Max true peak loudness"@en .
+                       dcterms:description "Der Wert für die maximale wahre Spitzenlautheit, gemessen auf AudioProgramme- oder AudioContent-Ebene."@de ,
+                                           "La valeur de l'intensité sonore maximale de crête vraie mesurée au niveau de l'AudioProgramme ou de l'AudioContent."@fr ,
+                                           "The value for maximum true peak loudness measured at AudioProgramme or AudioContent level."@en ;
+                       rdfs:label "Max true peak loudness"@en ,
+                                  "Max true peak loudness"@fr ,
+                                  "Max. wahre Spitzenlautstärke"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#loudnessMethod
 ec:loudnessMethod rdf:type owl:DatatypeProperty ;
                   rdfs:range rdfs:Literal ;
-                  dcterms:description "The method for loudness measurement at AudioProgramme or AudioContent level."@en ;
-                  rdfs:label "Loudness method"@en .
+                  dcterms:description "Die Methode zur Messung der Lautheit auf der Ebene des AudioProgramms oder AudioContents."@de ,
+                                      "La méthode de mesure de l'intensité sonore au niveau de l'AudioProgramme ou de l'AudioContent."@fr ,
+                                      "The method for loudness measurement at AudioProgramme or AudioContent level."@en ;
+                  rdfs:label "Loudness method"@en ,
+                             "Loudness-Methode"@de ,
+                             "Méthode de sonorité"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#loudnessRange
 ec:loudnessRange rdf:type owl:DatatypeProperty ;
                  rdfs:range xsd:float ;
-                 dcterms:description "The loudness range measured at AudioProgramme or AudioContent level."@en ;
-                 rdfs:label "Loudness range"@en .
+                 dcterms:description "Der Lautstärkebereich, gemessen auf der Ebene des AudioProgramms oder des AudioContents."@de ,
+                                     "La plage d'intensité sonore mesurée au niveau de l'AudioProgramme ou de l'AudioContent."@fr ,
+                                     "The loudness range measured at AudioProgramme or AudioContent level."@en ;
+                 rdfs:label "Loudness range"@en ,
+                            "Loudness-Bereich"@de ,
+                            "Plage de sonorité"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#maritalStatus
 ec:maritalStatus rdf:type owl:DatatypeProperty ;
                  rdfs:range rdfs:Literal ;
-                 dcterms:description "To identify the marital status of a Person."@en ;
-                 rdfs:label "Marital Status"@en .
+                 dcterms:description "Pour identifier l'état civil d'une personne."@fr ,
+                                     "To identify the marital status of a Person."@en ,
+                                     "Zur Identifizierung des Familienstandes einer Person."@de ;
+                 rdfs:label "Familienstand"@de ,
+                            "Marital Status"@en ,
+                            "État civil"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#midRollAdAllowed
 ec:midRollAdAllowed rdf:type owl:DatatypeProperty ,
                              owl:FunctionalProperty ;
                     rdfs:range xsd:boolean ;
-                    dcterms:description "A flag to indicate whether it is allowed to insert ad breaks in mid-roll."@en ;
-                    rdfs:label "Midroll ad allowed"@en .
+                    dcterms:description "A flag to indicate whether it is allowed to insert ad breaks in mid-roll."@en ,
+                                        "Ein Flag, das anzeigt, ob es erlaubt ist, Werbeunterbrechungen in der Mitte der Rolle einzufügen."@de ,
+                                        "Un drapeau pour indiquer s'il est autorisé d'insérer des coupures publicitaires en mid-roll."@fr ;
+                    rdfs:label "Midroll ad allowed"@en ,
+                               "Midroll-Anzeige erlaubt"@de ,
+                               "Publicité midroll autorisée"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#middleName
 ec:middleName rdf:type owl:DatatypeProperty ;
               rdfs:range rdfs:Literal ;
-              dcterms:description "To provide one or more middle names for a Person."@en ;
-              rdfs:label "Middle name"@en .
+              dcterms:description "Pour fournir un ou plusieurs seconds prénoms à une personne."@fr ,
+                                  "To provide one or more middle names for a Person."@en ,
+                                  "Um einen oder mehrere zweite Namen für eine Person anzugeben."@de ;
+              rdfs:label "Middle name"@en ,
+                         "Mittlerer Name"@de ,
+                         "Second prénom"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#month
 ec:month rdf:type owl:DatatypeProperty ;
          rdfs:range xsd:integer ;
-         rdfs:label "Month"@en .
+         rdfs:label "Mois"@fr ,
+                    "Monat"@de ,
+                    "Month"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#name
 ec:name rdf:type owl:DatatypeProperty ;
         rdfs:range rdfs:Literal ;
-        dcterms:description "The designation of the resource."@en ;
-        rdfs:label "Name"@en .
+        dcterms:description "Die Bezeichnung der Ressource."@de ,
+                            "La désignation de la ressource."@fr ,
+                            "The designation of the resource."@en ;
+        rdfs:label "Name"@de ,
+                   "Name"@en ,
+                   "Nom"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#nickName
 ec:nickName rdf:type owl:DatatypeProperty ;
             rdfs:range rdfs:Literal ;
-            dcterms:description "The nickname of a Person."@en ;
-            rdfs:label "Nickname"@en .
+            dcterms:description "Der Spitzname einer Person."@de ,
+                                "Le surnom d'une personne."@fr ,
+                                "The nickname of a Person."@en ;
+            rdfs:label "Nickname"@en ,
+                       "Spitzname"@de ,
+                       "Surnom"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#noiseFilter
 ec:noiseFilter rdf:type owl:DatatypeProperty ,
                         owl:FunctionalProperty ;
                rdfs:range xsd:boolean ;
-               dcterms:description """A flag to signal that a noise filter has been
-            used."""@en ;
-               rdfs:label "Noise filter"@en .
+               dcterms:description "A flag to signal that a noise filter has been used."@en ,
+                                   "Ein Flag, das anzeigt, dass ein Rauschfilter verwendet wurde. verwendet wurde."@de ,
+                                   "Un drapeau pour signaler qu'un filtre de bruit a été utilisé."@fr ;
+               rdfs:label "Filtre anti-bruit"@fr ,
+                          "Noise filter"@en ,
+                          "Rauschfilter"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#notRated
 ec:notRated rdf:type owl:DatatypeProperty ;
             rdfs:range xsd:boolean ;
-            dcterms:description "A flag to indicate that the EditorialObejct has not been rated."@en ;
-            rdfs:label "Not rated"@en .
+            dcterms:description "A flag to indicate that the EditorialObejct has not been rated."@en ,
+                                "Eine Markierung, die anzeigt, dass das EditorialObejct noch nicht bewertet wurde."@de ,
+                                "Un drapeau pour indiquer que l'EditorialObejct n'a pas été évalué."@fr ;
+            rdfs:label "Nicht bewertet"@de ,
+                       "Non évalué"@fr ,
+                       "Not rated"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#numberOfAudioTracks
 ec:numberOfAudioTracks rdf:type owl:DatatypeProperty ;
                        rdfs:range xsd:integer ;
-                       dcterms:description "To provide the number of audio tracks."@en ;
-                       rdfs:label "Number of audio tracks"@en .
+                       dcterms:description "Pour fournir le nombre de pistes audio."@fr ,
+                                           "To provide the number of audio tracks."@en ,
+                                           "Zur Angabe der Anzahl der Audiospuren."@de ;
+                       rdfs:label "Anzahl der Audiospuren"@de ,
+                                  "Nombre de pistes audio"@fr ,
+                                  "Number of audio tracks"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#numberOfVideoTracks
 ec:numberOfVideoTracks rdf:type owl:DatatypeProperty ;
                        rdfs:range xsd:integer ;
-                       dcterms:description "To provide the number of video tracks."@en ;
-                       rdfs:label "Number of video tracks"@en .
+                       dcterms:description "Pour fournir le nombre de pistes vidéo."@fr ,
+                                           "To provide the number of video tracks."@en ,
+                                           "Zur Angabe der Anzahl der Videospuren."@de ;
+                       rdfs:label "Anzahl der Videospuren"@de ,
+                                  "Nombre de pistes vidéo"@fr ,
+                                  "Number of video tracks"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#occupation
 ec:occupation rdf:type owl:DatatypeProperty ;
               rdfs:range rdfs:Literal ;
-              dcterms:description "The job / occupation name of a Person."@en ;
-              rdfs:label "Occupation"@en .
+              dcterms:description "Der Name der Tätigkeit / des Berufs einer Person."@de ,
+                                  "Le nom de l'emploi / de la profession d'une personne."@fr ,
+                                  "The job / occupation name of a Person."@en ;
+              rdfs:label "Beruf"@de ,
+                         "Occupation"@en ,
+                         "Profession"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#officeEmailAddress
 ec:officeEmailAddress rdf:type owl:DatatypeProperty ;
                       rdfs:subPropertyOf ec:agentEmailAddress ;
                       rdfs:range xsd:string ;
-                      dcterms:description """To provide the professional/office email
-            address of an Agent (Contact/Person or Organisation)."""@en ;
-                      rdfs:label "Office email"@en .
+                      dcterms:description "Pour fournir l'adresse électronique professionnelle/bureautique d'un agent (contact/personne ou organisation)."@fr ,
+                                          "So geben Sie die berufliche/offizielle E-Mail-Adresse Adresse eines Agenten (Kontaktperson/Person oder Organisation)."@de ,
+                                          "To provide the professional/office email address of an Agent (Contact/Person or Organisation)."@en ;
+                      rdfs:label "Büro E-Mail"@de ,
+                                 "Courriel du bureau"@fr ,
+                                 "Office email"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#officeMobileTelephoneNumber
 ec:officeMobileTelephoneNumber rdf:type owl:DatatypeProperty ;
                                rdfs:subPropertyOf ec:agentTelephoneNumber ;
                                rdfs:range xsd:string ;
-                               dcterms:description """To provide the office mobile telephone number of an
-            Agent (Contact/Person)."""@en ;
-                               rdfs:label "Telephone (private)"@en .
+                               dcterms:description "Pour fournir le numéro de téléphone mobile du bureau d'un agent (contact/personne)."@fr ,
+                                                   "To provide the office mobile telephone number of an Agent (Contact/Person)."@en ,
+                                                   "Um die Mobiltelefonnummer des Büros eines Agenten (Kontaktperson/Person)."@de ;
+                               rdfs:label "Telefon (privat)"@de ,
+                                          "Telephone (office)"@en ,
+                                          "Téléphone (bureau)"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#officeTelephoneNumber
 ec:officeTelephoneNumber rdf:type owl:DatatypeProperty ;
                          rdfs:subPropertyOf ec:agentTelephoneNumber ;
                          rdfs:range xsd:string ;
-                         dcterms:description """To provide the office telephone number of an
-            Agent (Contact/Person)."""@en ;
-                         rdfs:label "Telephone (private)"@en .
+                         dcterms:description "Pour fournir le numéro de téléphone du bureau d'un agent (contact/personne)."@fr ,
+                                             "To provide the office telephone number of an Agent (Contact/Person)."@en ,
+                                             "Zur Angabe der Bürotelefonnummer eines Agenten (Kontaktperson/Person)."@de ;
+                         rdfs:label "Telefon ()"@de ,
+                                    "Telephone (office)"@en ,
+                                    "Téléphone (bureau)"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#orderedFlag
 ec:orderedFlag rdf:type owl:DatatypeProperty ,
                         owl:FunctionalProperty ;
                rdfs:range xsd:boolean ;
-               dcterms:description "A flag to indicate that a EditorialObject is member of an ordered group or is an ordered group (e.g. Series)"@en ;
-               rdfs:label "Ordered flag"@en .
+               dcterms:description "A flag to indicate that a EditorialObject is member of an ordered group or is an ordered group (e.g. Series)"@en ,
+                                   "Ein Flag, das anzeigt, dass ein EditorialObject Mitglied einer geordneten Gruppe ist oder eine geordnete Gruppe ist (z.B. Serie)"@de ,
+                                   "Un drapeau pour indiquer qu'un ÉditorialObject est membre d'un groupe ordonné ou est un groupe ordonné (par ex. Série)"@fr ;
+               rdfs:label "Bestellte Flagge"@de ,
+                          "Drapeau commandé"@fr ,
+                          "Ordered flag"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#orientation
 ec:orientation rdf:type owl:DatatypeProperty ;
                rdfs:range rdfs:Literal ;
-               dcterms:description """The orientation of a Document or an Image i.e. landscape or
-            portrait."""@en ;
-               rdfs:label "Orientation"@en .
+               dcterms:description "Die Ausrichtung eines Dokuments oder eines Bildes, d.h. Querformat oder Hochformat Hochformat."@de ,
+                                   "L'orientation d'un document ou d'une image, c'est-à-dire paysage ou portrait."@fr ,
+                                   "The orientation of a Document or an Image i.e. landscape or portrait."@en ;
+               rdfs:label "Orientation"@en ,
+                          "Orientation"@fr ,
+                          "Orientierung"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#packageByteSize
 ec:packageByteSize rdf:type owl:DatatypeProperty ;
                    rdfs:range xsd:long ;
-                   dcterms:description """The size of a media package in
-            Bytes."""@en ;
-                   rdfs:label "Package size (in bytes)"@en .
+                   dcterms:description "Die Größe eines Medienpakets in Bytes."@de ,
+                                       "La taille d'un paquet média en octets."@fr ,
+                                       "The size of a media package in Bytes."@en ;
+                   rdfs:label "Package size (in bytes)"@en ,
+                              "Paketgröße (in Bytes)"@de ,
+                              "Taille du paquet (en octets)"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#packageName
 ec:packageName rdf:type owl:DatatypeProperty ;
                rdfs:range rdfs:Literal ;
-               dcterms:description "The name of a media package in Bytes."@en ;
-               rdfs:label "Package name"@en .
+               dcterms:description "Der Name eines Medienpakets in Bytes."@de ,
+                                   "Le nom d'un paquet média en octets."@fr ,
+                                   "The name of a media package in Bytes."@en ;
+               rdfs:label "Name des Pakets"@de ,
+                          "Nom du paquet"@fr ,
+                          "Package name"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#partTotalNumber
 ec:partTotalNumber rdf:type owl:DatatypeProperty ;
                    rdfs:range xsd:integer ;
-                   dcterms:description "The total number of Parts associated with an EditorialObject."@en ;
-                   rdfs:label "Part total number"@en .
+                   dcterms:description "Die Gesamtzahl der Teile, die mit einem EditorialObject verbunden sind."@de ,
+                                       "Le nombre total de Parts associées à un EditorialObject."@fr ,
+                                       "The total number of Parts associated with an EditorialObject."@en ;
+                   rdfs:label "Numéro total de la pièce"@fr ,
+                              "Part total number"@en ,
+                              "Teil Gesamtnummer"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#period
 ec:period rdf:type owl:DatatypeProperty ;
           rdfs:range rdfs:Literal ;
-          dcterms:description "The period of time during which an Event has occured."@en ;
-          rdfs:label "Period"@en .
+          dcterms:description "Die Zeitspanne, in der ein Ereignis eingetreten ist."@de ,
+                              "La période de temps pendant laquelle un événement s'est produit."@fr ,
+                              "The period of time during which an Event has occured."@en ;
+          rdfs:label "Period"@en ,
+                     "Période"@fr ,
+                     "Zeitraum"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#personHeight
 ec:personHeight rdf:type owl:DatatypeProperty ;
                 rdfs:range rdfs:Literal ;
-                dcterms:description "To indicate the height of a person."@en ;
-                rdfs:label "Person height"@en .
+                dcterms:description "Pour indiquer la taille d'une personne."@fr ,
+                                    "To indicate the height of a person."@en ,
+                                    "Zur Angabe der Größe einer Person."@de ;
+                rdfs:label "Hauteur de la personne"@fr ,
+                           "Höhe der Person"@de ,
+                           "Person height"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#personWeight
 ec:personWeight rdf:type owl:DatatypeProperty ;
                 rdfs:range rdfs:Literal ;
-                dcterms:description "To indicate the weight of a person."@en ;
-                rdfs:label "Person weight"@en .
+                dcterms:description "Pour indiquer le poids d'une personne."@fr ,
+                                    "To indicate the weight of a person."@en ,
+                                    "Zur Angabe des Gewichts einer Person."@de ;
+                rdfs:label "Gewicht der Person"@de ,
+                           "Person weight"@en ,
+                           "Poids de la personne"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#playbackSpeed
 ec:playbackSpeed rdf:type owl:DatatypeProperty ;
                  rdfs:range xsd:double ;
-                 dcterms:description "Identifies the rate of units against time at which the resource should be played back for human consumption.  If the unit of measure is known, use sub-properties framesPerSecond or inchesPerSecond."@en ;
-                 rdfs:label "Playback speed"@en .
+                 dcterms:description "Gibt die Rate der Zeiteinheiten an, in der die Ressource für den menschlichen Verzehr wiedergegeben werden soll. Wenn die Maßeinheit bekannt ist, verwenden Sie die Untereigenschaften framesPerSecond oder inchesPerSecond."@de ,
+                                     "Identifie le taux d'unités par rapport au temps auquel la ressource doit être lue pour la consommation humaine. Si l'unité de mesure est connue, utilisez les sous-propriétés framesPerSecond ou inchesPerSecond."@fr ,
+                                     "Identifies the rate of units against time at which the resource should be played back for human consumption. If the unit of measure is known, use sub-properties framesPerSecond or inchesPerSecond."@en ;
+                 rdfs:label "Playback speed"@en ,
+                            "Vitesse de lecture"@fr ,
+                            "Wiedergabegeschwindigkeit"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#playlist
 ec:playlist rdf:type owl:DatatypeProperty ;
             rdfs:subPropertyOf ec:contentDescription ;
             rdfs:range rdfs:Literal ;
-            dcterms:description "To provide a playlist."@en ;
-            rdfs:label "Playlist"@en .
+            dcterms:description "Pour fournir une liste de lecture."@fr ,
+                                "To provide a playlist."@en ,
+                                "Um eine Wiedergabeliste bereitzustellen."@de ;
+            rdfs:label "Liste de lecture"@fr ,
+                       "Playlist"@en ,
+                       "Wiedergabeliste"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#position
 ec:position rdf:type owl:DatatypeProperty ;
             rdfs:range rdfs:Literal ;
-            dcterms:description """To indicate the position of an EditorialObject in an ordered
-      group."""@en ;
-            rdfs:label "Position"@en .
+            dcterms:description "Pour indiquer la position d'un objet éditorial dans un groupe ordonné. groupe ordonné."@fr ,
+                                "To indicate the position of an EditorialObject in an ordered group."@en ,
+                                "Zur Angabe der Position eines EditorialObjects in einer geordneten Gruppe."@de ;
+            rdfs:label "Position"@de ,
+                       "Position"@en ,
+                       "Position"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#privateEmailAddress
 ec:privateEmailAddress rdf:type owl:DatatypeProperty ;
                        rdfs:subPropertyOf ec:agentEmailAddress ;
                        rdfs:range xsd:string ;
-                       dcterms:description """To provide the private email address of an
-            Agent (Contact/Person)"""@en ;
-                       rdfs:label "Private email"@en .
+                       dcterms:description "Pour fournir l'adresse électronique privée d'un agent (contact/personne)"@fr ,
+                                           "So geben Sie die private E-Mail-Adresse eines Agenten (Kontakt/Person)"@de ,
+                                           "To provide the private email address of an Agent (Contact/Person)"@en ;
+                       rdfs:label "Courriel privé"@fr ,
+                                  "Private E-Mail"@de ,
+                                  "Private email"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#privateHomepage
 ec:privateHomepage rdf:type owl:DatatypeProperty ;
                    rdfs:subPropertyOf ec:agentWebHomepage ;
                    rdfs:range xsd:anyURI ;
-                   dcterms:description """To provide an private web homepage of an Agent
-            (Contact/Person)."""@en ;
-                   rdfs:label "Homepage (private)"@en .
+                   dcterms:description "Pour fournir une page d'accueil web privée d'un agent (Contact/Personne)."@fr ,
+                                       "To provide an private web homepage of an Agent (Contact/Person)."@en ,
+                                       "Um eine private Web-Homepage eines Agenten bereitzustellen (Kontakt/Person)."@de ;
+                   rdfs:label "Homepage (privat)"@de ,
+                              "Homepage (private)"@en ,
+                              "Page d'accueil (privée)"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#privateMobileTelephoneNumber
 ec:privateMobileTelephoneNumber rdf:type owl:DatatypeProperty ;
                                 rdfs:subPropertyOf ec:agentTelephoneNumber ;
                                 rdfs:range xsd:string ;
-                                dcterms:description """To provide the private mobile telephone number of an
-            Agent (Contact/Person)."""@en ;
-                                rdfs:label "Telephone (private)"@en .
+                                dcterms:description "Pour fournir le numéro de téléphone mobile privé d'un agent (contact/personne)."@fr ,
+                                                    "To provide the private mobile telephone number of an Agent (Contact/Person)."@en ,
+                                                    "Zur Angabe der privaten Mobiltelefonnummer eines Agenten (Kontaktperson/Person)."@de ;
+                                rdfs:label "Telefon (privat)"@de ,
+                                           "Telephone (private)"@en ,
+                                           "Téléphone (privé)"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#privateTelephoneNumber
 ec:privateTelephoneNumber rdf:type owl:DatatypeProperty ;
                           rdfs:subPropertyOf ec:agentTelephoneNumber ;
                           rdfs:range xsd:string ;
-                          dcterms:description """To provide the private telephone number of an
-            Agent (Contact/Person)."""@en ;
-                          rdfs:label "Telephone (private)"@en .
+                          dcterms:description "Pour fournir le numéro de téléphone privé d'un agent (contact/personne)."@fr ,
+                                              "To provide the private telephone number of an Agent (Contact/Person)."@en ,
+                                              "Zur Angabe der privaten Telefonnummer eines Agenten (Kontakt/Person)."@de ;
+                          rdfs:label "Telefon (privat)"@de ,
+                                     "Telephone (private)"@en ,
+                                     "Téléphone (privé)"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#productionSynopsis
 ec:productionSynopsis rdf:type owl:DatatypeProperty ;
                       rdfs:subPropertyOf ec:contentDescription ;
                       rdfs:range rdfs:Literal ;
-                      dcterms:description "A synopsis or summary provided by the producer at the time of production."@en ;
-                      rdfs:label "Production synopsis"@en .
+                      dcterms:description "A synopsis or summary provided by the producer at the time of production."@en ,
+                                          "Eine Zusammenfassung, die der Produzent zum Zeitpunkt der Produktion zur Verfügung stellt."@de ,
+                                          "Un synopsis ou un résumé fourni par le producteur au moment de la production."@fr ;
+                      rdfs:label "Production synopsis"@en ,
+                                 "Synopse der Produktion"@de ,
+                                 "Synopsis de la production"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#promotionalInformation
 ec:promotionalInformation rdf:type owl:DatatypeProperty ;
                           rdfs:subPropertyOf ec:contentDescription ;
                           rdfs:range rdfs:Literal ;
-                          dcterms:description "To provide textual promotional information."@en ;
-                          rdfs:label "Promotional information"@en .
+                          dcterms:description "Pour fournir des informations promotionnelles textuelles."@fr ,
+                                              "To provide textual promotional information."@en ,
+                                              "Zur Bereitstellung von Werbeinformationen in Textform."@de ;
+                          rdfs:label "Informationen zur Werbung"@de ,
+                                     "Informations promotionnelles"@fr ,
+                                     "Promotional information"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#pubStatus
 ec:pubStatus rdf:type owl:DatatypeProperty ;
              rdfs:subPropertyOf ec:contentDescription ;
              rdfs:range rdfs:Literal ;
-             dcterms:description "To indicate a publication status."@en ;
-             rdfs:label "Publication status"@en .
+             dcterms:description "Pour indiquer un statut de publication."@fr ,
+                                 "To indicate a publication status."@en ,
+                                 "Zur Angabe eines Veröffentlichungsstatus."@de ;
+             rdfs:label "Publication status"@en ,
+                        "Status der Veröffentlichung"@de ,
+                        "État de la publication"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#publicationPlanTitle
@@ -4525,396 +6772,579 @@ ec:publishingEventsLeft rdf:type owl:DatatypeProperty .
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#ratingScaleMax
 ec:ratingScaleMax rdf:type owl:DatatypeProperty ;
                   rdfs:range rdfs:Literal ;
-                  dcterms:description "The maximum value of the scale used for the Rating."@en ;
-                  rdfs:label "Rating scale (top value)"@en .
+                  dcterms:description "Der maximale Wert der für die Bewertung verwendeten Skala."@de ,
+                                      "La valeur maximale de l'échelle utilisée pour le classement."@fr ,
+                                      "The maximum value of the scale used for the Rating."@en ;
+                  rdfs:label "Bewertungsskala (höchster Wert)"@de ,
+                             "Rating scale (top value)"@en ,
+                             "Échelle d'évaluation (valeur supérieure)"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#ratingScaleMin
 ec:ratingScaleMin rdf:type owl:DatatypeProperty ;
                   rdfs:range rdfs:Literal ;
-                  dcterms:description """The minimum value of the scale used for rating
-            a MediaResource."""@en ;
-                  rdfs:label "Rating scale (min. value)"@en .
+                  dcterms:description "Der Mindestwert der Skala, die für die Bewertung einer MediaResource."@de ,
+                                      "La valeur minimale de l'échelle utilisée pour la notation une MediaResource."@fr ,
+                                      "The minimum value of the scale used for rating a MediaResource."@en ;
+                  rdfs:label "Bewertungsskala (Mindestwert)"@de ,
+                             "Rating scale (min. value)"@en ,
+                             "Échelle d'évaluation (valeur minimale)"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#ratingSystemEnvironment
 ec:ratingSystemEnvironment rdf:type owl:DatatypeProperty ;
                            rdfs:range rdfs:Literal ;
-                           dcterms:description "To identify the environment in which rating applies."@en ;
-                           rdfs:label "Rating environment"@en .
+                           dcterms:description "Identifier l'environnement dans lequel la notation s'applique."@fr ,
+                                               "To identify the environment in which rating applies."@en ,
+                                               "Um die Umgebung zu identifizieren, in der die Bewertung gilt."@de ;
+                           rdfs:label "Bewertung der Umgebung"@de ,
+                                      "Environnement d'évaluation"@fr ,
+                                      "Rating environment"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#ratingSystemName
 ec:ratingSystemName rdf:type owl:DatatypeProperty ;
                     rdfs:range rdfs:Literal ;
-                    dcterms:description "To identify a Rating system by its name."@en ;
-                    rdfs:label "Rating system"@en .
+                    dcterms:description "Pour identifier un système de notation par son nom."@fr ,
+                                        "So identifizieren Sie ein Rating-System anhand seines Namens."@de ,
+                                        "To identify a Rating system by its name."@en ;
+                    rdfs:label "Bewertungssystem"@de ,
+                               "Rating system"@en ,
+                               "Système d'évaluation"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#ratingValue
 ec:ratingValue rdf:type owl:DatatypeProperty ;
                rdfs:range rdfs:Literal ;
-               dcterms:description """To express a free text Rating value defined in
-            a rating classification scheme."""@en ;
-               rdfs:label "Rating"@en .
+               dcterms:description "Pour exprimer une valeur de notation en texte libre définie dans un système de classification des notes."@fr ,
+                                   "To express a free text Rating value defined in a rating classification scheme."@en ,
+                                   "Um einen Freitext-Bewertungswert auszudrücken, der in einem einem Rating-Klassifizierungsschema."@de ;
+               rdfs:label "Bewertung"@de ,
+                          "Classement"@fr ,
+                          "Rating"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#reason
 ec:reason rdf:type owl:DatatypeProperty ;
           rdfs:range rdfs:Literal ;
-          dcterms:description "A reason given for a rating."@en ;
-          rdfs:label "Reason"@en .
+          dcterms:description "A reason given for a rating."@en ,
+                              "Ein Grund, der für eine Bewertung angegeben wird."@de ,
+                              "Une raison donnée pour une évaluation."@fr ;
+          rdfs:label "Grund"@de ,
+                     "Motif"@fr ,
+                     "Reason"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#regionDelimX
 ec:regionDelimX rdf:type owl:DatatypeProperty ;
                 rdfs:range xsd:integer ;
-                dcterms:description """To define the top left corner of a zone on
-            the x-axis. If present with regionDelimy, the zone definition is complemented by the
-            associated values of the height and width."""@en ;
-                rdfs:label "Region delimiter (x-axis)"@en .
+                dcterms:description "Pour définir le coin supérieur gauche d'une zone sur l'axe des x. Si elle est présente avec regionDelimy, la définition de la zone est complétée par les valeurs associées de la hauteur et de la largeur."@fr ,
+                                    "So definieren Sie die linke obere Ecke einer Zone auf der der x-Achse. Wenn mit regionDelimy vorhanden, wird die Zonendefinition ergänzt durch die zugehörigen Werte für Höhe und Breite ergänzt."@de ,
+                                    "To define the top left corner of a zone on the x-axis. If present with regionDelimy, the zone definition is complemented by the associated values of the height and width."@en ;
+                rdfs:label "Begrenzer der Region (x-Achse)"@de ,
+                           "Délimiteur de région (axe des x)"@fr ,
+                           "Region delimiter (x-axis)"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#regionDelimY
 ec:regionDelimY rdf:type owl:DatatypeProperty ;
                 rdfs:range xsd:integer ;
-                dcterms:description """To define the bottom right corner of a zone on
-            the y-axis. If present with regionDelimX, the zone definition is complemented by the
-            associated values of the height and width."""@en ;
-                rdfs:label "Region delimiter (y-axis)"@en .
+                dcterms:description "Pour définir le coin inférieur droit d'une zone sur l'axe des y. Si elle est présente avec regionDelimX, la définition de la zone est complétée par les valeurs associées de la hauteur et de la largeur."@fr ,
+                                    "So definieren Sie die untere rechte Ecke einer Zone auf der der y-Achse. Wenn mit regionDelimX vorhanden, wird die Zonendefinition ergänzt durch die zugehörigen Werte für Höhe und Breite ergänzt."@de ,
+                                    "To define the bottom right corner of a zone on the y-axis. If present with regionDelimX, the zone definition is complemented by the associated values of the height and width."@en ;
+                rdfs:label "Begrenzer der Region (y-Achse)"@de ,
+                           "Délimiteur de région (axe des ordonnées)"@fr ,
+                           "Region delimiter (y-axis)"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#relationOrderedGroupFlag
 ec:relationOrderedGroupFlag rdf:type owl:DatatypeProperty ;
                             rdfs:range xsd:boolean ;
-                            dcterms:description "A boolean to define if a Relation is defined within and ordered group."@en ;
-                            rdfs:label "Relation Ordered group flag"@en .
+                            dcterms:description "A boolean to define if a Relation is defined within and ordered group."@en ,
+                                                "Ein boolescher Wert, der angibt, ob eine Relation innerhalb einer geordneten Gruppe definiert ist."@de ,
+                                                "Un booléen pour définir si une Relation est définie dans un groupe ordonné."@fr ;
+                            rdfs:label "Relation Drapeau de groupe ordonné"@fr ,
+                                       "Relation Geordnete Gruppe Flagge"@de ,
+                                       "Relation Ordered group flag"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#relationRunningOrderNumber
 ec:relationRunningOrderNumber rdf:type owl:DatatypeProperty ;
                               rdfs:range xsd:integer ;
-                              dcterms:description "The order number in a list."@en ;
-                              rdfs:label "Relation Running Order Number"@en .
+                              dcterms:description "Die Bestellnummer in einer Liste."@de ,
+                                                  "Le numéro d'ordre dans une liste."@fr ,
+                                                  "The order number in a list."@en ;
+                              rdfs:label "Relation Laufende Bestellnummer"@de ,
+                                         "Relation Numéro d'ordre courant"@fr ,
+                                         "Relation Running Order Number"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#relationTotalNumberOfGroupMembers
 ec:relationTotalNumberOfGroupMembers rdf:type owl:DatatypeProperty ;
                                      rdfs:range xsd:integer ;
-                                     dcterms:description "Total number of group members in a Relation."@en ;
-                                     rdfs:label "Total number of group members."@en .
+                                     dcterms:description "Gesamtzahl der Gruppenmitglieder in einer Relation."@de ,
+                                                         "Nombre total de membres du groupe dans une Relation."@fr ,
+                                                         "Total number of group members in a Relation."@en ;
+                                     rdfs:label "Gesamtzahl der Gruppenmitglieder."@de ,
+                                                "Nombre total de membres du groupe."@fr ,
+                                                "Total number of group members."@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#resolution
 ec:resolution rdf:type owl:DatatypeProperty ;
               rdfs:range rdfs:Literal ;
-              dcterms:description "To define the resolution of an Asset e.g. video, image..."@en ;
-              rdfs:label "Resolution"@en .
+              dcterms:description "Pour définir la résolution d'un actif, par exemple une vidéo, une image..."@fr ,
+                                  "To define the resolution of an Asset e.g. video, image..."@en ,
+                                  "Zum Festlegen der Auflösung eines Assets, z.B. eines Videos, Bildes..."@de ;
+              rdfs:label "Auflösung"@de ,
+                         "Resolution"@en ,
+                         "Résolution"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#rightsClearanceFlag
 ec:rightsClearanceFlag rdf:type owl:DatatypeProperty ,
                                 owl:FunctionalProperty ;
                        rdfs:range xsd:boolean ;
-                       dcterms:description "A flag to indicate that righst have been cleared"@en ;
-                       rdfs:label "Rights clearance flag"@en .
+                       dcterms:description "A flag to indicate that righst have been cleared"@en ,
+                                           "Ein Flag, das anzeigt, dass die Rechte gelöscht wurden"@de ,
+                                           "Un drapeau pour indiquer que les droits ont été effacés."@fr ;
+                       rdfs:label "Drapeau d'autorisation de droits"@fr ,
+                                  "Flagge zur Rechteklärung"@de ,
+                                  "Rights clearance flag"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#rightsExpression
 ec:rightsExpression rdf:type owl:DatatypeProperty ;
                     rdfs:range rdfs:Literal ;
-                    dcterms:description "To express an expression of Rights."@en ;
-                    rdfs:label "Rights"@en .
+                    dcterms:description "Einen Ausdruck von Rechten zum Ausdruck bringen."@de ,
+                                        "Pour exprimer une expression de Droits."@fr ,
+                                        "To express an expression of Rights."@en ;
+                    rdfs:label "Droits"@fr ,
+                               "Rechte"@de ,
+                               "Rights"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#rightsLink
 ec:rightsLink rdf:type owl:DatatypeProperty ;
               rdfs:range xsd:anyURI ;
-              dcterms:description """A link to e.g. a webpage where an expression of
-            the rights can be found and consulted."""@en ;
-              rdfs:label "Rights web resource"@en .
+              dcterms:description "A link to e.g. a webpage where an expression of the rights can be found and consulted."@en ,
+                                  "Ein Link zu z.B. einer Webseite, auf der ein Ausdruck der der Rechte gefunden und konsultiert werden kann."@de ,
+                                  "Un lien vers, par exemple, une page web où une expression des les droits peut être trouvée et consultée."@fr ;
+              rdfs:label "Rechte Web-Ressource"@de ,
+                         "Ressource web sur les droits"@fr ,
+                         "Rights web resource"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#salutationTitle
 ec:salutationTitle rdf:type owl:DatatypeProperty ;
                    rdfs:range rdfs:Literal ;
-                   dcterms:description "To provide a salutation title e.g M. Ms, Dr, Pr."@en ;
-                   rdfs:label "Salutation title"@en .
+                   dcterms:description "Pour fournir un titre de salutation, par exemple M. Ms, Dr, Pr."@fr ,
+                                       "To provide a salutation title e.g M. Ms, Dr, Pr."@en ,
+                                       "Um einen Anrede-Titel anzugeben, z. B. M. Ms, Dr, Pr."@de ;
+                   rdfs:label "Anrede Titel"@de ,
+                              "Salutation title"@en ,
+                              "Titre de la salutation"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#sampleRate
 ec:sampleRate rdf:type owl:DatatypeProperty ;
               rdfs:range xsd:integer ;
-              dcterms:description "The frequency at which audio is sampled per second. Also called sampling rate."@en ;
-              rdfs:label "Sample Rate"@en .
+              dcterms:description "Die Frequenz, mit der Audio pro Sekunde abgetastet wird. Auch Sampling-Rate genannt."@de ,
+                                  "La fréquence à laquelle l'audio est échantillonné par seconde. Également appelée fréquence d'échantillonnage."@fr ,
+                                  "The frequency at which audio is sampled per second. Also called sampling rate."@en ;
+              rdfs:label "Sample Rate"@de ,
+                         "Sample Rate"@en ,
+                         "Taux d'échantillonnage"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#sampleSize
 ec:sampleSize rdf:type owl:DatatypeProperty ;
               rdfs:range xsd:integer ;
-              dcterms:description """The size of an audio sample in
-            bits. Also called bit depth."""@en ;
-              rdfs:label "Sample size"@en .
+              dcterms:description "Die Größe eines Audio-Samples in Bits. Auch Bittiefe genannt."@de ,
+                                  "La taille d'un échantillon audio en bits. Également appelée profondeur de bits."@fr ,
+                                  "The size of an audio sample in bits. Also called bit depth."@en ;
+              rdfs:label "Sample size"@en ,
+                         "Stichprobengröße"@de ,
+                         "Taille de l'échantillon"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#sampleType
 ec:sampleType rdf:type owl:DatatypeProperty ;
               rdfs:range rdfs:Literal ;
-              dcterms:description "The type of audio sample."@en ;
-              rdfs:label "Sample type"@en .
+              dcterms:description "Die Art der Hörprobe."@de ,
+                                  "Le type d'échantillon audio."@fr ,
+                                  "The type of audio sample."@en ;
+              rdfs:label "Sample type"@en ,
+                         "Typ der Probe"@de ,
+                         "Type d'échantillon"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#scanningFormat
 ec:scanningFormat rdf:type owl:DatatypeProperty ;
                   rdfs:range rdfs:Literal ;
-                  dcterms:description """To define the scanning format for a
-            MediaResource. For video, the two main values are \"interlaced\" or
-            \"progressive\"."""@en ;
-                  rdfs:label "Scanning format"@en .
+                  dcterms:description "Pour définir le format de numérisation d'une MediaResource. Pour la vidéo, les deux principales valeurs sont \"entrelacé\" ou \"progressif\"."@fr ,
+                                      "So definieren Sie das Scanformat für eine MediaResource. Für Video sind die beiden wichtigsten Werte \"interlaced\" oder \"progressiv\"."@de ,
+                                      "To define the scanning format for a MediaResource. For video, the two main values are \"interlaced\" or \"progressive\"."@en ;
+                  rdfs:label "Format de numérisation"@fr ,
+                             "Format scannen"@de ,
+                             "Scanning format"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#script
 ec:script rdf:type owl:DatatypeProperty ;
           rdfs:subPropertyOf ec:contentDescription ;
           rdfs:range rdfs:Literal ;
-          dcterms:description "To provide a script."@en ;
-          rdfs:label "Script"@en .
+          dcterms:description "Pour fournir un script."@fr ,
+                              "To provide a script."@en ,
+                              "Um ein Skript bereitzustellen."@de ;
+          rdfs:label "Script"@en ,
+                     "Script"@fr ,
+                     "Skript"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#seasonNumber
 ec:seasonNumber rdf:type owl:DatatypeProperty ;
                 rdfs:range xsd:integer ;
-                dcterms:description "To provide a Season number."@en ;
-                rdfs:label "Season number"@en .
+                dcterms:description "Pour fournir un numéro de saison."@fr ,
+                                    "To provide a Season number."@en ,
+                                    "Um eine Saisonnummer anzugeben."@de ;
+                rdfs:label "Numéro de la saison"@fr ,
+                           "Saison Nummer"@de ,
+                           "Season number"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#segmentNumber
 ec:segmentNumber rdf:type owl:DatatypeProperty ;
                  rdfs:range xsd:integer ;
-                 dcterms:description """The number associated to a sagment as one among
-            many."""@en ;
-                 rdfs:label "Segment number"@en .
+                 dcterms:description "Die Nummer, die einem Sagment als eines unter vielen zugeordnet ist. vielen."@de ,
+                                     "Le nombre associé à un affaissement comme un parmi plusieurs."@fr ,
+                                     "The number associated to a sagment as one among many."@en ;
+                 rdfs:label "Numéro de segment"@fr ,
+                            "Segment Nummer"@de ,
+                            "Segment number"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#shotLog
 ec:shotLog rdf:type owl:DatatypeProperty ;
            rdfs:subPropertyOf ec:contentDescription ;
            rdfs:range rdfs:Literal ;
-           dcterms:description "Provides a shot-by-shot description of a MediaResource."@en ;
-           rdfs:label "Shot log"@en .
+           dcterms:description "Fournit une description plan par plan d'une MediaResource."@fr ,
+                               "Liefert eine Shot-by-Shot-Beschreibung einer MediaResource."@de ,
+                               "Provides a shot-by-shot description of a MediaResource."@en ;
+           rdfs:label "Journal de bord"@fr ,
+                      "Schießprotokoll"@de ,
+                      "Shot log"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#suffix
 ec:suffix rdf:type owl:DatatypeProperty ;
           rdfs:range rdfs:Literal ;
-          dcterms:description "To provide a suffix associated with a Person name e.g. Jr."@en ;
-          rdfs:label "Suffix"@en .
+          dcterms:description "Pour fournir un suffixe associé à un nom de personne, par exemple Jr."@fr ,
+                              "To provide a suffix associated with a Person name e.g. Jr."@en ,
+                              "Zur Bereitstellung eines Suffixes in Verbindung mit einem Personennamen, z. B. Jr."@de ;
+          rdfs:label "Nachsilbe"@de ,
+                     "Suffix"@en ,
+                     "Suffixe"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#summary
 ec:summary rdf:type owl:DatatypeProperty ;
            rdfs:subPropertyOf ec:contentDescription ;
            rdfs:range rdfs:Literal ;
-           dcterms:description "To provide a summary."@en ;
-           rdfs:label "Summary"@en .
+           dcterms:description "Pour fournir un résumé."@fr ,
+                               "To provide a summary."@en ,
+                               "Um eine Zusammenfassung zu geben."@de ;
+           rdfs:label "Résumé"@fr ,
+                      "Summary"@en ,
+                      "Zusammenfassung"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#synopsis
 ec:synopsis rdf:type owl:DatatypeProperty ;
             rdfs:subPropertyOf ec:contentDescription ;
             rdfs:range rdfs:Literal ;
-            dcterms:description "To provide a summary."@en ;
-            rdfs:label "Synopsis"@en .
+            dcterms:description "Pour fournir un résumé."@fr ,
+                                "To provide a summary."@en ,
+                                "Um eine Zusammenfassung zu geben."@de ;
+            rdfs:label "Synopsis"@de ,
+                       "Synopsis"@en ,
+                       "Synopsis"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#tableOfContent
 ec:tableOfContent rdf:type owl:DatatypeProperty ;
                   rdfs:subPropertyOf ec:contentDescription ;
                   rdfs:range rdfs:Literal ;
-                  dcterms:description "to provide a table of content."@en ;
-                  rdfs:label "Table of content"@en .
+                  dcterms:description "pour fournir une table des matières."@fr ,
+                                      "to provide a table of content."@en ,
+                                      "um ein Inhaltsverzeichnis zu erstellen."@de ;
+                  rdfs:label "Inhaltsverzeichnis"@de ,
+                             "Table des matières"@fr ,
+                             "Table of content"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#tag
 ec:tag rdf:type owl:DatatypeProperty ;
        rdfs:subPropertyOf ec:contentDescription ;
        rdfs:range rdfs:Literal ;
-       dcterms:description "To provide a list of tags."@en ;
-       rdfs:label "Tag"@en .
+       dcterms:description "Pour fournir une liste de balises."@fr ,
+                           "To provide a list of tags."@en ,
+                           "Zur Bereitstellung einer Liste von Tags."@de ;
+       rdfs:label "Tag"@de ,
+                  "Tag"@en ,
+                  "Étiquette"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#targetAudienceSystem
 ec:targetAudienceSystem rdf:type owl:DatatypeProperty ;
                         rdfs:range rdfs:Literal ;
-                        dcterms:description "To define the system used to provide a TargetAudience."@en ;
-                        rdfs:label "Target audience system"@en .
+                        dcterms:description "Pour définir le système utilisé pour fournir un TargetAudience."@fr ,
+                                            "To define the system used to provide a TargetAudience."@en ,
+                                            "Um das System zu definieren, mit dem ein TargetAudience."@de ;
+                        rdfs:label "Système de public cible"@fr ,
+                                   "Target audience system"@en ,
+                                   "Zielgruppen-System"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#textLineBoxHeight
 ec:textLineBoxHeight rdf:type owl:DatatypeProperty ;
                      rdfs:range xsd:nonNegativeInteger ;
-                     dcterms:description "The height of the text box containing the TextLine."@en ;
-                     rdfs:label "Text line box height."@en .
+                     dcterms:description "Die Höhe des Textfeldes, das die TextLine enthält."@de ,
+                                         "La hauteur de la zone de texte contenant la TextLine."@fr ,
+                                         "The height of the text box containing the TextLine."@en ;
+                     rdfs:label "Hauteur de la boîte de la ligne de texte."@fr ,
+                                "Höhe des Textfeldes."@de ,
+                                "Text line box height."@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#textLineBoxTopLeftCornerLineNumber
 ec:textLineBoxTopLeftCornerLineNumber rdf:type owl:DatatypeProperty ;
                                       rdfs:range xsd:nonNegativeInteger ;
-                                      dcterms:description "The coordinates on a vertical axis of the position of the top left corner of the text box containing the TextLine."@en ;
-                                      rdfs:label "Text line box top left corner Y position."@en .
+                                      dcterms:description "Die Koordinaten auf einer vertikalen Achse für die Position der linken oberen Ecke des Textfeldes, das die TextLine enthält."@de ,
+                                                          "Les coordonnées sur un axe vertical de la position du coin supérieur gauche de la zone de texte contenant la TextLine."@fr ,
+                                                          "The coordinates on a vertical axis of the position of the top left corner of the text box containing the TextLine."@en ;
+                                      rdfs:label "Position Y du coin supérieur gauche de la ligne de texte."@fr ,
+                                                 "Text line box top left corner Y position."@en ,
+                                                 "Textzeilenfeld obere linke Ecke Y-Position."@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#textLineBoxTopLeftCornerPixelNumber
 ec:textLineBoxTopLeftCornerPixelNumber rdf:type owl:DatatypeProperty ;
                                        rdfs:range xsd:nonNegativeInteger ;
-                                       dcterms:description "The coordinates on an horizontal axis of the position of the top left corner of the text box containing the TextLine."@en ;
-                                       rdfs:label "Text line box top left Coner X position."@en .
+                                       dcterms:description "Die Koordinaten auf einer horizontalen Achse für die Position der linken oberen Ecke des Textfeldes, das die Textzeile enthält."@de ,
+                                                           "Les coordonnées sur un axe horizontal de la position du coin supérieur gauche de la zone de texte contenant la TextLine."@fr ,
+                                                           "The coordinates on an horizontal axis of the position of the top left corner of the text box containing the TextLine."@en ;
+                                       rdfs:label "Boîte de ligne de texte en haut à gauche Position Coner X."@fr ,
+                                                  "Text line box top left Coner X position."@en ,
+                                                  "Textzeilenfeld oben links Coner X Position."@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#textLineBoxWidth
 ec:textLineBoxWidth rdf:type owl:DatatypeProperty ;
                     rdfs:range xsd:nonNegativeInteger ;
-                    dcterms:description "The width of the text box containing the TextLine."@en ;
-                    rdfs:label "Text line box width."@en .
+                    dcterms:description "Die Breite des Textfeldes, das die TextLine enthält."@de ,
+                                        "La largeur de la zone de texte contenant la TextLine."@fr ,
+                                        "The width of the text box containing the TextLine."@en ;
+                    rdfs:label "Breite des Textfeldes."@de ,
+                               "Largeur de la boîte de la ligne de texte."@fr ,
+                               "Text line box width."@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#textLineContent
 ec:textLineContent rdf:type owl:DatatypeProperty ;
                    rdfs:range rdfs:Literal ;
-                   dcterms:description "To provide the content of a text line."@en ;
-                   rdfs:label "Text line"@en .
+                   dcterms:description "Pour fournir le contenu d'une ligne de texte."@fr ,
+                                       "To provide the content of a text line."@en ,
+                                       "Um den Inhalt einer Textzeile anzugeben."@de ;
+                   rdfs:label "Ligne de texte"@fr ,
+                              "Text line"@en ,
+                              "Textzeile"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#textLineOrder
 ec:textLineOrder rdf:type owl:DatatypeProperty ;
                  rdfs:range rdfs:Literal ;
-                 dcterms:description "The order in which a text line can be found e.g. in a scene."@en ;
-                 rdfs:label "Text line order"@en .
+                 dcterms:description "Die Reihenfolge, in der eine Textzeile z.B. in einer Szene zu finden ist."@de ,
+                                     "L'ordre dans lequel une ligne de texte peut être trouvée, par exemple dans une scène."@fr ,
+                                     "The order in which a text line can be found e.g. in a scene."@en ;
+                 rdfs:label "Ordre des lignes de texte"@fr ,
+                            "Reihenfolge der Textzeilen"@de ,
+                            "Text line order"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#timeOfDay
 ec:timeOfDay rdf:type owl:DatatypeProperty ;
              rdfs:range xsd:time ;
-             dcterms:description "A time expressed as a normal time of day"@en ;
-             rdfs:label "time of day"@en .
+             dcterms:description "A time expressed as a normal time of day"@en ,
+                                 "Eine Zeit, ausgedrückt als normale Tageszeit"@de ,
+                                 "Une heure exprimée comme une heure normale de la journée"@fr ;
+             rdfs:label "Tageszeit"@de ,
+                        "heure de la journée"@fr ,
+                        "time of day"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#timecodeExpression
 ec:timecodeExpression rdf:type owl:DatatypeProperty ;
                       rdfs:range xsd:string ;
-                      dcterms:description """A time expressed as
-            timecode."""@en ;
-                      rdfs:label "timecode expression"@en .
+                      dcterms:description "A time expressed as timecode."@en ,
+                                          "Eine Zeit ausgedrückt als Timecode."@de ,
+                                          "Un temps exprimé sous forme de timecode."@fr ;
+                      rdfs:label "Timecode-Ausdruck"@de ,
+                                 "expression du timecode"@fr ,
+                                 "timecode expression"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#title
 ec:title rdf:type owl:DatatypeProperty ;
          rdfs:range rdfs:Literal ;
-         dcterms:description """All value of the EBU title status classification scheme
-            (http://www.ebu.ch/metadata/cs/web/ebu_TitleStatusCodeCS_p.xml.htm) are candidates
-            subproperties of the title property as implemented for an example with
-        alternativeTitle."""@en ,
-                             """Specifies the title or name given to the
-            resource.  A root for the definition of subproperties defining ebucore titles of different types. The ebucore title type can be used to define sub-properties to optionally refine the category of
-            the title."""@en ;
-         rdfs:label "Title"@en .
+         dcterms:description "Alle Werte des EBU-Titelstatus-Klassifizierungsschemas (http://www.ebu.ch/metadata/cs/web/ebu_TitleStatusCodeCS_p.xml.htm) sind Kandidaten Untereigenschaften der Eigenschaft title, wie sie zum Beispiel mit alternativeTitel."@de ,
+                             "Specifies the title or name given to the resource. A root for the definition of subproperties defining ebucore titles of different types. The ebucore title type can be used to define sub-properties to optionally refine the category of the title. All value of the EBU title status classification scheme (http://www.ebu.ch/metadata/cs/web/ebu_TitleStatusCodeCS_p.xml.htm) are candidates subproperties of the title property as implemented for an example with alternativeTitle."@en ,
+                             "Toutes les valeurs du système de classification du statut du titre de l'UER (http://www.ebu.ch/metadata/cs/web/ebu_TitleStatusCodeCS_p.xml.htm) sont des candidats sous-propriétés de la propriété title comme implémenté par exemple avec alternativeTitle."@fr ;
+         rdfs:label "Titel"@de ,
+                    "Title"@en ,
+                    "Titre"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#totalNumberOfEpisodes
 ec:totalNumberOfEpisodes rdf:type owl:DatatypeProperty ;
                          rdfs:range xsd:integer ;
-                         dcterms:description "To provide the total number of episodes in a Series or a Season."@en ;
-                         rdfs:label "Total number of episodes"@en .
+                         dcterms:description "Pour fournir le nombre total d'épisodes d'une série ou d'une saison."@fr ,
+                                             "To provide the total number of episodes in a Series or a Season."@en ,
+                                             "Zur Angabe der Gesamtzahl der Episoden einer Serie oder einer Staffel."@de ;
+                         rdfs:label "Gesamtzahl der Episoden"@de ,
+                                    "Nombre total d'épisodes"@fr ,
+                                    "Total number of episodes"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#totalNumberOfGroupMembers
 ec:totalNumberOfGroupMembers rdf:type owl:DatatypeProperty ;
                              rdfs:range xsd:integer ;
-                             dcterms:description "To provide the total number of members in a Group."@en ;
-                             rdfs:label "Total number of Group members"@en .
+                             dcterms:description "Pour fournir le nombre total de membres dans un groupe."@fr ,
+                                                 "To provide the total number of members in a Group."@en ,
+                                                 "Zur Angabe der Gesamtzahl der Mitglieder einer Gruppe."@de ;
+                             rdfs:label "Gesamtzahl der Gruppenmitglieder"@de ,
+                                        "Nombre total de membres du groupe"@fr ,
+                                        "Total number of Group members"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#username
 ec:username rdf:type owl:DatatypeProperty ;
             rdfs:range rdfs:Literal ;
-            dcterms:description """The username by which a Person is
-            known e.g. when attributing a rating value."""@en ;
-            rdfs:label "Username"@en .
+            dcterms:description "Der Benutzername, unter dem eine Person bekannt ist bekannt ist, z.B. wenn Sie einen Bewertungswert zuweisen."@de ,
+                                "Le nom d'utilisateur par lequel une personne est connue, par exemple lors de l'attribution d'une valeur d'évaluation."@fr ,
+                                "The username by which a Person is known e.g. when attributing a rating value."@en ;
+            rdfs:label "Benutzername"@de ,
+                       "Nom d'utilisateur :"@fr ,
+                       "Username"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#version
 ec:version rdf:type owl:DatatypeProperty ;
            rdfs:range rdfs:Literal ;
-           dcterms:description "To provide information on the current version of an EditorialObject."@en ;
-           rdfs:label "Version"@en .
+           dcterms:description "Pour fournir des informations sur la version actuelle d'un EditorialObject."@fr ,
+                               "To provide information on the current version of an EditorialObject."@en ,
+                               "Um Informationen über die aktuelle Version eines EditorialObjects bereitzustellen."@de ;
+           rdfs:label "Version"@de ,
+                      "Version"@en ,
+                      "Version"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#videoBitRate
 ec:videoBitRate rdf:type owl:DatatypeProperty ;
                 rdfs:range xsd:nonNegativeInteger ;
-                dcterms:description """The video bitrate. To provide the bitrate at which the MediaResource can be played
-          in bits/second. Current bitrate if constant, and average bitrate if
-          variable."""@en ;
-                rdfs:label "Video bitrate"@en .
+                dcterms:description "Die Video-Bitrate. Zur Angabe der Bitrate, mit der die MediaResource abgespielt werden kann in Bits/Sekunde. Aktuelle Bitrate, wenn konstant, und durchschnittliche Bitrate, wenn variabel."@de ,
+                                    "Le débit binaire de la vidéo. Pour fournir le débit binaire auquel la MediaResource peut être lue en bits/seconde. Débit binaire actuel si constant, et débit binaire moyen si variable."@fr ,
+                                    "The video bitrate. To provide the bitrate at which the MediaResource can be played in bits/second. Current bitrate if constant, and average bitrate if variable."@en ;
+                rdfs:label "Débit binaire vidéo"@fr ,
+                           "Video bitrate"@en ,
+                           "Video-Bitrate"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#videoBitRateMax
 ec:videoBitRateMax rdf:type owl:DatatypeProperty ;
                    rdfs:range xsd:nonNegativeInteger ;
-                   dcterms:description "The maximum video bitrate."@en ;
-                   rdfs:label "Video bitrate max"@en .
+                   dcterms:description "Die maximale Video-Bitrate."@de ,
+                                       "Le débit binaire vidéo maximum."@fr ,
+                                       "The maximum video bitrate."@en ;
+                   rdfs:label "Débit binaire vidéo max"@fr ,
+                              "Video bitrate max"@en ,
+                              "Video-Bitrate max."@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#videoBitRateMode
 ec:videoBitRateMode rdf:type owl:DatatypeProperty ;
                     rdfs:range rdfs:Literal ;
-                    dcterms:description "The video bitrate mode."@en ;
-                    rdfs:label "Video bitrate mode"@en .
+                    dcterms:description "Der Modus für die Video-Bitrate."@de ,
+                                        "Le mode de débit binaire vidéo."@fr ,
+                                        "The video bitrate mode."@en ;
+                    rdfs:label "Mode de débit binaire vidéo"@fr ,
+                               "Video bitrate mode"@en ,
+                               "Video-Bitrate-Modus"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#videoEncodingLevel
 ec:videoEncodingLevel rdf:type owl:DatatypeProperty ;
                       rdfs:subPropertyOf ec:encodingLevel ;
                       rdfs:range rdfs:Literal ;
-                      dcterms:description "The encoding level as defined in specifications."@en ;
-                      rdfs:label "Video encoding level"@en .
+                      dcterms:description "Die Kodierungsebene, wie sie in den Spezifikationen definiert ist."@de ,
+                                          "Le niveau de codage tel que défini dans les spécifications."@fr ,
+                                          "The encoding level as defined in specifications."@en ;
+                      rdfs:label "Ebene der Videokodierung"@de ,
+                                 "Niveau d'encodage vidéo"@fr ,
+                                 "Video encoding level"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#videoEncodingProfile
 ec:videoEncodingProfile rdf:type owl:DatatypeProperty ;
                         rdfs:subPropertyOf ec:encodingProfile ;
                         rdfs:range rdfs:Literal ;
-                        dcterms:description "The encoding level as defined in specifications."@en ;
-                        rdfs:label "Video encoding profile"@en .
+                        dcterms:description "Die Kodierungsebene, wie sie in den Spezifikationen definiert ist."@de ,
+                                            "Le niveau de codage tel que défini dans les spécifications."@fr ,
+                                            "The encoding level as defined in specifications."@en ;
+                        rdfs:label "Profil d'encodage vidéo"@fr ,
+                                   "Video encoding profile"@en ,
+                                   "Video-Kodierungsprofil"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#width
 ec:width rdf:type owl:DatatypeProperty ;
          rdfs:range xsd:integer ;
-         dcterms:description """The width of e.g. a video frame typically
-            expressed as a number of pixels, or picture/image in millimeters."""@en ;
-         rdfs:label "Width"@en .
+         dcterms:description "Die Breite z.B. eines Videobildes wird normalerweise ausgedrückt als Anzahl von Pixeln oder als Bild in Millimetern."@de ,
+                             "La largeur d'une image vidéo, par exemple, généralement exprimée en nombre de pixels, ou image/photo en millimètres."@fr ,
+                             "The width of e.g. a video frame typically expressed as a number of pixels, or picture/image in millimeters."@en ;
+         rdfs:label "Breite"@de ,
+                    "Largeur"@fr ,
+                    "Width"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#widthUnit
 ec:widthUnit rdf:type owl:DatatypeProperty ;
              rdfs:range rdfs:Literal ;
-             dcterms:description """The unit used to measure a width e.g. in pixels
-            or number of lines or millimeters or else."""@en ;
-             rdfs:label "Width unit"@en .
+             dcterms:description "Die Einheit, mit der eine Breite gemessen wird, z.B. in Pixeln oder Anzahl der Zeilen oder Millimeter oder anderes."@de ,
+                                 "L'unité utilisée pour mesurer une largeur, par exemple en pixels ou en nombre de lignes ou en millimètres ou autre."@fr ,
+                                 "The unit used to measure a width e.g. in pixels or number of lines or millimeters or else."@en ;
+             rdfs:label "Einheit Breite"@de ,
+                        "Unité de largeur"@fr ,
+                        "Width unit"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#wordCount
 ec:wordCount rdf:type owl:DatatypeProperty ;
              rdfs:range xsd:integer ;
-             dcterms:description "The number of words contained in a document."@en ;
-             rdfs:label "Word count"@en .
+             dcterms:description "Die Anzahl der in einem Dokument enthaltenen Wörter."@de ,
+                                 "Le nombre de mots contenus dans un document."@fr ,
+                                 "The number of words contained in a document."@en ;
+             rdfs:label "Nombre de mots"@fr ,
+                        "Word count"@en ,
+                        "Wortzahl"@de .
 
 
 ###  http://www.w3.org/2006/time#day
 time:day rdf:type owl:DatatypeProperty ;
          rdfs:range xsd:gDay ;
-         rdfs:label "day"@en .
+         rdfs:label "Tag"@de ,
+                    "day"@en ,
+                    "jour"@fr .
 
 
 ###  http://www.w3.org/2006/time#inXSDDateTimeStamp
@@ -4925,13 +7355,17 @@ time:inXSDDateTimeStamp rdf:type owl:DatatypeProperty ;
 ###  http://www.w3.org/2006/time#month
 time:month rdf:type owl:DatatypeProperty ;
            rdfs:range xsd:gMonth ;
-           rdfs:label "month"@en .
+           rdfs:label "Monat"@de ,
+                      "mois"@fr ,
+                      "month"@en .
 
 
 ###  http://www.w3.org/2006/time#year
 time:year rdf:type owl:DatatypeProperty ;
           rdfs:range xsd:gYear ;
-          rdfs:label "year"@en .
+          rdfs:label "Jahr"@de ,
+                     "année"@fr ,
+                     "year"@en .
 
 
 #################################################################
@@ -4940,8 +7374,12 @@ time:year rdf:type owl:DatatypeProperty ;
 
 ###  http://purl.org/dc/elements/1.1/Agent
 dc:Agent rdf:type owl:Class ;
-         dcterms:description "A resource that acts or has the power to act."@en ;
-         rdfs:label "Agent"@en .
+         dcterms:description "A resource that acts or has the power to act."@en ,
+                             "Eine Ressource, die handelt oder die die Macht hat zu handeln."@de ,
+                             "Une ressource qui agit ou a le pouvoir d'agir."@fr ;
+         rdfs:label "Agent"@de ,
+                    "Agent"@en ,
+                    "Agent"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#Account
@@ -4974,13 +7412,11 @@ ebuccdm:Account rdf:type owl:Class ;
                                   owl:onProperty ec:name ;
                                   owl:allValuesFrom rdfs:Literal
                                 ] ;
-                dcterms:description """A registration Account to a Service. Account information can vary
-      from one Service to another. Such information covers e.g. a (nick)name, a login, an age, sex,
-      domains of interest or more."""@en ,
+                dcterms:description "A registration Account to a Service. Account information can vary from one Service to another. Such information covers e.g. a (nick)name, a login, an age, sex, domains of interest or more."@en ,
                                     "Das Konto, unter dem einen Nutzer bei einem Dienst registriert ist. Die registrierten Informationen zum Konto können je nach Service unterschiedlich sein. Beispiele: (Spitz-)name, Login-Name, Alter, Geschlecht, Interessensgebiete, etc."@de ,
                                     "Un compte d'inscription à un service. Les informations relatives au compte peuvent varier d'un service à l'autre. Ces informations couvrent par exemple un nom, un surnom, un loggin, un âge, le sexe, des domaines d'intérêt."@fr ;
                 rdfs:label "Account"@en ,
-                           "Compte"@en ,
+                           "Compte"@fr ,
                            "Nutzerkonto"@de .
 
 
@@ -5060,8 +7496,7 @@ ebuccdm:Audience rdf:type owl:Class ;
                                    owl:onProperty ec:name ;
                                    owl:allValuesFrom rdfs:Literal
                                  ] ;
-                 dcterms:description """A group of Consumers or an aggregation of groups of Consumers
-      clustered e.g. by class of age , social categories or else."""@en ,
+                 dcterms:description "A group of Consumers or an aggregation of groups of Consumers clustered e.g. by class of age , social categories or else."@en ,
                                      "Eine Gruppe von Nutzern oder eine Aggregation von Nutzergruppen gebildet durch z.B. Altersklasse, soziale Kategorien o.ä."@de ,
                                      "Un groupe de consommateurs ou une aggrégation de groupes de consommateurs. Par exemple, un groupe peut correspondre à un ensemble de consommateurs d'une même tranche d'âges ou d'une même catégorie socioprofessionnelle."@fr ;
                  rdfs:label "Audience"@en ,
@@ -5179,8 +7614,7 @@ ebuccdm:Campaign rdf:type owl:Class ;
                                    owl:allValuesFrom rdfs:Literal
                                  ] ;
                  dcterms:description "A Campaign defines a strategy for publishing content (EditorialObjects and related Resources/MediaResources/Essences) to a targeted Audience according to a PublicationPlan. Campaign strategies can be refined taking into account the analysis of the Resonance of related ConsumptionEvents (e.g. likes, downloads, etc). Campaigns can apply to a variety of broadcasting strategies e.g. advertising campaigns, promotional campaigns or else."@en ,
-                                     """Eine Kampagne legt die Strategie zur Publikation eines Produktes (Medieninhalt und damit verbundene Ressourcen/Medienobjekte/Essenzen) für ein Zielpublikum gemäß eines Publikationsplans fest.
-Kampagnenstrategien können verfeinert werden, indem die Resonanz auf Nutzungsereignisse (z.B. likes, downloads, etc.) analysiert wird. Kampagnen können für unterschiedlichste Produkte angewendet werden, z.B. Werbekampagnen, Promotionskampagnen, o.ä."""@de ,
+                                     "Eine Kampagne legt die Strategie zur Publikation eines Produktes (Medieninhalt und damit verbundene Ressourcen/Medienobjekte/Essenzen) für ein Zielpublikum gemäß eines Publikationsplans fest. Kampagnenstrategien können verfeinert werden, indem die Resonanz auf Nutzungsereignisse (z.B. likes, downloads, etc.) analysiert wird. Kampagnen können für unterschiedlichste Produkte angewendet werden, z.B. Werbekampagnen, Promotionskampagnen, o.ä."@de ,
                                      "Une campagne définit une stratégie de publication de contenu (objets éditoriaux et ressources/médias/essence) auprès d'un public cible conformément à un plan de publication. Les stratégies de campagne peuvent être affinées en fonction l'analyse de la Résonance de la Consommation des Evenements associée ( par exemple le nombre de like ou de téléchargements, etc ...). Les campagnes s'appliquent à différentes stratégies de diffusion, on peut citer par exemple les campagnes publicitaires ou les campagnes promotionnelles."@fr ;
                  rdfs:label "Campagne"@fr ,
                             "Campaign"@en ,
@@ -5207,8 +7641,7 @@ ebuccdm:Consumer rdf:type owl:Class ;
                                    owl:allValuesFrom ebuccdm:ConsumptionDevice
                                  ] ;
                  dcterms:description "An individual who consumes the Service using a ConsumptionDevice. The Consumer can be associated to an Audience. His actions lead to data around the ConsumptionEvents and associated ResonanceEvents. A consumer can be registered to a Service via an Account containing information about that Concumer to a varying degree of detaill (e.g. age, sex, matrimonial status, address). This is further defined in Consumption Licence when applicable."@en ,
-                                     """Eine Person, die einen Service konsumiert mit Hilfe eines Endgerätes.
-Der Nutzer kann zu einem Publikum gehören. Seine Aktivitäten führen zu Nutzungsereignissen und zu Resonanzereignissen. Ein Nutzer kann für einen Service registriert sein über ein Nutzerkonto, das den Nutzer in unterschiedlichem Detaillierungsgrad repräsentiert (z.B. Alter, Geschlecht, Adresse). Eine Nutzungslizenz definiert die genaueren Nutzungsbedingungen und -möglichkeiten."""@de ,
+                                     "Eine Person, die einen Service konsumiert mit Hilfe eines Endgerätes. Der Nutzer kann zu einem Publikum gehören. Seine Aktivitäten führen zu Nutzungsereignissen und zu Resonanzereignissen. Ein Nutzer kann für einen Service registriert sein über ein Nutzerkonto, das den Nutzer in unterschiedlichem Detaillierungsgrad repräsentiert (z.B. Alter, Geschlecht, Adresse). Eine Nutzungslizenz definiert die genaueren Nutzungsbedingungen und -möglichkeiten."@de ,
                                      "Un individu qui consomme le service en utilisant un ConsumptionDevice. Le Consommateur peut être associé à une Audience. Ses actions conduisent à des données autour des ConsumptionEvents et des ResonanceEvents associés. Un consommateur peut être enregistré auprès d'un service par le biais d'un compte contenant des informations plus ou moins détaillées sur ce consommateur (par exemple, âge, sexe, situation matrimoniale, adresse). Ces informations sont définies plus précisément dans la licence de consommation, le cas échéant."@fr ;
                  rdfs:label "Consommateur"@fr ,
                             "Consumer"@en ,
@@ -5265,8 +7698,12 @@ ebuccdm:ConsumptionCount rdf:type owl:Class ;
                                            owl:onProperty ec:name ;
                                            owl:allValuesFrom rdfs:Literal
                                          ] ;
-                         dcterms:description "An aggregation of groups of counted Consumers"@en ;
-                         rdfs:label "Consumption count"@en .
+                         dcterms:description "An aggregation of groups of counted Consumers"@en ,
+                                             "Eine Ansammlung von Gruppen von gezählten Verbrauchern"@de ,
+                                             "Une agrégation de groupes de Consommateurs comptés"@fr ;
+                         rdfs:label "Comptage des consommations"@fr ,
+                                    "Consumption count"@en ,
+                                    "Verbrauch zählen"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#ConsumptionDevice
@@ -5393,8 +7830,7 @@ ebuccdm:ConsumptionDeviceProfile rdf:type owl:Class ;
                                                    owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                                    owl:onDataRange xsd:boolean
                                                  ] ;
-                                 dcterms:description """Das Profil eines Endgerätes.
-(z.B. Hersteller, Modell, Hardwareausstattung, Softwareausstattung, etc.)"""@de ,
+                                 dcterms:description "Das Profil eines Endgerätes.(z.B. Hersteller, Modell, Hardwareausstattung, Softwareausstattung, etc.)"@de ,
                                                      "Profile d'un appareil permettant de consommer du contenu médiatique. Cela peut-être un nom de modèle avec une version de hardware ou de software."@fr ,
                                                      "The profile of a ConsumptionDevice."@en ;
                                  rdfs:label "Consumption device profile"@en ,
@@ -5465,10 +7901,8 @@ ebuccdm:ConsumptionEvent rdf:type owl:Class ;
                                            owl:allValuesFrom rdfs:Literal
                                          ] ;
                          dcterms:description "A ConsumptionEvent reflecting the consumption of content during a PublicationEvent. For linear services the ConsumptionEvent and PublicationEvent happen at the same time. For non-linear services, the consumer decides about the time of the ConsumptionEvent. The ConsumptionEvent results into ResonanceEvent aggregated into Resonance data."@en ,
-                                             """Ein Nutzungsereignis repräsentiert die Nutzung eines Medienanproduktes im Rahmen eines Publikationsereignisses.
-Bei linearen Medienservices finden Nutzungsereignis und Publikationsereignis zur gleichen Zeit statt. Bei nicht-linearen Medienservices entscheidet der Nutzer selbst über den Zeitpunkt des Nutzungsereignisses (im Rahmen des Publikationszeitraums).
-Das Nutzunsereignis führt zu Resonanzereignissen, die zu Resonanzdaten aggregiert werden."""@de ,
-                                             "Un événement de consommation, ConsumptionEvent, décrit la consommation de contenu médiatique durant un évènement de publication, PublicationEvent. Pour les services linéaires, le ConsumptionEvent et le PuclicationEvent, se produisent en même temps. Pour les services non linéaires, le consommateur décide du moment du ConsumptionEvent. Dans  les deux cas, un ConsumptionEvent génère un évènement de raisonance, ResonanceEvent qui est agrégé aux données de raisonance, ResonanceData."@fr ;
+                                             "Ein Nutzungsereignis repräsentiert die Nutzung eines Medienanproduktes im Rahmen eines Publikationsereignisses. Bei linearen Medienservices finden Nutzungsereignis und Publikationsereignis zur gleichen Zeit statt. Bei nicht-linearen Medienservices entscheidet der Nutzer selbst über den Zeitpunkt des Nutzungsereignisses (im Rahmen des Publikationszeitraums). Das Nutzunsereignis führt zu Resonanzereignissen, die zu Resonanzdaten aggregiert werden."@de ,
+                                             "Un événement de consommation, ConsumptionEvent, décrit la consommation de contenu médiatique durant un évènement de publication, PublicationEvent. Pour les services linéaires, le ConsumptionEvent et le PuclicationEvent, se produisent en même temps. Pour les services non linéaires, le consommateur décide du moment du ConsumptionEvent. Dans les deux cas, un ConsumptionEvent génère un évènement de raisonance, ResonanceEvent qui est agrégé aux données de raisonance, ResonanceData."@fr ;
                          rdfs:label "Consumption event"@en ,
                                     "Nutzungsereignis"@de ,
                                     "Événement de consommation"@fr .
@@ -5505,7 +7939,7 @@ ebuccdm:ConsumptionLicence rdf:type owl:Class ;
                                              owl:onProperty ebuccdm:consumptionLicenceText ;
                                              owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                            ] ;
-                           dcterms:description "A licence attributed to a Consumer defining the terms for the consumption of content.  The ConsumptionLicence is verified by a mechanism that is usually located in the device and referred to as DRM (Digital Rights Management)."@en ,
+                           dcterms:description "A licence attributed to a Consumer defining the terms for the consumption of content. The ConsumptionLicence is verified by a mechanism that is usually located in the device and referred to as DRM (Digital Rights Management)."@en ,
                                                "Eine Nutzungslizenz gehört zu einem Nutzer und legt die Nutzungsbedingungen für ein Produkt fest."@de ,
                                                "Licence attribuée à un consommateur, Consumer, définissant les conditions de consommation d'un contenu. La licence de consommation, ConsumptionLicence, est vérifiée par un mécanisme généralement situé dans l'appareil, Device, et appelé DRM (Digital Rights Management)"@fr ;
                            rdfs:label "Consumption licence"@en ,
@@ -5790,8 +8224,7 @@ ebuccdm:ProductionJob rdf:type owl:Class ;
                                         owl:allValuesFrom rdfs:Literal
                                       ] ;
                       dcterms:description "A job / process to be performed to manipulate/create/modify/store/etc. MediaResources and Essences as defined in an associated EditorialObject. It is ordered by Contract."@en ,
-                                          """Eine Aufgabe oder ein Prozess, der ausgeführt wird, um eine Medienressource oder eine Essenz zu erstellen, zu modifizieren, zu speichern o.ä.
-Medienressource und Essenz werden gemäß einen Medieninhalt hergestellt. Die Produktionsaufgabe wird durch einen Vertrag beauftragt."""@de ,
+                                          "Eine Aufgabe oder ein Prozess, der ausgeführt wird, um eine Medienressource oder eine Essenz zu erstellen, zu modifizieren, zu speichern o.ä. Medienressource und Essenz werden gemäß einen Medieninhalt hergestellt. Die Produktionsaufgabe wird durch einen Vertrag beauftragt."@de ,
                                           "Une tâche / un processus à exécuter pour manipuler/créer/modifier/stocker/etc. des MediaResources et Essences telles que définies dans un EditorialObject. Il est commandé par contrat, Contract."@fr ;
                       rdfs:label "Production job"@en ,
                                  "Produktionsaufgabe"@de ,
@@ -5820,12 +8253,11 @@ ebuccdm:ProductionOrder rdf:type owl:Class ;
                                           owl:onProperty ec:name ;
                                           owl:allValuesFrom rdfs:Literal
                                         ] ;
-                        dcterms:description """Die Beauftragung zur Erstellung, zum Kauf oder zur Wiederverwendung einer Medienressource.
-Die Bedingungen eines Produktionsauftrages sind in einem Vertrag definiert."""@de ,
+                        dcterms:description "Die Beauftragung zur Erstellung, zum Kauf oder zur Wiederverwendung einer Medienressource. Die Bedingungen eines Produktionsauftrages sind in einem Vertrag definiert."@de ,
                                             "L'acte d'ordonner la création/production, l'achat ou la réutilisation de MediaResources. Les termes d'un ProductionOrder sont définis par Contrat."@fr ,
-                                            "The act of ordering the creation/production, purchase or reuse of MediaResources.  The terms of a ProductionOrder are defined by Contract."@en ;
-                        rdfs:label "Production order"@en ,
-                                   "Production order"@fr ,
+                                            "The act of ordering the creation/production, purchase or reuse of MediaResources. The terms of a ProductionOrder are defined by Contract."@en ;
+                        rdfs:label "Commande de production"@fr ,
+                                   "Production order"@en ,
                                    "Produktionsauftrag"@de .
 
 
@@ -5859,12 +8291,9 @@ ebuccdm:Resonance rdf:type owl:Class ;
                                     owl:onProperty ec:name ;
                                     owl:allValuesFrom rdfs:Literal
                                   ] ;
-                  dcterms:description """Die Aggregation von Daten über die Nutzung von Produkten durch eine Gruppe von Nutzern.
-Repräsentiert alle zählbaren oder erfassbaren Nutzungsaktivitäten durch Nutzer während des Nutzungsereignisses, aber zu nicht-individualisierbaren Ausdrücken zusammengefasst, z.B. click-Zahlen, Anzahl von Likes, Prozentsatz von Stimmen, Anzahl der Downloads, ...
-Die Analyse der Resonanzdaten erlaubt eine genauere Verfeinerung einer Kampagnenstrategie und des verknüpften Publikationsplans."""@de ,
+                  dcterms:description "Die Aggregation von Daten über die Nutzung von Produkten durch eine Gruppe von Nutzern. Repräsentiert alle zählbaren oder erfassbaren Nutzungsaktivitäten durch Nutzer während des Nutzungsereignisses, aber zu nicht-individualisierbaren Ausdrücken zusammengefasst, z.B. click-Zahlen, Anzahl von Likes, Prozentsatz von Stimmen, Anzahl der Downloads, ... Die Analyse der Resonanzdaten erlaubt eine genauere Verfeinerung einer Kampagnenstrategie und des verknüpften Publikationsplans."@de ,
                                       "La raisonance est une agrégation des données relatives à la consommation de contenu par un groupe de consommateurs. Représente toutes les actions de consommation dénombrables ou perceptibles par les consommateurs au cours d'un ConsumptionEvent agrégées pour former une expression non individuelle, par exemple taux de clics, nombre d'appréciations, pourcentage de votes, nombre de téléchargements, likes, pourcentage de votes, nombre de téléchargements. L'analyse des données de résonance permet plus particulièrement d'affiner une stratégie de Campagne et son plan de publication, PublicationPlan."@fr ,
-                                      """The aggregation of data about the conumption of content by a group of Consumers. Represents all countable or noticeable consumption actions by consumers during a ConsumptionEvent aggregated to form a non-individual expression, e.g. click rates, number of likes, percentage of votes, number of downloads...
-The analysis of the Resonance Data allows more particularly refining a Campaign strategy and its associated PublicationPlan."""@en ;
+                                      "The aggregation of data about the conumption of content by a group of Consumers. Represents all countable or noticeable consumption actions by consumers during a ConsumptionEvent aggregated to form a non-individual expression, e.g. click rates, number of likes, percentage of votes, number of downloads... The analysis of the Resonance Data allows more particularly refining a Campaign strategy and its associated PublicationPlan."@en ;
                   rdfs:label "Resonance"@en ,
                              "Resonanz"@de ,
                              "Résonance"@fr .
@@ -5892,8 +8321,7 @@ ebuccdm:ResonanceEvent rdf:type owl:Class ;
                                          owl:onProperty ec:name ;
                                          owl:allValuesFrom rdfs:Literal
                                        ] ;
-                       dcterms:description """Data about the consumption of content by a Consumer using a particular ConsumptionDevice. Represents all individual countable or noticeable actions by consumers during a consumptionEvent using a particular ConsumptionDevice, e.g. clicks, likes, comments, votes, tweets preferences, downloads... All ResonanceEvents are linked to a ConsumptionEvent and the associated Essence or EditorialObject. ResonanceEvents represent raw-data, that need to be aggregated (e.g. summed up). Such data can be seen as \"Big
-Data\" and require appropriate technology and techniques (e.g. processing algorithms).The aggregationof this data is a set of Resonance results."""@en ,
+                       dcterms:description "Data about the consumption of content by a Consumer using a particular ConsumptionDevice. Represents all individual countable or noticeable actions by consumers during a consumptionEvent using a particular ConsumptionDevice, e.g. clicks, likes, comments, votes, tweets preferences, downloads... All ResonanceEvents are linked to a ConsumptionEvent and the associated Essence or EditorialObject. ResonanceEvents represent raw-data, that need to be aggregated (e.g. summed up). Such data can be seen as \"Big Data\" and require appropriate technology and techniques (e.g. processing algorithms).The aggregationof this data is a set of Resonance results."@en ,
                                            """Daten zur Nutzung eines Medienproduktes durch einen Nutzer mit Hilfe eines speziellen Endgerätes.
 Repräsentiert alle individuell zählbaren oder erfassbaren Aktivitäten des Nutzers währen eines Nutzungsereignisses mit Hilfe eines Endgerätes, z.B. Klicks, Likes, Kommntare, Abstimmungen, Tweets, Downloads, etc.
 Alle Resonanzereignisse sind mit einem Nutzungsereignis verknüpft und dessen Essenz oder Medieninhalt.
@@ -5943,11 +8371,11 @@ ebuccdm:Rule rdf:type owl:Class ;
                                owl:allValuesFrom rdfs:Literal
                              ] ;
              dcterms:description "A Rule defined from legal, technical or editorial, or regulatory requirements."@en ,
-                                 "Eine Regel aus gesetzlichen, technischen, inhaltlichen oder regulatorischen Anforderungen."@de ;
+                                 "Eine Regel aus gesetzlichen, technischen, inhaltlichen oder regulatorischen Anforderungen."@de ,
+                                 "Une règle définie à partir de contraintes légales, techniques, éditoriales ou réglementaires."@fr ;
              rdfs:label "Regel"@de ,
                         "Rule"@en ,
-                        "Règle"@fr ,
-                        "Une règle définie à partir de contraintes légales, techniques, éditoriales ou réglementaires."@fr .
+                        "Règle"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebuccdm#Stage
@@ -5991,8 +8419,12 @@ ec:AccessConditions rdf:type owl:Class ;
                                       owl:onProperty ec:geoBlockingWhitelist ;
                                       owl:allValuesFrom skos:Concept
                                     ] ;
-                    dcterms:description "The conditions under which content can be accessed."@en ;
-                    rdfs:label "Access conditions"@en .
+                    dcterms:description "Die Bedingungen, unter denen auf Inhalte zugegriffen werden kann."@de ,
+                                        "Les conditions dans lesquelles le contenu est accessible."@fr ,
+                                        "The conditions under which content can be accessed."@en ;
+                    rdfs:label "Access conditions"@en ,
+                               "Conditions d'accès"@fr ,
+                               "Zugangsbedingungen"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Action
@@ -6031,22 +8463,34 @@ ec:Action rdf:type owl:Class ;
                             owl:onProperty ec:name ;
                             owl:allValuesFrom rdfs:Literal
                           ] ;
-          dcterms:description "A class to log Actions."@en ;
-          rdfs:label "Action"@en .
+          dcterms:description "A class to log Actions."@en ,
+                              "Eine Klasse zum Protokollieren von Aktionen."@de ,
+                              "Une classe pour enregistrer les actions."@fr ;
+          rdfs:label "Action"@en ,
+                     "Action"@fr ,
+                     "Aktion"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Action_Type
 ec:Action_Type rdf:type owl:Class ;
                rdfs:subClassOf skos:Concept ;
-               dcterms:description "To define a type of Action."@en ;
-               rdfs:label "Action type"@en .
+               dcterms:description "Pour définir un type d'action."@fr ,
+                                   "To define a type of Action."@en ,
+                                   "Um eine Art von Aktion zu definieren."@de ;
+               rdfs:label "Action type"@en ,
+                          "Aktionstyp"@de ,
+                          "Type d'action"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#ActiveFormatDescriptorCode
 ec:ActiveFormatDescriptorCode rdf:type owl:Class ;
                               rdfs:subClassOf ec:Format ;
-                              dcterms:description "To define an active format code."@en ;
-                              rdfs:label "Active format descriptor code"@en .
+                              dcterms:description "Pour définir un code de format actif."@fr ,
+                                                  "So definieren Sie einen aktiven Formatcode."@de ,
+                                                  "To define an active format code."@en ;
+                              rdfs:label "Active format descriptor code"@en ,
+                                         "Aktiver Format-Deskriptor-Code"@de ,
+                                         "Code du descripteur de format actif"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Affiliation
@@ -6082,8 +8526,12 @@ ec:Affiliation rdf:type owl:Class ;
                                  owl:onProperty ec:name ;
                                  owl:allValuesFrom rdfs:Literal
                                ] ;
-               dcterms:description "An Organisation to which a Contact is affiliated (with period of validity)."@en ;
-               rdfs:label "Affiliation"@en .
+               dcterms:description "An Organisation to which a Contact is affiliated (with period of validity)."@en ,
+                                   "Eine Organisation, der ein Kontakt angehört (mit Gültigkeitsdauer)."@de ,
+                                   "Une organisation à laquelle un contact est affilié (avec une période de validité)."@fr ;
+               rdfs:label "Affiliation"@en ,
+                          "Affiliation"@fr ,
+                          "Zugehörigkeit"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Agent
@@ -6246,7 +8694,7 @@ ec:Agent rdf:type owl:Class ;
                          ] ;
          dcterms:description "An «Agent» is either a Contact/Person or Organisation to which is associated a Role corresponding to the contribution the «Agent» brings to the realisation of a MediaResource or EditorialObject."@en ,
                              "Ein Akteur ist entweder eine Kontaktperson oder eine Organisation, deren Beitrag zur Realisierung eines Inhaltsobjektes oder eines Medienobjektes durch eine Rolle beschrieben wird."@de ,
-                             "Un acteur  est un terme général, soit un  contact ou une personne ou une organisation à laquelle est associé un rôle correspondant à la contribution que l'acteur apporte à la réalisation d'une MediaResource ou d'un EditorialObject."@fr ;
+                             "Un acteur est un terme général, soit un contact ou une personne ou une organisation à laquelle est associé un rôle correspondant à la contribution que l'acteur apporte à la réalisation d'une MediaResource ou d'un EditorialObject."@fr ;
          rdfs:isDefinedBy dc:Agent ;
          rdfs:label "Agent"@en ,
                     "Akteur"@de ,
@@ -6285,7 +8733,9 @@ ec:AlternativeTitle rdf:type owl:Class ;
                                       owl:onProperty ec:name ;
                                       owl:allValuesFrom rdfs:Literal
                                     ] ;
-                    rdfs:label "Alternative title"@en .
+                    rdfs:label "Alternative title"@en ,
+                               "Alternativer Titel"@de ,
+                               "Titre alternatif"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#AncillaryData
@@ -6311,19 +8761,23 @@ ec:AncillaryData rdf:type owl:Class ;
                                    owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                    owl:onDataRange xsd:integer
                                  ] ;
-                 dcterms:description """Any ancillary data provided with the content
-            other than captioning and subtitling."""@en ;
-                 rdfs:label "Ancillary data"@en .
+                 dcterms:description "Alle mit dem Inhalt gelieferten Zusatzdaten mit Ausnahme von Untertiteln und Untertitelung."@de ,
+                                     "Any ancillary data provided with the content other than captioning and subtitling."@en ,
+                                     "Toute donnée auxiliaire fournie avec le contenu autres que le sous-titrage et le sous-titrage."@fr ;
+                 rdfs:label "Ancillary data"@en ,
+                            "Données auxiliaires"@fr ,
+                            "Ergänzende Daten"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#AncillaryDataFormat
 ec:AncillaryDataFormat rdf:type owl:Class ;
                        rdfs:subClassOf ec:DataFormat ;
-                       dcterms:description """To define the format of AncillaryData such as
-            legacy data used to be carried in vertical blanking intervals. This is provided as free
-            text in an annotation label or as an identifier pointing to a term in a classification
-            scheme."""@en ;
-                       rdfs:label "Ancillary data format"@en .
+                       dcterms:description "Pour définir le format des données auxiliaires telles que les les données patrimoniales qui étaient auparavant transportées dans des intervalles de suppression verticale. Ces données sont fournies sous forme de libre dans une étiquette d'annotation ou comme un identifiant pointant vers un terme dans un schéma de classification. de classification."@fr ,
+                                           "To define the format of AncillaryData such as legacy data used to be carried in vertical blanking intervals. This is provided as free text in an annotation label or as an identifier pointing to a term in a classification scheme."@en ,
+                                           "Zur Definition des Formats von Zusatzdaten wie z.B. Legacy-Daten, die in vertikalen Austastlücken übertragen werden. Diese werden als freier Text in einer Beschriftung oder als Bezeichner, der auf einen Begriff in einem Klassifikationsschema verweist Schema."@de ;
+                       rdfs:label "Ancillary data format"@en ,
+                                  "Format der Zusatzdaten"@de ,
+                                  "Format des données auxiliaires"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Animal
@@ -6394,22 +8848,34 @@ ec:Animal rdf:type owl:Class ;
                             owl:onProperty ec:gender ;
                             owl:maxCardinality "1"^^xsd:nonNegativeInteger
                           ] ;
-          dcterms:description "To identify an animal."@en ;
-          rdfs:label "Animal"@en .
+          dcterms:description "Pour identifier un animal."@fr ,
+                              "To identify an animal."@en ,
+                              "Um ein Tier zu identifizieren."@de ;
+          rdfs:label "Animal"@en ,
+                     "Animal"@fr ,
+                     "Tier"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#AnimalBreedCode
 ec:AnimalBreedCode rdf:type owl:Class ;
                    rdfs:subClassOf skos:Concept ;
-                   dcterms:description "To provide a breed code for an animal.."@en ;
-                   rdfs:label "Animal breed code"@en .
+                   dcterms:description "Pour fournir un code de race pour un animal.."@fr ,
+                                       "To provide a breed code for an animal.."@en ,
+                                       "Zur Bereitstellung eines Rassencodes für ein Tier..."@de ;
+                   rdfs:label "Animal breed code"@en ,
+                              "Code de la race animale"@fr ,
+                              "Code der Tierrasse"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#AnimalColourCode
 ec:AnimalColourCode rdf:type owl:Class ;
                     rdfs:subClassOf skos:Concept ;
-                    dcterms:description "To provide a colour code for an animal.."@en ;
-                    rdfs:label "Animal colour code"@en .
+                    dcterms:description "Pour fournir un code de couleur pour un animal..."@fr ,
+                                        "To provide a colour code for an animal.."@en ,
+                                        "Zur Bereitstellung eines Farbcodes für ein Tier..."@de ;
+                    rdfs:label "Animal colour code"@en ,
+                               "Code couleur des animaux"@fr ,
+                               "Farbcode für Tiere"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Annotation
@@ -6482,15 +8948,23 @@ ec:Annotation rdf:type owl:Class ;
                                 owl:onProperty ec:annotationSaliency ;
                                 owl:maxCardinality "1"^^xsd:nonNegativeInteger
                               ] ;
-              dcterms:description "A class used to annotate Assets."@en ;
-              rdfs:label "Annotation"@en .
+              dcterms:description "A class used to annotate Assets."@en ,
+                                  "Eine Klasse, mit der Sie Assets mit Anmerkungen versehen können."@de ,
+                                  "Une classe utilisée pour annoter les actifs."@fr ;
+              rdfs:label "Anmerkung"@de ,
+                         "Annotation"@en ,
+                         "Annotation"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Annotation_Type
 ec:Annotation_Type rdf:type owl:Class ;
                    rdfs:subClassOf skos:Concept ;
-                   dcterms:description "To define a type of Annotation."@en ;
-                   rdfs:label "Annotation type"@en .
+                   dcterms:description "Pour définir un type d'Annotation."@fr ,
+                                       "To define a type of Annotation."@en ,
+                                       "Um eine Art von Anmerkung zu definieren."@de ;
+                   rdfs:label "Annotation type"@en ,
+                              "Art der Annotation"@de ,
+                              "Type d'annotation"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Artefact
@@ -6617,8 +9091,7 @@ ec:Artefact rdf:type owl:Class ;
                             ] ;
             dcterms:description "Permet d'identifier tous les artefacts utilisés dans une production tels que les costumes, les objets, accessoires."@fr ,
                                 "Sämtliche Artefakte, die im Rahmen einer Produktion unterschieden werden können, z.B. Produkte, Kostüme, Requisiten"@de ,
-                                """To identify all Artefacts used in a production such as costumes, objects,
- products."""@en ;
+                                "To identify all Artefacts used in a production such as costumes, objects, products."@en ;
             rdfs:label "Artefact"@en ,
                        "Artefact"@fr ,
                        "Artefakt"@de .
@@ -6627,8 +9100,12 @@ ec:Artefact rdf:type owl:Class ;
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Artefact_Type
 ec:Artefact_Type rdf:type owl:Class ;
                  rdfs:subClassOf skos:Concept ;
-                 dcterms:description "To define a type of artefact."@en ;
-                 rdfs:label "Artefact type"@en .
+                 dcterms:description "Pour définir un type d'artefact."@fr ,
+                                     "To define a type of artefact."@en ,
+                                     "Um eine Art von Artefakt zu definieren."@de ;
+                 rdfs:label "Artefact type"@en ,
+                            "Artefakt-Typ"@de ,
+                            "Type d'artefact"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Article
@@ -6823,21 +9300,9 @@ ec:Asset rdf:type owl:Class ;
                            owl:onDataRange xsd:boolean
                          ] ;
          owl:disjointWith ec:Rating ;
-         dcterms:description """Assets are EditorialObjects or Resources with associated Rights. An
-      «Asset» is an object to which an identifier will be associated at commissioning time. It
-      serves as a central reference point to manage rights associated to EditorialObjects,
-      MediaResources or Essences, and - by inference - PublicationEvents (distribution and
-      exploitation conditions). Remember that the MediaResources or Essences will in this model
-      always be represented by an EditorialObject.
- Example: The CCDM model allows the
-      association of Rights to a related EditorialObject that is represented by one or more
-      Essences."""@en ,
-                             """Assets sind Inhaltsobjekte oder Medienobjekte und ihre zugeordneten (Verwertungs-)Rechte.
-Ein Asset erhält durch die Beauftragung einen Identifikator. Es dient als zentrale Referenz, um die Rechte zu verwalten, die mit Inhaltsobjekten, Medienobjekten,  Essenzen sowie Veröffentlichungsereignissen (per Deduktion) verknüpft sind.
-Achtung: Medienobjekte oder Essenzen werden in diesem Modell immer durch Inhaltsobjekte repräsentiert.
-Beispiel: CCDM gestattet die Verknüpfung von Verwertungsrechten mit einem Inhaltsobjekt, das von einem oder auch mehreren Essenzen repräsentiert wird."""@de ,
-                             """Les actifs sont des EditorialObjects ou des ressources avec des droits associés. Un \"Asset\" est un objet auquel un identifiant sera associé lors de la mise en service. Il sert de point de référence central pour gérer les droits associés aux EditorialObjects, MediaResources ou Essences, et par déduction - les PublicationEvents (conditions de distribution et d'exploitation). Il est a noté que les MediaResources ou Essences seront dans ce modèle toujours représentées par un EditorialObject.
-Exemple : Le modèle CCDM permet l'association de droits à un EditorialObject connexe représenté par une ou plusieurs essences, Essences."""@fr ;
+         dcterms:description "Assets are EditorialObjects or Resources with associated Rights. An «Asset» is an object to which an identifier will be associated at commissioning time. It serves as a central reference point to manage rights associated to EditorialObjects, MediaResources or Essences, and - by inference - PublicationEvents (distribution and exploitation conditions). Remember that the MediaResources or Essences will in this model always be represented by an EditorialObject. Example: The CCDM model allows the association of Rights to a related EditorialObject that is represented by one or more Essences."@en ,
+                             "Assets sind Inhaltsobjekte oder Medienobjekte und ihre zugeordneten (Verwertungs-)Rechte. Ein Asset erhält durch die Beauftragung einen Identifikator. Es dient als zentrale Referenz, um die Rechte zu verwalten, die mit Inhaltsobjekten, Medienobjekten, Essenzen sowie Veröffentlichungsereignissen (per Deduktion) verknüpft sind. Achtung: Medienobjekte oder Essenzen werden in diesem Modell immer durch Inhaltsobjekte repräsentiert. Beispiel: CCDM gestattet die Verknüpfung von Verwertungsrechten mit einem Inhaltsobjekt, das von einem oder auch mehreren Essenzen repräsentiert wird."@de ,
+                             "Les actifs sont des EditorialObjects ou des ressources avec des droits associés. Un \"Asset\" est un objet auquel un identifiant sera associé lors de la mise en service. Il sert de point de référence central pour gérer les droits associés aux EditorialObjects, MediaResources ou Essences, et par déduction - les PublicationEvents (conditions de distribution et d'exploitation). Il est a noté que les MediaResources ou Essences seront dans ce modèle toujours représentées par un EditorialObject. Exemple : Le modèle CCDM permet l'association de droits à un EditorialObject connexe représenté par une ou plusieurs essences, Essences."@fr ;
          rdfs:label "Actif"@fr ,
                     "Asset"@de ,
                     "Asset"@en .
@@ -6846,15 +9311,23 @@ Exemple : Le modèle CCDM permet l'association de droits à un EditorialObject c
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Asset_Type
 ec:Asset_Type rdf:type owl:Class ;
               rdfs:subClassOf skos:Concept ;
-              dcterms:description "To define a type of asset."@en ;
-              rdfs:label "Asset type"@en .
+              dcterms:description "Pour définir un type d'actif."@fr ,
+                                  "To define a type of asset."@en ,
+                                  "Um eine Art von Asset zu definieren."@de ;
+              rdfs:label "Asset type"@en ,
+                         "Asset-Typ"@de ,
+                         "Type d'actif"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Atmosphere
 ec:Atmosphere rdf:type owl:Class ;
               rdfs:subClassOf ec:Type ;
-              dcterms:description "To describe a feeling summarising the atmosphere."@en ;
-              rdfs:label "Atmosphere"@en .
+              dcterms:description "Pour décrire un sentiment résumant l'atmosphère."@fr ,
+                                  "To describe a feeling summarising the atmosphere."@en ,
+                                  "Um ein Gefühl zu beschreiben, das die Atmosphäre zusammenfasst."@de ;
+              rdfs:label "Atmosphere"@en ,
+                         "Atmosphäre"@de ,
+                         "Atmosphère"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#AudienceLevel
@@ -6864,12 +9337,12 @@ ec:AudienceLevel rdf:type owl:Class ;
                                    owl:onProperty ec:targetAudienceSystem ;
                                    owl:allValuesFrom rdfs:Literal
                                  ] ;
-                 dcterms:description """The target audience (target region, target
-            audience category but also parental guidance recommendation) for which the media
-            resource is intended."""@en ,
-                                     """This is provided as free text in an annotation
-            label or as an identifier pointing to a term in a classification scheme."""@en ;
-                 rdfs:label "Target audience"@en .
+                 dcterms:description "Das Zielpublikum (Zielregion, Zielgruppen Kategorie der Zielgruppe, aber auch Empfehlung der Eltern), für die die Medienressource Ressource bestimmt ist."@de ,
+                                     "Le public cible (région cible, catégorie de catégorie de public cible mais aussi recommandation d'orientation parentale) à laquelle la ressource médiatique est destinée."@fr ,
+                                     "The target audience (target region, target audience category but also parental guidance recommendation) for which the media resource is intended. This is provided as free text in an annotation label or as an identifier pointing to a term in a classification scheme."@en ;
+                 rdfs:label "Public cible"@fr ,
+                            "Target audience"@en ,
+                            "Zielpublikum"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#AudienceRating
@@ -6879,37 +9352,56 @@ ec:AudienceRating rdf:type owl:Class ;
                                     owl:onProperty ec:hasAudienceScoreRecordingTechnique ;
                                     owl:allValuesFrom skos:Concept
                                   ] ;
-                  dcterms:description """The audience by which the Resource can be
-            seen according to ratings like MPAA  (http://en.wikipedia.org/wiki/Motion_picture_rating_system) or other organisational / national / local standards."""@en ;
-                  rdfs:label "Audience rating"@en .
+                  dcterms:description "Die Zielgruppe, für die die Ressource geeignet ist gemäß Einstufungen wie MPAA (http://en.wikipedia.org/wiki/Motion_picture_rating_system) oder anderen organisatorischen / nationalen / lokalen Standards."@de ,
+                                      "Le public par lequel la ressource peut être vu selon des classements tels que MPAA (http://en.wikipedia.org/wiki/Motion_picture_rating_system) ou d'autres normes organisationnelles / nationales / locales."@fr ,
+                                      "The audience by which the Resource can be seen according to ratings like MPAA (http://en.wikipedia.org/wiki/Motion_picture_rating_system) or other organisational / national / local standards."@en ;
+                  rdfs:label "Audience rating"@en ,
+                             "Bewertung des Publikums"@de ,
+                             "Classification du public"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#AudienceScoreRecordingTechnique
 ec:AudienceScoreRecordingTechnique rdf:type owl:Class ;
                                    rdfs:subClassOf skos:Concept ;
-                                   dcterms:description "To define the technique use to measure an audience score."@en ;
-                                   rdfs:label "Audience score recording technique"@en .
+                                   dcterms:description "Définir la technique utilisée pour mesurer un score d'audience."@fr ,
+                                                       "To define the technique use to measure an audience score."@en ,
+                                                       "Um die Technik zu definieren, mit der ein Publikumsscore gemessen wird."@de ;
+                                   rdfs:label "Audience score recording technique"@en ,
+                                              "Aufnahmetechnik für Publikumspartituren"@de ,
+                                              "Technique d'enregistrement des partitions d'audience"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#AudioChannelFunction
 ec:AudioChannelFunction rdf:type owl:Class ;
                         rdfs:subClassOf skos:Concept ;
-                        dcterms:description "To define the function of an AudioChannel."@en ;
-                        rdfs:label "Audio channel function"@en .
+                        dcterms:description "Pour définir la fonction d'un AudioChannel."@fr ,
+                                            "So definieren Sie die Funktion eines AudioChannels."@de ,
+                                            "To define the function of an AudioChannel."@en ;
+                        rdfs:label "Audio channel function"@en ,
+                                   "Fonction de canal audio"@fr ,
+                                   "Funktion Audiokanal"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#AudioChannelPurpose
 ec:AudioChannelPurpose rdf:type owl:Class ;
                        rdfs:subClassOf skos:Concept ;
-                       dcterms:description "To define the purpose of an AudioChannel."@en ;
-                       rdfs:label "Audio channel purpose"@en .
+                       dcterms:description "Pour définir l'objectif d'un AudioChannel."@fr ,
+                                           "To define the purpose of an AudioChannel."@en ,
+                                           "Um den Zweck eines AudioChannels zu definieren."@de ;
+                       rdfs:label "Audio channel purpose"@en ,
+                                  "Objectif du canal audio"@fr ,
+                                  "Zweck des Audiokanals"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#AudioCodec
 ec:AudioCodec rdf:type owl:Class ;
               rdfs:subClassOf ec:Codec ;
-              dcterms:description "To provide information about an audio codec."@en ;
-              rdfs:label "Audio codec"@en .
+              dcterms:description "Pour fournir des informations sur un codec audio."@fr ,
+                                  "To provide information about an audio codec."@en ,
+                                  "Zur Bereitstellung von Informationen über einen Audiocodec."@de ;
+              rdfs:label "Audio Codec"@de ,
+                         "Audio codec"@en ,
+                         "Codec audio"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#AudioContent
@@ -6944,32 +9436,45 @@ ec:AudioContent rdf:type owl:Class ;
                                   owl:onProperty ec:loudnessMethod ;
                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                 ] ;
-                dcterms:description """An audioContent defines one component of a programme (e.g. background
-				music), its association with an audioGroup (e.g. a 2.0 audioPackFormat of
-				audioChannelFormats for stereo reproduction), its association with an
-				audioStreamFormat, and its set of loudness parameters."""@en ;
-                rdfs:label "Audio content"@en .
+                dcterms:description "An audioContent defines one component of a programme (e.g. background music), its association with an audioGroup (e.g. a 2.0 audioPackFormat of audioChannelFormats for stereo reproduction), its association with an audioStreamFormat, and its set of loudness parameters."@en ,
+                                    "Ein audioContent definiert eine Komponente eines Programms (z.B. Hintergrundmusik Musik), seine Zuordnung zu einer audioGroup (z.B. ein 2.0 audioPackFormat von audioChannelFormats für die Stereowiedergabe), seine Zuordnung zu einem audioStreamFormat und seine Lautheitsparameter."@de ,
+                                    "Un AudioContent définit un composant d'un programme (par exemple, une musique de fond musique), son association avec un audioGroup (par exemple, un 2.0 audioPackFormat de audioChannelFormats pour la reproduction stéréo), son association avec un audioStreamFormat, et son ensemble de paramètres d'intensité sonore."@fr ;
+                rdfs:label "Audio content"@en ,
+                           "Audio-Inhalt"@de ,
+                           "Contenu audio"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#AudioContent_Type
 ec:AudioContent_Type rdf:type owl:Class ;
                      rdfs:subClassOf skos:Concept ;
-                     dcterms:description "to define a type of AudioContent."@en ;
-                     rdfs:label "Audio content type"@en .
+                     dcterms:description "pour définir un type de AudioContent."@fr ,
+                                         "to define a type of AudioContent."@en ,
+                                         "um einen Typ von AudioContent zu definieren."@de ;
+                     rdfs:label "Audio content type"@en ,
+                                "Typ der Audio-Inhalte"@de ,
+                                "Type de contenu audio"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#AudioDescription
 ec:AudioDescription rdf:type owl:Class ;
                     rdfs:subClassOf ec:AudioTrack ;
-                    dcterms:description "A Track containing audio description."@en ;
-                    rdfs:label "Audio description"@en .
+                    dcterms:description "A Track containing audio description."@en ,
+                                        "Ein Track mit Audiobeschreibung."@de ,
+                                        "Une piste contenant une description audio."@fr ;
+                    rdfs:label "Audio description"@en ,
+                               "Audio-Beschreibung"@de ,
+                               "Description audio"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#AudioEncodingFormat
 ec:AudioEncodingFormat rdf:type owl:Class ;
                        rdfs:subClassOf ec:EncodingFormat ;
-                       dcterms:description "The encoding format for the audio."@en ;
-                       rdfs:label "Audio encoding format"@en .
+                       dcterms:description "Das Kodierungsformat für das Audio."@de ,
+                                           "Le format d'encodage pour l'audio."@fr ,
+                                           "The encoding format for the audio."@en ;
+                       rdfs:label "Audio encoding format"@en ,
+                                  "Format d'encodage audio"@fr ,
+                                  "Format der Audiokodierung"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#AudioFormat
@@ -6986,8 +9491,12 @@ ec:AudioFormat rdf:type owl:Class ;
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#AudioObject
 ec:AudioObject rdf:type owl:Class ;
                rdfs:subClassOf ec:MediaResource ;
-               dcterms:description "To define an audio object in reference to the Audio Definition Model (ADM)"@en ;
-               rdfs:label "Audio object"@en .
+               dcterms:description "Pour définir un objet audio en référence au Modèle de définition audio (ADM)"@fr ,
+                                   "So definieren Sie ein Audioobjekt mit Bezug auf das Audio Definition Model (ADM)"@de ,
+                                   "To define an audio object in reference to the Audio Definition Model (ADM)"@en ;
+               rdfs:label "Audio object"@en ,
+                          "Audio-Objekt"@de ,
+                          "Objet audio"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#AudioProgramme
@@ -7022,44 +9531,56 @@ ec:AudioProgramme rdf:type owl:Class ;
                                     owl:onProperty ec:loudnessMethod ;
                                     owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                   ] ;
-                  dcterms:description """A set of one or more audioContent that derive from the same material,
-				i.e. an audioMultiplex, and the definition of its multiplexed audioContents (e.g.
-				foreground and commentary, background music)."""@en ;
-                  rdfs:label "Audio programme"@en .
+                  dcterms:description "A set of one or more audioContent that derive from the same material, i.e. an audioMultiplex, and the definition of its multiplexed audioContents (e.g. foreground and commentary, background music)."@en ,
+                                      "Ein Satz von einem oder mehreren audioContents, die aus demselben Material stammen, d.h. ein audioMultiplex, und die Definition seiner gemultiplexten audioContents (z.B. Vordergrund und Kommentar, Hintergrundmusik)."@de ,
+                                      "Un ensemble d'un ou plusieurs contenus audio qui dérivent du même matériel, c'est-à-dire un audioMultiplex, et la définition de sesContenus audio multiplexés (par ex. avant-plan et commentaire, musique de fond)."@fr ;
+                  rdfs:label "Audio Programm"@de ,
+                             "Audio programme"@en ,
+                             "Programme audio"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#AudioProgramme_Type
 ec:AudioProgramme_Type rdf:type owl:Class ;
                        rdfs:subClassOf skos:Concept ;
-                       dcterms:description "to define a type of AudioProgramme."@en ;
-                       rdfs:label "Audio programme type"@en .
+                       dcterms:description "pour définir un type d'AudioProgramme."@fr ,
+                                           "to define a type of AudioProgramme."@en ,
+                                           "um einen Typ von AudioProgrammen zu definieren."@de ;
+                       rdfs:label "Audio programme type"@en ,
+                                  "Typ des Audioprogramms"@de ,
+                                  "Type de programme audio"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#AudioStream
 ec:AudioStream rdf:type owl:Class ;
                rdfs:subClassOf ec:Stream ;
-               dcterms:description "An audioStreamFormat describes a decodable signal - PCM signal or a Dolby E stream for example. It is composed of one or more AudioTracks."@en ;
-               rdfs:label "Audio stream"@en .
+               dcterms:description "An audioStreamFormat describes a decodable signal - PCM signal or a Dolby E stream for example. It is composed of one or more AudioTracks."@en ,
+                                   "Ein audioStreamFormat beschreibt ein dekodierbares Signal - zum Beispiel ein PCM-Signal oder einen Dolby E-Stream. Es besteht aus einem oder mehreren AudioTracks."@de ,
+                                   "Un AudioStreamFormat décrit un signal décodable - un signal PCM ou un flux Dolby E par exemple. Il est composé d'une ou plusieurs AudioTracks."@fr ;
+               rdfs:label "Audio stream"@en ,
+                          "Audio-Stream"@de ,
+                          "Flux audio"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#AudioTrack
 ec:AudioTrack rdf:type owl:Class ;
               rdfs:subClassOf ec:Track ;
-              dcterms:description """An audioTrack is the basic audio data container of a medium. Attribute is
-				an unambiguous reference to this container in a given medium."""@en ,
-                                  """An audioTrack object defines a component of an audioStream.
-				A single set of samples or data in the storage medium."""@en ,
-                                  """Represents a physical container or carrier to hold an audio stream. This
-				should be usually defined by many attributes such as ID, format (e.g. 48 kHz/24
-				bits), linkage information (e.g. odd/even)â€¦"""@en ;
-              rdfs:label "Audio track"@en .
+              dcterms:description "An audioTrack is the basic audio data container of a medium. Attribute is an unambiguous reference to this container in a given medium. An audioTrack object defines a component of an audioStream. A single set of samples or data in the storage medium. Represents a physical container or carrier to hold an audio stream. This should be usually defined by many attributes such as ID, format (e.g. 48 kHz/24 bits), linkage information (e.g. odd/even)â€¦"@en ,
+                                  "Ein audioTrack ist der grundlegende Audiodaten-Container eines Mediums. Ein Attribut ist ein eindeutiger Verweis auf diesen Container in einem bestimmten Medium."@de ,
+                                  "Une audioTrack est le conteneur de données audio de base d'un support. L'attribut est une référence non ambiguë à ce conteneur dans un support donné."@fr ;
+              rdfs:label "Audio track"@en ,
+                         "Audiospur"@de ,
+                         "Piste audio"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#AudioTrackPurpose
 ec:AudioTrackPurpose rdf:type owl:Class ;
                      rdfs:subClassOf skos:Concept ;
-                     dcterms:description "To describe the purpose of an AudioTrack e.g. dubbing."@en ;
-                     rdfs:label "Audio track purpose"@en .
+                     dcterms:description "Pour décrire l'objectif d'une piste audio, par exemple le doublage."@fr ,
+                                         "To describe the purpose of an AudioTrack e.g. dubbing."@en ,
+                                         "Um den Zweck eines AudioTracks zu beschreiben, z.B. die Nachvertonung."@de ;
+                     rdfs:label "Audio track purpose"@en ,
+                                "Objectif de la piste audio"@fr ,
+                                "Zweck der Audiospur"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Award
@@ -7105,29 +9626,45 @@ ec:Award rdf:type owl:Class ;
                            owl:onProperty ec:awardCeremony ;
                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ;
-         dcterms:description "To describe an Award and associated information."@en ;
-         rdfs:label "Award"@en .
+         dcterms:description "Pour décrire un prix et les informations associées."@fr ,
+                             "To describe an Award and associated information."@en ,
+                             "Zur Beschreibung eines Awards und der damit verbundenen Informationen."@de ;
+         rdfs:label "Auszeichnung"@de ,
+                    "Award"@en ,
+                    "Prix"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Award_Type
 ec:Award_Type rdf:type owl:Class ;
               rdfs:subClassOf skos:Concept ;
-              dcterms:description "To define a type of Award."@en ;
-              rdfs:label "Award type"@en .
+              dcterms:description "Pour définir un type d'attribution."@fr ,
+                                  "To define a type of Award."@en ,
+                                  "Um eine Art von Award zu definieren."@de ;
+              rdfs:label "Art der Auszeichnung"@de ,
+                         "Award type"@en ,
+                         "Type de prix"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#BMEssence
 ec:BMEssence rdf:type owl:Class ;
              rdfs:subClassOf ec:Essence ;
-             dcterms:description "The FIMS Essence"@en ;
-             rdfs:label "BMEssence"@en .
+             dcterms:description "Die FIMS-Essenz"@de ,
+                                 "L'essence du FIMS"@fr ,
+                                 "The FIMS Essence"@en ;
+             rdfs:label "BMEssence"@de ,
+                        "BMEssence"@en ,
+                        "BMEssence"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#BMTemplate
 ec:BMTemplate rdf:type owl:Class ;
               rdfs:subClassOf ec:Template ;
-              dcterms:description "A template describe as a BMEssence."@en ;
-              rdfs:label "BMTemplate"@en .
+              dcterms:description "A template describe as a BMEssence."@en ,
+                                  "Eine Vorlage, die als BMEssenz beschrieben wird."@de ,
+                                  "Un modèle décrit comme une BMEssence."@fr ;
+              rdfs:label "BMTemplate"@en ,
+                         "BMTemplate"@fr ,
+                         "BMVorlage"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#BibliographicalObject
@@ -7149,68 +9686,94 @@ ec:BibliographicalObject rdf:type owl:Class ;
                                            owl:onProperty ec:references ;
                                            owl:allValuesFrom ec:EditorialObject
                                          ] ;
-                         dcterms:description "Documents of various nature."@en ;
-                         rdfs:label "Bibliographical object"@en .
+                         dcterms:description "Documents de nature diverse."@fr ,
+                                             "Documents of various nature."@en ,
+                                             "Dokumente verschiedener Art."@de ;
+                         rdfs:label "Bibliographical object"@en ,
+                                    "Bibliographisches Objekt"@de ,
+                                    "Objet bibliographique"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Biography
 ec:Biography rdf:type owl:Class ;
              rdfs:subClassOf ec:BibliographicalObject ;
-             dcterms:description "To record a biography."@en ;
-             rdfs:label "Biography"@en .
+             dcterms:description "Pour enregistrer une biographie."@fr ,
+                                 "To record a biography."@en ,
+                                 "Um eine Biographie aufzunehmen."@de ;
+             rdfs:label "Biographie"@de ,
+                        "Biographie"@fr ,
+                        "Biography"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Bonus
 ec:Bonus rdf:type owl:Class ;
          rdfs:subClassOf ec:EditorialWork ;
-         rdfs:label "Bonus"@en .
+         rdfs:label "Bonus"@de ,
+                    "Bonus"@en ,
+                    "Bonus"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Brand
 ec:Brand rdf:type owl:Class ;
          rdfs:subClassOf ec:EditorialGroup ;
-         dcterms:description """A group of EditorialObjects having a Brand as a
-            common denominator."""@en ;
-         rdfs:label "Brand"@en .
+         dcterms:description "A group of EditorialObjects having a Brand as a common denominator."@en ,
+                             "Eine Gruppe von EditorialObjects mit einer Marke als gemeinsamen Nenner haben."@de ,
+                             "Un groupe d'EditorialObjects ayant une marque comme dénominateur commun."@fr ;
+         rdfs:label "Brand"@en ,
+                    "Marke"@de ,
+                    "Marque"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#BreakingNewsItem
 ec:BreakingNewsItem rdf:type owl:Class ;
                     rdfs:subClassOf ec:Item ;
-                    dcterms:description "To describe a breaking news."@en ;
-                    rdfs:label "Breaking news item"@en .
+                    dcterms:description "Pour décrire une nouvelle de dernière minute."@fr ,
+                                        "To describe a breaking news."@en ,
+                                        "Um eine Eilmeldung zu beschreiben."@de ;
+                    rdfs:label "Breaking news item"@en ,
+                               "Dernières nouvelles"@fr ,
+                               "Eilmeldung"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#CampaignPackage
 ec:CampaignPackage rdf:type owl:Class ;
                    rdfs:subClassOf ec:EditorialGroup ;
-                   rdfs:label "Campaign package"@en .
+                   rdfs:label "Campaign package"@en ,
+                              "Kampagnen-Paket"@de ,
+                              "Paquet de campagne"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Captioning
 ec:Captioning rdf:type owl:Class ;
               rdfs:subClassOf ec:Track ;
-              dcterms:description """To signal the presence of hard of hearing
-            captioning."""@en ;
-              rdfs:label "Captioning"@en .
+              dcterms:description "Pour signaler la présence de malentendants sous-titrage."@fr ,
+                                  "To signal the presence of hard of hearing captioning."@en ,
+                                  "Um das Vorhandensein von Schwerhörigkeit zu signalisieren Untertitelung."@de ;
+              rdfs:label "Captioning"@en ,
+                         "Sous-titrage"@fr ,
+                         "Untertitel"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#CaptioningFormat
 ec:CaptioningFormat rdf:type owl:Class ;
                     rdfs:subClassOf ec:DataFormat ;
-                    dcterms:description """To define the format of captioning.
-            Captioning's main use isfor hard of hearing transcription. This is provided as
-            free text in an annotation label or as an identifier pointing to a term in a
-            classification scheme."""@en ;
-                    rdfs:label "Captioning format"@en .
+                    dcterms:description "Définir le format du sous-titrage. L'utilisation principale du sous-titrage est la transcription pour les malentendants. Celle-ci est fournie sous forme de texte libre dans une étiquette d'annotation ou comme un identifiant pointant vers un terme dans un schéma de classification."@fr ,
+                                        "To define the format of captioning. Captioning's main use isfor hard of hearing transcription. This is provided as free text in an annotation label or as an identifier pointing to a term in a classification scheme."@en ,
+                                        "Zur Definition des Formats der Untertitelung. Untertitel werden hauptsächlich für die Übertragung für Hörgeschädigte verwendet. Diese wird als freier Text in einer Beschriftung oder als Kennung, die auf einen Begriff in einem Klassifikationsschema."@de ;
+                    rdfs:label "Captioning format"@en ,
+                               "Format de sous-titrage"@fr ,
+                               "Format der Untertitel"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#CastMember
 ec:CastMember rdf:type owl:Class ;
               rdfs:subClassOf ec:Person ;
-              dcterms:description """A member of the cast list (a list of performers/actors and associated fictitious
-            characters)."""@en ;
-              rdfs:label "Cast member"@en .
+              dcterms:description "A member of the cast list (a list of performers/actors and associated fictitious characters)."@en ,
+                                  "Ein Mitglied der Besetzungsliste (eine Liste von Darstellern/Schauspielern und zugehörigen fiktiven Charaktere)."@de ,
+                                  "Un membre de la liste des acteurs (une liste d'interprètes/acteurs et de personnages fictifs associés)."@fr ;
+              rdfs:label "Cast member"@en ,
+                         "Membre de la distribution"@fr ,
+                         "Mitglied der Besetzung"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Character
@@ -7237,31 +9800,45 @@ ec:Character rdf:type owl:Class ;
                                owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                owl:onClass ec:Person
                              ] ;
-             dcterms:description "E.g. a fictitious contact / person."@en ;
-             rdfs:label "Character"@en .
+             dcterms:description "E.g. a fictitious contact / person."@en ,
+                                 "Par exemple, un contact / une personne fictive."@fr ,
+                                 "Z.B. ein fiktiver Kontakt / eine fiktive Person."@de ;
+             rdfs:label "Caractère"@fr ,
+                        "Character"@en ,
+                        "Charakter"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#CityCode
 ec:CityCode rdf:type owl:Class ;
             rdfs:subClassOf skos:Concept ;
-            dcterms:description "To allocate a city code."@en ;
-            rdfs:label "City code"@en .
+            dcterms:description "Pour attribuer un code de ville."@fr ,
+                                "So weisen Sie einen Stadtcode zu."@de ,
+                                "To allocate a city code."@en ;
+            rdfs:label "City code"@en ,
+                       "Code de la ville"@fr ,
+                       "Stadtcode"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#ClosedCaptions
 ec:ClosedCaptions rdf:type owl:Class ;
                   rdfs:subClassOf ec:Captioning ;
-                  dcterms:description """Closed captioning is provided as separate
-            content."""@en ;
-                  rdfs:label "Closed caption"@en .
+                  dcterms:description "Closed captioning is provided as separate content."@en ,
+                                      "Le sous-titrage codé est fourni en tant que contenu."@fr ,
+                                      "Untertitel werden als separater Inhalt bereitgestellt. Inhalt."@de ;
+                  rdfs:label "Closed caption"@en ,
+                             "Geschlossene Unterschrift"@de ,
+                             "Légende fermée"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#ClosedSubtitling
 ec:ClosedSubtitling rdf:type owl:Class ;
                     rdfs:subClassOf ec:Subtitling ;
-                    dcterms:description """Closed subtitles are provided as separate
-            content."""@en ;
-                    rdfs:label "Closed subtitling"@en .
+                    dcterms:description "Closed subtitles are provided as separate content."@en ,
+                                        "Geschlossene Untertitel werden als separater Inhalt bereitgestellt. Inhalt."@de ,
+                                        "Les sous-titres fermés sont fournis en tant que contenu."@fr ;
+                    rdfs:label "Closed subtitling"@en ,
+                               "Geschlossene Untertitelung"@de ,
+                               "Sous-titrage fermé"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Codec
@@ -7294,67 +9871,89 @@ ec:Codec rdf:type owl:Class ;
                            owl:onProperty ec:name ;
                            owl:allValuesFrom rdfs:Literal
                          ] ;
-         dcterms:description "To provide information on a codec."@en ;
-         rdfs:label "Codec"@en .
+         dcterms:description "Pour fournir des informations sur un codec."@fr ,
+                             "To provide information on a codec."@en ,
+                             "Um Informationen über einen Codec bereitzustellen."@de ;
+         rdfs:label "Codec"@de ,
+                    "Codec"@en ,
+                    "Codec"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Collection
 ec:Collection rdf:type owl:Class ;
               rdfs:subClassOf ec:EditorialGroup ;
-              dcterms:description """A group of EditorialObjects. There can be many
-            types of collections for which specific sub-classes should be defined. In the worl of
-            archives, A collection corresponds to all items belonging to an individual /
-            collector."""@en ;
-              rdfs:label "Collection"@en .
+              dcterms:description "A group of EditorialObjects. There can be many types of collections for which specific sub-classes should be defined. In the worl of archives, A collection corresponds to all items belonging to an individual / collector."@en ,
+                                  "Eine Gruppe von EditorialObjects. Es kann viele Arten von Sammlungen geben, für die spezifische Unterklassen definiert werden sollten. In der Welt der Archiven entspricht eine Sammlung allen Objekten, die zu einem einzelnen / Sammler."@de ,
+                                  "Un groupe d'EditorialObjects. Il peut y avoir de nombreux types de collections pour lesquelles des sous-classes spécifiques doivent être définies. Dans le monde des archives, une collection correspond à tous les éléments appartenant à un individu / collectionneur."@fr ;
+              rdfs:label "Collection"@en ,
+                         "Collection"@fr ,
+                         "Kollektion"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#ColourSpace
 ec:ColourSpace rdf:type owl:Class ;
                rdfs:subClassOf ec:Format ;
-               dcterms:description """The CoulourSpace of a VideoResource. A
-            ColourSpace is defined as free text in an annotation label or as an identifier pointing
-            to a term in a classification scheme such as
-            http://www.ebu.ch/metadata/ontologies/skos/ebu_ColourCodeCS.rdf."""@en ;
-               rdfs:label "Colour space"@en .
+               dcterms:description "Der Farbraum einer VideoRessource. A ColourSpace wird als freier Text in einer Beschriftung oder als Bezeichner definiert, der auf einen Begriff in einem auf einen Begriff in einem Klassifizierungsschema wie http://www.ebu.ch/metadata/ontologies/skos/ebu_ColourCodeCS.rdf."@de ,
+                                   "L'espace-couleur d'une VideoResource. A espace couleur est défini comme du texte libre dans une étiquette d'annotation ou comme un identifiant pointant vers un terme dans un schéma de classification tel que http://www.ebu.ch/metadata/ontologies/skos/ebu_ColourCodeCS.rdf."@fr ,
+                                   "The CoulourSpace of a VideoResource. A ColourSpace is defined as free text in an annotation label or as an identifier pointing to a term in a classification scheme such as http://www.ebu.ch/metadata/ontologies/skos/ebu_ColourCodeCS.rdf."@en ;
+               rdfs:label "Colour space"@en ,
+                          "Espace couleur"@fr ,
+                          "Farbraum"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#CommercialCode
 ec:CommercialCode rdf:type owl:Class ;
                   rdfs:subClassOf ec:Type ;
-                  dcterms:description "To identify a type of commercial content."@en ;
-                  rdfs:label "Commercial code"@en .
+                  dcterms:description "Pour identifier un type de contenu commercial."@fr ,
+                                      "To identify a type of commercial content."@en ,
+                                      "Um eine Art von kommerziellen Inhalten zu identifizieren."@de ;
+                  rdfs:label "Code commercial"@fr ,
+                             "Commercial code"@en ,
+                             "Handelsgesetzbuch"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Component
 ec:Component rdf:type owl:Class ;
              rdfs:subClassOf ec:MediaResource ;
-             dcterms:description "A component e.g. audio, video, data or else or a MediaResource or Essence."@en ;
-             rdfs:label "Component"@en .
+             dcterms:description "A component e.g. audio, video, data or else or a MediaResource or Essence."@en ,
+                                 "Eine Komponente, z.B. Audio, Video, Daten oder sonstiges oder eine MediaResource oder Essence."@de ,
+                                 "Un composant, par exemple audio, vidéo, données ou autre, ou une MediaResource ou une Essence."@fr ;
+             rdfs:label "Component"@en ,
+                        "Composant"@fr ,
+                        "Komponente"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Contact
 ec:Contact rdf:type owl:Class ;
            rdfs:subClassOf ec:Person ;
            dcterms:description "A Contact e.g. for a Person or Organisation."@en ,
+                               "Ein Kontakt z.B. für eine Person oder Organisation."@de ,
                                "Un contact pour un personne ou une organisation"@fr ;
            rdfs:label "Contact"@en ,
                       "Contact"@fr ,
-                      "Die Kontaktinformationen einer Person oder einer Organisation"@de ,
                       "Kontakt"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#ContainerCodec
 ec:ContainerCodec rdf:type owl:Class ;
                   rdfs:subClassOf ec:Codec ;
-                  dcterms:description "To identify an container codec, e.g. MXF"@en ;
-                  rdfs:label "Container codec"@en .
+                  dcterms:description "Pour identifier un codec de conteneur, par exemple MXF"@fr ,
+                                      "To identify an container codec, e.g. MXF"@en ,
+                                      "Zur Identifizierung eines Container-Codecs, z.B. MXF"@de ;
+                  rdfs:label "Codec de conteneur"@fr ,
+                             "Container Codec"@de ,
+                             "Container codec"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#ContainerEncodingFormat
 ec:ContainerEncodingFormat rdf:type owl:Class ;
                            rdfs:subClassOf ec:EncodingFormat ;
-                           dcterms:description "To define the conatiner encoding format."@en ;
-                           rdfs:label "Container encoding format"@en .
+                           dcterms:description "Pour définir le format d'encodage du conatiner."@fr ,
+                                               "To define the conatiner encoding format."@en ,
+                                               "Zur Definition des Conatiner-Kodierungsformats."@de ;
+                           rdfs:label "Container encoding format"@en ,
+                                      "Container-Kodierungsformat"@de ,
+                                      "Format d'encodage du conteneur"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#ContainerFormat
@@ -7371,47 +9970,67 @@ ec:ContainerFormat rdf:type owl:Class ;
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#ContainerMimeType
 ec:ContainerMimeType rdf:type owl:Class ;
                      rdfs:subClassOf ec:Format ;
-                     dcterms:description """The definition of the container if available as
-            a MIME type. This is provided as free text in an annotation label or as an identifier
-            pointing to a term in a classification scheme. For more information:
-            http://www.iana.org/assignments/media-types/application/index.html."""@en ;
-                     rdfs:label "Container Mime type"@en .
+                     dcterms:description "Die Definition des Containers, falls er als ein MIME-Typ. Dies wird als freier Text in einer Beschriftung oder als Bezeichner angegeben der auf einen Begriff in einem Klassifizierungsschema verweist. Für weitere Informationen: http://www.iana.org/assignments/media-types/application/index.html."@de ,
+                                         "La définition du conteneur si elle est disponible en tant que un type MIME. Elle est fournie sous forme de texte libre dans une étiquette d'annotation ou comme identifiant pointant vers un terme dans un schéma de classification. Pour plus d'informations : http://www.iana.org/assignments/media-types/application/index.html."@fr ,
+                                         "The definition of the container if available as a MIME type. This is provided as free text in an annotation label or as an identifier pointing to a term in a classification scheme. For more information: http://www.iana.org/assignments/media-types/application/index.html."@en ;
+                     rdfs:label "Container Mime type"@en ,
+                                "Container Mime-Typ"@de ,
+                                "Type Mime du conteneur"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#ContentAlert
 ec:ContentAlert rdf:type owl:Class ;
                 rdfs:subClassOf ec:Type ;
-                dcterms:description "To provide information about a particular type of content potentially sensitive."@en ;
-                rdfs:label "Content alert"@en .
+                dcterms:description "Pour fournir des informations sur un type particulier de contenu potentiellement sensible."@fr ,
+                                    "To provide information about a particular type of content potentially sensitive."@en ,
+                                    "Zur Bereitstellung von Informationen über eine bestimmte Art von potenziell sensiblen Inhalten."@de ;
+                rdfs:label "Alerte de contenu"@fr ,
+                           "Content alert"@en ,
+                           "Inhalt Alarm"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#ContentEditorialCode
 ec:ContentEditorialCode rdf:type owl:Class ;
                         rdfs:subClassOf ec:Type ;
-                        dcterms:description "To define a code of EditorialFormat"@en ;
-                        rdfs:label "Editorial code"@en .
+                        dcterms:description "Pour définir un code de EditorialFormat"@fr ,
+                                            "To define a code of EditorialFormat"@en ,
+                                            "Um einen Code von EditorialFormat zu definieren"@de ;
+                        rdfs:label "Code éditorial"@fr ,
+                                   "Editorial code"@en ,
+                                   "Redaktioneller Code"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#ContentEditorialFormat
 ec:ContentEditorialFormat rdf:type owl:Class ;
                           rdfs:subClassOf ec:Type ;
-                          dcterms:description "To define an EditorialFormat"@en ;
-                          rdfs:label "Editorial format"@en .
+                          dcterms:description "Pour définir un EditorialFormat"@fr ,
+                                              "To define an EditorialFormat"@en ,
+                                              "Um ein EditorialFormat zu definieren"@de ;
+                          rdfs:label "Editorial format"@en ,
+                                     "Format rédactionnel"@fr ,
+                                     "Redaktionelles Format"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#ContractType
 ec:ContractType rdf:type owl:Class ;
                 rdfs:subClassOf skos:Concept ;
-                dcterms:description "To define a type of contract."@en ;
-                rdfs:label "Contract type"@en .
+                dcterms:description "Pour définir un type de contrat."@fr ,
+                                    "To define a type of contract."@en ,
+                                    "Um eine Art von Vertrag zu definieren."@de ;
+                rdfs:label "Contract type"@en ,
+                           "Type de contrat"@fr ,
+                           "Vertragstyp"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Copyright
 ec:Copyright rdf:type owl:Class ;
              rdfs:subClassOf ec:Rights ;
-             dcterms:description """To provide a copyright
-            statement."""@en ;
-             rdfs:label "Copyright"@en .
+             dcterms:description "Pour fournir un copyright d'auteur."@fr ,
+                                 "To provide a copyright statement."@en ,
+                                 "Um eine Urheberrechtserklärung abzugeben Erklärung."@de ;
+             rdfs:label "Copyright"@de ,
+                        "Copyright"@en ,
+                        "Copyright"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Costume
@@ -7437,45 +10056,64 @@ ec:Costume rdf:type owl:Class ;
                              owl:onProperty ec:gender ;
                              owl:maxCardinality "1"^^xsd:nonNegativeInteger
                            ] ;
-           dcterms:description "To identify and describe Costumes used in productions."@en ;
-           rdfs:label "Costume"@en .
+           dcterms:description "Die in den Produktionen verwendeten Kostüme zu identifizieren und zu beschreiben."@de ,
+                               "Identifier et décrire les costumes utilisés dans les productions."@fr ,
+                               "To identify and describe Costumes used in productions."@en ;
+           rdfs:label "Costume"@en ,
+                      "Costume"@fr ,
+                      "Kostüm"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#CostumeType
 ec:CostumeType rdf:type owl:Class ;
                rdfs:subClassOf skos:Concept ;
-               dcterms:description "To define a costume type."@en ;
-               rdfs:label "Costume type"@en .
+               dcterms:description "Pour définir un type de costume."@fr ,
+                                   "So definieren Sie einen Kostümtyp."@de ,
+                                   "To define a costume type."@en ;
+               rdfs:label "Costume type"@en ,
+                          "Typ Kostüm"@de ,
+                          "Type de costume"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#CountryCode
 ec:CountryCode rdf:type owl:Class ;
                rdfs:subClassOf skos:Concept ;
-               dcterms:description "To identify a country by its ISO code."@en ;
-               rdfs:label "Country code"@en .
+               dcterms:description "Pour identifier un pays par son code ISO."@fr ,
+                                   "So identifizieren Sie ein Land anhand seines ISO-Codes."@de ,
+                                   "To identify a country by its ISO code."@en ;
+               rdfs:label "Code pays"@fr ,
+                          "Country code"@en ,
+                          "Ländercode"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#CoverageRestrictions
 ec:CoverageRestrictions rdf:type owl:Class ;
                         rdfs:subClassOf ec:Rights ;
-                        dcterms:description """To provide information on possible restrictions
-            regarding the temporal and spatial coverage for publication."""@en ;
-                        rdfs:label "Coverage restrictions"@en .
+                        dcterms:description "Bereitstellung von Informationen über mögliche Einschränkungen hinsichtlich der zeitlichen und räumlichen Abdeckung für die Veröffentlichung."@de ,
+                                            "Fournir des informations sur les éventuelles restrictions concernant la couverture temporelle et spatiale pour la publication."@fr ,
+                                            "To provide information on possible restrictions regarding the temporal and spatial coverage for publication."@en ;
+                        rdfs:label "Coverage restrictions"@en ,
+                                   "Einschränkungen der Deckung"@de ,
+                                   "Restrictions de couverture"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#CreativeCommons
 ec:CreativeCommons rdf:type owl:Class ;
                    rdfs:subClassOf ec:Rights ;
-                   dcterms:description "A set of creative commons rights."@en ;
-                   rdfs:label "Creative commons"@en .
+                   dcterms:description "A set of creative commons rights."@en ,
+                                       "Eine Reihe von Creative-Commons-Rechten."@de ,
+                                       "Un ensemble de droits de creative commons."@fr ;
+                   rdfs:label "Creative commons"@en ,
+                              "Creative commons"@fr ,
+                              "Kreative Gemeingüter"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#CrewMember
 ec:CrewMember rdf:type owl:Class ;
               rdfs:subClassOf ec:Person ;
-              dcterms:description "To identify a member of the crew."@en ,
+              dcterms:description "Permet d'identifier un membre d'une équipe."@fr ,
+                                  "To identify a member of the crew."@en ,
                                   "Zur Identifikation eines Besatzungsmitglieds."@de ;
-              rdfs:comment "Permet d'identifier un membre d'une équipe."@fr ;
               rdfs:label "Besatzung"@de ,
                          "Crew"@en ,
                          "Équipe"@fr .
@@ -7484,15 +10122,23 @@ ec:CrewMember rdf:type owl:Class ;
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#CuisineStyle
 ec:CuisineStyle rdf:type owl:Class ;
                 rdfs:subClassOf skos:Concept ;
-                dcterms:description "To identify a style of Cuisine."@en ;
-                rdfs:label "Cuisine style"@en .
+                dcterms:description "Pour identifier un style de cuisine."@fr ,
+                                    "To identify a style of Cuisine."@en ,
+                                    "Um einen Küchenstil zu identifizieren."@de ;
+                rdfs:label "Cuisine style"@en ,
+                           "Stil der Küche"@de ,
+                           "Style de cuisine"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#CurrencyCode
 ec:CurrencyCode rdf:type owl:Class ;
                 rdfs:subClassOf skos:Concept ;
-                dcterms:description "To identify a currency by its ISO code."@en ;
-                rdfs:label "Currency code"@en .
+                dcterms:description "Pour identifier une devise par son code ISO."@fr ,
+                                    "So identifizieren Sie eine Währung anhand ihres ISO-Codes."@de ,
+                                    "To identify a currency by its ISO code."@en ;
+                rdfs:label "Code devise"@fr ,
+                           "Currency code"@en ,
+                           "Währungscode"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#DataFormat
@@ -7513,34 +10159,45 @@ ec:DataTrack rdf:type owl:Class ;
                                owl:onProperty ec:hasDataFormat ;
                                owl:allValuesFrom ec:DataFormat
                              ] ;
-             dcterms:description """Ancillary data track e.g. Â¨captioning\"
-            or \"subtitling\" in addition to video and audio tracks."""@en ;
-             rdfs:label "Data track"@en .
+             dcterms:description "Ancillary data track e.g. Â¨captioning\" or \"subtitling\" in addition to video and audio tracks."@en ,
+                                 "Piste de données auxiliaires, par exemple le \"sous-titrage\" ou le \"captioning\". ou \"sous-titrage\" en plus des pistes vidéo et audio."@fr ,
+                                 "Zusatzdatenspur z.B. Â¨Captioning\" oder \"Untertitelung\" zusätzlich zu den Video- und Audiospuren."@de ;
+             rdfs:label "Data track"@en ,
+                        "Daten verfolgen"@de ,
+                        "Suivi des données"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Department
 ec:Department rdf:type owl:Class ;
               rdfs:subClassOf ec:Organisation ;
-              dcterms:description """A department within and
-            organisation."""@en ;
-              rdfs:label "Department"@en .
+              dcterms:description "A department within and organisation."@en ,
+                                  "Eine Abteilung innerhalb einer Organisation."@de ,
+                                  "Un département au sein de l'organisation."@fr ;
+              rdfs:label "Abteilung"@de ,
+                         "Department"@en ,
+                         "Département"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#DepictedEvent
 ec:DepictedEvent rdf:type owl:Class ;
                  rdfs:subClassOf ec:Event ;
-                 dcterms:description """A DepictedEVent is fictitious or historical or
-            other sort of Event that the content of the EditorialObject or resource relates
-            to."""@en ;
-                 rdfs:label "Depicted Event"@en .
+                 dcterms:description "A DepictedEVent is fictitious or historical or other sort of Event that the content of the EditorialObject or resource relates to."@en ,
+                                     "Ein DepictedEVent ist ein fiktives oder historisches oder eine andere Art von Ereignis, auf das sich der Inhalt des EditorialObjects oder der Ressource bezieht bezieht."@de ,
+                                     "Un DepictedEVent est un événement fictif, historique ou autre type d'événement auquel le contenu de l'objet éditorial ou de la ressource se rapporte à."@fr ;
+                 rdfs:label "Dargestelltes Ereignis"@de ,
+                            "Depicted Event"@en ,
+                            "Événement décrit"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Disclaimer
 ec:Disclaimer rdf:type owl:Class ;
               rdfs:subClassOf ec:Rights ;
-              dcterms:description """To provide a disclaimer of any
-            form."""@en ;
-              rdfs:label "Disclaimer"@en .
+              dcterms:description "Einen Haftungsausschluss jeglicher Art bereitzustellen Form."@de ,
+                                  "Pour fournir une clause de non-responsabilité de toute forme."@fr ,
+                                  "To provide a disclaimer of any form."@en ;
+              rdfs:label "Avis de non-responsabilité"@fr ,
+                         "Disclaimer"@en ,
+                         "Haftungsausschluss"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Document
@@ -7559,26 +10216,34 @@ ec:Document rdf:type owl:Class ;
                               owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                               owl:onDataRange xsd:integer
                             ] ;
-            dcterms:description """To describe a publication in the form of a
-            document e.g. a html webpage (news item) or a pdf document e.g. a script."""@en ;
-            rdfs:label "Document"@en .
+            dcterms:description "Pour décrire une publication sous la forme d'un document, par exemple une page web html (actualité) ou un document pdf, par exemple un script."@fr ,
+                                "To describe a publication in the form of a document e.g. a html webpage (news item) or a pdf document e.g. a script."@en ,
+                                "Zur Beschreibung einer Veröffentlichung in Form eines Dokumentes, z.B. einer html-Webseite (Nachricht) oder eines pdf-Dokuments, z.B. eines Skripts."@de ;
+            rdfs:label "Document"@en ,
+                       "Document"@fr ,
+                       "Dokument"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#DocumentFormat
 ec:DocumentFormat rdf:type owl:Class ;
                   rdfs:subClassOf ec:Format ;
-                  dcterms:description """To provide technical information about the
-            format of a document such as the orientation. This is provided as free text in an
-            annotation label or as an identifier pointing to a term in a classification
-            scheme."""@en ;
-                  rdfs:label "Document format"@en .
+                  dcterms:description "Pour fournir des informations techniques sur le format d'un document tel que l'orientation. Ces informations sont fournies sous forme de texte libre dans une d'une étiquette d'annotation ou comme un identifiant pointant vers un terme dans un de classification."@fr ,
+                                      "To provide technical information about the format of a document such as the orientation. This is provided as free text in an annotation label or as an identifier pointing to a term in a classification scheme."@en ,
+                                      "Zur Bereitstellung technischer Informationen über das Format eines Dokuments, z. B. die Ausrichtung. Diese Informationen werden als freier Text in einer Beschriftung oder als Bezeichner, der auf einen Begriff in einem Klassifizierungsschema verweist Schema."@de ;
+                  rdfs:label "Document format"@en ,
+                             "Format des Dokuments"@de ,
+                             "Format du document"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Dopesheet
 ec:Dopesheet rdf:type owl:Class ;
              rdfs:subClassOf ec:Document ;
-             dcterms:description "Provides additional information about a NewsItem, e.g. date and place, subject."@en ;
-             rdfs:label "Dopesheet"@en .
+             dcterms:description "Bietet zusätzliche Informationen zu einem NewsItem, z.B. Datum und Ort, Thema."@de ,
+                                 "Fournit des informations supplémentaires sur un NewsItem, par exemple la date et le lieu, le sujet."@fr ,
+                                 "Provides additional information about a NewsItem, e.g. date and place, subject."@en ;
+             rdfs:label "Dopesheet"@de ,
+                        "Dopesheet"@en ,
+                        "Dopesheet"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#EditUnitCount
@@ -7594,8 +10259,12 @@ ec:EditUnitCount rdf:type owl:Class ;
                                    owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                    owl:onDataRange xsd:long
                                  ] ;
-                 dcterms:description "An edit unit can be a frame, a sample or a extend of time."@en ;
-                 rdfs:label "Edit unit count"@en .
+                 dcterms:description "An edit unit can be a frame, a sample or a extend of time."@en ,
+                                     "Eine Bearbeitungseinheit kann ein Frame, ein Sample oder eine Zeitspanne sein."@de ,
+                                     "Une unité de montage peut être un cadre, un échantillon ou une durée."@fr ;
+                 rdfs:label "Anzahl der Einheiten bearbeiten"@de ,
+                            "Edit unit count"@en ,
+                            "Modifier le nombre d'unités"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#EditorialGroup
@@ -7617,9 +10286,12 @@ ec:EditorialGroup rdf:type owl:Class ;
                                     owl:onProperty ec:totalNumberOfGroupMembers ;
                                     owl:allValuesFrom xsd:integer
                                   ] ;
-                  dcterms:description """To define a collection / group of media
-            resources, for example a series made of episodes."""@en ;
-                  rdfs:label "Editorial group"@en .
+                  dcterms:description "Pour définir une collection / un groupe de médias ressources, par exemple une série composée d'épisodes."@fr ,
+                                      "To define a collection / group of media resources, for example a series made of episodes."@en ,
+                                      "Zur Definition einer Sammlung/Gruppe von Medien Ressourcen zu definieren, zum Beispiel eine Serie, die aus Episoden besteht."@de ;
+                  rdfs:label "Editorial group"@en ,
+                             "Groupe de rédaction"@fr ,
+                             "Redaktionelle Gruppe"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#EditorialObject
@@ -8051,34 +10723,23 @@ ec:EditorialObject rdf:type owl:Class ;
                                      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                      owl:onDataRange xsd:boolean
                                    ] ;
-                   dcterms:description """An EditorialObject collects all the descriptive information about an object to be realised as a single MediaResource or a collection thereof. An «EditorialObject» describes any idea, any story and will be used to transform a concept into an editorial definition of a MediaResource before fabrication (Production Domain) and Distribution (Distribution Domain).
-An «EditorialObject» is a set of descriptive metadata summarising e.g. editing decisions. An «EditorialObject» can be a group of EditorialObjects. An «EditorialObject» can also be a part of another «EditorialObject», which is defined by its start time and duration. EditorialObjects can be ordered either as groups or as items on a timeline.
-Examples of simple EditorialObjects: Programme, Item, Shot,Part, etc. Examples of Groups: Brand, Series, Serial, Collection, etc.
+                   dcterms:description """An EditorialObject collects all the descriptive information about an object to be realised as a single MediaResource or a collection thereof. An «EditorialObject» describes any idea, any story and will be used to transform a concept into an editorial definition of a MediaResource before fabrication (Production Domain) and Distribution (Distribution Domain). An «EditorialObject» is a set of descriptive metadata summarising e.g. editing decisions. An «EditorialObject» can be a group of EditorialObjects. An «EditorialObject» can also be a part of another «EditorialObject», which is defined by its start time and duration. EditorialObjects can be ordered either as groups or as items on a timeline. Examples of simple EditorialObjects: Programme, Item, Shot,Part, etc. Examples of Groups: Brand, Series, Serial, Collection, etc.
+
 A simplifieduse-case:
-A news broadcast consists of two news items. One news item contains the last ten seconds of a one minute long interview taken from another source (i.e. 50\" >60\" ).
- This could be modelled as follows:
-• The NewsBroadcast is linked
-      to a MediaResource using the instantiates-property
-• The NewsItems are linked to the
-      NewsBroadcast using a TimelineTrack. Tech 3351 EBU CCDM 13
-• The InterviewPart is
-      linked to the NewsItem using the hasMember-property. Start and Duration are properties within
-      the InterviewPart indicating its appearance within the NewsItem2.
-• The InterviewPart
-      is linked to its original source using the existsAs-property
-• The Interview
-      instantiates a MediaResource, which in turn is linked from the MediaResource of the
-      NewsBroadcast using the hasSource-property
-• Representation of segmentation:
-      TimelineTracks are preferred over hasPart-properties, when a rundown is needed, e.g. for
-      playout."""@en ,
+A news broadcast consists of two news items. One news item contains the last ten seconds of a one minute long interview taken from another source (i.e. 50\" >60\" ). This could be modelled as follows:
+• The NewsBroadcast is linked to a MediaResource using the instantiates-property
+• The NewsItems are linked to the NewsBroadcast using a TimelineTrack. Tech 3351 EBU CCDM 13
+• The InterviewPart is linked to the NewsItem using the hasMember-property. Start and Duration are properties within the InterviewPart indicating its appearance within the NewsItem2.
+• The InterviewPart is linked to its original source using the existsAs-property
+• The Interview instantiates a MediaResource, which in turn is linked from the MediaResource of the NewsBroadcast using the hasSource-property
+• Representation of segmentation: TimelineTracks are preferred over hasPart-properties, when a rundown is needed, e.g. for playout."""@en ,
                                        """Ein Medieninhalt versammelt sämtliche deskriptiven informationen über ein Objekt, das als Ressource (oder eine Menge davon) realisiert werden soll. Der Medieninhalt beschreibt eine Idee, eine Geschichte und wird benutzt, um ein Konzept in eine inhaltliche Festlegung einer Ressource zu erreichen, und zwar vor der Herstellung und der Verbreitung.
 
 Ein Medieninhalt besteht aus einer Menge beschreibender Metadaten, z.B. Schnittlisten. Ein Medieninhalt kann eine Gruppe von anderen Medieninhalten sein. Ein Medieninhalt kann auch Teil eines anderen Medieninhalts sein, was durch den Zeitpunkt des Beginns und die Dauer dafiniert wird. Medieninhalte können gruppiert werden or entlang einer Zeitachse angeordnet werden.
 
 Beispiele für einfache Medieninhalte: Sendung, Beitrag, Szene
-Beispiele für Gruppierungen: Marke, Serie, Reihe, Sammlung"""@de ;
-                   rdfs:comment """Un EditorialObject rassemble toutes les informations descriptives d'un objet à réaliser comme une MediaResource ou une collection de MediaResource. Un EditorialObject décrit une idée, une histoire. Il est utilisé pour transformer un concept en une définition éditoriale, une MediaResource avant sa fabrication (domaine de la production) et sa distribution (domaine de la distribution).
+Beispiele für Gruppierungen: Marke, Serie, Reihe, Sammlung"""@de ,
+                                       """Un EditorialObject rassemble toutes les informations descriptives d'un objet à réaliser comme une MediaResource ou une collection de MediaResource. Un EditorialObject décrit une idée, une histoire. Il est utilisé pour transformer un concept en une définition éditoriale, une MediaResource avant sa fabrication (domaine de la production) et sa distribution (domaine de la distribution).
 Un EditorialObject est un ensemble de métadonnées descriptives résumant, par exemple, les décisions d'édition. Un EditorialObject peut être un groupe d'EditorialObjects. Un EditorialObject peut également faire partie d'un autre EditorialObject, qui est défini par son heure de début et sa durée.
 Les objets éditoriaux peuvent être ordonnés soit en tant que groupes, soit en tant qu'éléments sur une ligne de temps.
  Exemples d'EditorialObjects simples : Programme, Article, Une prise de vue, Une Partie, etc.
@@ -8112,8 +10773,12 @@ o Représentation de la segmentation : Les TimelineTracks sont préférés aux h
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#EditorialObject_Type
 ec:EditorialObject_Type rdf:type owl:Class ;
                         rdfs:subClassOf skos:Concept ;
-                        dcterms:description "To define a type of editorial object."@en ;
-                        rdfs:label "Editorial object type"@en .
+                        dcterms:description "Pour définir un type d'objet éditorial."@fr ,
+                                            "To define a type of editorial object."@en ,
+                                            "Um einen Typ eines redaktionellen Objekts zu definieren."@de ;
+                        rdfs:label "Editorial object type"@en ,
+                                   "Redaktioneller Objekttyp"@de ,
+                                   "Type d'objet rédactionnel"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#EditorialSegment
@@ -8158,7 +10823,9 @@ ec:EditorialWork rdf:type owl:Class ;
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#EidrIdentifier
 ec:EidrIdentifier rdf:type owl:Class ;
                   rdfs:subClassOf ec:Identifier ;
-                  rdfs:label "EIDR"@en .
+                  rdfs:label "EIDR"@de ,
+                             "EIDR"@en ,
+                             "IEDR"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Emotion
@@ -8197,26 +10864,34 @@ ec:Emotion rdf:type owl:Class ;
                              owl:onProperty ec:name ;
                              owl:allValuesFrom rdfs:Literal
                            ] ;
-           dcterms:description "A class to log Emotions."@en ;
-           rdfs:label "Emotion"@en .
+           dcterms:description "A class to log Emotions."@en ,
+                               "Eine Klasse zum Protokollieren von Emotionen."@de ,
+                               "Une classe pour enregistrer les émotions."@fr ;
+           rdfs:label "Emotion"@de ,
+                      "Emotion"@en ,
+                      "Émotion"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Emotion_Type
 ec:Emotion_Type rdf:type owl:Class ;
                 rdfs:subClassOf skos:Concept ;
-                dcterms:description "To define a type of emotion."@en ;
-                rdfs:label "Emotion type"@en .
+                dcterms:description "Pour définir un type d'émotion."@fr ,
+                                    "To define a type of emotion."@en ,
+                                    "Um eine Art von Emotion zu definieren."@de ;
+                rdfs:label "Emotion Typ"@de ,
+                           "Emotion type"@en ,
+                           "Type d'émotion"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#EncodingFormat
 ec:EncodingFormat rdf:type owl:Class ;
                   rdfs:subClassOf ec:Format ;
-                  dcterms:description """To provide a definition of the encoding format
-            for audio and video. This is provided as free text in an annotation label or as an
-            identifier pointing to a term in a classification scheme e.g.
-            http://www.ebu.ch/metadata/ontologies/skos/ebu_AudioCompressionCodeCS.rdf or
-            http://www.ebu.ch/metadata/ontologies/skos/ebu_VideoCompressionCodeCS.rdf."""@en ;
-                  rdfs:label "Encoding"@en .
+                  dcterms:description "Eine Definition des Kodierungsformats für Audio und Video. Dies wird als freier Text in einer Beschriftung oder als Bezeichner, der auf einen Begriff in einem Klassifikationsschema verweist, z.B. http://www.ebu.ch/metadata/ontologies/skos/ebu_AudioCompressionCodeCS.rdf oder http://www.ebu.ch/metadata/ontologies/skos/ebu_VideoCompressionCodeCS.rdf."@de ,
+                                      "Fournir une définition du format d'encodage pour l'audio et la vidéo. Cette définition est fournie sous forme de texte libre dans une étiquette d'annotation ou comme un identificateur pointant vers un terme dans un schéma de classification, par ex. http://www.ebu.ch/metadata/ontologies/skos/ebu_AudioCompressionCodeCS.rdf ou http://www.ebu.ch/metadata/ontologies/skos/ebu_VideoCompressionCodeCS.rdf."@fr ,
+                                      "To provide a definition of the encoding format for audio and video. This is provided as free text in an annotation label or as an identifier pointing to a term in a classification scheme e.g. http://www.ebu.ch/metadata/ontologies/skos/ebu_AudioCompressionCodeCS.rdf or http://www.ebu.ch/metadata/ontologies/skos/ebu_VideoCompressionCodeCS.rdf."@en ;
+                  rdfs:label "Encodage"@fr ,
+                             "Encoding"@en ,
+                             "Kodierung"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Essence
@@ -8232,16 +10907,10 @@ ec:Essence rdf:type owl:Class ;
                              owl:onDataRange xsd:boolean
                            ] ;
            dcterms:description "C'est une ressource multimédia, MediaResource,qui peut être composée d'une ou plusieurs Pistes, Tracks. Une ressource multimédia est définie par un objet éditorial d'un domaine éditorial, EditorialObject (Editorial Domain). Cet EditorialObject peut être matérialisé par des essences dans un ou plusieurs formats pour différents médias ou plateformes de diffusion."@fr ,
-                               """Die echte physische Repräsentation einer oder mehrerer Medienressourcen, die zur Nutzung bearbeitet wurde.
-Die Essenz ist eine physische Repräsentation einer Medienressource in einem spezillen Format für die Ausspielung oder Publikation. Essenz ist eine Sub-Klasse von Medienressource und erbt deren Eigenschaften. Essenzen treten auf in Form einfacher Dateien oder komplexer Pakete, z.B. wie es von verschiedenen Kameras verschiedener Hersteller geliefert wird."""@de ,
-                               """The actual physical representation of one or more MediaResource
-      edited for consumption. The Essence is a physical representation of a MediaResource in a
-      particular Format destined for play-out or publishing. \"Essence is a subclass of a
-      MediaResource and inherits the MediaResource properties. Essence can be available in a
-      form of a simple file or complex packages (e.g. as delivered by cameras of different
-      brands)."""@en ;
-           rdfs:label "Essence" ,
-                      "Essence"@en ,
+                               "Die echte physische Repräsentation einer oder mehrerer Medienressourcen, die zur Nutzung bearbeitet wurde. Die Essenz ist eine physische Repräsentation einer Medienressource in einem spezillen Format für die Ausspielung oder Publikation. Essenz ist eine Sub-Klasse von Medienressource und erbt deren Eigenschaften. Essenzen treten auf in Form einfacher Dateien oder komplexer Pakete, z.B. wie es von verschiedenen Kameras verschiedener Hersteller geliefert wird."@de ,
+                               "The actual physical representation of one or more MediaResource edited for consumption. The Essence is a physical representation of a MediaResource in a particular Format destined for play-out or publishing. \"Essence is a subclass of a MediaResource and inherits the MediaResource properties. Essence can be available in a form of a simple file or complex packages (e.g. as delivered by cameras of different brands)."@en ;
+           rdfs:label "Essence"@en ,
+                      "Essence"@fr ,
                       "Essenz"@de .
 
 
@@ -8305,54 +10974,78 @@ ec:Event rdf:type owl:Class ;
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#EventType
 ec:EventType rdf:type owl:Class ;
              rdfs:subClassOf skos:Concept ;
-             dcterms:description "To define a type of event."@en ;
-             rdfs:label "Event type"@en .
+             dcterms:description "Pour définir un type d'événement."@fr ,
+                                 "To define a type of event."@en ,
+                                 "Um eine Art von Ereignis zu definieren."@de ;
+             rdfs:label "Ereignis-Typ"@de ,
+                        "Event type"@en ,
+                        "Type d'événement"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#ExclusivityType
 ec:ExclusivityType rdf:type owl:Class ;
                    rdfs:subClassOf skos:Concept ;
-                   dcterms:description "To define a type of exclusity rights."@en ;
-                   rdfs:label "Exclusivity type"@en .
+                   dcterms:description "Définir un type de droits d'exclusivité."@fr ,
+                                       "To define a type of exclusity rights."@en ,
+                                       "Um eine Art von Ausschließlichkeitsrechten zu definieren."@de ;
+                   rdfs:label "Ausschließlichkeitstyp"@de ,
+                              "Exclusivity type"@en ,
+                              "Type d'exclusivité"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#ExploitationIssues
 ec:ExploitationIssues rdf:type owl:Class ;
                       rdfs:subClassOf ec:Rights ;
-                      dcterms:description """To highlight potential exploitation
-            issues."""@en ;
-                      rdfs:label "Exploitation issues"@en .
+                      dcterms:description "Mettre en évidence les problèmes potentiels d'exploitation d'exploitation."@fr ,
+                                          "Potenzielle Ausbeutung hervorheben Probleme."@de ,
+                                          "To highlight potential exploitation issues."@en ;
+                      rdfs:label "Exploitation issues"@en ,
+                                 "Fragen der Ausbeutung"@de ,
+                                 "Problèmes d'exploitation"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#FictionalEvent
 ec:FictionalEvent rdf:type owl:Class ;
                   rdfs:subClassOf ec:Event ;
-                  dcterms:description "To describe a fictional Event."@en ;
-                  rdfs:label "Fictional event"@en .
+                  dcterms:description "Pour décrire un événement fictif."@fr ,
+                                      "To describe a fictional Event."@en ,
+                                      "Um ein fiktives Ereignis zu beschreiben."@de ;
+                  rdfs:label "Fictional event"@en ,
+                             "Fiktives Ereignis"@de ,
+                             "Événement fictif"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#FictionalLocation
 ec:FictionalLocation rdf:type owl:Class ;
                      rdfs:subClassOf ec:Location ;
-                     dcterms:description "To describe a fictional Location."@en ;
-                     rdfs:label "Fictional location"@en .
+                     dcterms:description "Pour décrire un lieu fictif."@fr ,
+                                         "To describe a fictional Location."@en ,
+                                         "Um einen fiktiven Ort zu beschreiben."@de ;
+                     rdfs:label "Fictional location"@en ,
+                                "Fiktiver Ort"@de ,
+                                "Lieu fictif"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#FictionalOrganisation
 ec:FictionalOrganisation rdf:type owl:Class ;
                          rdfs:subClassOf ec:Organisation ;
-                         dcterms:description "To define a fictional Organisation."@en ;
-                         rdfs:label "Fictional organisation"@en .
+                         dcterms:description "Pour définir une organisation fictive."@fr ,
+                                             "To define a fictional Organisation."@en ,
+                                             "Um eine fiktive Organisation zu definieren."@de ;
+                         rdfs:label "Fictional organisation"@en ,
+                                    "Fiktive Organisation"@de ,
+                                    "Organisation fictive"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#FileFormat
 ec:FileFormat rdf:type owl:Class ;
               rdfs:subClassOf ec:Format ;
-              dcterms:description """A file format for Resources other than
-            audiovisual resources. The format is defined as free text or pointing at a term in a
-            classification scheme e.g.
-            http://www.ebu.ch/metadata/ontologies/skos/ebu_FileFormatCS.rdf."""@en ;
-              rdfs:label "File format"@en .
+              dcterms:description "A file format for Resources other than audiovisual resources. The format is defined as free text or pointing at a term in a classification scheme e.g. http://www.ebu.ch/metadata/ontologies/skos/ebu_FileFormatCS.rdf."@en ,
+                                  "Ein Dateiformat für andere Ressourcen als audiovisuelle Ressourcen. Das Format ist als freier Text oder als Verweis auf einen Begriff in einem Klassifikationsschema, z.B. http://www.ebu.ch/metadata/ontologies/skos/ebu_FileFormatCS.rdf."@de ,
+                                  "Un format de fichier pour les ressources autres que ressources audiovisuelles. Le format est défini comme texte libre ou pointant sur un terme dans un système de classification, par exemple http://www.ebu.ch/metadata/ontologies/skos/ebu_FileFormatCS.rdf."@fr ;
+              rdfs:label "Dateiformat"@de ,
+                         "File format"@en ,
+                         "Format de fichier"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Food
@@ -8378,15 +11071,23 @@ ec:Food rdf:type owl:Class ;
                           owl:onProperty ec:foodIngredient ;
                           owl:allValuesFrom rdfs:Literal
                         ] ;
-        dcterms:description "To describe Food shown or consumed in productions."@en ;
-        rdfs:label "Food"@en .
+        dcterms:description "Pour décrire les aliments montrés ou consommés dans les productions."@fr ,
+                            "To describe Food shown or consumed in productions."@en ,
+                            "Zur Beschreibung von Lebensmitteln, die in Produktionen gezeigt oder konsumiert werden."@de ;
+        rdfs:label "Alimentation"@fr ,
+                   "Essen"@de ,
+                   "Food"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#FoodStyle
 ec:FoodStyle rdf:type owl:Class ;
              rdfs:subClassOf skos:Concept ;
-             dcterms:description "To define a style of food."@en ;
-             rdfs:label "Food style"@en .
+             dcterms:description "Pour définir un style d'alimentation."@fr ,
+                                 "To define a style of food."@en ,
+                                 "Um einen Essensstil zu definieren."@de ;
+             rdfs:label "Essen Stil"@de ,
+                        "Food style"@en ,
+                        "Style alimentaire"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Format
@@ -8413,30 +11114,42 @@ ec:Format rdf:type owl:Class ;
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Generation
 ec:Generation rdf:type owl:Class ;
               rdfs:subClassOf ec:Format ;
-              dcterms:description "Identifies the generation of a version of a resource, i.e. master, edit master, distribution copy, etc."@en ;
-              rdfs:label "Generation"@en .
+              dcterms:description "Identifie la génération d'une version d'une ressource, c'est-à-dire master, edit master, copie de distribution, etc."@fr ,
+                                  "Identifies the generation of a version of a resource, i.e. master, edit master, distribution copy, etc."@en ,
+                                  "Identifiziert die Erzeugung einer Version einer Ressource, d.h. Master, Edit Master, Verteilungskopie, etc."@de ;
+              rdfs:label "Generation"@de ,
+                         "Generation"@en ,
+                         "Génération"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Genre
 ec:Genre rdf:type owl:Class ;
          rdfs:subClassOf ec:Type ;
-         dcterms:description """This class shall be used to provide information on the genre of the EditorialObject. This is provided as free text in an annotation label or as an identifier pointing to a term in a classification scheme e.g.          http://www.ebu.ch/metadata/ontologies/skos/ebu_ContentGenreCS.rdf or
-            http://www.ebu.ch/metadata/ontologies/skos/ebu_EditorialFormatCodeCS.rdf."""@en ;
-         rdfs:label "Genre"@en .
+         dcterms:description "Cette classe est utilisée pour fournir des informations sur le genre de l'EditorialObject. Cette information est fournie sous forme de texte libre dans une étiquette d'annotation ou sous forme d'identificateur pointant vers un terme dans un schéma de classification, par exemple http://www.ebu.ch/metadata/ontologies/skos/ebu_ContentGenreCS.rdf ou http://www.ebu.ch/metadata/ontologies/skos/ebu_EditorialFormatCodeCS.rdf."@fr ,
+                             "Diese Klasse wird verwendet, um Informationen über das Genre des EditorialObjects bereitzustellen. Dies wird als freier Text in einer Beschriftung oder als Kennung, die auf einen Begriff in einem Klassifizierungsschema verweist, bereitgestellt, z.B. http://www.ebu.ch/metadata/ontologies/skos/ebu_ContentGenreCS.rdf oder http://www.ebu.ch/metadata/ontologies/skos/ebu_EditorialFormatCodeCS.rdf."@de ,
+                             "This class shall be used to provide information on the genre of the EditorialObject. This is provided as free text in an annotation label or as an identifier pointing to a term in a classification scheme e.g. http://www.ebu.ch/metadata/ontologies/skos/ebu_ContentGenreCS.rdf or http://www.ebu.ch/metadata/ontologies/skos/ebu_EditorialFormatCodeCS.rdf."@en ;
+         rdfs:label "Genre"@de ,
+                    "Genre"@en ,
+                    "Genre"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#IMediaIdentifier
 ec:IMediaIdentifier rdf:type owl:Class ;
                     rdfs:subClassOf ec:Identifier ;
-                    rdfs:label "IMedia Identifier"@en .
+                    rdfs:label "IMedia Identifier"@en ,
+                               "IMedia-Bezeichner"@de ,
+                               "Identificateur de média"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#IPRRestrictions
 ec:IPRRestrictions rdf:type owl:Class ;
                    rdfs:subClassOf ec:Rights ;
-                   dcterms:description """To provide information on intellectual
-            property."""@en ;
-                   rdfs:label "IPR restrictions"@en .
+                   dcterms:description "Bereitstellung von Informationen über geistiges Eigentum."@de ,
+                                       "Fournir des informations sur la propriété intellectuelle."@fr ,
+                                       "To provide information on intellectual property."@en ;
+                   rdfs:label "IPR restrictions"@en ,
+                              "IPR-Beschränkungen"@de ,
+                              "Restrictions DPI"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Identifier
@@ -8467,45 +11180,64 @@ ec:Identifier rdf:type owl:Class ;
                                 owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                 owl:onDataRange xsd:string
                               ] ;
-              dcterms:description "To support the use of structured identifiers."@en ;
-              rdfs:label "Identifier"@en .
+              dcterms:description "Pour soutenir l'utilisation d'identifiants structurés."@fr ,
+                                  "To support the use of structured identifiers."@en ,
+                                  "Zur Unterstützung der Verwendung von strukturierten Identifikatoren."@de ;
+              rdfs:label "Identifiant"@fr ,
+                         "Identifier"@en ,
+                         "Kennung"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#IdentifierType
 ec:IdentifierType rdf:type owl:Class ;
                   rdfs:subClassOf skos:Concept ;
-                  dcterms:description "To define a type of identifier."@en ;
-                  rdfs:label "Identifier type"@en .
+                  dcterms:description "Pour définir un type d'identifiant."@fr ,
+                                      "So definieren Sie einen Typ von Identifikator."@de ,
+                                      "To define a type of identifier."@en ;
+                  rdfs:label "Identifier type"@en ,
+                             "Identifikator Typ"@de ,
+                             "Type d'identifiant"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#ImageCodec
 ec:ImageCodec rdf:type owl:Class ;
               rdfs:subClassOf ec:Codec ;
-              dcterms:description "to identify a codec for images"@en ;
-              rdfs:label "Image codec"@en .
+              dcterms:description "pour identifier un codec pour les images"@fr ,
+                                  "to identify a codec for images"@en ,
+                                  "um einen Codec für Bilder zu identifizieren"@de ;
+              rdfs:label "Bild-Codec"@de ,
+                         "Codec d'image"@fr ,
+                         "Image codec"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#ImageFormat
 ec:ImageFormat rdf:type owl:Class ;
                rdfs:subClassOf ec:Format ;
-               dcterms:description """To provide technical information about the
-            format of an image such as the orientation. This is provided as free text in an
-            annotation label or as an identifier pointing to a term in a classification
-            scheme."""@en ;
-               rdfs:label "Image format"@en .
+               dcterms:description "Pour fournir des informations techniques sur le format d'une image, comme l'orientation. Ces informations sont fournies sous forme de texte libre dans une d'annotation ou comme identifiant pointant vers un terme dans un schéma de classification. de classification."@fr ,
+                                   "To provide technical information about the format of an image such as the orientation. This is provided as free text in an annotation label or as an identifier pointing to a term in a classification scheme."@en ,
+                                   "Zur Bereitstellung technischer Informationen über das Format eines Bildes, wie z.B. die Ausrichtung. Diese Informationen werden als freier Text in einer Beschriftung oder als Kennung, die auf einen Begriff in einem Klassifizierungsschema verweist Schema."@de ;
+               rdfs:label "Bildformat"@de ,
+                          "Format de l'image"@fr ,
+                          "Image format"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#IntentionCode
 ec:IntentionCode rdf:type owl:Class ;
                  rdfs:subClassOf ec:Type ;
-                 dcterms:description "To indicate the purpose for which content was created."@en ;
-                 rdfs:label "Intention code"@en .
+                 dcterms:description "Pour indiquer le but dans lequel le contenu a été créé."@fr ,
+                                     "To indicate the purpose for which content was created."@en ,
+                                     "Zur Angabe des Zwecks, für den der Inhalt erstellt wurde."@de ;
+                 rdfs:label "Absichtscode"@de ,
+                            "Code d'intention"@fr ,
+                            "Intention code"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#IsanIdentifier
 ec:IsanIdentifier rdf:type owl:Class ;
                   rdfs:subClassOf ec:Identifier ;
-                  rdfs:label "ISAN"@en .
+                  rdfs:label "ISAN"@de ,
+                             "ISAN"@en ,
+                             "ISAN"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Item
@@ -8523,64 +11255,89 @@ ec:Item rdf:type owl:Class ;
                           owl:onProperty ec:hasProgramme ;
                           owl:allValuesFrom ec:Programme
                         ] ;
-        dcterms:description "An item e.g. newsItem or sportItem"@en ;
-        rdfs:label "Item"@en .
+        dcterms:description "An item e.g. newsItem or sportItem"@en ,
+                            "Ein Element, z.B. newsItem oder sportItem"@de ,
+                            "Un élément, par exemple newsItem ou sportItem"@fr ;
+        rdfs:label "Article"@fr ,
+                   "Artikel"@de ,
+                   "Item"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#KeyCareerEvent
 ec:KeyCareerEvent rdf:type owl:Class ;
                   rdfs:subClassOf ec:KeyEvent ;
-                  dcterms:description "To describe a key career Event of a Contact."@en ;
-                  rdfs:label "Key career event"@en .
+                  dcterms:description "Décrire un événement clé de la carrière d'un contact."@fr ,
+                                      "Ein wichtiges Karriereereignis einer Kontaktperson beschreiben."@de ,
+                                      "To describe a key career Event of a Contact."@en ;
+                  rdfs:label "Key career event"@en ,
+                             "Wichtiges Karriere-Ereignis"@de ,
+                             "Événement de carrière clé"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#KeyEvent
 ec:KeyEvent rdf:type owl:Class ;
             rdfs:subClassOf ec:Event ;
-            dcterms:description "To describe a significant event."@en ;
-            rdfs:label "Key event"@en .
+            dcterms:description "Pour décrire un événement important."@fr ,
+                                "To describe a significant event."@en ,
+                                "Um ein bedeutendes Ereignis zu beschreiben."@de ;
+            rdfs:label "Key event"@en ,
+                       "Wichtigstes Ereignis"@de ,
+                       "Événement clé"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#KeyPersonalEvent
 ec:KeyPersonalEvent rdf:type owl:Class ;
                     rdfs:subClassOf ec:KeyEvent ;
-                    dcterms:description "A key personal Event of a Contact."@en ;
-                    rdfs:label "Key personal event"@en .
+                    dcterms:description "A key personal Event of a Contact."@en ,
+                                        "Ein wichtiges persönliches Ereignis eines Kontakts."@de ,
+                                        "Un événement personnel clé d'un contact."@fr ;
+                    rdfs:label "Key personal event"@en ,
+                               "Persönliches Schlüsselereignis"@de ,
+                               "Événement personnel clé"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Keyframe
 ec:Keyframe rdf:type owl:Class ;
             rdfs:subClassOf ec:Picture ;
-            dcterms:description """A key frame is a frame extarcted from video,
-            e.g. representative of a part of a MediaResource."""@en ;
-            rdfs:label "key frame"@en .
+            dcterms:description "A key frame is a frame extarcted from video, e.g. representative of a part of a MediaResource."@en ,
+                                "Ein Schlüsselbild ist ein aus einem Video extrahiertes Bild, z.B. repräsentativ für einen Teil einer MediaResource."@de ,
+                                "Une image clé est une image extraite d'une vidéo, par exemple, représentative d'une partie d'une MediaResource."@fr ;
+            rdfs:label "Schlüsselbild"@de ,
+                       "cadre de la clé"@fr ,
+                       "key frame"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Keyword
 ec:Keyword rdf:type owl:Class ;
            rdfs:subClassOf skos:Concept ;
-           dcterms:description """To proivde keywords and define key concepts
-            illustrating the content of the Resource or EditorialObject. This is provided as free
-            text in an annotation label or as an identifier pointing to a term in a classification
-            scheme."""@en ;
-           rdfs:label "Keyword"@en .
+           dcterms:description "Pour fournir des mots-clés et définir des concepts clés illustrant le contenu de la ressource ou de l'objet éditorial. Ceci est fourni sous forme de texte libre libre dans une étiquette d'annotation ou comme identificateur pointant vers un terme dans un schéma de classification. de classification."@fr ,
+                               "To proivde keywords and define key concepts illustrating the content of the Resource or EditorialObject. This is provided as free text in an annotation label or as an identifier pointing to a term in a classification scheme."@en ,
+                               "Um Schlüsselwörter und Schlüsselkonzepte zu definieren die den Inhalt der Ressource oder des redaktionellen Objekts illustrieren. Dies wird als freier Text in einer Beschriftung oder als Bezeichner, der auf einen Begriff in einem Klassifikationsschema verweist Schema verweist."@de ;
+           rdfs:label "Keyword"@en ,
+                      "Mot-clé"@fr ,
+                      "Schlüsselwort"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Language
 ec:Language rdf:type owl:Class ;
             rdfs:subClassOf skos:Concept ;
-            dcterms:description """To provide information on languages present in
-            the EditorialObject and its purpose. This is provided as free text in an annotation label
-            or as an identifier pointing to a term in a classification scheme.Other language
-            specific types may be added as subclasses of language."""@en ;
-            rdfs:label "Language"@en .
+            dcterms:description "Fournir des informations sur les langues présentes dans l'EditorialObject et son objectif. Ces informations sont fournies sous forme de texte libre dans une étiquette d'annotation ou comme un identifiant pointant vers un terme dans un système de classification. D'autres types spécifiques à la langue peuvent être ajoutés en tant que sous-classes de la langue."@fr ,
+                                "To provide information on languages present in the EditorialObject and its purpose. This is provided as free text in an annotation label or as an identifier pointing to a term in a classification scheme.Other language specific types may be added as subclasses of language."@en ,
+                                "Zur Bereitstellung von Informationen über die Sprachen in des EditorialObjects und dessen Zweck. Dies wird als freier Text in einer Beschriftung angegeben. oder als Bezeichner, der auf einen Begriff in einem Klassifikationsschema verweist. spezifische Typen können als Unterklassen von language hinzugefügt werden."@de ;
+            rdfs:label "Language"@en ,
+                       "Langue"@fr ,
+                       "Sprache"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Licensing
 ec:Licensing rdf:type owl:Class ;
              rdfs:subClassOf ec:Rights ;
-             dcterms:description "To define the licensing terms associated with an Asset."@en ;
-             rdfs:label "Licensing"@en .
+             dcterms:description "Pour définir les conditions de licence associées à un actif."@fr ,
+                                 "To define the licensing terms associated with an Asset."@en ,
+                                 "Zur Definition der mit einem Asset verbundenen Lizenzbedingungen."@de ;
+             rdfs:label "Licences"@fr ,
+                        "Licensing"@en ,
+                        "Lizenzierung"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Location
@@ -8675,13 +11432,9 @@ ec:Location rdf:type owl:Class ;
                               owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                               owl:onDataRange xsd:float
                             ] ;
-            dcterms:description "A location related to the media resource, e.g. depicted in the resource (possibly fictional) or where the resource was created (shooting location), etc. A «Location» is used to define the spatial coverage of the story or recording locations like studios or in the field, associated with the EditorialObjects (or Part of EditorialObjects)."@en ,
-                                """Ein Ort, der mit einer Medienressource verknüpft ist, z.B. darin dargestellt (auch fiktional) oder dort hergestellt (Drehort), etc.
-Ein Ort definiert den räumliche Bezug der Geschichte oder des Aufnahmeortes in einem Medieninhalt, wie z.b. im Studio, Außenaufnahme."""@de ,
-                                "Note: a type of location shall be defined as a sub-class of Location."@en ,
-                                "Note: le type de localisation doit être décrit comme une sous-classe de localisation."@fr ,
-                                """Une localisation est liée à la ressource média, elle peut être décrite dans la ressource et donc être éventuellement fictive. Elle peut aussi représenter le lieu où la ressource a été créée (lieu de tournage).
-Une localisation est utilisée pour définir la couverture spatiale du reportage ou des lieux d'enregistrement comme par exemple : studios ou sur le terrain, associés aux EditorialObjects (ou à une partie des EditorialObjects)."""@fr ;
+            dcterms:description "A location related to the media resource, e.g. depicted in the resource (possibly fictional) or where the resource was created (shooting location), etc. A «Location» is used to define the spatial coverage of the story or recording locations like studios or in the field, associated with the EditorialObjects (or Part of EditorialObjects). Note: a type of location shall be defined as a sub-class of Location."@en ,
+                                "Ein Ort, der mit einer Medienressource verknüpft ist, z.B. darin dargestellt (auch fiktional) oder dort hergestellt (Drehort), etc. Ein Ort definiert den räumliche Bezug der Geschichte oder des Aufnahmeortes in einem Medieninhalt, wie z.b. im Studio, Außenaufnahme."@de ,
+                                "Une localisation est liée à la ressource média, elle peut être décrite dans la ressource et donc être éventuellement fictive. Elle peut aussi représenter le lieu où la ressource a été créée (lieu de tournage). Une localisation est utilisée pour définir la couverture spatiale du reportage ou des lieux d'enregistrement comme par exemple : studios ou sur le terrain, associés aux EditorialObjects (ou à une partie des EditorialObjects). Note: le type de localisation doit être décrit comme une sous-classe de localisation."@fr ;
             rdfs:label "Localisation"@fr ,
                        "Location"@en ,
                        "Ort"@de .
@@ -8690,15 +11443,23 @@ Une localisation est utilisée pour définir la couverture spatiale du reportage
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#LocationCode
 ec:LocationCode rdf:type owl:Class ;
                 rdfs:subClassOf skos:Concept ;
-                dcterms:description "A code given to a Location."@en ;
-                rdfs:label "Location code."@en .
+                dcterms:description "A code given to a Location."@en ,
+                                    "Ein Code, der einem Ort zugeordnet ist."@de ,
+                                    "Un code donné à un emplacement."@fr ;
+                rdfs:label "Code de localisation."@fr ,
+                           "Location code."@en ,
+                           "Standort-Code."@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#LocationType
 ec:LocationType rdf:type owl:Class ;
                 rdfs:subClassOf skos:Concept ;
-                dcterms:description "To define a type of location."@en ;
-                rdfs:label "Location type"@en .
+                dcterms:description "Pour définir un type d'emplacement."@fr ,
+                                    "So definieren Sie eine Art von Ort."@de ,
+                                    "To define a type of location."@en ;
+                rdfs:label "Location type"@en ,
+                           "Standorttyp"@de ,
+                           "Type d'emplacement"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Locator
@@ -8723,18 +11484,23 @@ ec:Locator rdf:type owl:Class ;
                              owl:onProperty ec:name ;
                              owl:allValuesFrom rdfs:Literal
                            ] ;
-           dcterms:description "Custom attributes are to be associated by implementers."@en ,
-                               "To provide information about complex locators."@en ;
-           rdfs:label "Locator"@en .
+           dcterms:description "Benutzerdefinierte Attribute müssen von den Implementierern zugewiesen werden."@de ,
+                               "Custom attributes are to be associated by implementers. To provide information about complex locators."@en ,
+                               "Les attributs personnalisés doivent être associés par les implémenteurs."@fr ;
+           rdfs:label "Localisateur"@fr ,
+                      "Locator"@de ,
+                      "Locator"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Logo
 ec:Logo rdf:type owl:Class ;
         rdfs:subClassOf ec:Picture ;
-        dcterms:description """A Logo allows to visually identify an
-            organisation, publicationService, publicationChannel, or ratings /
-            parentalGuidance"""@en ;
-        rdfs:label "Logo"@en .
+        dcterms:description "A Logo allows to visually identify an organisation, publicationService, publicationChannel, or ratings / parentalGuidance"@en ,
+                            "Ein Logo ermöglicht die visuelle Identifizierung einer Organisation, publicationService, publicationChannel oder Bewertungen / parentalGuidance"@de ,
+                            "Un Logo permet d'identifier visuellement une organisation, un service de publication, un canal de publication, ou un classement / parentalGuidance"@fr ;
+        rdfs:label "Logo"@de ,
+                   "Logo"@en ,
+                   "Logo"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#MakingOf
@@ -8744,7 +11510,12 @@ ec:MakingOf rdf:type owl:Class ;
                               owl:onProperty ec:hasTopic ;
                               owl:allValuesFrom ec:EditorialObject
                             ] ;
-            dcterms:description "makingOf"@en .
+            dcterms:description "A documentary film about the shooting or production of a film or audiovisual work (TV film, TV series, etc.), or even another artistic production (e.g. comic strip)."@en ,
+                                "Ein Dokumentarfilm über die Dreharbeiten oder die Produktion eines Films oder eines audiovisuellen Werks (Fernsehfilm, Fernsehserie usw.) oder einer anderen künstlerischen Produktion (z. B. Comic)."@de ,
+                                "Un film documentaire relatant le tournage ou la production d'un film ou d'une œuvre audiovisuelle (téléfilm, série télévisée…), voire d'une autre production artistique (bande dessinée par exemple)."@fr ;
+            rdfs:label "Making-of"@de ,
+                       "Making-of"@en ,
+                       "Making-of"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#MediaFragment
@@ -8754,8 +11525,12 @@ ec:MediaFragment rdf:type owl:Class ;
                                    owl:onProperty ec:isMediaFragmentOf ;
                                    owl:allValuesFrom ec:MediaResource
                                  ] ;
-                 dcterms:description "A MediaFragment is a temporal or spatial segment of a resource identified by a MediaGragment URI (http://www.w3.org/2008/WebVideo/Fragments/WD-media-fragments-spec/)."@en ;
-                 rdfs:label "Media Fragment"@en .
+                 dcterms:description "A MediaFragment is a temporal or spatial segment of a resource identified by a MediaGragment URI (http://www.w3.org/2008/WebVideo/Fragments/WD-media-fragments-spec/)."@en ,
+                                     "Ein MediaFragment ist ein zeitliches oder räumliches Segment einer Ressource, das durch einen MediaGragment-URI identifiziert wird (http://www.w3.org/2008/WebVideo/Fragments/WD-media-fragments-spec/)."@de ,
+                                     "Un MediaFragment est un segment temporel ou spatial d'une ressource identifiée par un URI MediaGragment (http://www.w3.org/2008/WebVideo/Fragments/WD-media-fragments-spec/)."@fr ;
+                 rdfs:label "Fragment de média"@fr ,
+                            "Media Fragment"@en ,
+                            "Medien Fragment"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#MediaResource
@@ -9214,49 +11989,65 @@ ec:MediaResource rdf:type owl:Class ;
                  dcterms:description "An audiovisual MediaResource, which can be composed of one or more Tracks. A MediaResource is defined by an EditorialObject (Editorial Domain), which can be realised in Essences in one or more Formats for different delivery medias or platforms."@en ,
                                      "Eine audiovisuelle Medienressource, die aus einer oder mehreren Spuren bestehen kann. Die Medienressource ist durch einen Medieninhalt definiert und kann durch Essenzen in einem oder mehreren Formaten für verschiedene Medien oder Plattformen realisiert werden."@de ,
                                      "Une MediaResource audiovisuelle, qui peut être composée d'une ou plusieurs Pistes. Une ressource multimédia, MediaResource est définie par un objet éditorial EditorialObject, (domaine éditorial), qui peut être réalisé dans des essences dans un ou plusieurs formats pour différents médias ou plateformes de diffusion."@fr ;
-                 rdfs:comment "Ressource médiatique" ;
+                 rdfs:comment "Ressource médiatique"^^xsd:string ;
                  rdfs:label "Media resource"@en ,
-                            "Medienressource"@de .
+                            "Medienressource"@de ,
+                            "Ressource médiatique"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#MediaResource_Type
 ec:MediaResource_Type rdf:type owl:Class ;
                       rdfs:subClassOf skos:Concept ;
-                      dcterms:description "To define a type of MediaResource."@en ;
-                      rdfs:label "Media resource type"@en .
+                      dcterms:description "Pour définir un type de MediaResource."@fr ,
+                                          "To define a type of MediaResource."@en ,
+                                          "Um einen Typ von MediaResource zu definieren."@de ;
+                      rdfs:label "Media resource type"@en ,
+                                 "Typ der Medienressource"@de ,
+                                 "Type de ressource média"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#MediaType
 ec:MediaType rdf:type owl:Class ;
              rdfs:subClassOf ec:Format ;
-             dcterms:description "To provide additional information on the type of media."@en ;
-             rdfs:label "Media type"@en .
+             dcterms:description "Pour fournir des informations supplémentaires sur le type de support."@fr ,
+                                 "To provide additional information on the type of media."@en ,
+                                 "Um zusätzliche Informationen über die Art des Mediums zu erhalten."@de ;
+             rdfs:label "Media type"@en ,
+                        "Medientyp"@de ,
+                        "Type de média"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Medium
 ec:Medium rdf:type owl:Class ;
           rdfs:subClassOf ec:Format ;
-          dcterms:description """To provide information on the medium formats in
-            which the resource is available. This is provided as free text in an annotation label or
-            as an identifier pointing to a term in a classification scheme."""@en ;
-          rdfs:label "Medium"@en .
+          dcterms:description "Fournir des informations sur les formats de support dans lesquels la ressource est disponible. Cette information est fournie sous forme de texte libre dans une étiquette d'annotation ou comme un identifiant pointant vers un terme dans un schéma de classification."@fr ,
+                              "Informationen zu den Medienformaten bereitstellen, in denen die in denen die Ressource verfügbar ist. Dies wird als freier Text in einer Beschriftung angegeben oder als Kennung, die auf einen Begriff in einem Klassifikationsschema verweist."@de ,
+                              "To provide information on the medium formats in which the resource is available. This is provided as free text in an annotation label or as an identifier pointing to a term in a classification scheme."@en ;
+          rdfs:label "Medium"@de ,
+                     "Medium"@en ,
+                     "Moyen"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#MetadataTrack
 ec:MetadataTrack rdf:type owl:Class ;
                  rdfs:subClassOf ec:Track ;
-                 dcterms:description "A Track on which metadata is embedded (e.g. MXF)."@en ;
-                 rdfs:label "Metadata track"@en .
+                 dcterms:description "A Track on which metadata is embedded (e.g. MXF)."@en ,
+                                     "Eine Spur, in die Metadaten eingebettet sind (z. B. MXF)."@de ,
+                                     "Une piste sur laquelle sont intégrées des métadonnées (par exemple, MXF)."@fr ;
+                 rdfs:label "Metadata track"@en ,
+                            "Metadaten Spur"@de ,
+                            "Piste de métadonnées"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#MimeType
 ec:MimeType rdf:type owl:Class ;
             rdfs:subClassOf ec:Format ;
-            dcterms:description """The definition of the container if available as
-            a MIME type. This is provided as free text in an annotation label or as an identifier
-            pointing to a term in a classification scheme. For more information:
-            http://www.iana.org/assignments/media-types/index.html."""@en ;
-            rdfs:label "Mime type"@en .
+            dcterms:description "Die Definition des Containers, falls er als ein MIME-Typ. Dies wird als freier Text in einer Beschriftung oder als Bezeichner angegeben der auf einen Begriff in einem Klassifizierungsschema verweist. Für weitere Informationen: http://www.iana.org/assignments/media-types/index.html."@de ,
+                                "La définition du conteneur si elle est disponible en tant que un type MIME. Elle est fournie sous forme de texte libre dans une étiquette d'annotation ou comme identifiant pointant vers un terme dans un schéma de classification. Pour plus d'informations : http://www.iana.org/assignments/media-types/index.html."@fr ,
+                                "The definition of the container if available as a MIME type. This is provided as free text in an annotation label or as an identifier pointing to a term in a classification scheme. For more information: http://www.iana.org/assignments/media-types/index.html."@en ;
+            rdfs:label "Mime type"@en ,
+                       "Mime-Typ"@de ,
+                       "Type Mime"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#NewsItem
@@ -9266,8 +12057,12 @@ ec:NewsItem rdf:type owl:Class ;
                               owl:onProperty ec:hasDopesheet ;
                               owl:allValuesFrom ec:Dopesheet
                             ] ;
-            dcterms:description "A NewsItem aggregates all information about a particular news event."@en ;
-            rdfs:label "News Item"@en .
+            dcterms:description "A NewsItem aggregates all information about a particular news event."@en ,
+                                "Ein NewsItem fasst alle Informationen über ein bestimmtes Nachrichtenereignis zusammen."@de ,
+                                "Un NewsItem regroupe toutes les informations sur un événement d'actualité particulier."@fr ;
+            rdfs:label "Nachrichten"@de ,
+                       "News Item"@en ,
+                       "Nouvelles"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#NormalPlayTime
@@ -9283,23 +12078,31 @@ ec:NormalPlayTime rdf:type owl:Class ;
                                     owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                     owl:onDataRange xsd:time
                                   ] ;
-                  rdfs:label "Normal play time"@en .
+                  rdfs:label "Normal play time"@en ,
+                             "Normale Spielzeit"@de ,
+                             "Temps de jeu normal"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#OpenCaptions
 ec:OpenCaptions rdf:type owl:Class ;
                 rdfs:subClassOf ec:Captioning ;
-                dcterms:description """Open Captions are burned in the
-            image."""@en ;
-                rdfs:label "Open captions"@en .
+                dcterms:description "Les légendes ouvertes sont gravées dans l l'image."@fr ,
+                                    "Offene Untertitel werden in das Bild eingebrannt Bild eingebrannt."@de ,
+                                    "Open Captions are burned in the image."@en ;
+                rdfs:label "Bildunterschriften öffnen"@de ,
+                           "Légendes ouvertes"@fr ,
+                           "Open captions"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#OpenSubtitling
 ec:OpenSubtitling rdf:type owl:Class ;
                   rdfs:subClassOf ec:Subtitling ;
-                  dcterms:description """Open subtitles are burned in the
-            image."""@en ;
-                  rdfs:label "Open subtitling"@en .
+                  dcterms:description "Les sous-titres ouverts sont gravés dans l l'image."@fr ,
+                                      "Offene Untertitel werden in das Bild gebrannt Bild eingebrannt."@de ,
+                                      "Open subtitles are burned in the image."@en ;
+                  rdfs:label "Open subtitling"@en ,
+                             "Ouvrir le sous-titrage"@fr ,
+                             "Untertitelung öffnen"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Organisation
@@ -9331,31 +12134,42 @@ ec:Organisation rdf:type owl:Class ;
                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                   owl:onClass time:Instant
                                 ] ;
-                dcterms:description "An organisation (business, corporation, federation, etc.) or moral agent (government body)."@en ;
-                rdfs:label "Organisation"@en .
+                dcterms:description "An organisation (business, corporation, federation, etc.) or moral agent (government body)."@en ,
+                                    "Eine Organisation (Unternehmen, Körperschaft, Verband usw.) oder ein moralischer Akteur (Regierungsstelle)."@de ,
+                                    "Une organisation (entreprise, société, fédération, etc.) ou un agent moral (organisme gouvernemental)."@fr ;
+                rdfs:label "Organisation"@de ,
+                           "Organisation"@en ,
+                           "Organisation"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#OriginalLanguage
 ec:OriginalLanguage rdf:type owl:Class ;
                     rdfs:subClassOf ec:Language ;
-                    dcterms:description """The original language in which the
-            EditorialObject or Resource has been created and released. This is provided as free text
-            in an annotation label or as an identifier pointing to a term in a classification
-            scheme."""@en ;
-                    rdfs:label "Language"@en .
+                    dcterms:description "Die Originalsprache, in der das Redaktionsobjekt oder Ressource erstellt und freigegeben wurde. Dies wird als freier Text angegeben in einer Beschriftung oder als Bezeichner, der auf einen Begriff in einem Klassifikationsschema verweist Schema verweist."@de ,
+                                        "La langue d'origine dans laquelle l objet éditorial ou ressource a été créé et diffusé. Elle est fournie sous forme de texte libre dans une étiquette d'annotation ou en tant qu'identifiant pointant vers un terme dans une classification de classification."@fr ,
+                                        "The original language in which the EditorialObject or Resource has been created and released. This is provided as free text in an annotation label or as an identifier pointing to a term in a classification scheme."@en ;
+                    rdfs:label "Language"@en ,
+                               "Langue"@fr ,
+                               "Sprache"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Outtakes
 ec:Outtakes rdf:type owl:Class ;
             rdfs:subClassOf ec:EditorialWork ;
-            rdfs:label "Outtakes"@en .
+            rdfs:label "Outtakes"@de ,
+                       "Outtakes"@en ,
+                       "Outtakes"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Part_Type
 ec:Part_Type rdf:type owl:Class ;
              rdfs:subClassOf skos:Concept ;
-             dcterms:description "To define a type or part."@en ;
-             rdfs:label "Part type"@en .
+             dcterms:description "Pour définir un type ou une pièce."@fr ,
+                                 "To define a type or part."@en ,
+                                 "Um einen Typ oder ein Teil zu definieren."@de ;
+             rdfs:label "Part type"@en ,
+                        "Teil Typ"@de ,
+                        "Type de pièce"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Person
@@ -9502,7 +12316,8 @@ ec:Person rdf:type owl:Class ;
                             owl:maxCardinality "1"^^xsd:nonNegativeInteger
                           ] ;
           dcterms:description "A Person."@en ,
-                              "Eine Person."@de ;
+                              "Eine Person."@de ,
+                              "Une personne."@fr ;
           rdfs:comment "Une personne physique."@fr ;
           rdfs:label "Person"@de ,
                      "Person"@en ,
@@ -9523,8 +12338,12 @@ ec:PhysicalResource rdf:type owl:Class ;
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Pictogram
 ec:Pictogram rdf:type owl:Class ;
              rdfs:subClassOf ec:Picture ;
-             dcterms:description "A visual / graphical representation of a concept."@en ;
-             rdfs:label "Pictogram"@en .
+             dcterms:description "A visual / graphical representation of a concept."@en ,
+                                 "Eine visuelle / grafische Darstellung eines Konzepts."@de ,
+                                 "Une représentation visuelle / graphique d'un concept."@fr ;
+             rdfs:label "Pictogram"@en ,
+                        "Pictogramme"@fr ,
+                        "Piktogramm"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Picture
@@ -9567,15 +12386,23 @@ ec:Picture rdf:type owl:Class ;
                              owl:onProperty ec:frameWidthUnit ;
                              owl:maxCardinality "1"^^xsd:nonNegativeInteger
                            ] ;
-           dcterms:description "A photography, a logo, a pictogram, etc."@en ;
-           rdfs:label "Picture"@en .
+           dcterms:description "A photography, a logo, a pictogram, etc."@en ,
+                               "Eine Fotografie, ein Logo, ein Piktogramm, usw."@de ,
+                               "Une photographie, un logo, un pictogramme, etc."@fr ;
+           rdfs:label "Bild"@de ,
+                      "Photo"@fr ,
+                      "Picture"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#PictureDisplayFormat
 ec:PictureDisplayFormat rdf:type owl:Class ;
                         rdfs:subClassOf ec:Format ;
-                        dcterms:description "To define a picture display format code."@en ;
-                        rdfs:label "Picture display format code"@en .
+                        dcterms:description "Pour définir un code de format d'affichage des images."@fr ,
+                                            "So definieren Sie einen Code für das Bildanzeigeformat."@de ,
+                                            "To define a picture display format code."@en ;
+                        rdfs:label "Code du format d'affichage des images"@fr ,
+                                   "Code für das Bildanzeigeformat"@de ,
+                                   "Picture display format code"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Post
@@ -9625,9 +12452,12 @@ ec:Programme rdf:type owl:Class ;
                                owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                owl:onDataRange xsd:integer
                              ] ;
-             dcterms:description """An EditorialObject corresponding to a
-            MediaResource ready for publication."""@en ;
-             rdfs:label "Programme"@en .
+             dcterms:description "An EditorialObject corresponding to a MediaResource ready for publication."@en ,
+                                 "Ein EditorialObject, das einer MediaResource, die zur Veröffentlichung bereit ist."@de ,
+                                 "Un EditorialObject correspondant à une MediaResource prête à être publiée."@fr ;
+             rdfs:label "Programm"@de ,
+                        "Programme"@en ,
+                        "Programme"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Promotion
@@ -9637,14 +12467,20 @@ ec:Promotion rdf:type owl:Class ;
                                owl:onProperty ec:isMemberOf ;
                                owl:allValuesFrom ec:CampaignPackage
                              ] ;
-             rdfs:label "Promotion"@en .
+             rdfs:label "Förderung"@de ,
+                        "Promotion"@en ,
+                        "Promotion"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Props
 ec:Props rdf:type owl:Class ;
          rdfs:subClassOf ec:Artefact ;
-         dcterms:description "To identify and describe Props used in productions (e.g. vehicles, objects of various shapes and brand and purpose, etc.)."@en ;
-         rdfs:label "Props"@en .
+         dcterms:description "Identifier et décrire les accessoires utilisés dans les productions (par exemple, les véhicules, les objets de formes et de marques diverses et leur fonction, etc.)"@fr ,
+                             "Requisiten, die in Produktionen verwendet werden, zu identifizieren und zu beschreiben (z.B. Fahrzeuge, Objekte verschiedener Formen und Marken und deren Zweck usw.)."@de ,
+                             "To identify and describe Props used in productions (e.g. vehicles, objects of various shapes and brand and purpose, etc.)."@en ;
+         rdfs:label "Accessoires"@fr ,
+                    "Props"@en ,
+                    "Requisiten"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Provenance
@@ -9689,8 +12525,12 @@ ec:Provenance rdf:type owl:Class ;
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Pseudonym
 ec:Pseudonym rdf:type owl:Class ;
              rdfs:subClassOf ec:Person ;
-             dcterms:description "a fictitious name; especially : pen name or stage name"@en ;
-             rdfs:label "Pseudonym"@en .
+             dcterms:description "a fictitious name; especially : pen name or stage name"@en ,
+                                 "ein fiktiver Name; insbesondere: Pseudonym oder Künstlername"@de ,
+                                 "un nom fictif ; en particulier : nom de plume ou nom de scène"@fr ;
+             rdfs:label "Pseudonym"@de ,
+                        "Pseudonym"@en ,
+                        "Pseudonyme"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#PublicationChannel
@@ -9761,17 +12601,23 @@ ec:PublicationChannel rdf:type owl:Class ;
                                         owl:onProperty ec:name ;
                                         owl:allValuesFrom rdfs:Literal
                                       ] ;
-                      dcterms:description "A channel through which content is published. It can take a variety of forms beyond broadcast and internet streaming, e.g. physical distribution of CDs /DVDs, etc."@en ;
-                      rdfs:comment "C'est un canal par lequel le contenu est publié. Il peut prendre diverses formes au-delà de la diffusion et du streaming sur Internet, par exemple la distribution physique de CD/DVD, etc."@fr ;
-                      rdfs:label "Canal de publication"@fr ,
+                      dcterms:description "A channel through which content is published. It can take a variety of forms beyond broadcast and internet streaming, e.g. physical distribution of CDs /DVDs, etc."@en ,
+                                          "Ein Kanal, über den Inhalte veröffentlicht werden. Er kann eine Vielzahl von Formen annehmen, die über Rundfunk und Internet-Streaming hinausgehen, z. B. den physischen Vertrieb von CDs/DVDs usw."@de ,
+                                          "Un canal par lequel le contenu est publié. Il peut prendre diverses formes au-delà de la diffusion et du streaming sur Internet, par exemple la distribution physique de CD /DVD, etc."@fr ;
+                      rdfs:label "Canal de publication"@de ,
+                                 "Canal de publication"@fr ,
                                  "Publication channel"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#PublicationChannel_Type
 ec:PublicationChannel_Type rdf:type owl:Class ;
                            rdfs:subClassOf skos:Concept ;
-                           dcterms:description "To define a type of publication channel."@en ;
-                           rdfs:label "Publication channel type"@en .
+                           dcterms:description "Pour définir un type de canal de publication."@fr ,
+                                               "To define a type of publication channel."@en ,
+                                               "Um eine Art von Publikationskanal zu definieren."@de ;
+                           rdfs:label "Publication channel type"@en ,
+                                      "Publikationskanal-Typ"@de ,
+                                      "Type de canal de publication"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#PublicationEvent
@@ -9905,11 +12751,9 @@ ec:PublicationEvent rdf:type owl:Class ;
                                       owl:onDataRange xsd:boolean
                                     ] ;
                     owl:disjointWith ec:Rating ;
-                    dcterms:description """Beschreibt die Bereitstellung eines Medieninhaltes und seiner Essenz durch ein beliebiges Medium.
-Ein Publikationsereignis kann ein geplantes oder ein ungeplantes Ereignis im Rahmen eines linearen Angebot sein, oder eine Abrufmöglichkeit sowie live-streaming im nicht-linearen Angebot."""@de ,
+                    dcterms:description "Beschreibt die Bereitstellung eines Medieninhaltes und seiner Essenz durch ein beliebiges Medium. Ein Publikationsereignis kann ein geplantes oder ein ungeplantes Ereignis im Rahmen eines linearen Angebot sein, oder eine Abrufmöglichkeit sowie live-streaming im nicht-linearen Angebot."@de ,
                                         "Décrit toute apparition, manifestation, d'un objet éditorial, EditorialObjec et d'une essence associée, Essence, sur n'importe quel média (en direct, à la demande, à la télévision, etc.). Un PublicationEvent peut être par exemple, un événement programmé, un événement diffusé (à l'origine non programmé comme les \"dernières nouvelles\"), ou des événements non linéaires à la demande et des diffusions en direct."@fr ,
-                                        """To describe any manifestation of an EditorialObject and associated Essence on any media (live, on demand, catch-up TV, etc.).
-A PublicationEvent can be e.g. a scheduled event, a broadcast event (originally not scheduled like \"latest news\"), or non-linear on-demand events and live-streaming."""@en ;
+                                        "To describe any manifestation of an EditorialObject and associated Essence on any media (live, on demand, catch-up TV, etc.). A PublicationEvent can be e.g. a scheduled event, a broadcast event (originally not scheduled like \"latest news\"), or non-linear on-demand events and live-streaming."@en ;
                     rdfs:label "Publication Event"@en ,
                                "Publikationsereignis"@de ,
                                "Événement de publication"@fr .
@@ -9918,8 +12762,12 @@ A PublicationEvent can be e.g. a scheduled event, a broadcast event (originally 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#PublicationEvent_Type
 ec:PublicationEvent_Type rdf:type owl:Class ;
                          rdfs:subClassOf skos:Concept ;
-                         dcterms:description "To define a type of publication event."@en ;
-                         rdfs:label "Publication event type"@en .
+                         dcterms:description "Pour définir un type d'événement de publication."@fr ,
+                                             "To define a type of publication event."@en ,
+                                             "Um eine Art von Publikationsereignis zu definieren."@de ;
+                         rdfs:label "Art der Veröffentlichung"@de ,
+                                    "Publication event type"@en ,
+                                    "Type d'événement de publication"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#PublicationHistory
@@ -9928,9 +12776,12 @@ ec:PublicationHistory rdf:type owl:Class ;
                                         owl:onProperty ec:hasPublicationEvent ;
                                         owl:someValuesFrom ec:PublicationEvent
                                       ] ;
-                      dcterms:description """A collection of PublicationEvents through which
-            a resource has been published."""@en ;
-                      rdfs:label "Publication History"@en .
+                      dcterms:description "A collection of PublicationEvents through which a resource has been published."@en ,
+                                          "Eine Sammlung von PublicationEvents, durch die eine Ressource veröffentlicht wurde."@de ,
+                                          "Une collection de PublicationEvents par lesquels une ressource a été publiée."@fr ;
+                      rdfs:label "Geschichte der Veröffentlichung"@de ,
+                                 "Histoire de la publication"@fr ,
+                                 "Publication History"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#PublicationLogg
@@ -9964,13 +12815,17 @@ ec:PublicationLogg rdf:type owl:Class ;
                                      owl:allValuesFrom rdfs:Literal
                                    ] ;
                    dc:description "For colecting data from the \"As run logg\""@en ;
-                   rdfs:label "Publication logg"@en .
+                   rdfs:label "Journal de bord de la publication"@fr ,
+                              "Protokoll der Veröffentlichung"@de ,
+                              "Publication logg"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#PublicationMedium
 ec:PublicationMedium rdf:type owl:Class ;
                      rdfs:subClassOf skos:Concept ;
-                     rdfs:label "Publication medium" .
+                     rdfs:label "Medium der Veröffentlichung"@de ,
+                                "Publication medium"@en ,
+                                "Support de publication"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#PublicationPlan
@@ -10042,15 +12897,8 @@ ec:PublicationPlan rdf:type owl:Class ;
                                      owl:onProperty ec:publicationPlanTitle ;
                                      owl:allValuesFrom rdfs:Literal
                                    ] ;
-                   dcterms:description """A PublicationPlan describes a schedule of PublicationEvents (and their Audiences). The realisation of a PublicationPlan may require the specific acquisition or creation of content defined as a pair of EditorialObjects and Essence, which occurs through ProductionOrders. A PublicationPlan can be the result of associated Publication(sub)Plans.
-
-Examples:
-
-Example 1: A campaign of commercials for a product, consists of set of planned PublicationEvents.
-Example 2: A fiction film is promoted with several trailers published before the publication of the film."""@en ,
-                                       """Ein Publikationsplan beschreibt eine Zeitplan von Publikationsereignissen und ihre Publika. Die Realisierung eines Publikationsplan erfordert möglicherweise den Einkauf oder die Herstellung von Medienprodukten (Medieninhalt mit Essenz), ausgelöst durch einen Produktionsauftrag. Ein Publikationsplan kann aus mehreren Publikationsplänen zusammengesetzt werden.
-Beispiele 1: Eine Werbekampagne für ein neues Produkt besteht aus einer Reihe geplanter Veröffentlichungsereignisse.
-Beispiel 2: Ein Film wird  durch mehrere Trailer beworben, bevor er veröffentlicht wird."""@de ,
+                   dcterms:description "A PublicationPlan describes a schedule of PublicationEvents (and their Audiences). The realisation of a PublicationPlan may require the specific acquisition or creation of content defined as a pair of EditorialObjects and Essence, which occurs through ProductionOrders. A PublicationPlan can be the result of associated Publication(sub)Plans. Examples: Example 1: A campaign of commercials for a product, consists of set of planned PublicationEvents. Example 2: A fiction film is promoted with several trailers published before the publication of the film."@en ,
+                                       "Ein Publikationsplan beschreibt eine Zeitplan von Publikationsereignissen und ihre Publika. Die Realisierung eines Publikationsplan erfordert möglicherweise den Einkauf oder die Herstellung von Medienprodukten (Medieninhalt mit Essenz), ausgelöst durch einen Produktionsauftrag. Ein Publikationsplan kann aus mehreren Publikationsplänen zusammengesetzt werden. Beispiele 1: Eine Werbekampagne für ein neues Produkt besteht aus einer Reihe geplanter Veröffentlichungsereignisse. Beispiel 2: Ein Film wird durch mehrere Trailer beworben, bevor er veröffentlicht wird."@de ,
                                        """Un PublicationPlan décrit un calendrier de PublicationEvents ainsi que leurs audiences. La réalisation d'un plan de publication, PublicationPlan, peut nécessiter l'acquisition ou la création spécifique d'un contenu défini comme une paire d'objets éditoriaux, EditorialObjects, et d'essences, d'Essence. Ceci se produit par le biais d'ordres de production, ProductionOrders.
 Un plan de publication peut être le résultat de plans ou sous plans de publication associés.
 Exemple 1 : Une campagne publicitaire pour un produit consiste en un ensemble d'événements de publication, PublicationPlan, planifiée.
@@ -10063,8 +12911,12 @@ Exemple 2 : Un film de fiction est promu avec plusieurs bandes annonces publiée
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#PublicationPlan_Type
 ec:PublicationPlan_Type rdf:type owl:Class ;
                         rdfs:subClassOf skos:Concept ;
-                        dcterms:description "To define a type of publication plan."@en ;
-                        rdfs:label "Publication plan type"@en .
+                        dcterms:description "Pour définir un type de plan de publication."@fr ,
+                                            "To define a type of publication plan."@en ,
+                                            "Um eine Art von Veröffentlichungsplan zu definieren."@de ;
+                        rdfs:label "Publication plan type"@en ,
+                                   "Publikationsplan Typ"@de ,
+                                   "Type de plan de publication"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#PublicationPlatform
@@ -10139,8 +12991,12 @@ ec:PublicationPlatform rdf:type owl:Class ;
                                          owl:onProperty ec:name ;
                                          owl:allValuesFrom rdfs:Literal
                                        ] ;
-                       dcterms:description "A platform like a network or operator platform."@en ;
-                       rdfs:label "Publication platform"@en .
+                       dcterms:description "A platform like a network or operator platform."@en ,
+                                           "Eine Plattform wie ein Netzwerk oder eine Betreiberplattform."@de ,
+                                           "Une plateforme comme celle d'un réseau ou d'un opérateur."@fr ;
+                       rdfs:label "Plate-forme de publication"@fr ,
+                                  "Plattform für Veröffentlichungen"@de ,
+                                  "Publication platform"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#PublicationService
@@ -10208,7 +13064,8 @@ ec:PublicationService rdf:type owl:Class ;
                                         owl:allValuesFrom rdfs:Literal
                                       ] ;
                       dcterms:description "A publication service is a channel or publishing platform that releases the content to a given Audience."@en ,
-                                          "Ein Service ist ein Kanal oder eine Publikationsplattform die einem Publikum den Zugriff auf Medienprodukte erlaubt."@de ;
+                                          "Ein Service ist ein Kanal oder eine Publikationsplattform die einem Publikum den Zugriff auf Medienprodukte erlaubt."@de ,
+                                          "Un service de publication est un canal ou une plate-forme de publication qui diffuse le contenu à une audience donnée."@fr ;
                       rdfs:comment "Un Service est un canal ou une plateforme de publication qui diffuse le contenu à un public donné."@fr ;
                       rdfs:label "Publication service"@en ,
                                  "Service"@de ,
@@ -10218,9 +13075,12 @@ ec:PublicationService rdf:type owl:Class ;
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#RadioProgramme
 ec:RadioProgramme rdf:type owl:Class ;
                   rdfs:subClassOf ec:Programme ;
-                  dcterms:description """A programme for distribution on radio
-            channels."""@en ;
-                  rdfs:label "Radio Programme"@en .
+                  dcterms:description "A programme for distribution on radio channels."@en ,
+                                      "Ein Programm zur Verbreitung im Radio Kanäle."@de ,
+                                      "Un programme pour la distribution sur les chaînes."@fr ;
+                  rdfs:label "Programme radio"@fr ,
+                             "Radio Programme"@en ,
+                             "Radioprogramm"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Rating
@@ -10292,26 +13152,34 @@ ec:Rating rdf:type owl:Class ;
                             owl:onProperty ec:ratingSystemName ;
                             owl:maxCardinality "1"^^xsd:nonNegativeInteger
                           ] ;
-          dcterms:description """All the information about the rating/evaluation
-            given to a media resource by an Agent i.e. a person/Contact or
-            Organisation."""@en ,
-                              """This is provided as free text in an annotation
-            label or as an identifier pointing to a term in a classification scheme."""@en ;
-          rdfs:label "Rating"@en .
+          dcterms:description "All the information about the rating/evaluation given to a media resource by an Agent i.e. a person/Contact or Organisation. This is provided as free text in an annotation label or as an identifier pointing to a term in a classification scheme."@en ,
+                              "Alle Informationen über die Bewertung/Beurteilung die einer Medienressource von einem Agenten, d.h. einer Person/Kontakt oder Organisation."@de ,
+                              "Toutes les informations concernant la note/évaluation donnée à une ressource média par un Agent c'est-à-dire une personne/Contact ou Organisation."@fr ;
+          rdfs:label "Bewertung"@de ,
+                     "Classement"@fr ,
+                     "Rating"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Record
 ec:Record rdf:type owl:Class ;
           rdfs:subClassOf ec:BibliographicalObject ;
-          dcterms:description "The record the description of an Asset."@en ;
-          rdfs:label "Record"@en .
+          dcterms:description "Die Aufzeichnung der Beschreibung eines Assets."@de ,
+                              "L'enregistrement de la description d'un actif."@fr ,
+                              "The record the description of an Asset."@en ;
+          rdfs:label "Enregistrement"@fr ,
+                     "Record"@en ,
+                     "Rekord"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#RegionCode
 ec:RegionCode rdf:type owl:Class ;
               rdfs:subClassOf skos:Concept ;
-              dcterms:description "To define a region.("@en} ;
-              rdfs:label "Region code"@en .
+              dcterms:description "Le code de région fait référence au code développé par l'Organisation internationale de normalisation (ISO). L'ISO a créé et maintient la norme ISO 3166 - Codes pour la représentation des noms de pays et de leurs subdivisions."@fr ,
+                                  "Region Code bezieht sich auf den von der Internationalen Organisation für Normung (ISO) entwickelten Code. Die ISO schuf und pflegt die Norm ISO 3166 - Codes für die Darstellung der Namen von Ländern und ihren Unterteilungen."@de ,
+                                  "Region Code refers to the code developed by the International Organization for Standardization (ISO). ISO created and maintains the ISO 3166 standard – Codes for the representation of names of countries and their subdivisions."@en ;
+              rdfs:label "Code de région"@fr ,
+                         "Region code"@en ,
+                         "Regionalcode"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Relation
@@ -10356,15 +13224,23 @@ ec:Relation rdf:type owl:Class ;
                               owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                               owl:onDataRange xsd:integer
                             ] ;
-            dcterms:description "To define links and relations."@en ;
-            rdfs:label "Relation"@en .
+            dcterms:description "Pour définir les liens et les relations."@fr ,
+                                "To define links and relations."@en ,
+                                "Zur Definition von Verbindungen und Beziehungen."@de ;
+            rdfs:label "Beziehung"@de ,
+                       "Relation"@en ,
+                       "Relation"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Relation_Type
 ec:Relation_Type rdf:type owl:Class ;
                  rdfs:subClassOf skos:Concept ;
-                 dcterms:description "To specify a type of relation."@en ;
-                 rdfs:label "Relation type"@en .
+                 dcterms:description "Pour spécifier un type de relation."@fr ,
+                                     "To specify a type of relation."@en ,
+                                     "Zur Angabe einer Art von Beziehung."@de ;
+                 rdfs:label "Beziehungstyp"@de ,
+                            "Relation type"@en ,
+                            "Type de relation"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Reminder
@@ -10378,7 +13254,9 @@ ec:Reminder rdf:type owl:Class ;
                               owl:onProperty ec:isMemberOf ;
                               owl:allValuesFrom ec:CampaignPackage
                             ] ;
-            rdfs:label "Reminder"@en .
+            rdfs:label "Erinnerung"@de ,
+                       "Rappel"@fr ,
+                       "Reminder"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Resource
@@ -10454,7 +13332,8 @@ ec:Resource rdf:type owl:Class ;
                               owl:onDataRange xsd:string
                             ] ;
             dcterms:description "A resource used or referred to in the workflow (e.g. a document or image or any objects defined as sub-classes of Resource). It has a locator indicating from where the Resource can be retrieved."@en ,
-                                "Eine Ressource, die in einem Arbeitsablauf genutzt oder referenziert wird, z.B. ein Dokument, ein Bild, oder ein beliebiges Objekt einer Sub-Klasse von Ressource). Die Ressource hat einen Locator, der angibt, wo auf die Ressource zugegriffen werden kann."@de ;
+                                "Eine Ressource, die in einem Arbeitsablauf genutzt oder referenziert wird, z.B. ein Dokument, ein Bild, oder ein beliebiges Objekt einer Sub-Klasse von Ressource). Die Ressource hat einen Locator, der angibt, wo auf die Ressource zugegriffen werden kann."@de ,
+                                "Une ressource utilisée ou à laquelle il est fait référence dans le workflow (par exemple, un document ou une image ou tout objet défini comme sous-classe de Ressource). Elle possède un localisateur indiquant l'endroit où la ressource peut être récupérée."@fr ;
             rdfs:comment "Une ressource est utilisée ou référencé dans un workflow (par exemple, un document ou une image ou tout objet défini comme sous-classe de la ressource). Elle possède un localisateur indiquant l'endroit où la ressource peut être récupérée"@fr ;
             rdfs:label "Resource"@en ,
                        "Ressource"@de ,
@@ -10464,15 +13343,23 @@ ec:Resource rdf:type owl:Class ;
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Resource_Type
 ec:Resource_Type rdf:type owl:Class ;
                  rdfs:subClassOf skos:Concept ;
-                 dcterms:description "To define a type of resource."@en ;
-                 rdfs:label "Resource type"@en .
+                 dcterms:description "Pour définir un type de ressource."@fr ,
+                                     "To define a type of resource."@en ,
+                                     "Um eine Art von Ressource zu definieren."@de ;
+                 rdfs:label "Resource type"@en ,
+                            "Ressourcentyp"@de ,
+                            "Type de ressource"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Review
 ec:Review rdf:type owl:Class ;
           rdfs:subClassOf ec:Item ;
-          dcterms:description "To provide a Review."@en ;
-          rdfs:label "Review"@en .
+          dcterms:description "Pour fournir un examen."@fr ,
+                              "To provide a Review."@en ,
+                              "Um eine Rezension zu erstellen."@de ;
+          rdfs:label "Consulter"@fr ,
+                     "Review"@en ,
+                     "Überprüfung"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Rights
@@ -10552,8 +13439,7 @@ ec:Rights rdf:type owl:Class ;
                             owl:onProperty ec:rightsLink ;
                             owl:allValuesFrom xsd:anyURI
                           ] ;
-          dcterms:description """Les droits, Rights, de propriété intellectuelle ou autres droits contractuels (par exemple, de publication) associés à un actif, un contrat ou un PublicationEvent.
-Les droits proviennent d'un contrat, Contract. Les droits sont associés à des EditorialObjects, MediaResource ou Essences par la définition d'un actif, Asset. Les droits sont liés à des détenteurs de droits, RightsHolders."""@fr ,
+          dcterms:description "Les droits, Rights, de propriété intellectuelle ou autres droits contractuels (par exemple, de publication) associés à un actif, un contrat ou un PublicationEvent. Les droits proviennent d'un contrat, Contract. Les droits sont associés à des EditorialObjects, MediaResource ou Essences par la définition d'un actif, Asset. Les droits sont liés à des détenteurs de droits, RightsHolders."@fr ,
                               "The intellectual property or other contractual (e.g. publication) Rights associated to an Asset, a Contract, or a PublicationEvent. Rights originate from a Contract. Rights are associated to EditorialObjects, MediaResource or Essences through the definition of an Asset. Rights have associated RightsHolders."@en ,
                               "Urheber- oder vertragliches Verwertungsrecht an einem Asset, einem Vertrag oder einem Publikationsereignis. Rechte entstammen einem Vertrag. Rechte sind gebunden an einen Medieninhalt, eine Medienressource oder eine Essenz durch die Definition des Assets. Rechte haben zugeordnete Rechteinhaber."@de ;
           rdfs:label "Droits"@fr ,
@@ -10564,16 +13450,23 @@ Les droits proviennent d'un contrat, Contract. Les droits sont associés à des 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#RightsClearance
 ec:RightsClearance rdf:type owl:Class ;
                    rdfs:subClassOf ec:Rights ;
-                   dcterms:description """To signal that rights have been cleared (or
-            not)"""@en ;
-                   rdfs:label "Rights Clearance"@en .
+                   dcterms:description "Pour signaler que les droits ont été effacés (ou pas)"@fr ,
+                                       "To signal that rights have been cleared (or not)"@en ,
+                                       "Um zu signalisieren, dass die Rechte gelöscht wurden (oder nicht) nicht)"@de ;
+                   rdfs:label "Apurement des droits"@fr ,
+                              "Freigabe der Rechte"@de ,
+                              "Rights Clearance"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#RightsType
 ec:RightsType rdf:type owl:Class ;
               rdfs:subClassOf skos:Concept ;
-              dcterms:description "To define a type of Rights."@en ;
-              rdfs:label "Rights type"@en .
+              dcterms:description "Pour définir un type de droits."@fr ,
+                                  "To define a type of Rights."@en ,
+                                  "Um eine Art von Rechten zu definieren."@de ;
+              rdfs:label "Art der Rechte"@de ,
+                         "Rights type"@en ,
+                         "Type de droits"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Role
@@ -10622,9 +13515,8 @@ ec:Role rdf:type owl:Class ;
                           owl:onProperty ec:name ;
                           owl:allValuesFrom rdfs:Literal
                         ] ;
-        dcterms:description """Definiert eine Rolle, die ein Akteur übernimmt.
-Eine Rolle kann durch ein Concept aus SKOS repräsentiert werden."""@de ,
-                            "Permet de définir le rôle, Role,  joué par un agent, Agent. Un rôle sera identifié, par exemple, par un Concept d'un schéma de classification SKOS."@fr ,
+        dcterms:description "Definiert eine Rolle, die ein Akteur übernimmt. Eine Rolle kann durch ein Concept aus SKOS repräsentiert werden."@de ,
+                            "Permet de définir le rôle, Role, joué par un agent, Agent. Un rôle sera identifié, par exemple, par un Concept d'un schéma de classification SKOS."@fr ,
                             "To define Role played by an Agent. A «Role» will be identified e.g. by a Concept from a SKOS Classification Scheme."@en ;
         rdfs:label "Role"@en ,
                    "Rolle"@de ,
@@ -10648,8 +13540,12 @@ ec:Scene rdf:type owl:Class ;
                          ] ;
          owl:disjointWith ec:Shot ,
                           ec:Take ;
-         dcterms:description "A sequence of continuous action"@en ;
-         rdfs:label "Scene"@en .
+         dcterms:description "A sequence of continuous action"@en ,
+                             "Eine Sequenz mit kontinuierlicher Handlung"@de ,
+                             "Une séquence d'action continue"@fr ;
+         rdfs:label "Scene"@en ,
+                    "Schauplatz"@de ,
+                    "Scène"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Season
@@ -10672,17 +13568,23 @@ ec:Season rdf:type owl:Class ;
                             owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                             owl:onDataRange xsd:integer
                           ] ;
-          dcterms:description """A series can be composed of one or more seasons
-            clustering a certain number of episodes. Fro this reason, seasons are related to series
-            using the isRelatedTo property."""@en ;
-          rdfs:label "Season"@en .
+          dcterms:description "A series can be composed of one or more seasons clustering a certain number of episodes. Fro this reason, seasons are related to series using the isRelatedTo property."@en ,
+                              "Eine Serie kann aus einer oder mehreren Staffeln bestehen die eine bestimmte Anzahl von Episoden zusammenfassen. Aus diesem Grund werden Staffeln mit Serien verknüpft mit Hilfe der Eigenschaft isRelatedTo."@de ,
+                              "Une série peut être composée d'une ou plusieurs saisons regroupant un certain nombre d'épisodes. Pour cette raison, les saisons sont liées aux séries à l'aide de la propriété isRelatedTo."@fr ;
+          rdfs:label "Saison"@de ,
+                     "Saison"@fr ,
+                     "Season"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Serial
 ec:Serial rdf:type owl:Class ;
           rdfs:subClassOf ec:EditorialGroup ;
-          dcterms:description "works appearing (as in a magazine or on television) in parts at intervals"@en ;
-          rdfs:label "Serial"@en .
+          dcterms:description "Werke, die (z. B. in einer Zeitschrift oder im Fernsehen) in regelmäßigen Abständen in Teilen erscheinen"@de ,
+                              "works appearing (as in a magazine or on television) in parts at intervals"@en ,
+                              "œuvres apparaissant (comme dans un magazine ou à la télévision) en parties à intervalles réguliers"@fr ;
+          rdfs:label "Serial"@en ,
+                     "Seriennummer"@de ,
+                     "Série"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Series
@@ -10700,16 +13602,23 @@ ec:Series rdf:type owl:Class ;
                             owl:onProperty ec:isSeriesOf ;
                             owl:allValuesFrom ec:Brand
                           ] ;
-          dcterms:description """Series is a particular type of collection. TV
-            or Radio Series are composed of Episodes."""@en ;
-          rdfs:label "Series"@en .
+          dcterms:description "Les séries sont un type particulier de collection. TV ou radio sont composées d'épisodes."@fr ,
+                              "Serien sind eine besondere Art von Sammlungen. TV oder Radio-Serien bestehen aus Episoden."@de ,
+                              "Series is a particular type of collection. TV or Radio Series are composed of Episodes."@en ;
+          rdfs:label "Serie"@de ,
+                     "Series"@en ,
+                     "Série"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Service_Type
 ec:Service_Type rdf:type owl:Class ;
                 rdfs:subClassOf skos:Concept ;
-                dcterms:description "To define a type of service."@en ;
-                rdfs:label "Service type"@en .
+                dcterms:description "Pour définir un type de service."@fr ,
+                                    "To define a type of service."@en ,
+                                    "Um eine Art von Dienst zu definieren."@de ;
+                rdfs:label "Art der Dienstleistung"@de ,
+                           "Service type"@en ,
+                           "Type de service"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Shot
@@ -10724,15 +13633,23 @@ ec:Shot rdf:type owl:Class ;
                           owl:allValuesFrom ec:Take
                         ] ;
         owl:disjointWith ec:Take ;
-        dcterms:description "A film sequence photographed continuously by one camera"@en ;
-        rdfs:label "Shot"@en .
+        dcterms:description "A film sequence photographed continuously by one camera"@en ,
+                            "Eine Filmsequenz, die kontinuierlich von einer Kamera aufgenommen wird"@de ,
+                            "Une séquence de film photographiée en continu par une seule caméra."@fr ;
+        rdfs:label "Coup de feu"@fr ,
+                   "Schuss"@de ,
+                   "Shot"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#SignLanguageCode
 ec:SignLanguageCode rdf:type owl:Class ;
                     rdfs:subClassOf skos:Concept ;
-                    dcterms:description "To identify a sign language by its code."@en ;
-                    rdfs:label "Sign language code"@en .
+                    dcterms:description "Eine Zeichensprache anhand ihres Codes zu identifizieren."@de ,
+                                        "Identifier une langue des signes par son code."@fr ,
+                                        "To identify a sign language by its code."@en ;
+                    rdfs:label "Code de la langue des signes"@fr ,
+                               "Code für Zeichensprache"@de ,
+                               "Sign language code"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Signing
@@ -10748,72 +13665,100 @@ ec:Signing rdf:type owl:Class ;
                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                              owl:onClass ec:Agent
                            ] ;
-           dcterms:description """To signal the presence of Signing for hard of
-            hearing users. The type of Signing (e.g. incursted in or else) or language of Signing
-            can be specified using the appropriate properties."""@en ;
-           rdfs:label "Signing"@en .
+           dcterms:description "Pour signaler la présence de la signalisation pour les utilisateurs malentendants. utilisateurs malentendants. Le type de Signing (par ex. incursion ou autre) ou la langue de Signing peuvent être spécifiés à l'aide des propriétés appropriées."@fr ,
+                               "To signal the presence of Signing for hard of hearing users. The type of Signing (e.g. incursted in or else) or language of Signing can be specified using the appropriate properties."@en ,
+                               "Um die Anwesenheit von Signing für schwerhörige hörende Benutzer. Die Art der Gebärde (z.B. eingeblendet oder nicht) oder die Sprache der Gebärde kann über die entsprechenden Eigenschaften festgelegt werden."@de ;
+           rdfs:label "Signer"@fr ,
+                      "Signing"@en ,
+                      "Unterzeichnung"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#SigningFormat
 ec:SigningFormat rdf:type owl:Class ;
                  rdfs:subClassOf skos:Concept ;
-                 dcterms:description """To provide additional information on the
-            signing format. This is provided as free text in an annotation label or as an identifier
-            pointing to a term in a classification scheme."""@en ;
-                 rdfs:label "Signing format"@en .
+                 dcterms:description "Pour fournir des informations supplémentaires sur le format de signature. Ces informations sont fournies sous forme de texte libre dans une étiquette d'annotation ou d'un identifiant pointant vers un terme dans un schéma de classification."@fr ,
+                                     "To provide additional information on the signing format. This is provided as free text in an annotation label or as an identifier pointing to a term in a classification scheme."@en ,
+                                     "Um zusätzliche Informationen über das Format der Unterschrift. Diese werden als freier Text in einer Beschriftung oder als Bezeichner der auf einen Begriff in einem Klassifizierungsschema verweist."@de ;
+                 rdfs:label "Format de signature"@fr ,
+                            "Format der Unterschrift"@de ,
+                            "Signing format"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#SportItem
 ec:SportItem rdf:type owl:Class ;
              rdfs:subClassOf ec:Item ;
-             dcterms:description "A SportItem aggregates all information about a sport event."@en ;
-             rdfs:label "Sport item"@en .
+             dcterms:description "A SportItem aggregates all information about a sport event."@en ,
+                                 "Ein SportItem fasst alle Informationen über ein Sportereignis zusammen."@de ,
+                                 "Un SportItem regroupe toutes les informations sur un événement sportif."@fr ;
+             rdfs:label "Article de sport"@fr ,
+                        "Sport item"@en ,
+                        "Sportartikel"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#StaffMember
 ec:StaffMember rdf:type owl:Class ;
                rdfs:subClassOf ec:Person ;
-               dcterms:description "A member of Staff."@en ;
-               rdfs:label "Staff member."@en .
+               dcterms:description "A member of Staff."@en ,
+                                   "Ein Mitglied des Personals."@de ,
+                                   "Un membre du personnel."@fr ;
+               rdfs:label "Membre du personnel."@fr ,
+                          "Mitarbeiterin."@de ,
+                          "Staff member."@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Standard
 ec:Standard rdf:type owl:Class ;
             rdfs:subClassOf ec:Format ;
-            dcterms:description "identifies the technical video standard of a resource, i.e. NTSC or PAL."@en ;
-            rdfs:label "Standard"@en .
+            dcterms:description "identifie la norme technique vidéo d'une ressource, c'est-à-dire NTSC ou PAL."@fr ,
+                                "identifies the technical video standard of a resource, i.e. NTSC or PAL."@en ,
+                                "identifiziert den technischen Videostandard einer Ressource, d.h. NTSC oder PAL."@de ;
+            rdfs:label "Standard"@de ,
+                       "Standard"@en ,
+                       "Standard"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Sticker
 ec:Sticker rdf:type owl:Class ;
            rdfs:subClassOf ec:Picture ;
-           dcterms:description "A sticker associated with a Costume."@en ;
-           rdfs:label "Sticker"@en .
+           dcterms:description "A sticker associated with a Costume."@en ,
+                               "Ein Aufkleber, der mit einem Kostüm verbunden ist."@de ,
+                               "Un autocollant associé à un Costume."@fr ;
+           rdfs:label "Aufkleber"@de ,
+                      "Autocollant"@fr ,
+                      "Sticker"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Storage_Type
 ec:Storage_Type rdf:type owl:Class ;
                 rdfs:subClassOf skos:Concept ;
-                dcterms:description """The type of storage used for the repository.
-            This is provided as free text in an annotation label or as an identifier pointing to a
-            term in a classification scheme."""@en ;
-                rdfs:label "Storage type"@en .
+                dcterms:description "Die Art der Speicherung, die für das Repository verwendet wird. Dies wird als freier Text in einer Beschriftung oder als Bezeichner angegeben, der auf einen Begriff in einem Klassifizierungsschema verweist."@de ,
+                                    "Le type de stockage utilisé pour le référentiel. Il est fourni sous forme de texte libre dans une étiquette d'annotation ou sous forme d'identifiant pointant vers un terme dans un schéma de classification."@fr ,
+                                    "The type of storage used for the repository. This is provided as free text in an annotation label or as an identifier pointing to a term in a classification scheme."@en ;
+                rdfs:label "Art der Lagerung"@de ,
+                           "Storage type"@en ,
+                           "Type de stockage"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Stream
 ec:Stream rdf:type owl:Class ;
           rdfs:subClassOf ec:Component ;
-          dcterms:description "A continuous stream of bits."@en ;
-          rdfs:label "Stream"@en .
+          dcterms:description "A continuous stream of bits."@en ,
+                              "Ein kontinuierlicher Strom von Bits."@de ,
+                              "Un flux continu de bits."@fr ;
+          rdfs:label "Stream"@de ,
+                     "Stream"@en ,
+                     "Stream"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Subject
 ec:Subject rdf:type owl:Class ;
            rdfs:subClassOf skos:Concept ;
-           dcterms:description """A term describing the topic covered by the
-            EditorialObject or resource. This is provided as free text in an annotation label or as
-            an identifier pointing to a term in a classification scheme."""@en ;
-           rdfs:label "Subject"@en .
+           dcterms:description "A term describing the topic covered by the EditorialObject or resource. This is provided as free text in an annotation label or as an identifier pointing to a term in a classification scheme."@en ,
+                               "Ein Begriff, der das Thema beschreibt, das von dem EditorialObject oder der Ressource. Er wird als freier Text in einer Beschriftung angegeben oder als ein Bezeichner, der auf einen Begriff in einem Klassifizierungsschema verweist."@de ,
+                               "Un terme décrivant le sujet couvert par l objet éditorial ou la ressource. Il est fourni sous forme de texte libre dans une étiquette d'annotation ou comme un identifiant pointant vers un terme dans un schéma de classification."@fr ;
+           rdfs:label "Subject"@en ,
+                      "Sujet"@fr ,
+                      "Thema"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Subtitling
@@ -10823,27 +13768,34 @@ ec:Subtitling rdf:type owl:Class ;
                                 owl:onProperty ec:hasSubtitlingSource ;
                                 owl:allValuesFrom ec:Agent
                               ] ;
-              dcterms:description """To signal the presence of subtitles for
-            translation in alternative languages."""@en ;
-              rdfs:label "Subtitling"@en .
+              dcterms:description "Pour signaler la présence de sous-titres pour traduction dans des langues alternatives."@fr ,
+                                  "To signal the presence of subtitles for translation in alternative languages."@en ,
+                                  "Um das Vorhandensein von Untertiteln für die Übersetzung in andere Sprachen."@de ;
+              rdfs:label "Sous-titrage"@fr ,
+                         "Subtitling"@en ,
+                         "Untertitelung"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#SubtitlingFormat
 ec:SubtitlingFormat rdf:type owl:Class ;
                     rdfs:subClassOf ec:DataFormat ;
-                    dcterms:description """To define the format of subtitling.
-            subtitling's main use isfor translation. This is provided as free text in an
-            annotation label  or as an identifier pointing to a term in a classification
-            scheme."""@en ;
-                    rdfs:label "Subtitling format"@en .
+                    dcterms:description "Définir le format du sous-titrage. L'utilisation principale du sous-titrage est la traduction. Celle-ci est fournie sous forme de texte libre dans une étiquette d'annotation ou comme un identifiant pointant vers un terme dans une classification de classification."@fr ,
+                                        "To define the format of subtitling. subtitling's main use isfor translation. This is provided as free text in an annotation label or as an identifier pointing to a term in a classification scheme."@en ,
+                                        "Um das Format der Untertitelung zu definieren. Die Untertitelung wird hauptsächlich für die Übersetzung verwendet. Diese wird als freier Text in einer Beschriftung oder als Kennung, die auf einen Begriff in einem Klassifizierungsschema verweist Schema verweist."@de ;
+                    rdfs:label "Format de sous-titrage"@fr ,
+                               "Format der Untertitelung"@de ,
+                               "Subtitling format"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#TVProgramme
 ec:TVProgramme rdf:type owl:Class ;
                rdfs:subClassOf ec:Programme ;
-               dcterms:description """A programme for distribution on television
-            channels."""@en ;
-               rdfs:label "TV Programme"@en .
+               dcterms:description "A programme for distribution on television channels."@en ,
+                                   "Ein Programm für die Ausstrahlung im Fernsehen Kanäle."@de ,
+                                   "Un programme destiné à être distribué sur les chaînes."@fr ;
+               rdfs:label "Programme TV"@fr ,
+                          "TV Programme"@en ,
+                          "TV-Programm"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Take
@@ -10853,15 +13805,23 @@ ec:Take rdf:type owl:Class ;
                           owl:onProperty ec:hasScene ;
                           owl:allValuesFrom ec:Scene
                         ] ;
-        dcterms:description "A particular version of a scene or sequence of sound or vision photographed or recorded continuously at one time"@en ;
-        rdfs:label "Take"@en .
+        dcterms:description "A particular version of a scene or sequence of sound or vision photographed or recorded continuously at one time"@en ,
+                            "Eine bestimmte Version einer Szene oder einer Bild- oder Tonsequenz, die kontinuierlich zu einem Zeitpunkt fotografiert oder aufgenommen wurde."@de ,
+                            "Une version particulière d'une scène ou d'une séquence sonore ou visuelle photographiée ou enregistrée en continu à un moment donné."@fr ;
+        rdfs:label "Nehmen Sie"@de ,
+                   "Prenez"@fr ,
+                   "Take"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#TargetPlatform
 ec:TargetPlatform rdf:type owl:Class ;
                   rdfs:subClassOf skos:Concept ;
-                  dcterms:description "To specify a target platform."@en ;
-                  rdfs:label "Target Platform"@en ;
+                  dcterms:description "Pour spécifier une plate-forme cible."@fr ,
+                                      "To specify a target platform."@en ,
+                                      "Um eine Zielplattform anzugeben."@de ;
+                  rdfs:label "Plate-forme cible"@fr ,
+                             "Target Platform"@en ,
+                             "Ziel-Plattform"@de ;
                   owl:deprecated "true"^^xsd:boolean .
 
 
@@ -10872,22 +13832,34 @@ ec:Team rdf:type owl:Class ;
                           owl:onProperty ec:hasTeamMember ;
                           owl:allValuesFrom ec:Person
                         ] ;
-        dcterms:description "To define a Team."@en ;
-        rdfs:label "Team"@en .
+        dcterms:description "Pour définir une équipe."@fr ,
+                            "So definieren Sie ein Team."@de ,
+                            "To define a Team."@en ;
+        rdfs:label "Team"@de ,
+                   "Team"@en ,
+                   "Équipe"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Template
 ec:Template rdf:type owl:Class ;
             rdfs:subClassOf ec:MediaResource ;
-            dcterms:description "An Essence defined as a Template with all associated technical parameters."@en ;
-            rdfs:label "Template"@en .
+            dcterms:description "An Essence defined as a Template with all associated technical parameters."@en ,
+                                "Eine Essenz, die als Vorlage mit allen zugehörigen technischen Parametern definiert ist."@de ,
+                                "Une essence définie comme un modèle avec tous les paramètres techniques associés."@fr ;
+            rdfs:label "Modèle"@fr ,
+                       "Template"@en ,
+                       "Vorlage"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#TerritoryCode
 ec:TerritoryCode rdf:type owl:Class ;
                  rdfs:subClassOf skos:Concept ;
-                 dcterms:description "To identify a territory e.g. by its UN code."@en ;
-                 rdfs:label "Territory code"@en .
+                 dcterms:description "Pour identifier un territoire, par exemple par son code ONU."@fr ,
+                                     "To identify a territory e.g. by its UN code."@en ,
+                                     "Um ein Gebiet z.B. durch seinen UN-Code zu identifizieren."@de ;
+                 rdfs:label "Code du territoire"@fr ,
+                            "Territorialer Code"@de ,
+                            "Territory code"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#TextAnnotation
@@ -10903,8 +13875,12 @@ ec:TextAnnotation rdf:type owl:Class ;
                                     owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                     owl:onDataRange xsd:integer
                                   ] ;
-                  dcterms:description "A class specific to the annotation of a text or portions of text."@en ;
-                  rdfs:label "Text Annotation"@en .
+                  dcterms:description "A class specific to the annotation of a text or portions of text."@en ,
+                                      "Eine Klasse, die speziell für die Beschriftung eines Textes oder von Teilen eines Textes gedacht ist."@de ,
+                                      "Une classe spécifique à l'annotation d'un texte ou de portions de texte."@fr ;
+                  rdfs:label "Annotation de texte"@fr ,
+                             "Text Annotation"@en ,
+                             "Text-Anmerkung"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#TextLine
@@ -10993,38 +13969,56 @@ ec:TextLine rdf:type owl:Class ;
                               owl:onProperty ec:textLineOrder ;
                               owl:maxCardinality "1"^^xsd:nonNegativeInteger
                             ] ;
-            dcterms:description "To provide lines of text extracted from or additional to the resource."@en ;
-            rdfs:label "Text line"@en .
+            dcterms:description "Pour fournir des lignes de texte extraites de la ressource ou complémentaires à celle-ci."@fr ,
+                                "To provide lines of text extracted from or additional to the resource."@en ,
+                                "Zur Bereitstellung von Textzeilen, die aus der Ressource extrahiert wurden oder diese ergänzen."@de ;
+            rdfs:label "Ligne de texte"@fr ,
+                       "Text line"@en ,
+                       "Textzeile"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#TextLine_Type
 ec:TextLine_Type rdf:type owl:Class ;
                  rdfs:subClassOf skos:Concept ;
-                 dcterms:description "To define a TextLine type."@en ;
-                 rdfs:label "Text line type"@en .
+                 dcterms:description "Pour définir un type TextLine."@fr ,
+                                     "To define a TextLine type."@en ,
+                                     "Um einen TextLine-Typ zu definieren."@de ;
+                 rdfs:label "Text line type"@en ,
+                            "Typ der Textzeile"@de ,
+                            "Type de ligne de texte"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#TextUsageType
 ec:TextUsageType rdf:type owl:Class ;
                  rdfs:subClassOf skos:Concept ;
-                 dcterms:description "To specify the usage of a text."@en ;
-                 rdfs:label "Text usage type"@en .
+                 dcterms:description "Pour spécifier l'usage d'un texte."@fr ,
+                                     "To specify the usage of a text."@en ,
+                                     "Um die Verwendung eines Textes anzugeben."@de ;
+                 rdfs:label "Art der Textverwendung"@de ,
+                            "Text usage type"@en ,
+                            "Type d'utilisation du texte"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Theme
 ec:Theme rdf:type owl:Class ;
          rdfs:subClassOf skos:Concept ;
-         dcterms:description "To define a Theme associated with an Asset."@en ;
-         rdfs:label "Theme"@en .
+         dcterms:description "Pour définir un thème associé à un actif."@fr ,
+                             "So definieren Sie ein Thema, das mit einem Asset verknüpft ist."@de ,
+                             "To define a Theme associated with an Asset."@en ;
+         rdfs:label "Thema"@de ,
+                    "Theme"@en ,
+                    "Thème"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Thumbnail
 ec:Thumbnail rdf:type owl:Class ;
              rdfs:subClassOf ec:Picture ;
-             dcterms:description """A thumbnail is a low resolution picture that
-            can be associated with EditorialObjects or e.g. MediaResources or
-            Contacts."""@en ;
-             rdfs:label "Thumbnail"@en .
+             dcterms:description "A thumbnail is a low resolution picture that can be associated with EditorialObjects or e.g. MediaResources or Contacts."@en ,
+                                 "Eine Miniaturansicht ist ein Bild mit geringer Auflösung, das mit EditorialObjects oder z.B. MediaResources oder Contacts verknüpft werden kann. Kontakte."@de ,
+                                 "Une vignette est une image de faible résolution qui peut être associée à EditorialObjects, par exemple MediaResources ou Contacts."@fr ;
+             rdfs:label "Thumbnail"@en ,
+                        "Vignette"@fr ,
+                        "Vorschaubild"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#TimeCode
@@ -11035,7 +14029,9 @@ ec:TimeCode rdf:type owl:Class ;
                               owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                               owl:onDataRange xsd:string
                             ] ;
-            rdfs:label "Time code"@en .
+            rdfs:label "Code temporel"@fr ,
+                       "Time code"@en ,
+                       "Zeitcode"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#TimeCodeDropFrame
@@ -11046,35 +14042,53 @@ ec:TimeCodeDropFrame rdf:type owl:Class ;
                                        owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                        owl:onDataRange xsd:string
                                      ] ;
-                     rdfs:label "Time code with dropframe"@en .
+                     rdfs:label "Code temporel avec dropframe"@fr ,
+                                "Time code with dropframe"@en ,
+                                "Zeitcode mit Dropframe"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#TimecodeTrack
 ec:TimecodeTrack rdf:type owl:Class ;
                  rdfs:subClassOf ec:Track ;
-                 dcterms:description "A track with timecode information e.g. in MXF."@en ;
-                 rdfs:label "Timecode track"@en .
+                 dcterms:description "A track with timecode information e.g. in MXF."@en ,
+                                     "Eine Spur mit Timecode-Informationen z.B. in MXF."@de ,
+                                     "Une piste avec des informations de timecode, par exemple en MXF."@fr ;
+                 rdfs:label "Piste de timecode"@fr ,
+                            "Timecode track"@en ,
+                            "Timecode-Spur"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#TimedTextAuthoringTechnique
 ec:TimedTextAuthoringTechnique rdf:type owl:Class ;
                                rdfs:subClassOf ec:Format ;
-                               dcterms:description "To define a timed text authoring technique."@en ;
-                               rdfs:label "Timed text authoring technique"@en .
+                               dcterms:description "Définir une technique de création de texte minuté."@fr ,
+                                                   "So definieren Sie eine Technik zum Verfassen von Texten mit Zeitvorgaben."@de ,
+                                                   "To define a timed text authoring technique."@en ;
+                               rdfs:label "Technik zum Verfassen von Texten mit Zeitvorgaben"@de ,
+                                          "Technique de création de textes temporisés"@fr ,
+                                          "Timed text authoring technique"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#TimedTextContentType
 ec:TimedTextContentType rdf:type owl:Class ;
                         rdfs:subClassOf ec:Format ;
-                        dcterms:description "To define a type of timed text."@en ;
-                        rdfs:label "Timed text content type"@en .
+                        dcterms:description "Pour définir un type de texte minuté."@fr ,
+                                            "To define a type of timed text."@en ,
+                                            "Um eine Art von zeitlich begrenztem Text zu definieren."@de ;
+                        rdfs:label "Inhaltstyp Zeitgesteuerter Text"@de ,
+                                   "Timed text content type"@en ,
+                                   "Type de contenu texte temporisé"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#TimedTextSubtitleTargetFormat
 ec:TimedTextSubtitleTargetFormat rdf:type owl:Class ;
                                  rdfs:subClassOf ec:Format ;
-                                 dcterms:description "To define a timed text subtitle format."@en ;
-                                 rdfs:label "Timed text subtitle target format"@en .
+                                 dcterms:description "Pour définir un format de sous-titres en texte minuté."@fr ,
+                                                     "So definieren Sie ein zeitgesteuertes Textuntertitelformat."@de ,
+                                                     "To define a timed text subtitle format."@en ;
+                                 rdfs:label "Format cible des sous-titres en texte minuté"@fr ,
+                                            "Timed text subtitle target format"@en ,
+                                            "Zeitgesteuertes Text-Zielformat für Untertitel"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#TimelinePoint
@@ -11085,7 +14099,9 @@ ec:TimelinePoint rdf:type owl:Class ;
                                    owl:onDataRange xsd:float
                                  ] ;
                  dc:description "A precise time point  of a media resource"@en ;
-                 rdfs:label "Timeline point"@en .
+                 rdfs:label "Point de repère chronologique"@fr ,
+                            "Punkt der Zeitleiste"@de ,
+                            "Timeline point"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#TimelineTrack
@@ -11117,6 +14133,7 @@ ec:TimelineTrack rdf:type owl:Class ;
                                    owl:allValuesFrom rdfs:Literal
                                  ] ;
                  dcterms:description "Definiert den zeitlichen Ablauf von Medieninhalten."@de ,
+                                     "Definiert den zeitlichen Ablauf von Medieninhalten."@fr ,
                                      "To define a timed sequence of EditorialObjects."@en ;
                  rdfs:comment "Permet de définir une séquence temporelle d'EditorialObjects."@fr ;
                  rdfs:label "Ablaufplan"@de ,
@@ -11127,17 +14144,23 @@ ec:TimelineTrack rdf:type owl:Class ;
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#TimelineTrack_Type
 ec:TimelineTrack_Type rdf:type owl:Class ;
                       rdfs:subClassOf skos:Concept ;
-                      dcterms:description "To specify a type or TimelineTrack."@en ;
-                      rdfs:label "Timeline track type"@en .
+                      dcterms:description "Pour spécifier un type ou un TimelineTrack."@fr ,
+                                          "To specify a type or TimelineTrack."@en ,
+                                          "Um einen Typ oder eine TimelineSpur anzugeben."@de ;
+                      rdfs:label "Timeline track type"@en ,
+                                 "Typ der Timeline-Spur"@de ,
+                                 "Type de piste de la ligne de temps"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Topic
 ec:Topic rdf:type owl:Class ;
          rdfs:subClassOf skos:Concept ;
-         dcterms:description """A type subject for use in some contexts. This
-            is provided as free text in an annotation label or as an identifier pointing to a term
-            in a classification scheme."""@en ;
-         rdfs:label "Topic"@en .
+         dcterms:description "A type subject for use in some contexts. This is provided as free text in an annotation label or as an identifier pointing to a term in a classification scheme."@en ,
+                             "Ein Typ, der in einigen Kontexten verwendet werden kann. Diese wird als freier Text in einer Beschriftung oder als Identifikator angegeben, der auf einen Begriff in einem Klassifikationsschema verweist."@de ,
+                             "Un sujet de type à utiliser dans certains contextes. Ce est fourni comme texte libre dans une étiquette d'annotation ou comme identifiant pointant vers un terme dans un schéma de classification."@fr ;
+         rdfs:label "Sujet"@fr ,
+                    "Thema"@de ,
+                    "Topic"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Track
@@ -11157,9 +14180,8 @@ ec:Track rdf:type owl:Class ;
                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                            owl:onClass ec:Track_Type
                          ] ;
-         dcterms:description "Cela peut être une piste audio ou  video ou timecode ou data provenant de la resource médiatique, MediaResource."@fr ,
-                             """E.g. audio, video, timcode and/or data Tracks forming the
-      MediaResource."""@en ,
+         dcterms:description "Cela peut être une piste audio ou video ou timecode ou data provenant de la resource médiatique, MediaResource."@fr ,
+                             "E.g. audio, video, timcode and/or data Tracks forming the MediaResource."@en ,
                              "z.B. Audio-, Video-, Timecode- und/oder Datenspuren bilden eine Medienressource."@de ;
          rdfs:label "Piste"@fr ,
                     "Spur"@de ,
@@ -11169,15 +14191,23 @@ ec:Track rdf:type owl:Class ;
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#TrackPurpose
 ec:TrackPurpose rdf:type owl:Class ;
                 rdfs:subClassOf skos:Concept ;
-                dcterms:description "To define the prupose of a track."@en ;
-                rdfs:label "Track purpose"@en .
+                dcterms:description "Définir le prupose d'une piste."@fr ,
+                                    "To define the prupose of a track."@en ,
+                                    "Um den Zweck eines Titels zu definieren."@de ;
+                rdfs:label "Objectif de la voie"@fr ,
+                           "Track purpose"@en ,
+                           "Zweck der Spur"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Track_Type
 ec:Track_Type rdf:type owl:Class ;
               rdfs:subClassOf skos:Concept ;
-              dcterms:description "To define a type of track."@en ;
-              rdfs:label "Track type"@en .
+              dcterms:description "Pour définir un type de piste."@fr ,
+                                  "To define a type of track."@en ,
+                                  "Um eine Art von Track zu definieren."@de ;
+              rdfs:label "Spur Typ"@de ,
+                         "Track type"@en ,
+                         "Type de voie"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Trailer
@@ -11191,14 +14221,23 @@ ec:Trailer rdf:type owl:Class ;
                              owl:onProperty ec:promotes ;
                              owl:allValuesFrom ec:EditorialWork
                            ] ;
-           dcterms:description "Trailer"@en .
+           dcterms:description "AV-Sequenz, die einen Film, eine Serie oder eine Fernsehsendung bewirbt."@de ,
+                               "An AV sequence promoting a film, series or television programme."@en ,
+                               "Séquence AV faisant la promotion d’un film, d'une série ou d’une émission de télévision."@fr ;
+           rdfs:label "Anhänger"@de ,
+                      "Bande annonce"@fr ,
+                      "Trailer"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Type
 ec:Type rdf:type owl:Class ;
         rdfs:subClassOf skos:Concept ;
-        dcterms:description "An expression of type in textual form or as a term from a classification scheme."@en ;
-        rdfs:label "Type"@en .
+        dcterms:description "An expression of type in textual form or as a term from a classification scheme."@en ,
+                            "Ein Ausdruck des Typs in Textform oder als Begriff aus einem Klassifikationsschema."@de ,
+                            "Une expression de type sous forme textuelle ou en tant que terme d'un schéma de classification."@fr ;
+        rdfs:label "Typ"@de ,
+                   "Type"@en ,
+                   "Type"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#UncertainDate
@@ -11228,71 +14267,100 @@ ec:UncertainDate rdf:type owl:Class ;
                                    owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                  ] ;
                  owl:disjointWith time:DateTimeDescription ;
-                 dcterms:description """The date expressed as an interval between start and end, for uncertain  dates.
-Aditional infomation can be written in the description property"""@en ;
-                 rdfs:label "Uncertain date"@en .
+                 dcterms:description "Das Datum, ausgedrückt als Intervall zwischen Start und Ende, für unsichere Daten. Zusätzliche Informationen können in der Eigenschaft Beschreibung angegeben werden"@de ,
+                                     "La date exprimée sous la forme d'un intervalle entre le début et la fin, pour les dates incertaines. Des informations supplémentaires peuvent être écrites dans la propriété description."@fr ,
+                                     "The date expressed as an interval between start and end, for uncertain dates. Aditional infomation can be written in the description property"@en ;
+                 rdfs:label "Date incertaine"@fr ,
+                            "Uncertain date"@en ,
+                            "Ungewisses Datum"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#UsageRestrictions
 ec:UsageRestrictions rdf:type owl:Class ;
                      rdfs:subClassOf ec:Rights ;
-                     dcterms:description "To define a set of UsageRestrictions."@en ;
-                     rdfs:label "Usage restrictions"@en .
+                     dcterms:description "Pour définir un ensemble de UsageRestrictions."@fr ,
+                                         "So definieren Sie eine Reihe von Nutzungseinschränkungen."@de ,
+                                         "To define a set of UsageRestrictions."@en ;
+                     rdfs:label "Einschränkungen bei der Verwendung"@de ,
+                                "Restrictions d'utilisation"@fr ,
+                                "Usage restrictions"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#UsageRights
 ec:UsageRights rdf:type owl:Class ;
                rdfs:subClassOf ec:Rights ;
-               dcterms:description "Usage rights associated with content."@en ;
-               rdfs:label "Usage rights"@en .
+               dcterms:description "Droits d'utilisation associés au contenu."@fr ,
+                                   "Mit den Inhalten verbundene Nutzungsrechte."@de ,
+                                   "Usage rights associated with content."@en ;
+               rdfs:label "Droits d'utilisation"@fr ,
+                          "Nutzungsrechte"@de ,
+                          "Usage rights"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#VideoCodec
 ec:VideoCodec rdf:type owl:Class ;
               rdfs:subClassOf ec:Codec ;
-              dcterms:description "To provide information about a video codec."@en ;
-              rdfs:label "Video codec"@en .
+              dcterms:description "Pour fournir des informations sur un codec vidéo."@fr ,
+                                  "To provide information about a video codec."@en ,
+                                  "Zur Bereitstellung von Informationen über einen Videocodec."@de ;
+              rdfs:label "Codec vidéo"@fr ,
+                         "Video Codec"@de ,
+                         "Video codec"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#VideoEncodingFormat
 ec:VideoEncodingFormat rdf:type owl:Class ;
                        rdfs:subClassOf ec:EncodingFormat ;
-                       dcterms:description "The encoding format of the video."@en ;
-                       rdfs:label "Video encoding format"@en .
+                       dcterms:description "Das Kodierungsformat des Videos."@de ,
+                                           "Le format d'encodage de la vidéo."@fr ,
+                                           "The encoding format of the video."@en ;
+                       rdfs:label "Format d'encodage vidéo"@fr ,
+                                  "Format der Videokodierung"@de ,
+                                  "Video encoding format"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#VideoFormat
 ec:VideoFormat rdf:type owl:Class ;
                rdfs:subClassOf ec:Format ;
                dcterms:description "Spezifiziert das Videoformat der Medienressource."@de ,
+                                   "Spezifiziert das Videoformat der Medienressource."@fr ,
                                    "To specify the format used for video."@en ;
-               rdfs:label "Video format"@en ,
+               rdfs:label "Format vidéo"@fr ,
+                          "Video format"@en ,
                           "Videoformat"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#VideoStream
 ec:VideoStream rdf:type owl:Class ;
                rdfs:subClassOf ec:Stream ;
-               dcterms:description "A decodable video stream of bits."@en ;
-               rdfs:label "Video stream"@en .
+               dcterms:description "A decodable video stream of bits."@en ,
+                                   "Ein dekodierbarer Videostrom aus Bits."@de ,
+                                   "Un flux vidéo décodable de bits."@fr ;
+               rdfs:label "Flux vidéo"@fr ,
+                          "Video stream"@en ,
+                          "Video-Stream"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#VideoTrack
 ec:VideoTrack rdf:type owl:Class ;
               rdfs:subClassOf ec:Track ;
-              dcterms:description """A specialisation of Track for Video to provide
-            a link to specific data properties such as frameRate, etc. Signing is another possible
-            example of video track. Specific VideoTracks such as Signing can be defined as sub
-            VideoTracks.. In advanced systems, different VideoTracks can be used to provide e.g.
-            different viewing angles."""@en ;
-              rdfs:label "Video track"@en .
+              dcterms:description "A specialisation of Track for Video to provide a link to specific data properties such as frameRate, etc. Signing is another possible example of video track. Specific VideoTracks such as Signing can be defined as sub VideoTracks.. In advanced systems, different VideoTracks can be used to provide e.g. different viewing angles."@en ,
+                                  "Eine Spezialisierung von Track for Video zur Bereitstellung eine Verknüpfung zu bestimmten Dateneigenschaften wie FrameRate usw. Signieren ist ein weiteres mögliches Beispiel für eine Videospur. Spezifische VideoTracks wie Signing können als Sub definiert werden VideoTracks definiert werden. In fortgeschrittenen Systemen können verschiedene VideoTracks verwendet werden, um z.B. unterschiedliche Blickwinkel zu bieten."@de ,
+                                  "Une spécialisation de Track for Video pour fournir un lien vers des propriétés de données spécifiques telles que le frameRate, etc. La signature est un autre exemple possible exemple possible de piste vidéo. Des VideoTracks spécifiques tels que Signing peuvent être définis en tant que sub VideoTracks . Dans les systèmes avancés, différents VideoTracks peuvent être utilisés pour fournir par exemple différents angles de vue."@fr ;
+              rdfs:label "Piste vidéo"@fr ,
+                         "Video track"@en ,
+                         "Video-Spur"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#WrappingType
 ec:WrappingType rdf:type owl:Class ;
                 rdfs:subClassOf skos:Concept ;
-                dcterms:description "To define a type of wrapping."@en ;
-                rdfs:label "Wrapping type"@en .
+                dcterms:description "Pour définir un type d'emballage."@fr ,
+                                    "To define a type of wrapping."@en ,
+                                    "Um eine Art der Umhüllung zu definieren."@de ;
+                rdfs:label "Art der Umhüllung"@de ,
+                           "Type d'emballage"@fr ,
+                           "Wrapping type"@en .
 
 
 ###  http://www.w3.org/2004/02/skos/core#Concept
@@ -11315,8 +14383,12 @@ time:DateTimeDescription rdf:type owl:Class ;
                                            owl:onProperty time:year ;
                                            owl:allValuesFrom xsd:gYear
                                          ] ;
-                         dcterms:description "Description of date and time structured with separate values for the various elements of a calendar-clock system. The temporal reference system is fixed to Gregorian Calendar, and the range of year, month, day properties restricted to corresponding XML Schema types xsd:gYear, xsd:gMonth and xsd:gDay, respectively."@en ;
-                         rdfs:label "Date-time description"@en .
+                         dcterms:description "Beschreibung von Datum und Uhrzeit, strukturiert mit separaten Werten für die verschiedenen Elemente eines Kalender-Uhr-Systems. Das zeitliche Bezugssystem ist auf den Gregorianischen Kalender festgelegt und der Bereich der Eigenschaften Jahr, Monat und Tag ist auf die entsprechenden XML-Schema-Typen xsd:gYear, xsd:gMonth bzw. xsd:gDay beschränkt."@de ,
+                                             "Description de la date et de l'heure structurée avec des valeurs distinctes pour les différents éléments d'un système calendrier-horloge. Le système de référence temporel est fixé au calendrier grégorien, et la plage des propriétés année, mois, jour est limitée aux types XML Schema correspondants xsd:gYear, xsd:gMonth et xsd:gDay, respectivement."@fr ,
+                                             "Description of date and time structured with separate values for the various elements of a calendar-clock system. The temporal reference system is fixed to Gregorian Calendar, and the range of year, month, day properties restricted to corresponding XML Schema types xsd:gYear, xsd:gMonth and xsd:gDay, respectively."@en ;
+                         rdfs:label "Date-time description"@en ,
+                                    "Datum-Zeit-Beschreibung"@de ,
+                                    "Description de la date et de l'heure"@fr .
 
 
 ###  http://www.w3.org/2006/time#Instant
@@ -11330,14 +14402,22 @@ time:Instant rdf:type owl:Class ;
                                owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                owl:onDataRange xsd:dateTimeStamp
                              ] ;
-             dc:description "A temporal entity with zero extent or duration"@en ;
-             rdfs:label "Time instant"@en .
+             dcterms:description "A temporal entity with zero extent or duration"@en ,
+                                 "Eine zeitliche Einheit ohne Ausmaß oder Dauer"@de ,
+                                 "Une entité temporelle dont l'étendue ou la durée est nulle"@fr ;
+             rdfs:label "Time instant"@en ,
+                        "Un instant"@fr ,
+                        "Zeit sofort"@de .
 
 
 ###  http://www.w3.org/2006/time#TRS
 time:TRS rdf:type owl:Class ;
-         dcterms:description "A temporal reference system, such as a temporal coordinate reference system (with an origin, direction, and scale), a calendar-clock combination, or a (possibly hierarchical) ordinal system."@en ;
-         rdfs:label "Temporal reference system"@en .
+         dcterms:description "A temporal reference system, such as a temporal coordinate reference system (with an origin, direction, and scale), a calendar-clock combination, or a (possibly hierarchical) ordinal system."@en ,
+                             "Ein zeitliches Referenzsystem, wie z.B. ein zeitliches Koordinatenreferenzsystem (mit Ursprung, Richtung und Maßstab), eine Kalender-Uhr-Kombination oder ein (möglicherweise hierarchisches) Ordinalsystem."@de ,
+                             "Un système de référence temporel, tel qu'un système de référence à coordonnées temporelles (avec une origine, une direction et une échelle), une combinaison calendrier-horloge ou un système ordinal (éventuellement hiérarchique)."@fr ;
+         rdfs:label "Système de référence temporel"@fr ,
+                    "Temporal reference system"@en ,
+                    "Zeitliches Bezugssystem"@de .
 
 
 #################################################################
@@ -11425,13 +14505,12 @@ ec:workingTitle rdf:type owl:NamedIndividual ,
 #    Annotations
 #################################################################
 
-dcterms:contributor dcterms:description "In the context of EBUCore, reserved for the annotation of RDF properties."@en ;
-                     rdfs:label "Contributor"@en .
-
-
-<http://www.w3.org/ns/ma-ont#hasPermissions> dcterms:description "To define permissions as defined in the W3C media ontology (ma-ont)" ;
-                                             skos:prefLabel "Permissions" ;
-                                             rdfs:label "Permissions" .
+dcterms:contributor dcterms:description "Dans le contexte d'EBUCore, réservé à l'annotation des propriétés RDF."@fr ;
+                     rdfs:label "Beitragender"@de ;
+                     dcterms:description "In the context of EBUCore, reserved for the annotation of RDF properties."@en ,
+                                         "Im Kontext von EBUCore für die Annotation von RDF-Eigenschaften reserviert."@de ;
+                     rdfs:label "Contributor"@en ,
+                                "Contributeur"@fr .
 
 
 ###  Generated by the OWL API (version 4.5.9.2019-02-01T07:24:44Z) https://github.com/owlcs/owlapi


### PR DESCRIPTION
Added rdfs:label and dcterms:description in French and German and sometimes English for:
- classes
- object properties
- data properties 
Corrected type of rdfs:label and dcterms:description. 
Defined labels and descriptions when it is possible.