### PR TITLE
inconsistent use of `promotes`

### DIFF
--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -10669,7 +10669,11 @@ ec:EditorialWork rdf:type owl:Class ;
                                  ] ,
                                  [ rdf:type owl:Restriction ;
                                    owl:onProperty ec:promotes ;
-                                   owl:allValuesFrom ec:EditorialWork
+                                   owl:allValuesFrom [ rdf:type owl:Class ;
+                                                       owl:unionOf ( ec:EditorialGroup
+                                                                     ec:EditorialWork
+                                                                   )
+                                                     ]
                                  ] ;
                  rdfs:label "Editorial work"@en ,
                             "Werk"@de ,
@@ -14906,15 +14910,7 @@ ec:Track_Type rdf:type owl:Class ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Trailer
 ec:Trailer rdf:type owl:Class ;
-           rdfs:subClassOf ec:EditorialWork ,
-                           [ rdf:type owl:Restriction ;
-                             owl:onProperty ec:promotes ;
-                             owl:allValuesFrom ec:EditorialGroup
-                           ] ,
-                           [ rdf:type owl:Restriction ;
-                             owl:onProperty ec:promotes ;
-                             owl:allValuesFrom ec:EditorialWork
-                           ] ;
+           rdfs:subClassOf ec:EditorialWork ;
            dcterms:description "AV-Sequenz, die einen Film, eine Serie oder eine Fernsehsendung bewirbt."@de ,
                                "An AV sequence promoting a film, series or television programme."@en ,
                                "Séquence AV faisant la promotion d’un film, d'une série ou d’une émission de télévision."@fr ;


### PR DESCRIPTION
cleaned up inconsistent use of `promotes` for `Trailer` and `EditorialWork`