### PR TITLE
299 refactoring has property cluster 1

### DIFF
--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -308,7 +308,7 @@ ec:approvedBy rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#artefactDateOfSell
 ec:artefactDateOfSell rdf:type owl:ObjectProperty ;
-                      rdfs:subPropertyOf ec:date ;
+                      rdfs:subPropertyOf ec:hasDate ;
                       rdfs:range time:Instant ;
                       dcterms:description "Das Datum, an dem ein Artefakt verkauft wurde."@de ,
                                           "La date à laquelle un artefact a été vendu."@fr ,
@@ -340,7 +340,7 @@ ec:auditReportDate rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#awardDate
 ec:awardDate rdf:type owl:ObjectProperty ;
-             rdfs:subPropertyOf ec:date ;
+             rdfs:subPropertyOf ec:hasDate ;
              rdfs:range time:Instant ;
              dcterms:description "Pour fournir une date à laquelle un prix a été livré."@fr ,
                                  "To provide an date when an Award was delivered."@en ,
@@ -533,22 +533,9 @@ ec:createsMetadata rdf:type owl:ObjectProperty ;
                               "erstellt Metadaten"@de .
 
 
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#date
-ec:date rdf:type owl:ObjectProperty ;
-        rdfs:range time:Instant ;
-        dc:description "Range: Litteral, on the instance level, this can be restricted to dateTime, date or another suitable format."@en ;
-        dcterms:description "A date associated to an Asset. Range: Litteral, on the instance level, this can be restricted to dateTime, date or another suitable format."@en ,
-                            "Ein Datum, das mit einem Asset verbunden ist. Range: Litteral, auf Instanzebene kann dies auf dateTime, Datum oder ein anderes geeignetes Format beschränkt werden."@de ,
-                            "Une date associée à un actif. Range : Litteral, au niveau de l'instance, cela peut être limité à dateTime, date ou un autre format approprié."@fr ;
-        rdfs:isDefinedBy dc:date ;
-        rdfs:label "Date"@en ,
-                   "Date"@fr ,
-                   "Datum"@de .
-
-
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateArchived
 ec:dateArchived rdf:type owl:ObjectProperty ;
-                rdfs:subPropertyOf ec:date ;
+                rdfs:subPropertyOf ec:hasDate ;
                 rdfs:range time:Instant ;
                 dcterms:description "Das Datum, an dem das Asset archiviert wurde."@de ,
                                     "La date à laquelle l'actif a été archivé."@fr ,
@@ -560,7 +547,7 @@ ec:dateArchived rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateBroadcast
 ec:dateBroadcast rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf ec:date ;
+                 rdfs:subPropertyOf ec:hasDate ;
                  rdfs:range time:Instant ;
                  dcterms:description "Das Datum, an dem der Asset zum ersten Mal öffentlich im Fernsehen, Radio oder per Streaming ausgestrahlt wurde."@de ,
                                      "La date à laquelle l'actif a été diffusé pour la première fois en public à la télévision ou à la radio ou par streaming."@fr ,
@@ -572,7 +559,7 @@ ec:dateBroadcast rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateCreated
 ec:dateCreated rdf:type owl:ObjectProperty ;
-               rdfs:subPropertyOf ec:date ;
+               rdfs:subPropertyOf ec:hasDate ;
                rdfs:range time:Instant ;
                dcterms:description "Das Datum der Erstellung des Assets."@de ,
                                    "La date de création de l'actif."@fr ,
@@ -584,7 +571,7 @@ ec:dateCreated rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateDeleted
 ec:dateDeleted rdf:type owl:ObjectProperty ;
-               rdfs:subPropertyOf ec:date ;
+               rdfs:subPropertyOf ec:hasDate ;
                rdfs:range time:Instant ;
                dcterms:description "Das Datum, an dem die Ressource gelöscht wurde."@de ,
                                    "La date à laquelle la ressource a été supprimée."@fr ,
@@ -596,7 +583,7 @@ ec:dateDeleted rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateDigitised
 ec:dateDigitised rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf ec:date ;
+                 rdfs:subPropertyOf ec:hasDate ;
                  rdfs:range time:Instant ;
                  dcterms:description "Das Datum, an dem die Ressource digitalisiert wurde."@de ,
                                      "La date à laquelle la ressource a été numérisée."@fr ,
@@ -608,7 +595,7 @@ ec:dateDigitised rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateDistributed
 ec:dateDistributed rdf:type owl:ObjectProperty ;
-                   rdfs:subPropertyOf ec:date ;
+                   rdfs:subPropertyOf ec:hasDate ;
                    rdfs:range time:Instant ;
                    dcterms:description "Das Datum, an dem die Ressource erstmals der Öffentlichkeit zum Kauf, Download oder Online-Zugriff zur Verfügung gestellt wurde."@de ,
                                        "La date à laquelle la ressource a été mise pour la première fois à la disposition du public pour l'achat, le téléchargement ou l'accès en ligne."@fr ,
@@ -620,7 +607,7 @@ ec:dateDistributed rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateIngested
 ec:dateIngested rdf:type owl:ObjectProperty ;
-                rdfs:subPropertyOf ec:date ;
+                rdfs:subPropertyOf ec:hasDate ;
                 rdfs:range time:Instant ;
                 dcterms:description "Das Datum, an dem die Ressource in den institutionellen Bestand aufgenommen/erworben wurde."@de ,
                                     "La date à laquelle la ressource a été ingérée/acquise dans les fonds institutionnels."@fr ,
@@ -632,7 +619,7 @@ ec:dateIngested rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateIssued
 ec:dateIssued rdf:type owl:ObjectProperty ;
-              rdfs:subPropertyOf ec:date ;
+              rdfs:subPropertyOf ec:hasDate ;
               rdfs:range time:Instant ;
               dcterms:description "Das Datum, an dem das Asset ausgegeben wurde."@de ,
                                   "La date à laquelle l'actif a été émis."@fr ,
@@ -644,7 +631,7 @@ ec:dateIssued rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateLicenseEnd
 ec:dateLicenseEnd rdf:type owl:ObjectProperty ;
-                  rdfs:subPropertyOf ec:date ;
+                  rdfs:subPropertyOf ec:hasDate ;
                   rdfs:range time:Instant ;
                   dcterms:description "Das Datum, an dem die Lizenz für das Asset endet."@de ,
                                       "La date à laquelle la licence de l'actif prend fin."@fr ,
@@ -656,7 +643,7 @@ ec:dateLicenseEnd rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateMigrated
 ec:dateMigrated rdf:type owl:ObjectProperty ;
-                rdfs:subPropertyOf ec:date ;
+                rdfs:subPropertyOf ec:hasDate ;
                 rdfs:range time:Instant ;
                 dcterms:description "Das Datum, an dem die Ressource kopiert oder von einem veralteten oder gefährdeten Originalformat in ein aktuelleres Format zur Aufbewahrung konvertiert wurde."@de ,
                                     "La date à laquelle la ressource a été copiée ou convertie d'un format original obsolète ou menacé à un format plus actualisé pour la conservation."@fr ,
@@ -668,7 +655,7 @@ ec:dateMigrated rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateModified
 ec:dateModified rdf:type owl:ObjectProperty ;
-                rdfs:subPropertyOf ec:date ;
+                rdfs:subPropertyOf ec:hasDate ;
                 rdfs:range time:Instant ;
                 dcterms:description "Pour indiquer la date à laquelle l'actif a été modifié."@fr ,
                                     "To indicate the date at which the Asset has been modified."@en ,
@@ -680,7 +667,7 @@ ec:dateModified rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateNormalized
 ec:dateNormalized rdf:type owl:ObjectProperty ;
-                  rdfs:subPropertyOf ec:date ;
+                  rdfs:subPropertyOf ec:hasDate ;
                   rdfs:range time:Instant ;
                   dcterms:description "Das Datum, an dem die Ressource aus ihrem ursprünglichen Format in ein von der Institution für die Aufbewahrung ausgewähltes Format konvertiert wurde."@de ,
                                       "La date à laquelle la ressource a été convertie de son format original en un format présélectionné par l'institution pour la préservation."@fr ,
@@ -692,7 +679,7 @@ ec:dateNormalized rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateOfBirth
 ec:dateOfBirth rdf:type owl:ObjectProperty ;
-               rdfs:subPropertyOf ec:date ;
+               rdfs:subPropertyOf ec:hasDate ;
                rdfs:range time:Instant ;
                dcterms:description "Das Datum, an dem ein Kontakt/eine Person geboren wird."@de ,
                                    "La date de naissance d'un contact/personne."@fr ,
@@ -704,7 +691,7 @@ ec:dateOfBirth rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateOfDeath
 ec:dateOfDeath rdf:type owl:ObjectProperty ;
-               rdfs:subPropertyOf ec:date ;
+               rdfs:subPropertyOf ec:hasDate ;
                rdfs:range time:Instant ;
                dcterms:description "Das Datum, an dem ein Kontakt/eine Person verstorben ist."@de ,
                                    "La date à laquelle un contact/personne est décédé."@fr ,
@@ -716,7 +703,7 @@ ec:dateOfDeath rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateOfRetirement
 ec:dateOfRetirement rdf:type owl:ObjectProperty ;
-                    rdfs:subPropertyOf ec:date ;
+                    rdfs:subPropertyOf ec:hasDate ;
                     rdfs:range time:Instant ;
                     dcterms:description "Das Datum, an dem ein Kontakt/eine Person in den Ruhestand getreten ist."@de ,
                                         "La date à laquelle un contact/personne a pris sa retraite."@fr ,
@@ -728,7 +715,7 @@ ec:dateOfRetirement rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateProduced
 ec:dateProduced rdf:type owl:ObjectProperty ;
-                rdfs:subPropertyOf ec:date ;
+                rdfs:subPropertyOf ec:hasDate ;
                 rdfs:range time:Instant ;
                 dcterms:description "Das Datum der Produktion des Assets."@de ,
                                     "La date de production de l'actif."@fr ,
@@ -740,7 +727,7 @@ ec:dateProduced rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateReleased
 ec:dateReleased rdf:type owl:ObjectProperty ;
-                rdfs:subPropertyOf ec:date ;
+                rdfs:subPropertyOf ec:hasDate ;
                 rdfs:range time:Instant ;
                 dcterms:description "Das Datum, an dem die Ressource erstmals der Öffentlichkeit zum Kauf, Download oder Online-Zugriff zur Verfügung gestellt wurde."@de ,
                                     "La date à laquelle la ressource a été mise pour la première fois à la disposition du public pour l'achat, le téléchargement ou l'accès en ligne."@fr ,
@@ -752,7 +739,7 @@ ec:dateReleased rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateTransferred
 ec:dateTransferred rdf:type owl:ObjectProperty ;
-                   rdfs:subPropertyOf ec:date ;
+                   rdfs:subPropertyOf ec:hasDate ;
                    rdfs:range time:Instant ;
                    dcterms:description "Das Datum, an dem das Asset von einem digitalen oder physischen Ort zu einem anderen verschoben wurde."@de ,
                                        "La date à laquelle l'actif a été déplacé d'un emplacement numérique ou physique à un autre."@fr ,
@@ -764,7 +751,7 @@ ec:dateTransferred rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateValidated
 ec:dateValidated rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf ec:date ;
+                 rdfs:subPropertyOf ec:hasDate ;
                  rdfs:range time:Instant ;
                  dcterms:description "Das letzte Datum, an dem die Ressource durch manuelle oder digitale QC als gültig bestätigt wurde."@de ,
                                      "La date la plus récente à laquelle la validité de la ressource a été confirmée par un CQ manuel ou numérique."@fr ,
@@ -776,7 +763,7 @@ ec:dateValidated rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#datelicensedStart
 ec:datelicensedStart rdf:type owl:ObjectProperty ;
-                     rdfs:subPropertyOf ec:date ;
+                     rdfs:subPropertyOf ec:hasDate ;
                      rdfs:range time:Instant ;
                      dcterms:description "Das Datum, an dem die Lizenz für das Asset beginnt."@de ,
                                          "La date à laquelle la licence pour le bien commence."@fr ,
@@ -833,7 +820,7 @@ ec:end rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#endDateTime
 ec:endDateTime rdf:type owl:ObjectProperty ;
-               rdfs:subPropertyOf ec:date ;
+               rdfs:subPropertyOf ec:hasDate ;
                rdfs:range time:Instant ;
                dcterms:description "Das Ende eines Intervalls beschreiben"@de ,
                                    "Describing an end of an interval"@en ,
@@ -1100,7 +1087,7 @@ ec:hasArtefactBuyer rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasArtefactDateOfPurchase
 ec:hasArtefactDateOfPurchase rdf:type owl:ObjectProperty ;
-                             rdfs:subPropertyOf ec:date ;
+                             rdfs:subPropertyOf ec:hasDate ;
                              rdfs:range time:Instant ;
                              dcterms:description "Das Datum, an dem ein Artefakt gekauft wurde. ."@de ,
                                                  "La date à laquelle un artefact a été acheté. ."@fr ,
@@ -1720,6 +1707,19 @@ ec:hasDataTrack rdf:type owl:ObjectProperty ;
                 rdfs:label "Data track"@en ,
                            "Daten verfolgen"@de ,
                            "Suivi des données"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDate
+ec:hasDate rdf:type owl:ObjectProperty ;
+           rdfs:range time:Instant ;
+           dc:description "Range: Litteral, on the instance level, this can be restricted to dateTime, date or another suitable format."@en ;
+           dcterms:description "A date associated to an Asset. Range: Litteral, on the instance level, this can be restricted to dateTime, date or another suitable format."@en ,
+                               "Ein Datum, das mit einem Asset verbunden ist. Range: Litteral, auf Instanzebene kann dies auf dateTime, Datum oder ein anderes geeignetes Format beschränkt werden."@de ,
+                               "Une date associée à un actif. Range : Litteral, au niveau de l'instance, cela peut être limité à dateTime, date ou un autre format approprié."@fr ;
+           rdfs:isDefinedBy dc:date ;
+           rdfs:label "Date"@en ,
+                      "Date"@fr ,
+                      "Datum"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDepartment
@@ -4415,7 +4415,7 @@ ec:start rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#startDateTime
 ec:startDateTime rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf ec:date ;
+                 rdfs:subPropertyOf ec:hasDate ;
                  rdfs:range time:Instant ;
                  dcterms:description "A point of time or start of an interval"@en ,
                                      "Ein Zeitpunkt oder der Beginn eines Intervalls"@de ,

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -306,16 +306,6 @@ ec:approvedBy rdf:type owl:ObjectProperty ;
                          "Agent"@fr .
 
 
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#auditReportDate
-ec:auditReportDate rdf:type owl:ObjectProperty ;
-                   dcterms:description "Das Datum der Veröffentlichung eines AuditReports."@de ,
-                                       "La date de publication d'un rapport d'audit."@fr ,
-                                       "The date of release of an AuditReport."@en ;
-                   rdfs:label "Audit report date"@en ,
-                              "Date du rapport d'audit"@fr ,
-                              "Datum des Prüfungsberichts"@de .
-
-
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#awardDate
 ec:awardDate rdf:type owl:ObjectProperty ;
              rdfs:subPropertyOf ec:hasDate ;
@@ -1325,6 +1315,16 @@ ec:hasAuditJobRelatedAuditReport rdf:type owl:ObjectProperty ;
                                  rdfs:label "Rapport d'audit connexe"@fr ,
                                             "Related audit report"@en ,
                                             "Zugehöriger Prüfbericht"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAuditReportDate
+ec:hasAuditReportDate rdf:type owl:ObjectProperty ;
+                      dcterms:description "Das Datum der Veröffentlichung eines AuditReports."@de ,
+                                          "La date de publication d'un rapport d'audit."@fr ,
+                                          "The date of release of an AuditReport."@en ;
+                      rdfs:label "Audit report date"@en ,
+                                 "Date du rapport d'audit"@fr ,
+                                 "Datum des Prüfungsberichts"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasBeenAwarded
@@ -8787,7 +8787,7 @@ ec:AuditJob rdf:type owl:Class ;
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AuditReport
 ec:AuditReport rdf:type owl:Class ;
                rdfs:subClassOf [ rdf:type owl:Restriction ;
-                                 owl:onProperty ec:auditReportDate ;
+                                 owl:onProperty ec:hasAuditReportDate ;
                                  owl:allValuesFrom time:Instant
                                ] ,
                                [ rdf:type owl:Restriction ;

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -306,18 +306,6 @@ ec:approvedBy rdf:type owl:ObjectProperty ;
                          "Agent"@fr .
 
 
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#awardDate
-ec:awardDate rdf:type owl:ObjectProperty ;
-             rdfs:subPropertyOf ec:hasDate ;
-             rdfs:range time:Instant ;
-             dcterms:description "Pour fournir une date à laquelle un prix a été livré."@fr ,
-                                 "To provide an date when an Award was delivered."@en ,
-                                 "Zur Angabe des Datums, an dem ein Award zugestellt wurde."@de ;
-             rdfs:label "Award date"@en ,
-                        "Date d'attribution"@fr ,
-                        "Datum der Vergabe"@de .
-
-
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#basedOn
 ec:basedOn rdf:type owl:ObjectProperty ;
            dcterms:description "Pour identifier l'EditorialObject auquel se rapporte un ProductionJob à."@fr ,
@@ -1325,6 +1313,18 @@ ec:hasAuditReportDate rdf:type owl:ObjectProperty ;
                       rdfs:label "Audit report date"@en ,
                                  "Date du rapport d'audit"@fr ,
                                  "Datum des Prüfungsberichts"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAwardDate
+ec:hasAwardDate rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf ec:hasDate ;
+                rdfs:range time:Instant ;
+                dcterms:description "Pour fournir une date à laquelle un prix a été livré."@fr ,
+                                    "To provide an date when an Award was delivered."@en ,
+                                    "Zur Angabe des Datums, an dem ein Award zugestellt wurde."@de ;
+                rdfs:label "Award date"@en ,
+                           "Date d'attribution"@fr ,
+                           "Datum der Vergabe"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasBeenAwarded
@@ -8868,7 +8868,7 @@ ec:Award rdf:type owl:Class ;
                            owl:allValuesFrom skos:Concept
                          ] ,
                          [ rdf:type owl:Restriction ;
-                           owl:onProperty ec:awardDate ;
+                           owl:onProperty ec:hasAwardDate ;
                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                            owl:onClass time:Instant
                          ] ,

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -395,16 +395,6 @@ ec:consumesEssence rdf:type owl:ObjectProperty ;
                               "Essenz"@de .
 
 
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#consumptionLicenceLink
-ec:consumptionLicenceLink rdf:type owl:ObjectProperty ;
-                          dcterms:description "A link to the terms of a ConsumptionLicence."@en ,
-                                              "Ein Link zu den Bedingungen einer ConsumptionLicence."@de ,
-                                              "Un lien vers les conditions d'une licence de consommation."@fr ;
-                          rdfs:label "Consumption licence link"@en ,
-                                     "Lien vers le permis de consommation"@fr ,
-                                     "Link zur Verbrauchslizenz"@de .
-
-
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#contractCostAmountCurrency
 ec:contractCostAmountCurrency rdf:type owl:ObjectProperty ;
                               dcterms:description "Die Währung des Betrags der ContractCost."@de ,
@@ -1473,6 +1463,16 @@ ec:hasConsumptionEventResumePoint rdf:type owl:ObjectProperty ;
                                   rdfs:label "Consumption event resume point"@en ,
                                              "Point de reprise de l'événement de consommation"@fr ,
                                              "Punkt für die Fortsetzung des Verbrauchsereignisses"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasConsumptionLicenceLink
+ec:hasConsumptionLicenceLink rdf:type owl:ObjectProperty ;
+                             dcterms:description "A link to the terms of a ConsumptionLicence."@en ,
+                                                 "Ein Link zu den Bedingungen einer ConsumptionLicence."@de ,
+                                                 "Un lien vers les conditions d'une licence de consommation."@fr ;
+                             rdfs:label "Consumption licence link"@en ,
+                                        "Lien vers le permis de consommation"@fr ,
+                                        "Link zur Verbrauchslizenz"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContact
@@ -9645,7 +9645,7 @@ ec:ConsumptionLicence rdf:type owl:Class ;
                                         owl:allValuesFrom skos:Concept
                                       ] ,
                                       [ rdf:type owl:Restriction ;
-                                        owl:onProperty ec:consumptionLicenceLink ;
+                                        owl:onProperty ec:hasConsumptionLicenceLink ;
                                         owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                         owl:onClass ec:Contract
                                       ] ,

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -1,7 +1,6 @@
-@prefix :<http://www.ebu.ch/metadata/ontologies/ebucoreplus#> .
+@prefix : <http://www.ebu.ch/metadata/ontologies/ebucoreplus#> .
 @prefix cc: <http://creativecommons.org/ns#> .
-@prefix dc: <http://purl.org/dc/elements/1.1/>
- .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix ec: <http://www.ebu.ch/metadata/ontologies/ebucoreplus#> .
 @prefix vs: <http://www.w3.org/2003/06/sw-vocab-status/ns#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
@@ -12,12 +11,9 @@
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix spin: <http://spinrdf.org/spin#> .
 @prefix time: <http://www.w3.org/2006/time#> .
-@prefix vann: <http://purl.org/vocab/vann/>
- .
-@prefix xkos: <https://rdf-vocabulary.ddialliance.org/xkos/>
- .
-@prefix dcterms: <http://purl.org/dc/terms/>
- .
+@prefix vann: <http://purl.org/vocab/vann/> .
+@prefix xkos: <https://rdf-vocabulary.ddialliance.org/xkos/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
 @base <http://www.ebu.ch/metadata/ontologies/ebucoreplus> .
 
 <http://www.ebu.ch/metadata/ontologies/ebucoreplus> rdf:type owl:Ontology ;
@@ -308,18 +304,6 @@ ec:approvedBy rdf:type owl:ObjectProperty ;
               rdfs:label "Agent"@de ,
                          "Agent"@en ,
                          "Agent"@fr .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#artefactDateOfPurchase
-ec:artefactDateOfPurchase rdf:type owl:ObjectProperty ;
-                          rdfs:subPropertyOf ec:date ;
-                          rdfs:range time:Instant ;
-                          dcterms:description "Das Datum, an dem ein Artefakt gekauft wurde. ."@de ,
-                                              "La date à laquelle un artefact a été acheté. ."@fr ,
-                                              "The date when an Artefact was purchased. ."@en ;
-                          rdfs:label "Artefact date of purchase"@en ,
-                                     "Date d'achat de l'artefact"@fr ,
-                                     "Kaufdatum des Artefakts"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#artefactDateOfSell
@@ -1112,6 +1096,18 @@ ec:hasArtefactBuyer rdf:type owl:ObjectProperty ;
                     rdfs:label "Acheteur"@fr ,
                                "Buyer"@en ,
                                "Käufer"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasArtefactDateOfPurchase
+ec:hasArtefactDateOfPurchase rdf:type owl:ObjectProperty ;
+                             rdfs:subPropertyOf ec:date ;
+                             rdfs:range time:Instant ;
+                             dcterms:description "Das Datum, an dem ein Artefakt gekauft wurde. ."@de ,
+                                                 "La date à laquelle un artefact a été acheté. ."@fr ,
+                                                 "The date when an Artefact was purchased. ."@en ;
+                             rdfs:label "Artefact date of purchase"@en ,
+                                        "Date d'achat de l'artefact"@fr ,
+                                        "Kaufdatum des Artefakts"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasArtefactOwner
@@ -8045,12 +8041,12 @@ ec:Artefact rdf:type owl:Class ;
                               owl:allValuesFrom skos:Concept
                             ] ,
                             [ rdf:type owl:Restriction ;
-                              owl:onProperty ec:artefactDateOfPurchase ;
+                              owl:onProperty ec:artefactDateOfSell ;
                               owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                               owl:onClass time:Instant
                             ] ,
                             [ rdf:type owl:Restriction ;
-                              owl:onProperty ec:artefactDateOfSell ;
+                              owl:onProperty ec:hasArtefactDateOfPurchase ;
                               owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                               owl:onClass time:Instant
                             ] ,

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -395,16 +395,6 @@ ec:consumesEssence rdf:type owl:ObjectProperty ;
                               "Essenz"@de .
 
 
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#consumptionDeviceManufacturer
-ec:consumptionDeviceManufacturer rdf:type owl:ObjectProperty ;
-                                 dcterms:description "Der Hersteller eines ConsumptionDevice."@de ,
-                                                     "Le fabricant d'un ConsumptionDevice."@fr ,
-                                                     "The manufacturer of a ConsumptionDevice."@en ;
-                                 rdfs:label "Consumption device manufacturer"@en ,
-                                            "Fabricant de dispositifs de consommation"@fr ,
-                                            "Hersteller von Verbrauchsgeräten"@de .
-
-
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#consumptionEventResumePoint
 ec:consumptionEventResumePoint rdf:type owl:ObjectProperty ;
                                dcterms:description "Das Datum und der Zeitpunkt, zu dem der Konsum wieder aufgenommen wurde wiederaufgenommen wurde."@de ,
@@ -1463,6 +1453,16 @@ ec:hasConsumptionCount rdf:type owl:ObjectProperty ;
                        rdfs:label "a compte de la consommation"@fr ,
                                   "has consumption count"@en ,
                                   "hat den Verbrauch gezählt"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasConsumptionDeviceManufacturer
+ec:hasConsumptionDeviceManufacturer rdf:type owl:ObjectProperty ;
+                                    dcterms:description "Der Hersteller eines ConsumptionDevice."@de ,
+                                                        "Le fabricant d'un ConsumptionDevice."@fr ,
+                                                        "The manufacturer of a ConsumptionDevice."@en ;
+                                    rdfs:label "Consumption device manufacturer"@en ,
+                                               "Fabricant de dispositifs de consommation"@fr ,
+                                               "Hersteller von Verbrauchsgeräten"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasConsumptionEvent
@@ -9396,7 +9396,7 @@ ec:ConsumptionDevice rdf:type owl:Class ;
                                        owl:allValuesFrom ec:ConsumptionDeviceProfile
                                      ] ,
                                      [ rdf:type owl:Restriction ;
-                                       owl:onProperty ec:consumptionDeviceManufacturer ;
+                                       owl:onProperty ec:hasConsumptionDeviceManufacturer ;
                                        owl:allValuesFrom ec:Agent
                                      ] ,
                                      [ rdf:type owl:Restriction ;

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -306,16 +306,6 @@ ec:approvedBy rdf:type owl:ObjectProperty ;
                          "Agent"@fr .
 
 
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#assetValueCurrency
-ec:assetValueCurrency rdf:type owl:ObjectProperty ;
-                      dcterms:description "Pour fournir la devise dans laquelle la valeur de l'actif est donnée."@fr ,
-                                          "To provide the currency in which the assetValue is given."@en ,
-                                          "Zur Angabe der Währung, in der der assetValue angegeben wird. gegeben ist."@de ;
-                      rdfs:label "Asset value currency"@en ,
-                                 "Devise de la valeur de l'actif"@fr ,
-                                 "Vermögenswert Währung"@de .
-
-
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#auditReportDate
 ec:auditReportDate rdf:type owl:ObjectProperty ;
                    dcterms:description "Das Datum der Veröffentlichung eines AuditReports."@de ,
@@ -1189,6 +1179,16 @@ ec:hasAssetValue rdf:type owl:ObjectProperty ;
                  rdfs:label "Asset value"@en ,
                             "Valeur de l'actif"@fr ,
                             "Vermögenswert"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAssetValueCurrency
+ec:hasAssetValueCurrency rdf:type owl:ObjectProperty ;
+                         dcterms:description "Pour fournir la devise dans laquelle la valeur de l'actif est donnée."@fr ,
+                                             "To provide the currency in which the assetValue is given."@en ,
+                                             "Zur Angabe der Währung, in der der assetValue angegeben wird. gegeben ist."@de ;
+                         rdfs:label "Asset value currency"@en ,
+                                    "Devise de la valeur de l'actif"@fr ,
+                                    "Vermögenswert Währung"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAssociatedArtefact
@@ -8363,7 +8363,7 @@ ec:Asset rdf:type owl:Class ;
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AssetValue
 ec:AssetValue rdf:type owl:Class ;
               rdfs:subClassOf [ rdf:type owl:Restriction ;
-                                owl:onProperty ec:assetValueCurrency ;
+                                owl:onProperty ec:hasAssetValueCurrency ;
                                 owl:allValuesFrom skos:Concept
                               ] ,
                               [ rdf:type owl:Restriction ;

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -395,16 +395,6 @@ ec:consumesEssence rdf:type owl:ObjectProperty ;
                               "Essenz"@de .
 
 
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#consumptionEventResumePoint
-ec:consumptionEventResumePoint rdf:type owl:ObjectProperty ;
-                               dcterms:description "Das Datum und der Zeitpunkt, zu dem der Konsum wieder aufgenommen wurde wiederaufgenommen wurde."@de ,
-                                                   "La date et l'heure à laquelle la consommation a repris."@fr ,
-                                                   "The date and time point at which consumption has resumed."@en ;
-                               rdfs:label "Consumption event resume point"@en ,
-                                          "Point de reprise de l'événement de consommation"@fr ,
-                                          "Punkt für die Fortsetzung des Verbrauchsereignisses"@de .
-
-
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#consumptionLicenceLink
 ec:consumptionLicenceLink rdf:type owl:ObjectProperty ;
                           dcterms:description "A link to the terms of a ConsumptionLicence."@en ,
@@ -1473,6 +1463,16 @@ ec:hasConsumptionEvent rdf:type owl:ObjectProperty ;
                        rdfs:label "Consumption event"@en ,
                                   "Verbrauchsereignis"@de ,
                                   "Événement de consommation"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasConsumptionEventResumePoint
+ec:hasConsumptionEventResumePoint rdf:type owl:ObjectProperty ;
+                                  dcterms:description "Das Datum und der Zeitpunkt, zu dem der Konsum wieder aufgenommen wurde wiederaufgenommen wurde."@de ,
+                                                      "La date et l'heure à laquelle la consommation a repris."@fr ,
+                                                      "The date and time point at which consumption has resumed."@en ;
+                                  rdfs:label "Consumption event resume point"@en ,
+                                             "Point de reprise de l'événement de consommation"@fr ,
+                                             "Punkt für die Fortsetzung des Verbrauchsereignisses"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContact
@@ -9555,7 +9555,7 @@ ec:ConsumptionEvent rdf:type owl:Class ;
                                       owl:allValuesFrom ec:Essence
                                     ] ,
                                     [ rdf:type owl:Restriction ;
-                                      owl:onProperty ec:consumptionEventResumePoint ;
+                                      owl:onProperty ec:hasConsumptionEventResumePoint ;
                                       owl:allValuesFrom ec:TimelinePoint
                                     ] ,
                                     [ rdf:type owl:Restriction ;

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -405,16 +405,6 @@ ec:contractCostAmountCurrency rdf:type owl:ObjectProperty ;
                                          "Kostenwährung"@de .
 
 
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#contractLink
-ec:contractLink rdf:type owl:ObjectProperty ;
-                dcterms:description "A link to a location where information can be found about a Contract."@en ,
-                                    "Ein Link zu einem Ort, an dem Sie Informationen über einen Vertrag."@de ,
-                                    "Un lien vers un emplacement où l'on peut trouver des informations sur un contrat."@fr ;
-                rdfs:label "Contract link"@en ,
-                           "Lien vers le contrat"@fr ,
-                           "Vertrag Link"@de .
-
-
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#coversConsumptionDevice
 ec:coversConsumptionDevice rdf:type owl:ObjectProperty ;
                            dcterms:description "Pour identifier un appareil compatible avec le licence de consommation."@fr ,
@@ -1531,6 +1521,16 @@ ec:hasContentEditorialFormat rdf:type owl:ObjectProperty ;
                              rdfs:label "Editorial format"@en ,
                                         "Format rédactionnel"@fr ,
                                         "Redaktionelles Format"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContractLink
+ec:hasContractLink rdf:type owl:ObjectProperty ;
+                   dcterms:description "A link to a location where information can be found about a Contract."@en ,
+                                       "Ein Link zu einem Ort, an dem Sie Informationen über einen Vertrag."@de ,
+                                       "Un lien vers un emplacement où l'on peut trouver des informations sur un contrat."@fr ;
+                   rdfs:label "Contract link"@en ,
+                              "Lien vers le contrat"@fr ,
+                              "Vertrag Link"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContractRelatedCost
@@ -9772,7 +9772,7 @@ ec:ContentEditorialFormat rdf:type owl:Class ;
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Contract
 ec:Contract rdf:type owl:Class ;
             rdfs:subClassOf [ rdf:type owl:Restriction ;
-                              owl:onProperty ec:contractLink ;
+                              owl:onProperty ec:hasContractLink ;
                               owl:allValuesFrom ec:Resource
                             ] ,
                             [ rdf:type owl:Restriction ;

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -306,18 +306,6 @@ ec:approvedBy rdf:type owl:ObjectProperty ;
                          "Agent"@fr .
 
 
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#artefactDateOfSell
-ec:artefactDateOfSell rdf:type owl:ObjectProperty ;
-                      rdfs:subPropertyOf ec:hasDate ;
-                      rdfs:range time:Instant ;
-                      dcterms:description "Das Datum, an dem ein Artefakt verkauft wurde."@de ,
-                                          "La date à laquelle un artefact a été vendu."@fr ,
-                                          "The date when an Artefact was sold."@en ;
-                      rdfs:label "Artefact date of sell"@en ,
-                                 "Date de vente de l'artefact"@fr ,
-                                 "Verkaufsdatum des Artefakts"@de .
-
-
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#assetValueCurrency
 ec:assetValueCurrency rdf:type owl:ObjectProperty ;
                       dcterms:description "Pour fournir la devise dans laquelle la valeur de l'actif est donnée."@fr ,
@@ -1095,6 +1083,18 @@ ec:hasArtefactDateOfPurchase rdf:type owl:ObjectProperty ;
                              rdfs:label "Artefact date of purchase"@en ,
                                         "Date d'achat de l'artefact"@fr ,
                                         "Kaufdatum des Artefakts"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasArtefactDateOfSell
+ec:hasArtefactDateOfSell rdf:type owl:ObjectProperty ;
+                         rdfs:subPropertyOf ec:hasDate ;
+                         rdfs:range time:Instant ;
+                         dcterms:description "Das Datum, an dem ein Artefakt verkauft wurde."@de ,
+                                             "La date à laquelle un artefact a été vendu."@fr ,
+                                             "The date when an Artefact was sold."@en ;
+                         rdfs:label "Artefact date of sell"@en ,
+                                    "Date de vente de l'artefact"@fr ,
+                                    "Verkaufsdatum des Artefakts"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasArtefactOwner
@@ -8041,12 +8041,12 @@ ec:Artefact rdf:type owl:Class ;
                               owl:allValuesFrom skos:Concept
                             ] ,
                             [ rdf:type owl:Restriction ;
-                              owl:onProperty ec:artefactDateOfSell ;
+                              owl:onProperty ec:hasArtefactDateOfPurchase ;
                               owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                               owl:onClass time:Instant
                             ] ,
                             [ rdf:type owl:Restriction ;
-                              owl:onProperty ec:hasArtefactDateOfPurchase ;
+                              owl:onProperty ec:hasArtefactDateOfSell ;
                               owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                               owl:onClass time:Instant
                             ] ,


### PR DESCRIPTION
In this pull request, I have standardized the naming of ten object properties by adding a 'has' prefix.
   
- `artefactDateOfPurchase` to `hasArtefactDateOfPurchase`
- `date` to `hasDate`
- `artefactDateOfSell` to `hasArtefactDateOfSell`
- `assetValueCurrency` to `hasAssetValueCurrency`
- `auditReportDate` to `hasAuditReportDate`
- `awardDate` to `hasAwardDate`
- `consumptionDeviceManufacturer` to `hasConsumptionDeviceManufacturer`
- `consumptionEventResumePoint` to `hasConsumptionEventResumePoint`
- `consumptionLicenceLink` to `hasConsumptionLicenceLink`
- `contractLink` to `hasContractLink`

**Reviewers**
- @JuergenGrupp 
- @aro-max 