### PR TITLE
299 refactoring has property cluster 02

### DIFF
--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -558,18 +558,6 @@ ec:date rdf:type owl:ObjectProperty ;
                    "Datum"@de .
 
 
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateIssued
-ec:dateIssued rdf:type owl:ObjectProperty ;
-              rdfs:subPropertyOf ec:date ;
-              rdfs:range time:Instant ;
-              dcterms:description "Das Datum, an dem das Asset ausgegeben wurde."@de ,
-                                  "La date à laquelle l'actif a été émis."@fr ,
-                                  "The date when the Asset was issued."@en ;
-              rdfs:label "Date d'émission"@fr ,
-                         "Date issued"@en ,
-                         "Datum der Ausstellung"@de .
-
-
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateLicenseEnd
 ec:dateLicenseEnd rdf:type owl:ObjectProperty ;
                   rdfs:subPropertyOf ec:date ;
@@ -1720,6 +1708,18 @@ ec:hasDateIngested rdf:type owl:ObjectProperty ;
                    rdfs:label "Date d'ingestion"@fr ,
                               "Ingest date"@en ,
                               "Ingest-Datum"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateIssued
+ec:hasDateIssued rdf:type owl:ObjectProperty ;
+                 rdfs:subPropertyOf ec:date ;
+                 rdfs:range time:Instant ;
+                 dcterms:description "Das Datum, an dem das Asset ausgegeben wurde."@de ,
+                                     "La date à laquelle l'actif a été émis."@fr ,
+                                     "The date when the Asset was issued."@en ;
+                 rdfs:label "Date d'émission"@fr ,
+                            "Date issued"@en ,
+                            "Datum der Ausstellung"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDepartment
@@ -10458,11 +10458,6 @@ ec:EditorialObject rdf:type owl:Class ;
                                      owl:allValuesFrom skos:Concept
                                    ] ,
                                    [ rdf:type owl:Restriction ;
-                                     owl:onProperty ec:dateIssued ;
-                                     owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                                     owl:onClass time:Instant
-                                   ] ,
-                                   [ rdf:type owl:Restriction ;
                                      owl:onProperty ec:duration ;
                                      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                      owl:onClass ec:TimelinePoint
@@ -10474,6 +10469,11 @@ ec:EditorialObject rdf:type owl:Class ;
                                    ] ,
                                    [ rdf:type owl:Restriction ;
                                      owl:onProperty ec:hasDateBroadcast ;
+                                     owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                     owl:onClass time:Instant
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasDateIssued ;
                                      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                      owl:onClass time:Instant
                                    ] ,

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -558,18 +558,6 @@ ec:date rdf:type owl:ObjectProperty ;
                    "Datum"@de .
 
 
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateCreated
-ec:dateCreated rdf:type owl:ObjectProperty ;
-               rdfs:subPropertyOf ec:date ;
-               rdfs:range time:Instant ;
-               dcterms:description "Das Datum der Erstellung des Assets."@de ,
-                                   "La date de création de l'actif."@fr ,
-                                   "The date of creation of the Asset."@en ;
-               rdfs:label "Creation date/time"@en ,
-                          "Date/heure de création"@fr ,
-                          "Erstellungsdatum/-zeit"@de .
-
-
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateDeleted
 ec:dateDeleted rdf:type owl:ObjectProperty ;
                rdfs:subPropertyOf ec:date ;
@@ -1720,6 +1708,18 @@ ec:hasDateBroadcast rdf:type owl:ObjectProperty ;
                     rdfs:label "Broadcast date"@en ,
                                "Date de diffusion"@fr ,
                                "Datum der Ausstrahlung"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateCreated
+ec:hasDateCreated rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf ec:date ;
+                  rdfs:range time:Instant ;
+                  dcterms:description "Das Datum der Erstellung des Assets."@de ,
+                                      "La date de création de l'actif."@fr ,
+                                      "The date of creation of the Asset."@en ;
+                  rdfs:label "Creation date/time"@en ,
+                             "Date/heure de création"@fr ,
+                             "Erstellungsdatum/-zeit"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDepartment
@@ -8269,11 +8269,6 @@ ec:Asset rdf:type owl:Class ;
                            owl:allValuesFrom ec:Asset
                          ] ,
                          [ rdf:type owl:Restriction ;
-                           owl:onProperty ec:dateCreated ;
-                           owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                           owl:onClass time:Instant
-                         ] ,
-                         [ rdf:type owl:Restriction ;
                            owl:onProperty ec:dateDeleted ;
                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                            owl:onClass time:Instant
@@ -8310,6 +8305,11 @@ ec:Asset rdf:type owl:Class ;
                          ] ,
                          [ rdf:type owl:Restriction ;
                            owl:onProperty ec:hasDateArchived ;
+                           owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                           owl:onClass time:Instant
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasDateCreated ;
                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                            owl:onClass time:Instant
                          ] ,
@@ -11108,7 +11108,7 @@ ec:Identifier rdf:type owl:Class ;
                                 owl:allValuesFrom skos:Concept
                               ] ,
                               [ rdf:type owl:Restriction ;
-                                owl:onProperty ec:dateCreated ;
+                                owl:onProperty ec:hasDateCreated ;
                                 owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                 owl:onClass time:Instant
                               ] ,
@@ -12967,12 +12967,12 @@ ec:Provenance rdf:type owl:Class ;
                                 owl:allValuesFrom skos:Concept
                               ] ,
                               [ rdf:type owl:Restriction ;
-                                owl:onProperty ec:dateCreated ;
+                                owl:onProperty ec:dateModified ;
                                 owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                 owl:onClass time:DateTimeDescription
                               ] ,
                               [ rdf:type owl:Restriction ;
-                                owl:onProperty ec:dateModified ;
+                                owl:onProperty ec:hasDateCreated ;
                                 owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                 owl:onClass time:DateTimeDescription
                               ] ,

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -1,7 +1,6 @@
-@prefix :<http://www.ebu.ch/metadata/ontologies/ebucoreplus#> .
+@prefix : <http://www.ebu.ch/metadata/ontologies/ebucoreplus#> .
 @prefix cc: <http://creativecommons.org/ns#> .
-@prefix dc: <http://purl.org/dc/elements/1.1/>
- .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix ec: <http://www.ebu.ch/metadata/ontologies/ebucoreplus#> .
 @prefix vs: <http://www.w3.org/2003/06/sw-vocab-status/ns#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
@@ -12,12 +11,9 @@
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix spin: <http://spinrdf.org/spin#> .
 @prefix time: <http://www.w3.org/2006/time#> .
-@prefix vann: <http://purl.org/vocab/vann/>
- .
-@prefix xkos: <https://rdf-vocabulary.ddialliance.org/xkos/>
- .
-@prefix dcterms: <http://purl.org/dc/terms/>
- .
+@prefix vann: <http://purl.org/vocab/vann/> .
+@prefix xkos: <https://rdf-vocabulary.ddialliance.org/xkos/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
 @base <http://www.ebu.ch/metadata/ontologies/ebucoreplus> .
 
 <http://www.ebu.ch/metadata/ontologies/ebucoreplus> rdf:type owl:Ontology ;
@@ -560,18 +556,6 @@ ec:date rdf:type owl:ObjectProperty ;
         rdfs:label "Date"@en ,
                    "Date"@fr ,
                    "Datum"@de .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateArchived
-ec:dateArchived rdf:type owl:ObjectProperty ;
-                rdfs:subPropertyOf ec:date ;
-                rdfs:range time:Instant ;
-                dcterms:description "Das Datum, an dem das Asset archiviert wurde."@de ,
-                                    "La date à laquelle l'actif a été archivé."@fr ,
-                                    "The date when the Asset was archived."@en ;
-                rdfs:label "Archiving date"@en ,
-                           "Date d'archivage"@fr ,
-                           "Datum der Archivierung"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateBroadcast
@@ -1724,6 +1708,18 @@ ec:hasDataTrack rdf:type owl:ObjectProperty ;
                 rdfs:label "Data track"@en ,
                            "Daten verfolgen"@de ,
                            "Suivi des données"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateArchived
+ec:hasDateArchived rdf:type owl:ObjectProperty ;
+                   rdfs:subPropertyOf ec:date ;
+                   rdfs:range time:Instant ;
+                   dcterms:description "Das Datum, an dem das Asset archiviert wurde."@de ,
+                                       "La date à laquelle l'actif a été archivé."@fr ,
+                                       "The date when the Asset was archived."@en ;
+                   rdfs:label "Archiving date"@en ,
+                              "Date d'archivage"@fr ,
+                              "Datum der Archivierung"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDepartment
@@ -8273,11 +8269,6 @@ ec:Asset rdf:type owl:Class ;
                            owl:allValuesFrom ec:Asset
                          ] ,
                          [ rdf:type owl:Restriction ;
-                           owl:onProperty ec:dateArchived ;
-                           owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                           owl:onClass time:Instant
-                         ] ,
-                         [ rdf:type owl:Restriction ;
                            owl:onProperty ec:dateCreated ;
                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                            owl:onClass time:Instant
@@ -8314,6 +8305,11 @@ ec:Asset rdf:type owl:Class ;
                          ] ,
                          [ rdf:type owl:Restriction ;
                            owl:onProperty ec:datelicensedStart ;
+                           owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                           owl:onClass time:Instant
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasDateArchived ;
                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                            owl:onClass time:Instant
                          ] ,

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -558,18 +558,6 @@ ec:date rdf:type owl:ObjectProperty ;
                    "Datum"@de .
 
 
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateMigrated
-ec:dateMigrated rdf:type owl:ObjectProperty ;
-                rdfs:subPropertyOf ec:date ;
-                rdfs:range time:Instant ;
-                dcterms:description "Das Datum, an dem die Ressource kopiert oder von einem veralteten oder gefährdeten Originalformat in ein aktuelleres Format zur Aufbewahrung konvertiert wurde."@de ,
-                                    "La date à laquelle la ressource a été copiée ou convertie d'un format original obsolète ou menacé à un format plus actualisé pour la conservation."@fr ,
-                                    "The date when the Resource was copied or converted from an obsolete or endangered original format to a more updated format for preservation."@en ;
-                rdfs:label "Date de migration"@fr ,
-                           "Datum der Migration"@de ,
-                           "Migration date"@en .
-
-
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateModified
 ec:dateModified rdf:type owl:ObjectProperty ;
                 rdfs:subPropertyOf ec:date ;
@@ -1720,6 +1708,18 @@ ec:hasDateLicenseEnd rdf:type owl:ObjectProperty ;
                      rdfs:label "Date de fin de licence"@fr ,
                                 "Enddatum der Lizenz"@de ,
                                 "Licence end date"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateMigrated
+ec:hasDateMigrated rdf:type owl:ObjectProperty ;
+                   rdfs:subPropertyOf ec:date ;
+                   rdfs:range time:Instant ;
+                   dcterms:description "Das Datum, an dem die Ressource kopiert oder von einem veralteten oder gefährdeten Originalformat in ein aktuelleres Format zur Aufbewahrung konvertiert wurde."@de ,
+                                       "La date à laquelle la ressource a été copiée ou convertie d'un format original obsolète ou menacé à un format plus actualisé pour la conservation."@fr ,
+                                       "The date when the Resource was copied or converted from an obsolete or endangered original format to a more updated format for preservation."@en ;
+                   rdfs:label "Date de migration"@fr ,
+                              "Datum der Migration"@de ,
+                              "Migration date"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDepartment
@@ -11749,11 +11749,6 @@ ec:MediaResource rdf:type owl:Class ;
                                    owl:allValuesFrom ec:MediaResource
                                  ] ,
                                  [ rdf:type owl:Restriction ;
-                                   owl:onProperty ec:dateMigrated ;
-                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                                   owl:onClass time:Instant
-                                 ] ,
-                                 [ rdf:type owl:Restriction ;
                                    owl:onProperty ec:dateNormalized ;
                                    owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                    owl:onClass time:Instant
@@ -11815,6 +11810,11 @@ ec:MediaResource rdf:type owl:Class ;
                                  ] ,
                                  [ rdf:type owl:Restriction ;
                                    owl:onProperty ec:hasDateIngested ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass time:Instant
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasDateMigrated ;
                                    owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                    owl:onClass time:Instant
                                  ] ,

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -427,10 +427,6 @@ ec:createsMetadata rdf:type owl:ObjectProperty ;
                               "erstellt Metadaten"@de .
 
 
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#date
-ec:date rdf:type owl:ObjectProperty .
-
-
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#derivedTo
 ec:derivedTo rdf:type owl:ObjectProperty ;
              owl:inverseOf ec:isDerivedFrom ;
@@ -1632,7 +1628,7 @@ ec:hasDateLicenseEnd rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateLicensedStart
 ec:hasDateLicensedStart rdf:type owl:ObjectProperty ;
-                        rdfs:subPropertyOf ec:date ;
+                        rdfs:subPropertyOf ec:hasDate ;
                         rdfs:range time:Instant ;
                         dcterms:description "Das Datum, an dem die Lizenz für das Asset beginnt."@de ,
                                             "La date à laquelle la licence pour le bien commence."@fr ,
@@ -1656,7 +1652,7 @@ ec:hasDateMigrated rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateModified
 ec:hasDateModified rdf:type owl:ObjectProperty ;
-                   rdfs:subPropertyOf ec:date ;
+                   rdfs:subPropertyOf ec:hasDate ;
                    rdfs:range time:Instant ;
                    dcterms:description "Pour indiquer la date à laquelle l'actif a été modifié."@fr ,
                                        "To indicate the date at which the Asset has been modified."@en ,
@@ -1668,7 +1664,7 @@ ec:hasDateModified rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateNormalized
 ec:hasDateNormalized rdf:type owl:ObjectProperty ;
-                     rdfs:subPropertyOf ec:date ;
+                     rdfs:subPropertyOf ec:hasDate ;
                      rdfs:range time:Instant ;
                      dcterms:description "Das Datum, an dem die Ressource aus ihrem ursprünglichen Format in ein von der Institution für die Aufbewahrung ausgewähltes Format konvertiert wurde."@de ,
                                          "La date à laquelle la ressource a été convertie de son format original en un format présélectionné par l'institution pour la préservation."@fr ,
@@ -1680,7 +1676,7 @@ ec:hasDateNormalized rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateOfBirth
 ec:hasDateOfBirth rdf:type owl:ObjectProperty ;
-                  rdfs:subPropertyOf ec:date ;
+                  rdfs:subPropertyOf ec:hasDate ;
                   rdfs:range time:Instant ;
                   dcterms:description "Das Datum, an dem ein Kontakt/eine Person geboren wird."@de ,
                                       "La date de naissance d'un contact/personne."@fr ,
@@ -1692,7 +1688,7 @@ ec:hasDateOfBirth rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateOfDeath
 ec:hasDateOfDeath rdf:type owl:ObjectProperty ;
-                  rdfs:subPropertyOf ec:date ;
+                  rdfs:subPropertyOf ec:hasDate ;
                   rdfs:range time:Instant ;
                   dcterms:description "Das Datum, an dem ein Kontakt/eine Person verstorben ist."@de ,
                                       "La date à laquelle un contact/personne est décédé."@fr ,
@@ -1704,7 +1700,7 @@ ec:hasDateOfDeath rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateOfRetirement
 ec:hasDateOfRetirement rdf:type owl:ObjectProperty ;
-                       rdfs:subPropertyOf ec:date ;
+                       rdfs:subPropertyOf ec:hasDate ;
                        rdfs:range time:Instant ;
                        dcterms:description "Das Datum, an dem ein Kontakt/eine Person in den Ruhestand getreten ist."@de ,
                                            "La date à laquelle un contact/personne a pris sa retraite."@fr ,
@@ -1716,7 +1712,7 @@ ec:hasDateOfRetirement rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateProduced
 ec:hasDateProduced rdf:type owl:ObjectProperty ;
-                   rdfs:subPropertyOf ec:date ;
+                   rdfs:subPropertyOf ec:hasDate ;
                    rdfs:range time:Instant ;
                    dcterms:description "Das Datum der Produktion des Assets."@de ,
                                        "La date de production de l'actif."@fr ,
@@ -1728,7 +1724,7 @@ ec:hasDateProduced rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateReleased
 ec:hasDateReleased rdf:type owl:ObjectProperty ;
-                   rdfs:subPropertyOf ec:date ;
+                   rdfs:subPropertyOf ec:hasDate ;
                    rdfs:range time:Instant ;
                    dcterms:description "Das Datum, an dem die Ressource erstmals der Öffentlichkeit zum Kauf, Download oder Online-Zugriff zur Verfügung gestellt wurde."@de ,
                                        "La date à laquelle la ressource a été mise pour la première fois à la disposition du public pour l'achat, le téléchargement ou l'accès en ligne."@fr ,
@@ -1740,7 +1736,7 @@ ec:hasDateReleased rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateTransferred
 ec:hasDateTransferred rdf:type owl:ObjectProperty ;
-                      rdfs:subPropertyOf ec:date ;
+                      rdfs:subPropertyOf ec:hasDate ;
                       rdfs:range time:Instant ;
                       dcterms:description "Das Datum, an dem das Asset von einem digitalen oder physischen Ort zu einem anderen verschoben wurde."@de ,
                                           "La date à laquelle l'actif a été déplacé d'un emplacement numérique ou physique à un autre."@fr ,
@@ -1752,7 +1748,7 @@ ec:hasDateTransferred rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateValidated
 ec:hasDateValidated rdf:type owl:ObjectProperty ;
-                    rdfs:subPropertyOf ec:date ;
+                    rdfs:subPropertyOf ec:hasDate ;
                     rdfs:range time:Instant ;
                     dcterms:description "Das letzte Datum, an dem die Ressource durch manuelle oder digitale QC als gültig bestätigt wurde."@de ,
                                         "La date la plus récente à laquelle la validité de la ressource a été confirmée par un CQ manuel ou numérique."@fr ,
@@ -3163,7 +3159,7 @@ ec:hasStart rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasStartDateTime
 ec:hasStartDateTime rdf:type owl:ObjectProperty ;
-                    rdfs:subPropertyOf ec:date ;
+                    rdfs:subPropertyOf ec:hasDate ;
                     rdfs:range time:Instant ;
                     dcterms:description "A point of time or start of an interval"@en ,
                                         "Ein Zeitpunkt oder der Beginn eines Intervalls"@de ,

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -558,18 +558,6 @@ ec:date rdf:type owl:ObjectProperty ;
                    "Datum"@de .
 
 
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateDigitised
-ec:dateDigitised rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf ec:date ;
-                 rdfs:range time:Instant ;
-                 dcterms:description "Das Datum, an dem die Ressource digitalisiert wurde."@de ,
-                                     "La date à laquelle la ressource a été numérisée."@fr ,
-                                     "The date when the Resource was digitised."@en ;
-                 rdfs:label "Date de numérisation"@fr ,
-                            "Datum der Digitalisierung"@de ,
-                            "Digitisation date"@en .
-
-
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateDistributed
 ec:dateDistributed rdf:type owl:ObjectProperty ;
                    rdfs:subPropertyOf ec:date ;
@@ -1720,6 +1708,18 @@ ec:hasDateDeleted rdf:type owl:ObjectProperty ;
                   rdfs:label "Date de suppression"@fr ,
                              "Datum der Löschung"@de ,
                              "Deletion date"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateDigitised
+ec:hasDateDigitised rdf:type owl:ObjectProperty ;
+                    rdfs:subPropertyOf ec:date ;
+                    rdfs:range time:Instant ;
+                    dcterms:description "Das Datum, an dem die Ressource digitalisiert wurde."@de ,
+                                        "La date à laquelle la ressource a été numérisée."@fr ,
+                                        "The date when the Resource was digitised."@en ;
+                    rdfs:label "Date de numérisation"@fr ,
+                               "Datum der Digitalisierung"@de ,
+                               "Digitisation date"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDepartment
@@ -11749,11 +11749,6 @@ ec:MediaResource rdf:type owl:Class ;
                                    owl:allValuesFrom ec:MediaResource
                                  ] ,
                                  [ rdf:type owl:Restriction ;
-                                   owl:onProperty ec:dateDigitised ;
-                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                                   owl:onClass time:Instant
-                                 ] ,
-                                 [ rdf:type owl:Restriction ;
                                    owl:onProperty ec:dateIngested ;
                                    owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                    owl:onClass time:Instant
@@ -11817,6 +11812,11 @@ ec:MediaResource rdf:type owl:Class ;
                                    owl:onProperty ec:hasContainerMimeType ;
                                    owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                    owl:onClass ec:MimeType
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasDateDigitised ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass time:Instant
                                  ] ,
                                  [ rdf:type owl:Restriction ;
                                    owl:onProperty ec:hasFileFormat ;

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -558,18 +558,6 @@ ec:date rdf:type owl:ObjectProperty ;
                    "Datum"@de .
 
 
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateLicenseEnd
-ec:dateLicenseEnd rdf:type owl:ObjectProperty ;
-                  rdfs:subPropertyOf ec:date ;
-                  rdfs:range time:Instant ;
-                  dcterms:description "Das Datum, an dem die Lizenz für das Asset endet."@de ,
-                                      "La date à laquelle la licence de l'actif prend fin."@fr ,
-                                      "The date when the licence for the Asset ends."@en ;
-                  rdfs:label "Date de fin de licence"@fr ,
-                             "Enddatum der Lizenz"@de ,
-                             "Licence end date"@en .
-
-
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateMigrated
 ec:dateMigrated rdf:type owl:ObjectProperty ;
                 rdfs:subPropertyOf ec:date ;
@@ -1720,6 +1708,18 @@ ec:hasDateIssued rdf:type owl:ObjectProperty ;
                  rdfs:label "Date d'émission"@fr ,
                             "Date issued"@en ,
                             "Datum der Ausstellung"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateLicenseEnd
+ec:hasDateLicenseEnd rdf:type owl:ObjectProperty ;
+                     rdfs:subPropertyOf ec:date ;
+                     rdfs:range time:Instant ;
+                     dcterms:description "Das Datum, an dem die Lizenz für das Asset endet."@de ,
+                                         "La date à laquelle la licence de l'actif prend fin."@fr ,
+                                         "The date when the licence for the Asset ends."@en ;
+                     rdfs:label "Date de fin de licence"@fr ,
+                                "Enddatum der Lizenz"@de ,
+                                "Licence end date"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDepartment
@@ -8269,11 +8269,6 @@ ec:Asset rdf:type owl:Class ;
                            owl:allValuesFrom ec:Asset
                          ] ,
                          [ rdf:type owl:Restriction ;
-                           owl:onProperty ec:dateLicenseEnd ;
-                           owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                           owl:onClass time:Instant
-                         ] ,
-                         [ rdf:type owl:Restriction ;
                            owl:onProperty ec:dateModified ;
                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                            owl:onClass time:Instant
@@ -8310,6 +8305,11 @@ ec:Asset rdf:type owl:Class ;
                          ] ,
                          [ rdf:type owl:Restriction ;
                            owl:onProperty ec:hasDateDistributed ;
+                           owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                           owl:onClass time:Instant
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasDateLicenseEnd ;
                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                            owl:onClass time:Instant
                          ] ,

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -558,18 +558,6 @@ ec:date rdf:type owl:ObjectProperty ;
                    "Datum"@de .
 
 
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateDeleted
-ec:dateDeleted rdf:type owl:ObjectProperty ;
-               rdfs:subPropertyOf ec:date ;
-               rdfs:range time:Instant ;
-               dcterms:description "Das Datum, an dem die Ressource gelöscht wurde."@de ,
-                                   "La date à laquelle la ressource a été supprimée."@fr ,
-                                   "The date when the Resource was deleted."@en ;
-               rdfs:label "Date de suppression"@fr ,
-                          "Datum der Löschung"@de ,
-                          "Deletion date"@en .
-
-
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateDigitised
 ec:dateDigitised rdf:type owl:ObjectProperty ;
                  rdfs:subPropertyOf ec:date ;
@@ -1720,6 +1708,18 @@ ec:hasDateCreated rdf:type owl:ObjectProperty ;
                   rdfs:label "Creation date/time"@en ,
                              "Date/heure de création"@fr ,
                              "Erstellungsdatum/-zeit"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateDeleted
+ec:hasDateDeleted rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf ec:date ;
+                  rdfs:range time:Instant ;
+                  dcterms:description "Das Datum, an dem die Ressource gelöscht wurde."@de ,
+                                      "La date à laquelle la ressource a été supprimée."@fr ,
+                                      "The date when the Resource was deleted."@en ;
+                  rdfs:label "Date de suppression"@fr ,
+                             "Datum der Löschung"@de ,
+                             "Deletion date"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDepartment
@@ -8269,11 +8269,6 @@ ec:Asset rdf:type owl:Class ;
                            owl:allValuesFrom ec:Asset
                          ] ,
                          [ rdf:type owl:Restriction ;
-                           owl:onProperty ec:dateDeleted ;
-                           owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                           owl:onClass time:Instant
-                         ] ,
-                         [ rdf:type owl:Restriction ;
                            owl:onProperty ec:dateDistributed ;
                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                            owl:onClass time:Instant
@@ -8310,6 +8305,11 @@ ec:Asset rdf:type owl:Class ;
                          ] ,
                          [ rdf:type owl:Restriction ;
                            owl:onProperty ec:hasDateCreated ;
+                           owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                           owl:onClass time:Instant
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasDateDeleted ;
                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                            owl:onClass time:Instant
                          ] ,
@@ -13968,12 +13968,12 @@ ec:Resource rdf:type owl:Class ;
                               owl:allValuesFrom skos:Concept
                             ] ,
                             [ rdf:type owl:Restriction ;
-                              owl:onProperty ec:dateDeleted ;
+                              owl:onProperty ec:dateValidated ;
                               owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                               owl:onClass time:Instant
                             ] ,
                             [ rdf:type owl:Restriction ;
-                              owl:onProperty ec:dateValidated ;
+                              owl:onProperty ec:hasDateDeleted ;
                               owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                               owl:onClass time:Instant
                             ] ,

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -383,7 +383,6 @@ ec:consumesEssence rdf:type owl:ObjectProperty ;
                               "Essence"@fr ,
                               "Essenz"@de .
 
-
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#coversConsumptionDevice
 ec:coversConsumptionDevice rdf:type owl:ObjectProperty ;
                            dcterms:description "Pour identifier un appareil compatible avec le licence de consommation."@fr ,
@@ -1275,6 +1274,43 @@ ec:hasContentEditorialFormat rdf:type owl:ObjectProperty ;
                              rdfs:label "Editorial format"@en ,
                                         "Format rédactionnel"@fr ,
                                         "Redaktionelles Format"@de .
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContractLink
+ec:hasContractLink rdf:type owl:ObjectProperty ;
+                   dcterms:description "A link to a location where information can be found about a Contract."@en ,
+                                       "Ein Link zu einem Ort, an dem Sie Informationen über einen Vertrag."@de ,
+                                       "Un lien vers un emplacement où l'on peut trouver des informations sur un contrat."@fr ;
+                   rdfs:label "Contract link"@en ,
+                              "Lien vers le contrat"@fr ,
+                              "Vertrag Link"@de .
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContractCostAmountCurrency
+ec:hasContractCostAmountCurrency rdf:type owl:ObjectProperty ;
+                                 dcterms:description "Die Währung des Betrags der ContractCost."@de ,
+                                                     "La devise du montant du ContractCost."@fr ,
+                                                     "The currency of the amount of the ContractCost."@en ;
+                                 rdfs:label "Cost currency"@en ,
+                                            "Devise de coût"@fr ,
+                                            "Kostenwährung"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContractCostAmountCurrency
+ec:hasContractCostAmountCurrency rdf:type owl:ObjectProperty ;
+                                 dcterms:description "Die Währung des Betrags der ContractCost."@de ,
+                                                     "La devise du montant du ContractCost."@fr ,
+                                                     "The currency of the amount of the ContractCost."@en ;
+                                 rdfs:label "Cost currency"@en ,
+                                            "Devise de coût"@fr ,
+                                            "Kostenwährung"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContractCostAmountCurrency
+ec:hasContractCostAmountCurrency rdf:type owl:ObjectProperty ;
+                                 dcterms:description "Die Währung des Betrags der ContractCost."@de ,
+                                                     "La devise du montant du ContractCost."@fr ,
+                                                     "The currency of the amount of the ContractCost."@en ;
+                                 rdfs:label "Cost currency"@en ,
+                                            "Devise de coût"@fr ,
+                                            "Kostenwährung"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContractCostAmountCurrency

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -558,18 +558,6 @@ ec:date rdf:type owl:ObjectProperty ;
                    "Datum"@de .
 
 
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateIngested
-ec:dateIngested rdf:type owl:ObjectProperty ;
-                rdfs:subPropertyOf ec:date ;
-                rdfs:range time:Instant ;
-                dcterms:description "Das Datum, an dem die Ressource in den institutionellen Bestand aufgenommen/erworben wurde."@de ,
-                                    "La date à laquelle la ressource a été ingérée/acquise dans les fonds institutionnels."@fr ,
-                                    "The date when the Resource was ingested/acquired in institutional holdings."@en ;
-                rdfs:label "Date d'ingestion"@fr ,
-                           "Ingest date"@en ,
-                           "Ingest-Datum"@de .
-
-
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateIssued
 ec:dateIssued rdf:type owl:ObjectProperty ;
               rdfs:subPropertyOf ec:date ;
@@ -1720,6 +1708,18 @@ ec:hasDateDistributed rdf:type owl:ObjectProperty ;
                       rdfs:label "Date de distribution"@fr ,
                                  "Datum der Verteilung"@de ,
                                  "Distribution date"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateIngested
+ec:hasDateIngested rdf:type owl:ObjectProperty ;
+                   rdfs:subPropertyOf ec:date ;
+                   rdfs:range time:Instant ;
+                   dcterms:description "Das Datum, an dem die Ressource in den institutionellen Bestand aufgenommen/erworben wurde."@de ,
+                                       "La date à laquelle la ressource a été ingérée/acquise dans les fonds institutionnels."@fr ,
+                                       "The date when the Resource was ingested/acquired in institutional holdings."@en ;
+                   rdfs:label "Date d'ingestion"@fr ,
+                              "Ingest date"@en ,
+                              "Ingest-Datum"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDepartment
@@ -11749,11 +11749,6 @@ ec:MediaResource rdf:type owl:Class ;
                                    owl:allValuesFrom ec:MediaResource
                                  ] ,
                                  [ rdf:type owl:Restriction ;
-                                   owl:onProperty ec:dateIngested ;
-                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                                   owl:onClass time:Instant
-                                 ] ,
-                                 [ rdf:type owl:Restriction ;
                                    owl:onProperty ec:dateMigrated ;
                                    owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                    owl:onClass time:Instant
@@ -11815,6 +11810,11 @@ ec:MediaResource rdf:type owl:Class ;
                                  ] ,
                                  [ rdf:type owl:Restriction ;
                                    owl:onProperty ec:hasDateDigitised ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass time:Instant
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasDateIngested ;
                                    owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                    owl:onClass time:Instant
                                  ] ,

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -383,7 +383,6 @@ ec:consumesEssence rdf:type owl:ObjectProperty ;
                               "Essence"@fr ,
                               "Essenz"@de .
 
-
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#coversConsumptionDevice
 ec:coversConsumptionDevice rdf:type owl:ObjectProperty ;
                            dcterms:description "Pour identifier un appareil compatible avec le licence de consommation."@fr ,
@@ -426,6 +425,126 @@ ec:createsMetadata rdf:type owl:ObjectProperty ;
                    rdfs:label "creates metadata"@en ,
                               "crée des métadonnées"@fr ,
                               "erstellt Metadaten"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateArchived
+ec:dateArchived rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf ec:hasDate ;
+                rdfs:range time:Instant ;
+                dcterms:description "Das Datum, an dem das Asset archiviert wurde."@de ,
+                                    "La date à laquelle l'actif a été archivé."@fr ,
+                                    "The date when the Asset was archived."@en ;
+                rdfs:label "Archiving date"@en ,
+                           "Date d'archivage"@fr ,
+                           "Datum der Archivierung"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateBroadcast
+ec:dateBroadcast rdf:type owl:ObjectProperty ;
+                 rdfs:subPropertyOf ec:hasDate ;
+                 rdfs:range time:Instant ;
+                 dcterms:description "Das Datum, an dem der Asset zum ersten Mal öffentlich im Fernsehen, Radio oder per Streaming ausgestrahlt wurde."@de ,
+                                     "La date à laquelle l'actif a été diffusé pour la première fois en public à la télévision ou à la radio ou par streaming."@fr ,
+                                     "The date when the Asset was first broadcast publicly on television or radio or via streaming."@en ;
+                 rdfs:label "Broadcast date"@en ,
+                            "Date de diffusion"@fr ,
+                            "Datum der Ausstrahlung"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateCreated
+ec:dateCreated rdf:type owl:ObjectProperty ;
+               rdfs:subPropertyOf ec:hasDate ;
+               rdfs:range time:Instant ;
+               dcterms:description "Das Datum der Erstellung des Assets."@de ,
+                                   "La date de création de l'actif."@fr ,
+                                   "The date of creation of the Asset."@en ;
+               rdfs:label "Creation date/time"@en ,
+                          "Date/heure de création"@fr ,
+                          "Erstellungsdatum/-zeit"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateDeleted
+ec:dateDeleted rdf:type owl:ObjectProperty ;
+               rdfs:subPropertyOf ec:hasDate ;
+               rdfs:range time:Instant ;
+               dcterms:description "Das Datum, an dem die Ressource gelöscht wurde."@de ,
+                                   "La date à laquelle la ressource a été supprimée."@fr ,
+                                   "The date when the Resource was deleted."@en ;
+               rdfs:label "Date de suppression"@fr ,
+                          "Datum der Löschung"@de ,
+                          "Deletion date"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateDigitised
+ec:dateDigitised rdf:type owl:ObjectProperty ;
+                 rdfs:subPropertyOf ec:hasDate ;
+                 rdfs:range time:Instant ;
+                 dcterms:description "Das Datum, an dem die Ressource digitalisiert wurde."@de ,
+                                     "La date à laquelle la ressource a été numérisée."@fr ,
+                                     "The date when the Resource was digitised."@en ;
+                 rdfs:label "Date de numérisation"@fr ,
+                            "Datum der Digitalisierung"@de ,
+                            "Digitisation date"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateDistributed
+ec:dateDistributed rdf:type owl:ObjectProperty ;
+                   rdfs:subPropertyOf ec:hasDate ;
+                   rdfs:range time:Instant ;
+                   dcterms:description "Das Datum, an dem die Ressource erstmals der Öffentlichkeit zum Kauf, Download oder Online-Zugriff zur Verfügung gestellt wurde."@de ,
+                                       "La date à laquelle la ressource a été mise pour la première fois à la disposition du public pour l'achat, le téléchargement ou l'accès en ligne."@fr ,
+                                       "The date when the Resource was first made available to the public for purchase, download, or online access."@en ;
+                   rdfs:label "Date de distribution"@fr ,
+                              "Datum der Verteilung"@de ,
+                              "Distribution date"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateIngested
+ec:dateIngested rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf ec:hasDate ;
+                rdfs:range time:Instant ;
+                dcterms:description "Das Datum, an dem die Ressource in den institutionellen Bestand aufgenommen/erworben wurde."@de ,
+                                    "La date à laquelle la ressource a été ingérée/acquise dans les fonds institutionnels."@fr ,
+                                    "The date when the Resource was ingested/acquired in institutional holdings."@en ;
+                rdfs:label "Date d'ingestion"@fr ,
+                           "Ingest date"@en ,
+                           "Ingest-Datum"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateIssued
+ec:dateIssued rdf:type owl:ObjectProperty ;
+              rdfs:subPropertyOf ec:hasDate ;
+              rdfs:range time:Instant ;
+              dcterms:description "Das Datum, an dem das Asset ausgegeben wurde."@de ,
+                                  "La date à laquelle l'actif a été émis."@fr ,
+                                  "The date when the Asset was issued."@en ;
+              rdfs:label "Date d'émission"@fr ,
+                         "Date issued"@en ,
+                         "Datum der Ausstellung"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateLicenseEnd
+ec:dateLicenseEnd rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf ec:hasDate ;
+                  rdfs:range time:Instant ;
+                  dcterms:description "Das Datum, an dem die Lizenz für das Asset endet."@de ,
+                                      "La date à laquelle la licence de l'actif prend fin."@fr ,
+                                      "The date when the licence for the Asset ends."@en ;
+                  rdfs:label "Date de fin de licence"@fr ,
+                             "Enddatum der Lizenz"@de ,
+                             "Licence end date"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateMigrated
+ec:dateMigrated rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf ec:hasDate ;
+                rdfs:range time:Instant ;
+                dcterms:description "Das Datum, an dem die Ressource kopiert oder von einem veralteten oder gefährdeten Originalformat in ein aktuelleres Format zur Aufbewahrung konvertiert wurde."@de ,
+                                    "La date à laquelle la ressource a été copiée ou convertie d'un format original obsolète ou menacé à un format plus actualisé pour la conservation."@fr ,
+                                    "The date when the Resource was copied or converted from an obsolete or endangered original format to a more updated format for preservation."@en ;
+                rdfs:label "Date de migration"@fr ,
+                           "Datum der Migration"@de ,
+                           "Migration date"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#derivedTo
@@ -1272,6 +1391,23 @@ ec:hasContentEditorialFormat rdf:type owl:ObjectProperty ;
                                         "Format rédactionnel"@fr ,
                                         "Redaktionelles Format"@de .
 
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContractLink
+ec:hasContractLink rdf:type owl:ObjectProperty ;
+                   dcterms:description "A link to a location where information can be found about a Contract."@en ,
+                                       "Ein Link zu einem Ort, an dem Sie Informationen über einen Vertrag."@de ,
+                                       "Un lien vers un emplacement où l'on peut trouver des informations sur un contrat."@fr ;
+                   rdfs:label "Contract link"@en ,
+                              "Lien vers le contrat"@fr ,
+                              "Vertrag Link"@de .
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContractCostAmountCurrency
+ec:hasContractCostAmountCurrency rdf:type owl:ObjectProperty ;
+                                 dcterms:description "Die Währung des Betrags der ContractCost."@de ,
+                                                     "La devise du montant du ContractCost."@fr ,
+                                                     "The currency of the amount of the ContractCost."@en ;
+                                 rdfs:label "Cost currency"@en ,
+                                            "Devise de coût"@fr ,
+                                            "Kostenwährung"@de .
+
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContractCostAmountCurrency
 ec:hasContractCostAmountCurrency rdf:type owl:ObjectProperty ;
@@ -1283,14 +1419,14 @@ ec:hasContractCostAmountCurrency rdf:type owl:ObjectProperty ;
                                             "Kostenwährung"@de .
 
 
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContractLink
-ec:hasContractLink rdf:type owl:ObjectProperty ;
-                   dcterms:description "A link to a location where information can be found about a Contract."@en ,
-                                       "Ein Link zu einem Ort, an dem Sie Informationen über einen Vertrag."@de ,
-                                       "Un lien vers un emplacement où l'on peut trouver des informations sur un contrat."@fr ;
-                   rdfs:label "Contract link"@en ,
-                              "Lien vers le contrat"@fr ,
-                              "Vertrag Link"@de .
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContractCostAmountCurrency
+ec:hasContractCostAmountCurrency rdf:type owl:ObjectProperty ;
+                                 dcterms:description "Die Währung des Betrags der ContractCost."@de ,
+                                                     "La devise du montant du ContractCost."@fr ,
+                                                     "The currency of the amount of the ContractCost."@en ;
+                                 rdfs:label "Cost currency"@en ,
+                                            "Devise de coût"@fr ,
+                                            "Kostenwährung"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContractRelatedCost
@@ -1480,119 +1616,9 @@ ec:hasDate rdf:type owl:ObjectProperty ;
            rdfs:label "Date"@en ,
                       "Date"@fr ,
                       "Datum"@de .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateArchived
-ec:hasDateArchived rdf:type owl:ObjectProperty ;
-                   rdfs:subPropertyOf ec:hasDate ;
-                   rdfs:range time:Instant ;
-                   dcterms:description "Das Datum, an dem das Asset archiviert wurde."@de ,
-                                       "La date à laquelle l'actif a été archivé."@fr ,
-                                       "The date when the Asset was archived."@en ;
-                   rdfs:label "Archiving date"@en ,
-                              "Date d'archivage"@fr ,
-                              "Datum der Archivierung"@de .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateBroadcast
-ec:hasDateBroadcast rdf:type owl:ObjectProperty ;
-                    rdfs:subPropertyOf ec:hasDate ;
-                    rdfs:range time:Instant ;
-                    dcterms:description "Das Datum, an dem der Asset zum ersten Mal öffentlich im Fernsehen, Radio oder per Streaming ausgestrahlt wurde."@de ,
-                                        "La date à laquelle l'actif a été diffusé pour la première fois en public à la télévision ou à la radio ou par streaming."@fr ,
-                                        "The date when the Asset was first broadcast publicly on television or radio or via streaming."@en ;
-                    rdfs:label "Broadcast date"@en ,
-                               "Date de diffusion"@fr ,
-                               "Datum der Ausstrahlung"@de .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateCreated
-ec:hasDateCreated rdf:type owl:ObjectProperty ;
-                  rdfs:subPropertyOf ec:hasDate ;
-                  rdfs:range time:Instant ;
-                  dcterms:description "Das Datum der Erstellung des Assets."@de ,
-                                      "La date de création de l'actif."@fr ,
-                                      "The date of creation of the Asset."@en ;
-                  rdfs:label "Creation date/time"@en ,
-                             "Date/heure de création"@fr ,
-                             "Erstellungsdatum/-zeit"@de .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateDeleted
-ec:hasDateDeleted rdf:type owl:ObjectProperty ;
-                  rdfs:subPropertyOf ec:hasDate ;
-                  rdfs:range time:Instant ;
-                  dcterms:description "Das Datum, an dem die Ressource gelöscht wurde."@de ,
-                                      "La date à laquelle la ressource a été supprimée."@fr ,
-                                      "The date when the Resource was deleted."@en ;
-                  rdfs:label "Date de suppression"@fr ,
-                             "Datum der Löschung"@de ,
-                             "Deletion date"@en .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateDigitised
-ec:hasDateDigitised rdf:type owl:ObjectProperty ;
-                    rdfs:subPropertyOf ec:hasDate ;
-                    rdfs:range time:Instant ;
-                    dcterms:description "Das Datum, an dem die Ressource digitalisiert wurde."@de ,
-                                        "La date à laquelle la ressource a été numérisée."@fr ,
-                                        "The date when the Resource was digitised."@en ;
-                    rdfs:label "Date de numérisation"@fr ,
-                               "Datum der Digitalisierung"@de ,
-                               "Digitisation date"@en .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateDistributed
-ec:hasDateDistributed rdf:type owl:ObjectProperty ;
-                      rdfs:subPropertyOf ec:hasDate ;
-                      rdfs:range time:Instant ;
-                      dcterms:description "Das Datum, an dem die Ressource erstmals der Öffentlichkeit zum Kauf, Download oder Online-Zugriff zur Verfügung gestellt wurde."@de ,
-                                          "La date à laquelle la ressource a été mise pour la première fois à la disposition du public pour l'achat, le téléchargement ou l'accès en ligne."@fr ,
-                                          "The date when the Resource was first made available to the public for purchase, download, or online access."@en ;
-                      rdfs:label "Date de distribution"@fr ,
-                                 "Datum der Verteilung"@de ,
-                                 "Distribution date"@en .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateIngested
-ec:hasDateIngested rdf:type owl:ObjectProperty ;
-                   rdfs:subPropertyOf ec:hasDate ;
-                   rdfs:range time:Instant ;
-                   dcterms:description "Das Datum, an dem die Ressource in den institutionellen Bestand aufgenommen/erworben wurde."@de ,
-                                       "La date à laquelle la ressource a été ingérée/acquise dans les fonds institutionnels."@fr ,
-                                       "The date when the Resource was ingested/acquired in institutional holdings."@en ;
-                   rdfs:label "Date d'ingestion"@fr ,
-                              "Ingest date"@en ,
-                              "Ingest-Datum"@de .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateIssued
-ec:hasDateIssued rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf ec:hasDate ;
-                 rdfs:range time:Instant ;
-                 dcterms:description "Das Datum, an dem das Asset ausgegeben wurde."@de ,
-                                     "La date à laquelle l'actif a été émis."@fr ,
-                                     "The date when the Asset was issued."@en ;
-                 rdfs:label "Date d'émission"@fr ,
-                            "Date issued"@en ,
-                            "Datum der Ausstellung"@de .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateLicenseEnd
-ec:hasDateLicenseEnd rdf:type owl:ObjectProperty ;
-                     rdfs:subPropertyOf ec:hasDate ;
-                     rdfs:range time:Instant ;
-                     dcterms:description "Das Datum, an dem die Lizenz für das Asset endet."@de ,
-                                         "La date à laquelle la licence de l'actif prend fin."@fr ,
-                                         "The date when the licence for the Asset ends."@en ;
-                     rdfs:label "Date de fin de licence"@fr ,
-                                "Enddatum der Lizenz"@de ,
-                                "Licence end date"@en .
-
-
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateLicensedStart
 ec:hasDateLicensedStart rdf:type owl:ObjectProperty ;
-                        rdfs:subPropertyOf ec:hasDate ;
+                        rdfs:subPropertyOf ec:date ;
                         rdfs:range time:Instant ;
                         dcterms:description "Das Datum, an dem die Lizenz für das Asset beginnt."@de ,
                                             "La date à laquelle la licence pour le bien commence."@fr ,
@@ -1602,21 +1628,9 @@ ec:hasDateLicensedStart rdf:type owl:ObjectProperty ;
                                    "Startdatum der Lizenz"@de .
 
 
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateMigrated
-ec:hasDateMigrated rdf:type owl:ObjectProperty ;
-                   rdfs:subPropertyOf ec:hasDate ;
-                   rdfs:range time:Instant ;
-                   dcterms:description "Das Datum, an dem die Ressource kopiert oder von einem veralteten oder gefährdeten Originalformat in ein aktuelleres Format zur Aufbewahrung konvertiert wurde."@de ,
-                                       "La date à laquelle la ressource a été copiée ou convertie d'un format original obsolète ou menacé à un format plus actualisé pour la conservation."@fr ,
-                                       "The date when the Resource was copied or converted from an obsolete or endangered original format to a more updated format for preservation."@en ;
-                   rdfs:label "Date de migration"@fr ,
-                              "Datum der Migration"@de ,
-                              "Migration date"@en .
-
-
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateModified
 ec:hasDateModified rdf:type owl:ObjectProperty ;
-                   rdfs:subPropertyOf ec:hasDate ;
+                   rdfs:subPropertyOf ec:date ;
                    rdfs:range time:Instant ;
                    dcterms:description "Pour indiquer la date à laquelle l'actif a été modifié."@fr ,
                                        "To indicate the date at which the Asset has been modified."@en ,
@@ -1628,7 +1642,7 @@ ec:hasDateModified rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateNormalized
 ec:hasDateNormalized rdf:type owl:ObjectProperty ;
-                     rdfs:subPropertyOf ec:hasDate ;
+                     rdfs:subPropertyOf ec:date ;
                      rdfs:range time:Instant ;
                      dcterms:description "Das Datum, an dem die Ressource aus ihrem ursprünglichen Format in ein von der Institution für die Aufbewahrung ausgewähltes Format konvertiert wurde."@de ,
                                          "La date à laquelle la ressource a été convertie de son format original en un format présélectionné par l'institution pour la préservation."@fr ,
@@ -1640,7 +1654,7 @@ ec:hasDateNormalized rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateOfBirth
 ec:hasDateOfBirth rdf:type owl:ObjectProperty ;
-                  rdfs:subPropertyOf ec:hasDate ;
+                  rdfs:subPropertyOf ec:date ;
                   rdfs:range time:Instant ;
                   dcterms:description "Das Datum, an dem ein Kontakt/eine Person geboren wird."@de ,
                                       "La date de naissance d'un contact/personne."@fr ,
@@ -1652,7 +1666,7 @@ ec:hasDateOfBirth rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateOfDeath
 ec:hasDateOfDeath rdf:type owl:ObjectProperty ;
-                  rdfs:subPropertyOf ec:hasDate ;
+                  rdfs:subPropertyOf ec:date ;
                   rdfs:range time:Instant ;
                   dcterms:description "Das Datum, an dem ein Kontakt/eine Person verstorben ist."@de ,
                                       "La date à laquelle un contact/personne est décédé."@fr ,
@@ -1664,7 +1678,7 @@ ec:hasDateOfDeath rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateOfRetirement
 ec:hasDateOfRetirement rdf:type owl:ObjectProperty ;
-                       rdfs:subPropertyOf ec:hasDate ;
+                       rdfs:subPropertyOf ec:date ;
                        rdfs:range time:Instant ;
                        dcterms:description "Das Datum, an dem ein Kontakt/eine Person in den Ruhestand getreten ist."@de ,
                                            "La date à laquelle un contact/personne a pris sa retraite."@fr ,
@@ -1676,7 +1690,7 @@ ec:hasDateOfRetirement rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateProduced
 ec:hasDateProduced rdf:type owl:ObjectProperty ;
-                   rdfs:subPropertyOf ec:hasDate ;
+                   rdfs:subPropertyOf ec:date ;
                    rdfs:range time:Instant ;
                    dcterms:description "Das Datum der Produktion des Assets."@de ,
                                        "La date de production de l'actif."@fr ,
@@ -1688,7 +1702,7 @@ ec:hasDateProduced rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateReleased
 ec:hasDateReleased rdf:type owl:ObjectProperty ;
-                   rdfs:subPropertyOf ec:hasDate ;
+                   rdfs:subPropertyOf ec:date ;
                    rdfs:range time:Instant ;
                    dcterms:description "Das Datum, an dem die Ressource erstmals der Öffentlichkeit zum Kauf, Download oder Online-Zugriff zur Verfügung gestellt wurde."@de ,
                                        "La date à laquelle la ressource a été mise pour la première fois à la disposition du public pour l'achat, le téléchargement ou l'accès en ligne."@fr ,
@@ -1700,7 +1714,7 @@ ec:hasDateReleased rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateTransferred
 ec:hasDateTransferred rdf:type owl:ObjectProperty ;
-                      rdfs:subPropertyOf ec:hasDate ;
+                      rdfs:subPropertyOf ec:date ;
                       rdfs:range time:Instant ;
                       dcterms:description "Das Datum, an dem das Asset von einem digitalen oder physischen Ort zu einem anderen verschoben wurde."@de ,
                                           "La date à laquelle l'actif a été déplacé d'un emplacement numérique ou physique à un autre."@fr ,
@@ -1712,7 +1726,7 @@ ec:hasDateTransferred rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateValidated
 ec:hasDateValidated rdf:type owl:ObjectProperty ;
-                    rdfs:subPropertyOf ec:hasDate ;
+                    rdfs:subPropertyOf ec:date ;
                     rdfs:range time:Instant ;
                     dcterms:description "Das letzte Datum, an dem die Ressource durch manuelle oder digitale QC als gültig bestätigt wurde."@de ,
                                         "La date la plus récente à laquelle la validité de la ressource a été confirmée par un CQ manuel ou numérique."@fr ,
@@ -3123,7 +3137,7 @@ ec:hasStart rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasStartDateTime
 ec:hasStartDateTime rdf:type owl:ObjectProperty ;
-                    rdfs:subPropertyOf ec:hasDate ;
+                    rdfs:subPropertyOf ec:date ;
                     rdfs:range time:Instant ;
                     dcterms:description "A point of time or start of an interval"@en ,
                                         "Ein Zeitpunkt oder der Beginn eines Intervalls"@de ,
@@ -8269,27 +8283,27 @@ ec:Asset rdf:type owl:Class ;
                            owl:allValuesFrom ec:Asset
                          ] ,
                          [ rdf:type owl:Restriction ;
-                           owl:onProperty ec:hasDateArchived ;
+                           owl:onProperty ec:dateArchived ;
                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                            owl:onClass time:Instant
                          ] ,
                          [ rdf:type owl:Restriction ;
-                           owl:onProperty ec:hasDateCreated ;
+                           owl:onProperty ec:dateCreated ;
                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                            owl:onClass time:Instant
                          ] ,
                          [ rdf:type owl:Restriction ;
-                           owl:onProperty ec:hasDateDeleted ;
+                           owl:onProperty ec:dateDeleted ;
                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                            owl:onClass time:Instant
                          ] ,
                          [ rdf:type owl:Restriction ;
-                           owl:onProperty ec:hasDateDistributed ;
+                           owl:onProperty ec:dateDistributed ;
                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                            owl:onClass time:Instant
                          ] ,
                          [ rdf:type owl:Restriction ;
-                           owl:onProperty ec:hasDateLicenseEnd ;
+                           owl:onProperty ec:dateLicenseEnd ;
                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                            owl:onClass time:Instant
                          ] ,
@@ -10458,6 +10472,16 @@ ec:EditorialObject rdf:type owl:Class ;
                                      owl:allValuesFrom ec:EditorialObject
                                    ] ,
                                    [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:dateBroadcast ;
+                                     owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                     owl:onClass time:Instant
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:dateIssued ;
+                                     owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                     owl:onClass time:Instant
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
                                      owl:onProperty ec:duration ;
                                      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                      owl:onClass ec:TimelinePoint
@@ -10466,16 +10490,6 @@ ec:EditorialObject rdf:type owl:Class ;
                                      owl:onProperty ec:end ;
                                      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                      owl:onClass ec:TimelinePoint
-                                   ] ,
-                                   [ rdf:type owl:Restriction ;
-                                     owl:onProperty ec:hasDateBroadcast ;
-                                     owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                                     owl:onClass time:Instant
-                                   ] ,
-                                   [ rdf:type owl:Restriction ;
-                                     owl:onProperty ec:hasDateIssued ;
-                                     owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                                     owl:onClass time:Instant
                                    ] ,
                                    [ rdf:type owl:Restriction ;
                                      owl:onProperty ec:hasLocation ;
@@ -11108,7 +11122,7 @@ ec:Identifier rdf:type owl:Class ;
                                 owl:allValuesFrom skos:Concept
                               ] ,
                               [ rdf:type owl:Restriction ;
-                                owl:onProperty ec:hasDateCreated ;
+                                owl:onProperty ec:dateCreated ;
                                 owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                 owl:onClass time:Instant
                               ] ,
@@ -11745,6 +11759,21 @@ ec:MediaResource rdf:type owl:Class ;
                                    owl:allValuesFrom ec:MediaResource
                                  ] ,
                                  [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:dateDigitised ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass time:Instant
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:dateIngested ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass time:Instant
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:dateMigrated ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass time:Instant
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
                                    owl:onProperty ec:displayAspectRatio ;
                                    owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                    owl:onClass ec:ActiveFormatDescriptorCode
@@ -11788,21 +11817,6 @@ ec:MediaResource rdf:type owl:Class ;
                                    owl:onProperty ec:hasContainerMimeType ;
                                    owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                    owl:onClass ec:MimeType
-                                 ] ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty ec:hasDateDigitised ;
-                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                                   owl:onClass time:Instant
-                                 ] ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty ec:hasDateIngested ;
-                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                                   owl:onClass time:Instant
-                                 ] ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty ec:hasDateMigrated ;
-                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                                   owl:onClass time:Instant
                                  ] ,
                                  [ rdf:type owl:Restriction ;
                                    owl:onProperty ec:hasDateNormalized ;
@@ -12963,7 +12977,7 @@ ec:Provenance rdf:type owl:Class ;
                                 owl:allValuesFrom skos:Concept
                               ] ,
                               [ rdf:type owl:Restriction ;
-                                owl:onProperty ec:hasDateCreated ;
+                                owl:onProperty ec:dateCreated ;
                                 owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                 owl:onClass time:DateTimeDescription
                               ] ,
@@ -13964,7 +13978,7 @@ ec:Resource rdf:type owl:Class ;
                               owl:allValuesFrom skos:Concept
                             ] ,
                             [ rdf:type owl:Restriction ;
-                              owl:onProperty ec:hasDateDeleted ;
+                              owl:onProperty ec:dateDeleted ;
                               owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                               owl:onClass time:Instant
                             ] ,

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -558,18 +558,6 @@ ec:date rdf:type owl:ObjectProperty ;
                    "Datum"@de .
 
 
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateBroadcast
-ec:dateBroadcast rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf ec:date ;
-                 rdfs:range time:Instant ;
-                 dcterms:description "Das Datum, an dem der Asset zum ersten Mal öffentlich im Fernsehen, Radio oder per Streaming ausgestrahlt wurde."@de ,
-                                     "La date à laquelle l'actif a été diffusé pour la première fois en public à la télévision ou à la radio ou par streaming."@fr ,
-                                     "The date when the Asset was first broadcast publicly on television or radio or via streaming."@en ;
-                 rdfs:label "Broadcast date"@en ,
-                            "Date de diffusion"@fr ,
-                            "Datum der Ausstrahlung"@de .
-
-
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateCreated
 ec:dateCreated rdf:type owl:ObjectProperty ;
                rdfs:subPropertyOf ec:date ;
@@ -1720,6 +1708,18 @@ ec:hasDateArchived rdf:type owl:ObjectProperty ;
                    rdfs:label "Archiving date"@en ,
                               "Date d'archivage"@fr ,
                               "Datum der Archivierung"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateBroadcast
+ec:hasDateBroadcast rdf:type owl:ObjectProperty ;
+                    rdfs:subPropertyOf ec:date ;
+                    rdfs:range time:Instant ;
+                    dcterms:description "Das Datum, an dem der Asset zum ersten Mal öffentlich im Fernsehen, Radio oder per Streaming ausgestrahlt wurde."@de ,
+                                        "La date à laquelle l'actif a été diffusé pour la première fois en public à la télévision ou à la radio ou par streaming."@fr ,
+                                        "The date when the Asset was first broadcast publicly on television or radio or via streaming."@en ;
+                    rdfs:label "Broadcast date"@en ,
+                               "Date de diffusion"@fr ,
+                               "Datum der Ausstrahlung"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDepartment
@@ -10458,11 +10458,6 @@ ec:EditorialObject rdf:type owl:Class ;
                                      owl:allValuesFrom skos:Concept
                                    ] ,
                                    [ rdf:type owl:Restriction ;
-                                     owl:onProperty ec:dateBroadcast ;
-                                     owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                                     owl:onClass time:Instant
-                                   ] ,
-                                   [ rdf:type owl:Restriction ;
                                      owl:onProperty ec:dateIssued ;
                                      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                      owl:onClass time:Instant
@@ -10476,6 +10471,11 @@ ec:EditorialObject rdf:type owl:Class ;
                                      owl:onProperty ec:end ;
                                      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                      owl:onClass ec:TimelinePoint
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasDateBroadcast ;
+                                     owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                     owl:onClass time:Instant
                                    ] ,
                                    [ rdf:type owl:Restriction ;
                                      owl:onProperty ec:hasLocation ;

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -383,6 +383,7 @@ ec:consumesEssence rdf:type owl:ObjectProperty ;
                               "Essence"@fr ,
                               "Essenz"@de .
 
+
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#coversConsumptionDevice
 ec:coversConsumptionDevice rdf:type owl:ObjectProperty ;
                            dcterms:description "Pour identifier un appareil compatible avec le licence de consommation."@fr ,
@@ -427,124 +428,8 @@ ec:createsMetadata rdf:type owl:ObjectProperty ;
                               "erstellt Metadaten"@de .
 
 
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateArchived
-ec:dateArchived rdf:type owl:ObjectProperty ;
-                rdfs:subPropertyOf ec:hasDate ;
-                rdfs:range time:Instant ;
-                dcterms:description "Das Datum, an dem das Asset archiviert wurde."@de ,
-                                    "La date à laquelle l'actif a été archivé."@fr ,
-                                    "The date when the Asset was archived."@en ;
-                rdfs:label "Archiving date"@en ,
-                           "Date d'archivage"@fr ,
-                           "Datum der Archivierung"@de .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateBroadcast
-ec:dateBroadcast rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf ec:hasDate ;
-                 rdfs:range time:Instant ;
-                 dcterms:description "Das Datum, an dem der Asset zum ersten Mal öffentlich im Fernsehen, Radio oder per Streaming ausgestrahlt wurde."@de ,
-                                     "La date à laquelle l'actif a été diffusé pour la première fois en public à la télévision ou à la radio ou par streaming."@fr ,
-                                     "The date when the Asset was first broadcast publicly on television or radio or via streaming."@en ;
-                 rdfs:label "Broadcast date"@en ,
-                            "Date de diffusion"@fr ,
-                            "Datum der Ausstrahlung"@de .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateCreated
-ec:dateCreated rdf:type owl:ObjectProperty ;
-               rdfs:subPropertyOf ec:hasDate ;
-               rdfs:range time:Instant ;
-               dcterms:description "Das Datum der Erstellung des Assets."@de ,
-                                   "La date de création de l'actif."@fr ,
-                                   "The date of creation of the Asset."@en ;
-               rdfs:label "Creation date/time"@en ,
-                          "Date/heure de création"@fr ,
-                          "Erstellungsdatum/-zeit"@de .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateDeleted
-ec:dateDeleted rdf:type owl:ObjectProperty ;
-               rdfs:subPropertyOf ec:hasDate ;
-               rdfs:range time:Instant ;
-               dcterms:description "Das Datum, an dem die Ressource gelöscht wurde."@de ,
-                                   "La date à laquelle la ressource a été supprimée."@fr ,
-                                   "The date when the Resource was deleted."@en ;
-               rdfs:label "Date de suppression"@fr ,
-                          "Datum der Löschung"@de ,
-                          "Deletion date"@en .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateDigitised
-ec:dateDigitised rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf ec:hasDate ;
-                 rdfs:range time:Instant ;
-                 dcterms:description "Das Datum, an dem die Ressource digitalisiert wurde."@de ,
-                                     "La date à laquelle la ressource a été numérisée."@fr ,
-                                     "The date when the Resource was digitised."@en ;
-                 rdfs:label "Date de numérisation"@fr ,
-                            "Datum der Digitalisierung"@de ,
-                            "Digitisation date"@en .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateDistributed
-ec:dateDistributed rdf:type owl:ObjectProperty ;
-                   rdfs:subPropertyOf ec:hasDate ;
-                   rdfs:range time:Instant ;
-                   dcterms:description "Das Datum, an dem die Ressource erstmals der Öffentlichkeit zum Kauf, Download oder Online-Zugriff zur Verfügung gestellt wurde."@de ,
-                                       "La date à laquelle la ressource a été mise pour la première fois à la disposition du public pour l'achat, le téléchargement ou l'accès en ligne."@fr ,
-                                       "The date when the Resource was first made available to the public for purchase, download, or online access."@en ;
-                   rdfs:label "Date de distribution"@fr ,
-                              "Datum der Verteilung"@de ,
-                              "Distribution date"@en .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateIngested
-ec:dateIngested rdf:type owl:ObjectProperty ;
-                rdfs:subPropertyOf ec:hasDate ;
-                rdfs:range time:Instant ;
-                dcterms:description "Das Datum, an dem die Ressource in den institutionellen Bestand aufgenommen/erworben wurde."@de ,
-                                    "La date à laquelle la ressource a été ingérée/acquise dans les fonds institutionnels."@fr ,
-                                    "The date when the Resource was ingested/acquired in institutional holdings."@en ;
-                rdfs:label "Date d'ingestion"@fr ,
-                           "Ingest date"@en ,
-                           "Ingest-Datum"@de .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateIssued
-ec:dateIssued rdf:type owl:ObjectProperty ;
-              rdfs:subPropertyOf ec:hasDate ;
-              rdfs:range time:Instant ;
-              dcterms:description "Das Datum, an dem das Asset ausgegeben wurde."@de ,
-                                  "La date à laquelle l'actif a été émis."@fr ,
-                                  "The date when the Asset was issued."@en ;
-              rdfs:label "Date d'émission"@fr ,
-                         "Date issued"@en ,
-                         "Datum der Ausstellung"@de .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateLicenseEnd
-ec:dateLicenseEnd rdf:type owl:ObjectProperty ;
-                  rdfs:subPropertyOf ec:hasDate ;
-                  rdfs:range time:Instant ;
-                  dcterms:description "Das Datum, an dem die Lizenz für das Asset endet."@de ,
-                                      "La date à laquelle la licence de l'actif prend fin."@fr ,
-                                      "The date when the licence for the Asset ends."@en ;
-                  rdfs:label "Date de fin de licence"@fr ,
-                             "Enddatum der Lizenz"@de ,
-                             "Licence end date"@en .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateMigrated
-ec:dateMigrated rdf:type owl:ObjectProperty ;
-                rdfs:subPropertyOf ec:hasDate ;
-                rdfs:range time:Instant ;
-                dcterms:description "Das Datum, an dem die Ressource kopiert oder von einem veralteten oder gefährdeten Originalformat in ein aktuelleres Format zur Aufbewahrung konvertiert wurde."@de ,
-                                    "La date à laquelle la ressource a été copiée ou convertie d'un format original obsolète ou menacé à un format plus actualisé pour la conservation."@fr ,
-                                    "The date when the Resource was copied or converted from an obsolete or endangered original format to a more updated format for preservation."@en ;
-                rdfs:label "Date de migration"@fr ,
-                           "Datum der Migration"@de ,
-                           "Migration date"@en .
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#date
+ec:date rdf:type owl:ObjectProperty .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#derivedTo
@@ -1391,6 +1276,17 @@ ec:hasContentEditorialFormat rdf:type owl:ObjectProperty ;
                                         "Format rédactionnel"@fr ,
                                         "Redaktionelles Format"@de .
 
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContractCostAmountCurrency
+ec:hasContractCostAmountCurrency rdf:type owl:ObjectProperty ;
+                                 dcterms:description "Die Währung des Betrags der ContractCost."@de ,
+                                                     "La devise du montant du ContractCost."@fr ,
+                                                     "The currency of the amount of the ContractCost."@en ;
+                                 rdfs:label "Cost currency"@en ,
+                                            "Devise de coût"@fr ,
+                                            "Kostenwährung"@de .
+
+
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContractLink
 ec:hasContractLink rdf:type owl:ObjectProperty ;
                    dcterms:description "A link to a location where information can be found about a Contract."@en ,
@@ -1399,34 +1295,6 @@ ec:hasContractLink rdf:type owl:ObjectProperty ;
                    rdfs:label "Contract link"@en ,
                               "Lien vers le contrat"@fr ,
                               "Vertrag Link"@de .
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContractCostAmountCurrency
-ec:hasContractCostAmountCurrency rdf:type owl:ObjectProperty ;
-                                 dcterms:description "Die Währung des Betrags der ContractCost."@de ,
-                                                     "La devise du montant du ContractCost."@fr ,
-                                                     "The currency of the amount of the ContractCost."@en ;
-                                 rdfs:label "Cost currency"@en ,
-                                            "Devise de coût"@fr ,
-                                            "Kostenwährung"@de .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContractCostAmountCurrency
-ec:hasContractCostAmountCurrency rdf:type owl:ObjectProperty ;
-                                 dcterms:description "Die Währung des Betrags der ContractCost."@de ,
-                                                     "La devise du montant du ContractCost."@fr ,
-                                                     "The currency of the amount of the ContractCost."@en ;
-                                 rdfs:label "Cost currency"@en ,
-                                            "Devise de coût"@fr ,
-                                            "Kostenwährung"@de .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContractCostAmountCurrency
-ec:hasContractCostAmountCurrency rdf:type owl:ObjectProperty ;
-                                 dcterms:description "Die Währung des Betrags der ContractCost."@de ,
-                                                     "La devise du montant du ContractCost."@fr ,
-                                                     "The currency of the amount of the ContractCost."@en ;
-                                 rdfs:label "Cost currency"@en ,
-                                            "Devise de coût"@fr ,
-                                            "Kostenwährung"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContractRelatedCost
@@ -1616,6 +1484,116 @@ ec:hasDate rdf:type owl:ObjectProperty ;
            rdfs:label "Date"@en ,
                       "Date"@fr ,
                       "Datum"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateArchived
+ec:hasDateArchived rdf:type owl:ObjectProperty ;
+                   rdfs:subPropertyOf ec:hasDate ;
+                   rdfs:range time:Instant ;
+                   dcterms:description "Das Datum, an dem das Asset archiviert wurde."@de ,
+                                       "La date à laquelle l'actif a été archivé."@fr ,
+                                       "The date when the Asset was archived."@en ;
+                   rdfs:label "Archiving date"@en ,
+                              "Date d'archivage"@fr ,
+                              "Datum der Archivierung"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateBroadcast
+ec:hasDateBroadcast rdf:type owl:ObjectProperty ;
+                    rdfs:subPropertyOf ec:hasDate ;
+                    rdfs:range time:Instant ;
+                    dcterms:description "Das Datum, an dem der Asset zum ersten Mal öffentlich im Fernsehen, Radio oder per Streaming ausgestrahlt wurde."@de ,
+                                        "La date à laquelle l'actif a été diffusé pour la première fois en public à la télévision ou à la radio ou par streaming."@fr ,
+                                        "The date when the Asset was first broadcast publicly on television or radio or via streaming."@en ;
+                    rdfs:label "Broadcast date"@en ,
+                               "Date de diffusion"@fr ,
+                               "Datum der Ausstrahlung"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateCreated
+ec:hasDateCreated rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf ec:hasDate ;
+                  rdfs:range time:Instant ;
+                  dcterms:description "Das Datum der Erstellung des Assets."@de ,
+                                      "La date de création de l'actif."@fr ,
+                                      "The date of creation of the Asset."@en ;
+                  rdfs:label "Creation date/time"@en ,
+                             "Date/heure de création"@fr ,
+                             "Erstellungsdatum/-zeit"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateDeleted
+ec:hasDateDeleted rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf ec:hasDate ;
+                  rdfs:range time:Instant ;
+                  dcterms:description "Das Datum, an dem die Ressource gelöscht wurde."@de ,
+                                      "La date à laquelle la ressource a été supprimée."@fr ,
+                                      "The date when the Resource was deleted."@en ;
+                  rdfs:label "Date de suppression"@fr ,
+                             "Datum der Löschung"@de ,
+                             "Deletion date"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateDigitised
+ec:hasDateDigitised rdf:type owl:ObjectProperty ;
+                    rdfs:subPropertyOf ec:hasDate ;
+                    rdfs:range time:Instant ;
+                    dcterms:description "Das Datum, an dem die Ressource digitalisiert wurde."@de ,
+                                        "La date à laquelle la ressource a été numérisée."@fr ,
+                                        "The date when the Resource was digitised."@en ;
+                    rdfs:label "Date de numérisation"@fr ,
+                               "Datum der Digitalisierung"@de ,
+                               "Digitisation date"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateDistributed
+ec:hasDateDistributed rdf:type owl:ObjectProperty ;
+                      rdfs:subPropertyOf ec:hasDate ;
+                      rdfs:range time:Instant ;
+                      dcterms:description "Das Datum, an dem die Ressource erstmals der Öffentlichkeit zum Kauf, Download oder Online-Zugriff zur Verfügung gestellt wurde."@de ,
+                                          "La date à laquelle la ressource a été mise pour la première fois à la disposition du public pour l'achat, le téléchargement ou l'accès en ligne."@fr ,
+                                          "The date when the Resource was first made available to the public for purchase, download, or online access."@en ;
+                      rdfs:label "Date de distribution"@fr ,
+                                 "Datum der Verteilung"@de ,
+                                 "Distribution date"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateIngested
+ec:hasDateIngested rdf:type owl:ObjectProperty ;
+                   rdfs:subPropertyOf ec:hasDate ;
+                   rdfs:range time:Instant ;
+                   dcterms:description "Das Datum, an dem die Ressource in den institutionellen Bestand aufgenommen/erworben wurde."@de ,
+                                       "La date à laquelle la ressource a été ingérée/acquise dans les fonds institutionnels."@fr ,
+                                       "The date when the Resource was ingested/acquired in institutional holdings."@en ;
+                   rdfs:label "Date d'ingestion"@fr ,
+                              "Ingest date"@en ,
+                              "Ingest-Datum"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateIssued
+ec:hasDateIssued rdf:type owl:ObjectProperty ;
+                 rdfs:subPropertyOf ec:hasDate ;
+                 rdfs:range time:Instant ;
+                 dcterms:description "Das Datum, an dem das Asset ausgegeben wurde."@de ,
+                                     "La date à laquelle l'actif a été émis."@fr ,
+                                     "The date when the Asset was issued."@en ;
+                 rdfs:label "Date d'émission"@fr ,
+                            "Date issued"@en ,
+                            "Datum der Ausstellung"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateLicenseEnd
+ec:hasDateLicenseEnd rdf:type owl:ObjectProperty ;
+                     rdfs:subPropertyOf ec:hasDate ;
+                     rdfs:range time:Instant ;
+                     dcterms:description "Das Datum, an dem die Lizenz für das Asset endet."@de ,
+                                         "La date à laquelle la licence de l'actif prend fin."@fr ,
+                                         "The date when the licence for the Asset ends."@en ;
+                     rdfs:label "Date de fin de licence"@fr ,
+                                "Enddatum der Lizenz"@de ,
+                                "Licence end date"@en .
+
+
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateLicensedStart
 ec:hasDateLicensedStart rdf:type owl:ObjectProperty ;
                         rdfs:subPropertyOf ec:date ;
@@ -1626,6 +1604,18 @@ ec:hasDateLicensedStart rdf:type owl:ObjectProperty ;
                         rdfs:label "Date de début de la licence"@fr ,
                                    "Licence start date"@en ,
                                    "Startdatum der Lizenz"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateMigrated
+ec:hasDateMigrated rdf:type owl:ObjectProperty ;
+                   rdfs:subPropertyOf ec:hasDate ;
+                   rdfs:range time:Instant ;
+                   dcterms:description "Das Datum, an dem die Ressource kopiert oder von einem veralteten oder gefährdeten Originalformat in ein aktuelleres Format zur Aufbewahrung konvertiert wurde."@de ,
+                                       "La date à laquelle la ressource a été copiée ou convertie d'un format original obsolète ou menacé à un format plus actualisé pour la conservation."@fr ,
+                                       "The date when the Resource was copied or converted from an obsolete or endangered original format to a more updated format for preservation."@en ;
+                   rdfs:label "Date de migration"@fr ,
+                              "Datum der Migration"@de ,
+                              "Migration date"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateModified
@@ -8283,27 +8273,27 @@ ec:Asset rdf:type owl:Class ;
                            owl:allValuesFrom ec:Asset
                          ] ,
                          [ rdf:type owl:Restriction ;
-                           owl:onProperty ec:dateArchived ;
+                           owl:onProperty ec:hasDateArchived ;
                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                            owl:onClass time:Instant
                          ] ,
                          [ rdf:type owl:Restriction ;
-                           owl:onProperty ec:dateCreated ;
+                           owl:onProperty ec:hasDateCreated ;
                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                            owl:onClass time:Instant
                          ] ,
                          [ rdf:type owl:Restriction ;
-                           owl:onProperty ec:dateDeleted ;
+                           owl:onProperty ec:hasDateDeleted ;
                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                            owl:onClass time:Instant
                          ] ,
                          [ rdf:type owl:Restriction ;
-                           owl:onProperty ec:dateDistributed ;
+                           owl:onProperty ec:hasDateDistributed ;
                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                            owl:onClass time:Instant
                          ] ,
                          [ rdf:type owl:Restriction ;
-                           owl:onProperty ec:dateLicenseEnd ;
+                           owl:onProperty ec:hasDateLicenseEnd ;
                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                            owl:onClass time:Instant
                          ] ,
@@ -10472,16 +10462,6 @@ ec:EditorialObject rdf:type owl:Class ;
                                      owl:allValuesFrom ec:EditorialObject
                                    ] ,
                                    [ rdf:type owl:Restriction ;
-                                     owl:onProperty ec:dateBroadcast ;
-                                     owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                                     owl:onClass time:Instant
-                                   ] ,
-                                   [ rdf:type owl:Restriction ;
-                                     owl:onProperty ec:dateIssued ;
-                                     owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                                     owl:onClass time:Instant
-                                   ] ,
-                                   [ rdf:type owl:Restriction ;
                                      owl:onProperty ec:duration ;
                                      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                      owl:onClass ec:TimelinePoint
@@ -10490,6 +10470,16 @@ ec:EditorialObject rdf:type owl:Class ;
                                      owl:onProperty ec:end ;
                                      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                      owl:onClass ec:TimelinePoint
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasDateBroadcast ;
+                                     owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                     owl:onClass time:Instant
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasDateIssued ;
+                                     owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                     owl:onClass time:Instant
                                    ] ,
                                    [ rdf:type owl:Restriction ;
                                      owl:onProperty ec:hasLocation ;
@@ -11122,7 +11112,7 @@ ec:Identifier rdf:type owl:Class ;
                                 owl:allValuesFrom skos:Concept
                               ] ,
                               [ rdf:type owl:Restriction ;
-                                owl:onProperty ec:dateCreated ;
+                                owl:onProperty ec:hasDateCreated ;
                                 owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                 owl:onClass time:Instant
                               ] ,
@@ -11759,21 +11749,6 @@ ec:MediaResource rdf:type owl:Class ;
                                    owl:allValuesFrom ec:MediaResource
                                  ] ,
                                  [ rdf:type owl:Restriction ;
-                                   owl:onProperty ec:dateDigitised ;
-                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                                   owl:onClass time:Instant
-                                 ] ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty ec:dateIngested ;
-                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                                   owl:onClass time:Instant
-                                 ] ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty ec:dateMigrated ;
-                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                                   owl:onClass time:Instant
-                                 ] ,
-                                 [ rdf:type owl:Restriction ;
                                    owl:onProperty ec:displayAspectRatio ;
                                    owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                    owl:onClass ec:ActiveFormatDescriptorCode
@@ -11817,6 +11792,21 @@ ec:MediaResource rdf:type owl:Class ;
                                    owl:onProperty ec:hasContainerMimeType ;
                                    owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                    owl:onClass ec:MimeType
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasDateDigitised ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass time:Instant
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasDateIngested ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass time:Instant
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasDateMigrated ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass time:Instant
                                  ] ,
                                  [ rdf:type owl:Restriction ;
                                    owl:onProperty ec:hasDateNormalized ;
@@ -12977,7 +12967,7 @@ ec:Provenance rdf:type owl:Class ;
                                 owl:allValuesFrom skos:Concept
                               ] ,
                               [ rdf:type owl:Restriction ;
-                                owl:onProperty ec:dateCreated ;
+                                owl:onProperty ec:hasDateCreated ;
                                 owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                 owl:onClass time:DateTimeDescription
                               ] ,
@@ -13978,7 +13968,7 @@ ec:Resource rdf:type owl:Class ;
                               owl:allValuesFrom skos:Concept
                             ] ,
                             [ rdf:type owl:Restriction ;
-                              owl:onProperty ec:dateDeleted ;
+                              owl:onProperty ec:hasDateDeleted ;
                               owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                               owl:onClass time:Instant
                             ] ,
@@ -15302,8 +15292,8 @@ dcterms:contributor dcterms:description "Dans le contexte d'EBUCore, réservé �
                      rdfs:label "Beitragender"@de ;
                      dcterms:description "In the context of EBUCore, reserved for the annotation of RDF properties."@en ,
                                          "Im Kontext von EBUCore für die Annotation von RDF-Eigenschaften reserviert."@de ;
-                     rdfs:label "Contributor"@en ,
-                                "Contributeur"@fr .
+                     rdfs:label "Contributeur"@fr ,
+                                "Contributor"@en .
 
 
 ###  Generated by the OWL API (version 4.5.9.2019-02-01T07:24:44Z) https://github.com/owlcs/owlapi

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -383,6 +383,7 @@ ec:consumesEssence rdf:type owl:ObjectProperty ;
                               "Essence"@fr ,
                               "Essenz"@de .
 
+
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#coversConsumptionDevice
 ec:coversConsumptionDevice rdf:type owl:ObjectProperty ;
                            dcterms:description "Pour identifier un appareil compatible avec le licence de consommation."@fr ,
@@ -427,124 +428,8 @@ ec:createsMetadata rdf:type owl:ObjectProperty ;
                               "erstellt Metadaten"@de .
 
 
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateArchived
-ec:dateArchived rdf:type owl:ObjectProperty ;
-                rdfs:subPropertyOf ec:hasDate ;
-                rdfs:range time:Instant ;
-                dcterms:description "Das Datum, an dem das Asset archiviert wurde."@de ,
-                                    "La date à laquelle l'actif a été archivé."@fr ,
-                                    "The date when the Asset was archived."@en ;
-                rdfs:label "Archiving date"@en ,
-                           "Date d'archivage"@fr ,
-                           "Datum der Archivierung"@de .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateBroadcast
-ec:dateBroadcast rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf ec:hasDate ;
-                 rdfs:range time:Instant ;
-                 dcterms:description "Das Datum, an dem der Asset zum ersten Mal öffentlich im Fernsehen, Radio oder per Streaming ausgestrahlt wurde."@de ,
-                                     "La date à laquelle l'actif a été diffusé pour la première fois en public à la télévision ou à la radio ou par streaming."@fr ,
-                                     "The date when the Asset was first broadcast publicly on television or radio or via streaming."@en ;
-                 rdfs:label "Broadcast date"@en ,
-                            "Date de diffusion"@fr ,
-                            "Datum der Ausstrahlung"@de .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateCreated
-ec:dateCreated rdf:type owl:ObjectProperty ;
-               rdfs:subPropertyOf ec:hasDate ;
-               rdfs:range time:Instant ;
-               dcterms:description "Das Datum der Erstellung des Assets."@de ,
-                                   "La date de création de l'actif."@fr ,
-                                   "The date of creation of the Asset."@en ;
-               rdfs:label "Creation date/time"@en ,
-                          "Date/heure de création"@fr ,
-                          "Erstellungsdatum/-zeit"@de .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateDeleted
-ec:dateDeleted rdf:type owl:ObjectProperty ;
-               rdfs:subPropertyOf ec:hasDate ;
-               rdfs:range time:Instant ;
-               dcterms:description "Das Datum, an dem die Ressource gelöscht wurde."@de ,
-                                   "La date à laquelle la ressource a été supprimée."@fr ,
-                                   "The date when the Resource was deleted."@en ;
-               rdfs:label "Date de suppression"@fr ,
-                          "Datum der Löschung"@de ,
-                          "Deletion date"@en .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateDigitised
-ec:dateDigitised rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf ec:hasDate ;
-                 rdfs:range time:Instant ;
-                 dcterms:description "Das Datum, an dem die Ressource digitalisiert wurde."@de ,
-                                     "La date à laquelle la ressource a été numérisée."@fr ,
-                                     "The date when the Resource was digitised."@en ;
-                 rdfs:label "Date de numérisation"@fr ,
-                            "Datum der Digitalisierung"@de ,
-                            "Digitisation date"@en .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateDistributed
-ec:dateDistributed rdf:type owl:ObjectProperty ;
-                   rdfs:subPropertyOf ec:hasDate ;
-                   rdfs:range time:Instant ;
-                   dcterms:description "Das Datum, an dem die Ressource erstmals der Öffentlichkeit zum Kauf, Download oder Online-Zugriff zur Verfügung gestellt wurde."@de ,
-                                       "La date à laquelle la ressource a été mise pour la première fois à la disposition du public pour l'achat, le téléchargement ou l'accès en ligne."@fr ,
-                                       "The date when the Resource was first made available to the public for purchase, download, or online access."@en ;
-                   rdfs:label "Date de distribution"@fr ,
-                              "Datum der Verteilung"@de ,
-                              "Distribution date"@en .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateIngested
-ec:dateIngested rdf:type owl:ObjectProperty ;
-                rdfs:subPropertyOf ec:hasDate ;
-                rdfs:range time:Instant ;
-                dcterms:description "Das Datum, an dem die Ressource in den institutionellen Bestand aufgenommen/erworben wurde."@de ,
-                                    "La date à laquelle la ressource a été ingérée/acquise dans les fonds institutionnels."@fr ,
-                                    "The date when the Resource was ingested/acquired in institutional holdings."@en ;
-                rdfs:label "Date d'ingestion"@fr ,
-                           "Ingest date"@en ,
-                           "Ingest-Datum"@de .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateIssued
-ec:dateIssued rdf:type owl:ObjectProperty ;
-              rdfs:subPropertyOf ec:hasDate ;
-              rdfs:range time:Instant ;
-              dcterms:description "Das Datum, an dem das Asset ausgegeben wurde."@de ,
-                                  "La date à laquelle l'actif a été émis."@fr ,
-                                  "The date when the Asset was issued."@en ;
-              rdfs:label "Date d'émission"@fr ,
-                         "Date issued"@en ,
-                         "Datum der Ausstellung"@de .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateLicenseEnd
-ec:dateLicenseEnd rdf:type owl:ObjectProperty ;
-                  rdfs:subPropertyOf ec:hasDate ;
-                  rdfs:range time:Instant ;
-                  dcterms:description "Das Datum, an dem die Lizenz für das Asset endet."@de ,
-                                      "La date à laquelle la licence de l'actif prend fin."@fr ,
-                                      "The date when the licence for the Asset ends."@en ;
-                  rdfs:label "Date de fin de licence"@fr ,
-                             "Enddatum der Lizenz"@de ,
-                             "Licence end date"@en .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateMigrated
-ec:dateMigrated rdf:type owl:ObjectProperty ;
-                rdfs:subPropertyOf ec:hasDate ;
-                rdfs:range time:Instant ;
-                dcterms:description "Das Datum, an dem die Ressource kopiert oder von einem veralteten oder gefährdeten Originalformat in ein aktuelleres Format zur Aufbewahrung konvertiert wurde."@de ,
-                                    "La date à laquelle la ressource a été copiée ou convertie d'un format original obsolète ou menacé à un format plus actualisé pour la conservation."@fr ,
-                                    "The date when the Resource was copied or converted from an obsolete or endangered original format to a more updated format for preservation."@en ;
-                rdfs:label "Date de migration"@fr ,
-                           "Datum der Migration"@de ,
-                           "Migration date"@en .
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#date
+ec:date rdf:type owl:ObjectProperty .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#derivedTo
@@ -1391,6 +1276,17 @@ ec:hasContentEditorialFormat rdf:type owl:ObjectProperty ;
                                         "Format rédactionnel"@fr ,
                                         "Redaktionelles Format"@de .
 
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContractCostAmountCurrency
+ec:hasContractCostAmountCurrency rdf:type owl:ObjectProperty ;
+                                 dcterms:description "Die Währung des Betrags der ContractCost."@de ,
+                                                     "La devise du montant du ContractCost."@fr ,
+                                                     "The currency of the amount of the ContractCost."@en ;
+                                 rdfs:label "Cost currency"@en ,
+                                            "Devise de coût"@fr ,
+                                            "Kostenwährung"@de .
+
+
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContractLink
 ec:hasContractLink rdf:type owl:ObjectProperty ;
                    dcterms:description "A link to a location where information can be found about a Contract."@en ,
@@ -1399,34 +1295,6 @@ ec:hasContractLink rdf:type owl:ObjectProperty ;
                    rdfs:label "Contract link"@en ,
                               "Lien vers le contrat"@fr ,
                               "Vertrag Link"@de .
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContractCostAmountCurrency
-ec:hasContractCostAmountCurrency rdf:type owl:ObjectProperty ;
-                                 dcterms:description "Die Währung des Betrags der ContractCost."@de ,
-                                                     "La devise du montant du ContractCost."@fr ,
-                                                     "The currency of the amount of the ContractCost."@en ;
-                                 rdfs:label "Cost currency"@en ,
-                                            "Devise de coût"@fr ,
-                                            "Kostenwährung"@de .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContractCostAmountCurrency
-ec:hasContractCostAmountCurrency rdf:type owl:ObjectProperty ;
-                                 dcterms:description "Die Währung des Betrags der ContractCost."@de ,
-                                                     "La devise du montant du ContractCost."@fr ,
-                                                     "The currency of the amount of the ContractCost."@en ;
-                                 rdfs:label "Cost currency"@en ,
-                                            "Devise de coût"@fr ,
-                                            "Kostenwährung"@de .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContractCostAmountCurrency
-ec:hasContractCostAmountCurrency rdf:type owl:ObjectProperty ;
-                                 dcterms:description "Die Währung des Betrags der ContractCost."@de ,
-                                                     "La devise du montant du ContractCost."@fr ,
-                                                     "The currency of the amount of the ContractCost."@en ;
-                                 rdfs:label "Cost currency"@en ,
-                                            "Devise de coût"@fr ,
-                                            "Kostenwährung"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContractRelatedCost
@@ -1616,6 +1484,116 @@ ec:hasDate rdf:type owl:ObjectProperty ;
            rdfs:label "Date"@en ,
                       "Date"@fr ,
                       "Datum"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateArchived
+ec:hasDateArchived rdf:type owl:ObjectProperty ;
+                   rdfs:subPropertyOf ec:hasDate ;
+                   rdfs:range time:Instant ;
+                   dcterms:description "Das Datum, an dem das Asset archiviert wurde."@de ,
+                                       "La date à laquelle l'actif a été archivé."@fr ,
+                                       "The date when the Asset was archived."@en ;
+                   rdfs:label "Archiving date"@en ,
+                              "Date d'archivage"@fr ,
+                              "Datum der Archivierung"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateBroadcast
+ec:hasDateBroadcast rdf:type owl:ObjectProperty ;
+                    rdfs:subPropertyOf ec:hasDate ;
+                    rdfs:range time:Instant ;
+                    dcterms:description "Das Datum, an dem der Asset zum ersten Mal öffentlich im Fernsehen, Radio oder per Streaming ausgestrahlt wurde."@de ,
+                                        "La date à laquelle l'actif a été diffusé pour la première fois en public à la télévision ou à la radio ou par streaming."@fr ,
+                                        "The date when the Asset was first broadcast publicly on television or radio or via streaming."@en ;
+                    rdfs:label "Broadcast date"@en ,
+                               "Date de diffusion"@fr ,
+                               "Datum der Ausstrahlung"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateCreated
+ec:hasDateCreated rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf ec:hasDate ;
+                  rdfs:range time:Instant ;
+                  dcterms:description "Das Datum der Erstellung des Assets."@de ,
+                                      "La date de création de l'actif."@fr ,
+                                      "The date of creation of the Asset."@en ;
+                  rdfs:label "Creation date/time"@en ,
+                             "Date/heure de création"@fr ,
+                             "Erstellungsdatum/-zeit"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateDeleted
+ec:hasDateDeleted rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf ec:hasDate ;
+                  rdfs:range time:Instant ;
+                  dcterms:description "Das Datum, an dem die Ressource gelöscht wurde."@de ,
+                                      "La date à laquelle la ressource a été supprimée."@fr ,
+                                      "The date when the Resource was deleted."@en ;
+                  rdfs:label "Date de suppression"@fr ,
+                             "Datum der Löschung"@de ,
+                             "Deletion date"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateDigitised
+ec:hasDateDigitised rdf:type owl:ObjectProperty ;
+                    rdfs:subPropertyOf ec:hasDate ;
+                    rdfs:range time:Instant ;
+                    dcterms:description "Das Datum, an dem die Ressource digitalisiert wurde."@de ,
+                                        "La date à laquelle la ressource a été numérisée."@fr ,
+                                        "The date when the Resource was digitised."@en ;
+                    rdfs:label "Date de numérisation"@fr ,
+                               "Datum der Digitalisierung"@de ,
+                               "Digitisation date"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateDistributed
+ec:hasDateDistributed rdf:type owl:ObjectProperty ;
+                      rdfs:subPropertyOf ec:hasDate ;
+                      rdfs:range time:Instant ;
+                      dcterms:description "Das Datum, an dem die Ressource erstmals der Öffentlichkeit zum Kauf, Download oder Online-Zugriff zur Verfügung gestellt wurde."@de ,
+                                          "La date à laquelle la ressource a été mise pour la première fois à la disposition du public pour l'achat, le téléchargement ou l'accès en ligne."@fr ,
+                                          "The date when the Resource was first made available to the public for purchase, download, or online access."@en ;
+                      rdfs:label "Date de distribution"@fr ,
+                                 "Datum der Verteilung"@de ,
+                                 "Distribution date"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateIngested
+ec:hasDateIngested rdf:type owl:ObjectProperty ;
+                   rdfs:subPropertyOf ec:hasDate ;
+                   rdfs:range time:Instant ;
+                   dcterms:description "Das Datum, an dem die Ressource in den institutionellen Bestand aufgenommen/erworben wurde."@de ,
+                                       "La date à laquelle la ressource a été ingérée/acquise dans les fonds institutionnels."@fr ,
+                                       "The date when the Resource was ingested/acquired in institutional holdings."@en ;
+                   rdfs:label "Date d'ingestion"@fr ,
+                              "Ingest date"@en ,
+                              "Ingest-Datum"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateIssued
+ec:hasDateIssued rdf:type owl:ObjectProperty ;
+                 rdfs:subPropertyOf ec:hasDate ;
+                 rdfs:range time:Instant ;
+                 dcterms:description "Das Datum, an dem das Asset ausgegeben wurde."@de ,
+                                     "La date à laquelle l'actif a été émis."@fr ,
+                                     "The date when the Asset was issued."@en ;
+                 rdfs:label "Date d'émission"@fr ,
+                            "Date issued"@en ,
+                            "Datum der Ausstellung"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateLicenseEnd
+ec:hasDateLicenseEnd rdf:type owl:ObjectProperty ;
+                     rdfs:subPropertyOf ec:hasDate ;
+                     rdfs:range time:Instant ;
+                     dcterms:description "Das Datum, an dem die Lizenz für das Asset endet."@de ,
+                                         "La date à laquelle la licence de l'actif prend fin."@fr ,
+                                         "The date when the licence for the Asset ends."@en ;
+                     rdfs:label "Date de fin de licence"@fr ,
+                                "Enddatum der Lizenz"@de ,
+                                "Licence end date"@en .
+
+
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateLicensedStart
 ec:hasDateLicensedStart rdf:type owl:ObjectProperty ;
                         rdfs:subPropertyOf ec:date ;
@@ -1626,6 +1604,18 @@ ec:hasDateLicensedStart rdf:type owl:ObjectProperty ;
                         rdfs:label "Date de début de la licence"@fr ,
                                    "Licence start date"@en ,
                                    "Startdatum der Lizenz"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateMigrated
+ec:hasDateMigrated rdf:type owl:ObjectProperty ;
+                   rdfs:subPropertyOf ec:hasDate ;
+                   rdfs:range time:Instant ;
+                   dcterms:description "Das Datum, an dem die Ressource kopiert oder von einem veralteten oder gefährdeten Originalformat in ein aktuelleres Format zur Aufbewahrung konvertiert wurde."@de ,
+                                       "La date à laquelle la ressource a été copiée ou convertie d'un format original obsolète ou menacé à un format plus actualisé pour la conservation."@fr ,
+                                       "The date when the Resource was copied or converted from an obsolete or endangered original format to a more updated format for preservation."@en ;
+                   rdfs:label "Date de migration"@fr ,
+                              "Datum der Migration"@de ,
+                              "Migration date"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateModified
@@ -8283,27 +8273,27 @@ ec:Asset rdf:type owl:Class ;
                            owl:allValuesFrom ec:Asset
                          ] ,
                          [ rdf:type owl:Restriction ;
-                           owl:onProperty ec:dateArchived ;
+                           owl:onProperty ec:hasDateArchived ;
                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                            owl:onClass time:Instant
                          ] ,
                          [ rdf:type owl:Restriction ;
-                           owl:onProperty ec:dateCreated ;
+                           owl:onProperty ec:hasDateCreated ;
                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                            owl:onClass time:Instant
                          ] ,
                          [ rdf:type owl:Restriction ;
-                           owl:onProperty ec:dateDeleted ;
+                           owl:onProperty ec:hasDateDeleted ;
                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                            owl:onClass time:Instant
                          ] ,
                          [ rdf:type owl:Restriction ;
-                           owl:onProperty ec:dateDistributed ;
+                           owl:onProperty ec:hasDateDistributed ;
                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                            owl:onClass time:Instant
                          ] ,
                          [ rdf:type owl:Restriction ;
-                           owl:onProperty ec:dateLicenseEnd ;
+                           owl:onProperty ec:hasDateLicenseEnd ;
                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                            owl:onClass time:Instant
                          ] ,
@@ -10472,16 +10462,6 @@ ec:EditorialObject rdf:type owl:Class ;
                                      owl:allValuesFrom ec:EditorialObject
                                    ] ,
                                    [ rdf:type owl:Restriction ;
-                                     owl:onProperty ec:dateBroadcast ;
-                                     owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                                     owl:onClass time:Instant
-                                   ] ,
-                                   [ rdf:type owl:Restriction ;
-                                     owl:onProperty ec:dateIssued ;
-                                     owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                                     owl:onClass time:Instant
-                                   ] ,
-                                   [ rdf:type owl:Restriction ;
                                      owl:onProperty ec:duration ;
                                      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                      owl:onClass ec:TimelinePoint
@@ -10490,6 +10470,16 @@ ec:EditorialObject rdf:type owl:Class ;
                                      owl:onProperty ec:end ;
                                      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                      owl:onClass ec:TimelinePoint
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasDateBroadcast ;
+                                     owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                     owl:onClass time:Instant
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasDateIssued ;
+                                     owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                     owl:onClass time:Instant
                                    ] ,
                                    [ rdf:type owl:Restriction ;
                                      owl:onProperty ec:hasLocation ;
@@ -11122,7 +11112,7 @@ ec:Identifier rdf:type owl:Class ;
                                 owl:allValuesFrom skos:Concept
                               ] ,
                               [ rdf:type owl:Restriction ;
-                                owl:onProperty ec:dateCreated ;
+                                owl:onProperty ec:hasDateCreated ;
                                 owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                 owl:onClass time:Instant
                               ] ,
@@ -11759,21 +11749,6 @@ ec:MediaResource rdf:type owl:Class ;
                                    owl:allValuesFrom ec:MediaResource
                                  ] ,
                                  [ rdf:type owl:Restriction ;
-                                   owl:onProperty ec:dateDigitised ;
-                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                                   owl:onClass time:Instant
-                                 ] ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty ec:dateIngested ;
-                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                                   owl:onClass time:Instant
-                                 ] ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty ec:dateMigrated ;
-                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                                   owl:onClass time:Instant
-                                 ] ,
-                                 [ rdf:type owl:Restriction ;
                                    owl:onProperty ec:displayAspectRatio ;
                                    owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                    owl:onClass ec:ActiveFormatDescriptorCode
@@ -11817,6 +11792,21 @@ ec:MediaResource rdf:type owl:Class ;
                                    owl:onProperty ec:hasContainerMimeType ;
                                    owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                    owl:onClass ec:MimeType
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasDateDigitised ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass time:Instant
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasDateIngested ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass time:Instant
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasDateMigrated ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass time:Instant
                                  ] ,
                                  [ rdf:type owl:Restriction ;
                                    owl:onProperty ec:hasDateNormalized ;
@@ -12977,7 +12967,7 @@ ec:Provenance rdf:type owl:Class ;
                                 owl:allValuesFrom skos:Concept
                               ] ,
                               [ rdf:type owl:Restriction ;
-                                owl:onProperty ec:dateCreated ;
+                                owl:onProperty ec:hasDateCreated ;
                                 owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                 owl:onClass time:DateTimeDescription
                               ] ,
@@ -13978,7 +13968,7 @@ ec:Resource rdf:type owl:Class ;
                               owl:allValuesFrom skos:Concept
                             ] ,
                             [ rdf:type owl:Restriction ;
-                              owl:onProperty ec:dateDeleted ;
+                              owl:onProperty ec:hasDateDeleted ;
                               owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                               owl:onClass time:Instant
                             ] ,

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -427,6 +427,126 @@ ec:createsMetadata rdf:type owl:ObjectProperty ;
                               "erstellt Metadaten"@de .
 
 
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateArchived
+ec:dateArchived rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf ec:hasDate ;
+                rdfs:range time:Instant ;
+                dcterms:description "Das Datum, an dem das Asset archiviert wurde."@de ,
+                                    "La date à laquelle l'actif a été archivé."@fr ,
+                                    "The date when the Asset was archived."@en ;
+                rdfs:label "Archiving date"@en ,
+                           "Date d'archivage"@fr ,
+                           "Datum der Archivierung"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateBroadcast
+ec:dateBroadcast rdf:type owl:ObjectProperty ;
+                 rdfs:subPropertyOf ec:hasDate ;
+                 rdfs:range time:Instant ;
+                 dcterms:description "Das Datum, an dem der Asset zum ersten Mal öffentlich im Fernsehen, Radio oder per Streaming ausgestrahlt wurde."@de ,
+                                     "La date à laquelle l'actif a été diffusé pour la première fois en public à la télévision ou à la radio ou par streaming."@fr ,
+                                     "The date when the Asset was first broadcast publicly on television or radio or via streaming."@en ;
+                 rdfs:label "Broadcast date"@en ,
+                            "Date de diffusion"@fr ,
+                            "Datum der Ausstrahlung"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateCreated
+ec:dateCreated rdf:type owl:ObjectProperty ;
+               rdfs:subPropertyOf ec:hasDate ;
+               rdfs:range time:Instant ;
+               dcterms:description "Das Datum der Erstellung des Assets."@de ,
+                                   "La date de création de l'actif."@fr ,
+                                   "The date of creation of the Asset."@en ;
+               rdfs:label "Creation date/time"@en ,
+                          "Date/heure de création"@fr ,
+                          "Erstellungsdatum/-zeit"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateDeleted
+ec:dateDeleted rdf:type owl:ObjectProperty ;
+               rdfs:subPropertyOf ec:hasDate ;
+               rdfs:range time:Instant ;
+               dcterms:description "Das Datum, an dem die Ressource gelöscht wurde."@de ,
+                                   "La date à laquelle la ressource a été supprimée."@fr ,
+                                   "The date when the Resource was deleted."@en ;
+               rdfs:label "Date de suppression"@fr ,
+                          "Datum der Löschung"@de ,
+                          "Deletion date"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateDigitised
+ec:dateDigitised rdf:type owl:ObjectProperty ;
+                 rdfs:subPropertyOf ec:hasDate ;
+                 rdfs:range time:Instant ;
+                 dcterms:description "Das Datum, an dem die Ressource digitalisiert wurde."@de ,
+                                     "La date à laquelle la ressource a été numérisée."@fr ,
+                                     "The date when the Resource was digitised."@en ;
+                 rdfs:label "Date de numérisation"@fr ,
+                            "Datum der Digitalisierung"@de ,
+                            "Digitisation date"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateDistributed
+ec:dateDistributed rdf:type owl:ObjectProperty ;
+                   rdfs:subPropertyOf ec:hasDate ;
+                   rdfs:range time:Instant ;
+                   dcterms:description "Das Datum, an dem die Ressource erstmals der Öffentlichkeit zum Kauf, Download oder Online-Zugriff zur Verfügung gestellt wurde."@de ,
+                                       "La date à laquelle la ressource a été mise pour la première fois à la disposition du public pour l'achat, le téléchargement ou l'accès en ligne."@fr ,
+                                       "The date when the Resource was first made available to the public for purchase, download, or online access."@en ;
+                   rdfs:label "Date de distribution"@fr ,
+                              "Datum der Verteilung"@de ,
+                              "Distribution date"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateIngested
+ec:dateIngested rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf ec:hasDate ;
+                rdfs:range time:Instant ;
+                dcterms:description "Das Datum, an dem die Ressource in den institutionellen Bestand aufgenommen/erworben wurde."@de ,
+                                    "La date à laquelle la ressource a été ingérée/acquise dans les fonds institutionnels."@fr ,
+                                    "The date when the Resource was ingested/acquired in institutional holdings."@en ;
+                rdfs:label "Date d'ingestion"@fr ,
+                           "Ingest date"@en ,
+                           "Ingest-Datum"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateIssued
+ec:dateIssued rdf:type owl:ObjectProperty ;
+              rdfs:subPropertyOf ec:hasDate ;
+              rdfs:range time:Instant ;
+              dcterms:description "Das Datum, an dem das Asset ausgegeben wurde."@de ,
+                                  "La date à laquelle l'actif a été émis."@fr ,
+                                  "The date when the Asset was issued."@en ;
+              rdfs:label "Date d'émission"@fr ,
+                         "Date issued"@en ,
+                         "Datum der Ausstellung"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateLicenseEnd
+ec:dateLicenseEnd rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf ec:hasDate ;
+                  rdfs:range time:Instant ;
+                  dcterms:description "Das Datum, an dem die Lizenz für das Asset endet."@de ,
+                                      "La date à laquelle la licence de l'actif prend fin."@fr ,
+                                      "The date when the licence for the Asset ends."@en ;
+                  rdfs:label "Date de fin de licence"@fr ,
+                             "Enddatum der Lizenz"@de ,
+                             "Licence end date"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateMigrated
+ec:dateMigrated rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf ec:hasDate ;
+                rdfs:range time:Instant ;
+                dcterms:description "Das Datum, an dem die Ressource kopiert oder von einem veralteten oder gefährdeten Originalformat in ein aktuelleres Format zur Aufbewahrung konvertiert wurde."@de ,
+                                    "La date à laquelle la ressource a été copiée ou convertie d'un format original obsolète ou menacé à un format plus actualisé pour la conservation."@fr ,
+                                    "The date when the Resource was copied or converted from an obsolete or endangered original format to a more updated format for preservation."@en ;
+                rdfs:label "Date de migration"@fr ,
+                           "Datum der Migration"@de ,
+                           "Migration date"@en .
+
+
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#derivedTo
 ec:derivedTo rdf:type owl:ObjectProperty ;
              owl:inverseOf ec:isDerivedFrom ;
@@ -1309,26 +1429,6 @@ ec:hasContractCostAmountCurrency rdf:type owl:ObjectProperty ;
                                             "Kostenwährung"@de .
 
 
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContractCostAmountCurrency
-ec:hasContractCostAmountCurrency rdf:type owl:ObjectProperty ;
-                                 dcterms:description "Die Währung des Betrags der ContractCost."@de ,
-                                                     "La devise du montant du ContractCost."@fr ,
-                                                     "The currency of the amount of the ContractCost."@en ;
-                                 rdfs:label "Cost currency"@en ,
-                                            "Devise de coût"@fr ,
-                                            "Kostenwährung"@de .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContractLink
-ec:hasContractLink rdf:type owl:ObjectProperty ;
-                   dcterms:description "A link to a location where information can be found about a Contract."@en ,
-                                       "Ein Link zu einem Ort, an dem Sie Informationen über einen Vertrag."@de ,
-                                       "Un lien vers un emplacement où l'on peut trouver des informations sur un contrat."@fr ;
-                   rdfs:label "Contract link"@en ,
-                              "Lien vers le contrat"@fr ,
-                              "Vertrag Link"@de .
-
-
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContractRelatedCost
 ec:hasContractRelatedCost rdf:type owl:ObjectProperty ;
                           dcterms:description "Pour identifier les coûts liés au contrat."@fr ,
@@ -1516,119 +1616,9 @@ ec:hasDate rdf:type owl:ObjectProperty ;
            rdfs:label "Date"@en ,
                       "Date"@fr ,
                       "Datum"@de .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateArchived
-ec:hasDateArchived rdf:type owl:ObjectProperty ;
-                   rdfs:subPropertyOf ec:hasDate ;
-                   rdfs:range time:Instant ;
-                   dcterms:description "Das Datum, an dem das Asset archiviert wurde."@de ,
-                                       "La date à laquelle l'actif a été archivé."@fr ,
-                                       "The date when the Asset was archived."@en ;
-                   rdfs:label "Archiving date"@en ,
-                              "Date d'archivage"@fr ,
-                              "Datum der Archivierung"@de .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateBroadcast
-ec:hasDateBroadcast rdf:type owl:ObjectProperty ;
-                    rdfs:subPropertyOf ec:hasDate ;
-                    rdfs:range time:Instant ;
-                    dcterms:description "Das Datum, an dem der Asset zum ersten Mal öffentlich im Fernsehen, Radio oder per Streaming ausgestrahlt wurde."@de ,
-                                        "La date à laquelle l'actif a été diffusé pour la première fois en public à la télévision ou à la radio ou par streaming."@fr ,
-                                        "The date when the Asset was first broadcast publicly on television or radio or via streaming."@en ;
-                    rdfs:label "Broadcast date"@en ,
-                               "Date de diffusion"@fr ,
-                               "Datum der Ausstrahlung"@de .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateCreated
-ec:hasDateCreated rdf:type owl:ObjectProperty ;
-                  rdfs:subPropertyOf ec:hasDate ;
-                  rdfs:range time:Instant ;
-                  dcterms:description "Das Datum der Erstellung des Assets."@de ,
-                                      "La date de création de l'actif."@fr ,
-                                      "The date of creation of the Asset."@en ;
-                  rdfs:label "Creation date/time"@en ,
-                             "Date/heure de création"@fr ,
-                             "Erstellungsdatum/-zeit"@de .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateDeleted
-ec:hasDateDeleted rdf:type owl:ObjectProperty ;
-                  rdfs:subPropertyOf ec:hasDate ;
-                  rdfs:range time:Instant ;
-                  dcterms:description "Das Datum, an dem die Ressource gelöscht wurde."@de ,
-                                      "La date à laquelle la ressource a été supprimée."@fr ,
-                                      "The date when the Resource was deleted."@en ;
-                  rdfs:label "Date de suppression"@fr ,
-                             "Datum der Löschung"@de ,
-                             "Deletion date"@en .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateDigitised
-ec:hasDateDigitised rdf:type owl:ObjectProperty ;
-                    rdfs:subPropertyOf ec:hasDate ;
-                    rdfs:range time:Instant ;
-                    dcterms:description "Das Datum, an dem die Ressource digitalisiert wurde."@de ,
-                                        "La date à laquelle la ressource a été numérisée."@fr ,
-                                        "The date when the Resource was digitised."@en ;
-                    rdfs:label "Date de numérisation"@fr ,
-                               "Datum der Digitalisierung"@de ,
-                               "Digitisation date"@en .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateDistributed
-ec:hasDateDistributed rdf:type owl:ObjectProperty ;
-                      rdfs:subPropertyOf ec:hasDate ;
-                      rdfs:range time:Instant ;
-                      dcterms:description "Das Datum, an dem die Ressource erstmals der Öffentlichkeit zum Kauf, Download oder Online-Zugriff zur Verfügung gestellt wurde."@de ,
-                                          "La date à laquelle la ressource a été mise pour la première fois à la disposition du public pour l'achat, le téléchargement ou l'accès en ligne."@fr ,
-                                          "The date when the Resource was first made available to the public for purchase, download, or online access."@en ;
-                      rdfs:label "Date de distribution"@fr ,
-                                 "Datum der Verteilung"@de ,
-                                 "Distribution date"@en .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateIngested
-ec:hasDateIngested rdf:type owl:ObjectProperty ;
-                   rdfs:subPropertyOf ec:hasDate ;
-                   rdfs:range time:Instant ;
-                   dcterms:description "Das Datum, an dem die Ressource in den institutionellen Bestand aufgenommen/erworben wurde."@de ,
-                                       "La date à laquelle la ressource a été ingérée/acquise dans les fonds institutionnels."@fr ,
-                                       "The date when the Resource was ingested/acquired in institutional holdings."@en ;
-                   rdfs:label "Date d'ingestion"@fr ,
-                              "Ingest date"@en ,
-                              "Ingest-Datum"@de .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateIssued
-ec:hasDateIssued rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf ec:hasDate ;
-                 rdfs:range time:Instant ;
-                 dcterms:description "Das Datum, an dem das Asset ausgegeben wurde."@de ,
-                                     "La date à laquelle l'actif a été émis."@fr ,
-                                     "The date when the Asset was issued."@en ;
-                 rdfs:label "Date d'émission"@fr ,
-                            "Date issued"@en ,
-                            "Datum der Ausstellung"@de .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateLicenseEnd
-ec:hasDateLicenseEnd rdf:type owl:ObjectProperty ;
-                     rdfs:subPropertyOf ec:hasDate ;
-                     rdfs:range time:Instant ;
-                     dcterms:description "Das Datum, an dem die Lizenz für das Asset endet."@de ,
-                                         "La date à laquelle la licence de l'actif prend fin."@fr ,
-                                         "The date when the licence for the Asset ends."@en ;
-                     rdfs:label "Date de fin de licence"@fr ,
-                                "Enddatum der Lizenz"@de ,
-                                "Licence end date"@en .
-
-
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateLicensedStart
 ec:hasDateLicensedStart rdf:type owl:ObjectProperty ;
-                        rdfs:subPropertyOf ec:hasDate ;
+                        rdfs:subPropertyOf ec:date ;
                         rdfs:range time:Instant ;
                         dcterms:description "Das Datum, an dem die Lizenz für das Asset beginnt."@de ,
                                             "La date à laquelle la licence pour le bien commence."@fr ,
@@ -1638,21 +1628,9 @@ ec:hasDateLicensedStart rdf:type owl:ObjectProperty ;
                                    "Startdatum der Lizenz"@de .
 
 
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateMigrated
-ec:hasDateMigrated rdf:type owl:ObjectProperty ;
-                   rdfs:subPropertyOf ec:hasDate ;
-                   rdfs:range time:Instant ;
-                   dcterms:description "Das Datum, an dem die Ressource kopiert oder von einem veralteten oder gefährdeten Originalformat in ein aktuelleres Format zur Aufbewahrung konvertiert wurde."@de ,
-                                       "La date à laquelle la ressource a été copiée ou convertie d'un format original obsolète ou menacé à un format plus actualisé pour la conservation."@fr ,
-                                       "The date when the Resource was copied or converted from an obsolete or endangered original format to a more updated format for preservation."@en ;
-                   rdfs:label "Date de migration"@fr ,
-                              "Datum der Migration"@de ,
-                              "Migration date"@en .
-
-
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateModified
 ec:hasDateModified rdf:type owl:ObjectProperty ;
-                   rdfs:subPropertyOf ec:hasDate ;
+                   rdfs:subPropertyOf ec:date ;
                    rdfs:range time:Instant ;
                    dcterms:description "Pour indiquer la date à laquelle l'actif a été modifié."@fr ,
                                        "To indicate the date at which the Asset has been modified."@en ,
@@ -1664,7 +1642,7 @@ ec:hasDateModified rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateNormalized
 ec:hasDateNormalized rdf:type owl:ObjectProperty ;
-                     rdfs:subPropertyOf ec:hasDate ;
+                     rdfs:subPropertyOf ec:date ;
                      rdfs:range time:Instant ;
                      dcterms:description "Das Datum, an dem die Ressource aus ihrem ursprünglichen Format in ein von der Institution für die Aufbewahrung ausgewähltes Format konvertiert wurde."@de ,
                                          "La date à laquelle la ressource a été convertie de son format original en un format présélectionné par l'institution pour la préservation."@fr ,
@@ -1676,7 +1654,7 @@ ec:hasDateNormalized rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateOfBirth
 ec:hasDateOfBirth rdf:type owl:ObjectProperty ;
-                  rdfs:subPropertyOf ec:hasDate ;
+                  rdfs:subPropertyOf ec:date ;
                   rdfs:range time:Instant ;
                   dcterms:description "Das Datum, an dem ein Kontakt/eine Person geboren wird."@de ,
                                       "La date de naissance d'un contact/personne."@fr ,
@@ -1688,7 +1666,7 @@ ec:hasDateOfBirth rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateOfDeath
 ec:hasDateOfDeath rdf:type owl:ObjectProperty ;
-                  rdfs:subPropertyOf ec:hasDate ;
+                  rdfs:subPropertyOf ec:date ;
                   rdfs:range time:Instant ;
                   dcterms:description "Das Datum, an dem ein Kontakt/eine Person verstorben ist."@de ,
                                       "La date à laquelle un contact/personne est décédé."@fr ,
@@ -1700,7 +1678,7 @@ ec:hasDateOfDeath rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateOfRetirement
 ec:hasDateOfRetirement rdf:type owl:ObjectProperty ;
-                       rdfs:subPropertyOf ec:hasDate ;
+                       rdfs:subPropertyOf ec:date ;
                        rdfs:range time:Instant ;
                        dcterms:description "Das Datum, an dem ein Kontakt/eine Person in den Ruhestand getreten ist."@de ,
                                            "La date à laquelle un contact/personne a pris sa retraite."@fr ,
@@ -1712,7 +1690,7 @@ ec:hasDateOfRetirement rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateProduced
 ec:hasDateProduced rdf:type owl:ObjectProperty ;
-                   rdfs:subPropertyOf ec:hasDate ;
+                   rdfs:subPropertyOf ec:date ;
                    rdfs:range time:Instant ;
                    dcterms:description "Das Datum der Produktion des Assets."@de ,
                                        "La date de production de l'actif."@fr ,
@@ -1724,7 +1702,7 @@ ec:hasDateProduced rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateReleased
 ec:hasDateReleased rdf:type owl:ObjectProperty ;
-                   rdfs:subPropertyOf ec:hasDate ;
+                   rdfs:subPropertyOf ec:date ;
                    rdfs:range time:Instant ;
                    dcterms:description "Das Datum, an dem die Ressource erstmals der Öffentlichkeit zum Kauf, Download oder Online-Zugriff zur Verfügung gestellt wurde."@de ,
                                        "La date à laquelle la ressource a été mise pour la première fois à la disposition du public pour l'achat, le téléchargement ou l'accès en ligne."@fr ,
@@ -1736,7 +1714,7 @@ ec:hasDateReleased rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateTransferred
 ec:hasDateTransferred rdf:type owl:ObjectProperty ;
-                      rdfs:subPropertyOf ec:hasDate ;
+                      rdfs:subPropertyOf ec:date ;
                       rdfs:range time:Instant ;
                       dcterms:description "Das Datum, an dem das Asset von einem digitalen oder physischen Ort zu einem anderen verschoben wurde."@de ,
                                           "La date à laquelle l'actif a été déplacé d'un emplacement numérique ou physique à un autre."@fr ,
@@ -1748,7 +1726,7 @@ ec:hasDateTransferred rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateValidated
 ec:hasDateValidated rdf:type owl:ObjectProperty ;
-                    rdfs:subPropertyOf ec:hasDate ;
+                    rdfs:subPropertyOf ec:date ;
                     rdfs:range time:Instant ;
                     dcterms:description "Das letzte Datum, an dem die Ressource durch manuelle oder digitale QC als gültig bestätigt wurde."@de ,
                                         "La date la plus récente à laquelle la validité de la ressource a été confirmée par un CQ manuel ou numérique."@fr ,
@@ -3159,7 +3137,7 @@ ec:hasStart rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasStartDateTime
 ec:hasStartDateTime rdf:type owl:ObjectProperty ;
-                    rdfs:subPropertyOf ec:hasDate ;
+                    rdfs:subPropertyOf ec:date ;
                     rdfs:range time:Instant ;
                     dcterms:description "A point of time or start of an interval"@en ,
                                         "Ein Zeitpunkt oder der Beginn eines Intervalls"@de ,
@@ -8305,27 +8283,27 @@ ec:Asset rdf:type owl:Class ;
                            owl:allValuesFrom ec:Asset
                          ] ,
                          [ rdf:type owl:Restriction ;
-                           owl:onProperty ec:hasDateArchived ;
+                           owl:onProperty ec:dateArchived ;
                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                            owl:onClass time:Instant
                          ] ,
                          [ rdf:type owl:Restriction ;
-                           owl:onProperty ec:hasDateCreated ;
+                           owl:onProperty ec:dateCreated ;
                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                            owl:onClass time:Instant
                          ] ,
                          [ rdf:type owl:Restriction ;
-                           owl:onProperty ec:hasDateDeleted ;
+                           owl:onProperty ec:dateDeleted ;
                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                            owl:onClass time:Instant
                          ] ,
                          [ rdf:type owl:Restriction ;
-                           owl:onProperty ec:hasDateDistributed ;
+                           owl:onProperty ec:dateDistributed ;
                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                            owl:onClass time:Instant
                          ] ,
                          [ rdf:type owl:Restriction ;
-                           owl:onProperty ec:hasDateLicenseEnd ;
+                           owl:onProperty ec:dateLicenseEnd ;
                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                            owl:onClass time:Instant
                          ] ,
@@ -10494,6 +10472,16 @@ ec:EditorialObject rdf:type owl:Class ;
                                      owl:allValuesFrom ec:EditorialObject
                                    ] ,
                                    [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:dateBroadcast ;
+                                     owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                     owl:onClass time:Instant
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:dateIssued ;
+                                     owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                     owl:onClass time:Instant
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
                                      owl:onProperty ec:duration ;
                                      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                      owl:onClass ec:TimelinePoint
@@ -10502,16 +10490,6 @@ ec:EditorialObject rdf:type owl:Class ;
                                      owl:onProperty ec:end ;
                                      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                      owl:onClass ec:TimelinePoint
-                                   ] ,
-                                   [ rdf:type owl:Restriction ;
-                                     owl:onProperty ec:hasDateBroadcast ;
-                                     owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                                     owl:onClass time:Instant
-                                   ] ,
-                                   [ rdf:type owl:Restriction ;
-                                     owl:onProperty ec:hasDateIssued ;
-                                     owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                                     owl:onClass time:Instant
                                    ] ,
                                    [ rdf:type owl:Restriction ;
                                      owl:onProperty ec:hasLocation ;
@@ -11144,7 +11122,7 @@ ec:Identifier rdf:type owl:Class ;
                                 owl:allValuesFrom skos:Concept
                               ] ,
                               [ rdf:type owl:Restriction ;
-                                owl:onProperty ec:hasDateCreated ;
+                                owl:onProperty ec:dateCreated ;
                                 owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                 owl:onClass time:Instant
                               ] ,
@@ -11781,6 +11759,21 @@ ec:MediaResource rdf:type owl:Class ;
                                    owl:allValuesFrom ec:MediaResource
                                  ] ,
                                  [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:dateDigitised ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass time:Instant
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:dateIngested ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass time:Instant
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:dateMigrated ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass time:Instant
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
                                    owl:onProperty ec:displayAspectRatio ;
                                    owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                    owl:onClass ec:ActiveFormatDescriptorCode
@@ -11824,21 +11817,6 @@ ec:MediaResource rdf:type owl:Class ;
                                    owl:onProperty ec:hasContainerMimeType ;
                                    owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                    owl:onClass ec:MimeType
-                                 ] ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty ec:hasDateDigitised ;
-                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                                   owl:onClass time:Instant
-                                 ] ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty ec:hasDateIngested ;
-                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                                   owl:onClass time:Instant
-                                 ] ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty ec:hasDateMigrated ;
-                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                                   owl:onClass time:Instant
                                  ] ,
                                  [ rdf:type owl:Restriction ;
                                    owl:onProperty ec:hasDateNormalized ;
@@ -12999,7 +12977,7 @@ ec:Provenance rdf:type owl:Class ;
                                 owl:allValuesFrom skos:Concept
                               ] ,
                               [ rdf:type owl:Restriction ;
-                                owl:onProperty ec:hasDateCreated ;
+                                owl:onProperty ec:dateCreated ;
                                 owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                 owl:onClass time:DateTimeDescription
                               ] ,
@@ -14000,7 +13978,7 @@ ec:Resource rdf:type owl:Class ;
                               owl:allValuesFrom skos:Concept
                             ] ,
                             [ rdf:type owl:Restriction ;
-                              owl:onProperty ec:hasDateDeleted ;
+                              owl:onProperty ec:dateDeleted ;
                               owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                               owl:onClass time:Instant
                             ] ,

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -558,18 +558,6 @@ ec:date rdf:type owl:ObjectProperty ;
                    "Datum"@de .
 
 
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateDistributed
-ec:dateDistributed rdf:type owl:ObjectProperty ;
-                   rdfs:subPropertyOf ec:date ;
-                   rdfs:range time:Instant ;
-                   dcterms:description "Das Datum, an dem die Ressource erstmals der Öffentlichkeit zum Kauf, Download oder Online-Zugriff zur Verfügung gestellt wurde."@de ,
-                                       "La date à laquelle la ressource a été mise pour la première fois à la disposition du public pour l'achat, le téléchargement ou l'accès en ligne."@fr ,
-                                       "The date when the Resource was first made available to the public for purchase, download, or online access."@en ;
-                   rdfs:label "Date de distribution"@fr ,
-                              "Datum der Verteilung"@de ,
-                              "Distribution date"@en .
-
-
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateIngested
 ec:dateIngested rdf:type owl:ObjectProperty ;
                 rdfs:subPropertyOf ec:date ;
@@ -1720,6 +1708,18 @@ ec:hasDateDigitised rdf:type owl:ObjectProperty ;
                     rdfs:label "Date de numérisation"@fr ,
                                "Datum der Digitalisierung"@de ,
                                "Digitisation date"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateDistributed
+ec:hasDateDistributed rdf:type owl:ObjectProperty ;
+                      rdfs:subPropertyOf ec:date ;
+                      rdfs:range time:Instant ;
+                      dcterms:description "Das Datum, an dem die Ressource erstmals der Öffentlichkeit zum Kauf, Download oder Online-Zugriff zur Verfügung gestellt wurde."@de ,
+                                          "La date à laquelle la ressource a été mise pour la première fois à la disposition du public pour l'achat, le téléchargement ou l'accès en ligne."@fr ,
+                                          "The date when the Resource was first made available to the public for purchase, download, or online access."@en ;
+                      rdfs:label "Date de distribution"@fr ,
+                                 "Datum der Verteilung"@de ,
+                                 "Distribution date"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDepartment
@@ -8269,11 +8269,6 @@ ec:Asset rdf:type owl:Class ;
                            owl:allValuesFrom ec:Asset
                          ] ,
                          [ rdf:type owl:Restriction ;
-                           owl:onProperty ec:dateDistributed ;
-                           owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                           owl:onClass time:Instant
-                         ] ,
-                         [ rdf:type owl:Restriction ;
                            owl:onProperty ec:dateLicenseEnd ;
                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                            owl:onClass time:Instant
@@ -8310,6 +8305,11 @@ ec:Asset rdf:type owl:Class ;
                          ] ,
                          [ rdf:type owl:Restriction ;
                            owl:onProperty ec:hasDateDeleted ;
+                           owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                           owl:onClass time:Instant
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasDateDistributed ;
                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                            owl:onClass time:Instant
                          ] ,

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -17,7 +17,7 @@
 @base <http://www.ebu.ch/metadata/ontologies/ebucoreplus> .
 
 <http://www.ebu.ch/metadata/ontologies/ebucoreplus> rdf:type owl:Ontology ;
-                                                     owl:versionIRI <http://www.ebu.ch/metadata/ontologies/ebucoreplus/1.0.0> ;
+                                                     owl:versionIRI <http://www.ebu.ch/metadata/ontologies/ebucoreplus/1.0.7> ;
                                                      owl:imports <http://www.w3.org/2004/02/skos/core> ;
                                                      cc:licence "http://creativecommons.org/licenses/by-sa/3.0/" ;
                                                      dc:contributor "Adam Wead, Penn State University"@en-us ,
@@ -251,17 +251,6 @@ ec:accountingTo rdf:type owl:ObjectProperty ;
                            "Konto"@de .
 
 
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#annotationCurationDateTime
-ec:annotationCurationDateTime rdf:type owl:ObjectProperty ;
-                              rdfs:range time:Instant ;
-                              dcterms:description "Pour fournir la date et l'heure auxquelles une Annotation a été révisée."@fr ,
-                                                  "To provide the date and time when an Annotation has been reviewed."@en ,
-                                                  "Um das Datum und die Uhrzeit anzugeben, zu der eine Anmerkung überprüft wurde."@de ;
-                              rdfs:label "Annotation curation date & time"@en ,
-                                         "Date et heure de la curation des annotations"@fr ,
-                                         "Datum und Uhrzeit der Kommentarkuration"@de .
-
-
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#appliesOutOf
 ec:appliesOutOf rdf:type owl:ObjectProperty ;
                 rdfs:range ec:CountryCode ;
@@ -304,62 +293,6 @@ ec:approvedBy rdf:type owl:ObjectProperty ;
               rdfs:label "Agent"@de ,
                          "Agent"@en ,
                          "Agent"@fr .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#artefactDateOfPurchase
-ec:artefactDateOfPurchase rdf:type owl:ObjectProperty ;
-                          rdfs:subPropertyOf ec:date ;
-                          rdfs:range time:Instant ;
-                          dcterms:description "Das Datum, an dem ein Artefakt gekauft wurde. ."@de ,
-                                              "La date à laquelle un artefact a été acheté. ."@fr ,
-                                              "The date when an Artefact was purchased. ."@en ;
-                          rdfs:label "Artefact date of purchase"@en ,
-                                     "Date d'achat de l'artefact"@fr ,
-                                     "Kaufdatum des Artefakts"@de .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#artefactDateOfSell
-ec:artefactDateOfSell rdf:type owl:ObjectProperty ;
-                      rdfs:subPropertyOf ec:date ;
-                      rdfs:range time:Instant ;
-                      dcterms:description "Das Datum, an dem ein Artefakt verkauft wurde."@de ,
-                                          "La date à laquelle un artefact a été vendu."@fr ,
-                                          "The date when an Artefact was sold."@en ;
-                      rdfs:label "Artefact date of sell"@en ,
-                                 "Date de vente de l'artefact"@fr ,
-                                 "Verkaufsdatum des Artefakts"@de .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#assetValueCurrency
-ec:assetValueCurrency rdf:type owl:ObjectProperty ;
-                      dcterms:description "Pour fournir la devise dans laquelle la valeur de l'actif est donnée."@fr ,
-                                          "To provide the currency in which the assetValue is given."@en ,
-                                          "Zur Angabe der Währung, in der der assetValue angegeben wird. gegeben ist."@de ;
-                      rdfs:label "Asset value currency"@en ,
-                                 "Devise de la valeur de l'actif"@fr ,
-                                 "Vermögenswert Währung"@de .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#auditReportDate
-ec:auditReportDate rdf:type owl:ObjectProperty ;
-                   dcterms:description "Das Datum der Veröffentlichung eines AuditReports."@de ,
-                                       "La date de publication d'un rapport d'audit."@fr ,
-                                       "The date of release of an AuditReport."@en ;
-                   rdfs:label "Audit report date"@en ,
-                              "Date du rapport d'audit"@fr ,
-                              "Datum des Prüfungsberichts"@de .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#awardDate
-ec:awardDate rdf:type owl:ObjectProperty ;
-             rdfs:subPropertyOf ec:date ;
-             rdfs:range time:Instant ;
-             dcterms:description "Pour fournir une date à laquelle un prix a été livré."@fr ,
-                                 "To provide an date when an Award was delivered."@en ,
-                                 "Zur Angabe des Datums, an dem ein Award zugestellt wurde."@de ;
-             rdfs:label "Award date"@en ,
-                        "Date d'attribution"@fr ,
-                        "Datum der Vergabe"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#basedOn
@@ -451,56 +384,6 @@ ec:consumesEssence rdf:type owl:ObjectProperty ;
                               "Essenz"@de .
 
 
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#consumptionDeviceManufacturer
-ec:consumptionDeviceManufacturer rdf:type owl:ObjectProperty ;
-                                 dcterms:description "Der Hersteller eines ConsumptionDevice."@de ,
-                                                     "Le fabricant d'un ConsumptionDevice."@fr ,
-                                                     "The manufacturer of a ConsumptionDevice."@en ;
-                                 rdfs:label "Consumption device manufacturer"@en ,
-                                            "Fabricant de dispositifs de consommation"@fr ,
-                                            "Hersteller von Verbrauchsgeräten"@de .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#consumptionEventResumePoint
-ec:consumptionEventResumePoint rdf:type owl:ObjectProperty ;
-                               dcterms:description "Das Datum und der Zeitpunkt, zu dem der Konsum wieder aufgenommen wurde wiederaufgenommen wurde."@de ,
-                                                   "La date et l'heure à laquelle la consommation a repris."@fr ,
-                                                   "The date and time point at which consumption has resumed."@en ;
-                               rdfs:label "Consumption event resume point"@en ,
-                                          "Point de reprise de l'événement de consommation"@fr ,
-                                          "Punkt für die Fortsetzung des Verbrauchsereignisses"@de .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#consumptionLicenceLink
-ec:consumptionLicenceLink rdf:type owl:ObjectProperty ;
-                          dcterms:description "A link to the terms of a ConsumptionLicence."@en ,
-                                              "Ein Link zu den Bedingungen einer ConsumptionLicence."@de ,
-                                              "Un lien vers les conditions d'une licence de consommation."@fr ;
-                          rdfs:label "Consumption licence link"@en ,
-                                     "Lien vers le permis de consommation"@fr ,
-                                     "Link zur Verbrauchslizenz"@de .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#contractCostAmountCurrency
-ec:contractCostAmountCurrency rdf:type owl:ObjectProperty ;
-                              dcterms:description "Die Währung des Betrags der ContractCost."@de ,
-                                                  "La devise du montant du ContractCost."@fr ,
-                                                  "The currency of the amount of the ContractCost."@en ;
-                              rdfs:label "Cost currency"@en ,
-                                         "Devise de coût"@fr ,
-                                         "Kostenwährung"@de .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#contractLink
-ec:contractLink rdf:type owl:ObjectProperty ;
-                dcterms:description "A link to a location where information can be found about a Contract."@en ,
-                                    "Ein Link zu einem Ort, an dem Sie Informationen über einen Vertrag."@de ,
-                                    "Un lien vers un emplacement où l'on peut trouver des informations sur un contrat."@fr ;
-                rdfs:label "Contract link"@en ,
-                           "Lien vers le contrat"@fr ,
-                           "Vertrag Link"@de .
-
-
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#coversConsumptionDevice
 ec:coversConsumptionDevice rdf:type owl:ObjectProperty ;
                            dcterms:description "Pour identifier un appareil compatible avec le licence de consommation."@fr ,
@@ -543,139 +426,6 @@ ec:createsMetadata rdf:type owl:ObjectProperty ;
                    rdfs:label "creates metadata"@en ,
                               "crée des métadonnées"@fr ,
                               "erstellt Metadaten"@de .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#date
-ec:date rdf:type owl:ObjectProperty ;
-        rdfs:range time:Instant ;
-        dc:description "Range: Litteral, on the instance level, this can be restricted to dateTime, date or another suitable format."@en ;
-        dcterms:description "A date associated to an Asset. Range: Litteral, on the instance level, this can be restricted to dateTime, date or another suitable format."@en ,
-                            "Ein Datum, das mit einem Asset verbunden ist. Range: Litteral, auf Instanzebene kann dies auf dateTime, Datum oder ein anderes geeignetes Format beschränkt werden."@de ,
-                            "Une date associée à un actif. Range : Litteral, au niveau de l'instance, cela peut être limité à dateTime, date ou un autre format approprié."@fr ;
-        rdfs:isDefinedBy dc:date ;
-        rdfs:label "Date"@en ,
-                   "Date"@fr ,
-                   "Datum"@de .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateModified
-ec:dateModified rdf:type owl:ObjectProperty ;
-                rdfs:subPropertyOf ec:date ;
-                rdfs:range time:Instant ;
-                dcterms:description "Pour indiquer la date à laquelle l'actif a été modifié."@fr ,
-                                    "To indicate the date at which the Asset has been modified."@en ,
-                                    "Zur Angabe des Datums, an dem das Asset geändert wurde."@de ;
-                rdfs:label "Date/heure de modification"@fr ,
-                           "Datum/Uhrzeit der Änderung"@de ,
-                           "Modification date/time"@en .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateNormalized
-ec:dateNormalized rdf:type owl:ObjectProperty ;
-                  rdfs:subPropertyOf ec:date ;
-                  rdfs:range time:Instant ;
-                  dcterms:description "Das Datum, an dem die Ressource aus ihrem ursprünglichen Format in ein von der Institution für die Aufbewahrung ausgewähltes Format konvertiert wurde."@de ,
-                                      "La date à laquelle la ressource a été convertie de son format original en un format présélectionné par l'institution pour la préservation."@fr ,
-                                      "The date when the Resource was converted from its original format into a format pre-selected by the institution for preservation."@en ;
-                  rdfs:label "Date de normalisation"@fr ,
-                             "Datum der Normalisierung"@de ,
-                             "Normalization date"@en .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateOfBirth
-ec:dateOfBirth rdf:type owl:ObjectProperty ;
-               rdfs:subPropertyOf ec:date ;
-               rdfs:range time:Instant ;
-               dcterms:description "Das Datum, an dem ein Kontakt/eine Person geboren wird."@de ,
-                                   "La date de naissance d'un contact/personne."@fr ,
-                                   "The date when a Contact/Person is born."@en ;
-               rdfs:label "Date de naissance"@fr ,
-                          "Date of birth"@en ,
-                          "Geburtsdatum"@de .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateOfDeath
-ec:dateOfDeath rdf:type owl:ObjectProperty ;
-               rdfs:subPropertyOf ec:date ;
-               rdfs:range time:Instant ;
-               dcterms:description "Das Datum, an dem ein Kontakt/eine Person verstorben ist."@de ,
-                                   "La date à laquelle un contact/personne est décédé."@fr ,
-                                   "The date when a Contact/Person has passed away."@en ;
-               rdfs:label "Date du décès"@fr ,
-                          "Date of death"@en ,
-                          "Datum des Todes"@de .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateOfRetirement
-ec:dateOfRetirement rdf:type owl:ObjectProperty ;
-                    rdfs:subPropertyOf ec:date ;
-                    rdfs:range time:Instant ;
-                    dcterms:description "Das Datum, an dem ein Kontakt/eine Person in den Ruhestand getreten ist."@de ,
-                                        "La date à laquelle un contact/personne a pris sa retraite."@fr ,
-                                        "The date when a Contact/Person has retired."@en ;
-                    rdfs:label "Date de la retraite"@fr ,
-                               "Date of retirement"@en ,
-                               "Datum der Pensionierung"@de .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateProduced
-ec:dateProduced rdf:type owl:ObjectProperty ;
-                rdfs:subPropertyOf ec:date ;
-                rdfs:range time:Instant ;
-                dcterms:description "Das Datum der Produktion des Assets."@de ,
-                                    "La date de production de l'actif."@fr ,
-                                    "The date of production of the Asset."@en ;
-                rdfs:label "Produktionsdatum"@de ,
-                           "date de production"@fr ,
-                           "production date"@en .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateReleased
-ec:dateReleased rdf:type owl:ObjectProperty ;
-                rdfs:subPropertyOf ec:date ;
-                rdfs:range time:Instant ;
-                dcterms:description "Das Datum, an dem die Ressource erstmals der Öffentlichkeit zum Kauf, Download oder Online-Zugriff zur Verfügung gestellt wurde."@de ,
-                                    "La date à laquelle la ressource a été mise pour la première fois à la disposition du public pour l'achat, le téléchargement ou l'accès en ligne."@fr ,
-                                    "The date when the Resource was first made available to the public for purchase, download, or online access."@en ;
-                rdfs:label "Date de sortie"@fr ,
-                           "Datum der Veröffentlichung"@de ,
-                           "Release date"@en .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateTransferred
-ec:dateTransferred rdf:type owl:ObjectProperty ;
-                   rdfs:subPropertyOf ec:date ;
-                   rdfs:range time:Instant ;
-                   dcterms:description "Das Datum, an dem das Asset von einem digitalen oder physischen Ort zu einem anderen verschoben wurde."@de ,
-                                       "La date à laquelle l'actif a été déplacé d'un emplacement numérique ou physique à un autre."@fr ,
-                                       "The date when the Asset was moved from one digital or physical location to another."@en ;
-                   rdfs:label "Date de transfert"@fr ,
-                              "Datum der Übertragung"@de ,
-                              "Transfer date"@en .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dateValidated
-ec:dateValidated rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf ec:date ;
-                 rdfs:range time:Instant ;
-                 dcterms:description "Das letzte Datum, an dem die Ressource durch manuelle oder digitale QC als gültig bestätigt wurde."@de ,
-                                     "La date la plus récente à laquelle la validité de la ressource a été confirmée par un CQ manuel ou numérique."@fr ,
-                                     "The most recent date when the Resource was confirmed to be valid through manual or digital QC."@en ;
-                 rdfs:label "Date de validation"@fr ,
-                            "Datum der Validierung"@de ,
-                            "Validation date"@en .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#datelicensedStart
-ec:datelicensedStart rdf:type owl:ObjectProperty ;
-                     rdfs:subPropertyOf ec:date ;
-                     rdfs:range time:Instant ;
-                     dcterms:description "Das Datum, an dem die Lizenz für das Asset beginnt."@de ,
-                                         "La date à laquelle la licence pour le bien commence."@fr ,
-                                         "The date when the licence for the Asset begins."@en ;
-                     rdfs:label "Date de début de la licence"@fr ,
-                                "Licence start date"@en ,
-                                "Startdatum der Lizenz"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#derivedTo
@@ -725,7 +475,7 @@ ec:end rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#endDateTime
 ec:endDateTime rdf:type owl:ObjectProperty ;
-               rdfs:subPropertyOf ec:date ;
+               rdfs:subPropertyOf ec:hasDate ;
                rdfs:range time:Instant ;
                dcterms:description "Das Ende eines Intervalls beschreiben"@de ,
                                    "Describing an end of an interval"@en ,
@@ -968,6 +718,17 @@ ec:hasAnnotationAgent rdf:type owl:ObjectProperty ;
                                  "Annotation agent"@en .
 
 
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAnnotationCurationDateTime
+ec:hasAnnotationCurationDateTime rdf:type owl:ObjectProperty ;
+                                 rdfs:range time:Instant ;
+                                 dcterms:description "Pour fournir la date et l'heure auxquelles une Annotation a été révisée."@fr ,
+                                                     "To provide the date and time when an Annotation has been reviewed."@en ,
+                                                     "Um das Datum und die Uhrzeit anzugeben, zu der eine Anmerkung überprüft wurde."@de ;
+                                 rdfs:label "Annotation curation date & time"@en ,
+                                            "Date et heure de la curation des annotations"@fr ,
+                                            "Datum und Uhrzeit der Kommentarkuration"@de .
+
+
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAnnotationTarget
 ec:hasAnnotationTarget rdf:type owl:ObjectProperty ;
                        rdfs:range owl:Thing ;
@@ -988,6 +749,30 @@ ec:hasArtefactBuyer rdf:type owl:ObjectProperty ;
                     rdfs:label "Acheteur"@fr ,
                                "Buyer"@en ,
                                "Käufer"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasArtefactDateOfPurchase
+ec:hasArtefactDateOfPurchase rdf:type owl:ObjectProperty ;
+                             rdfs:subPropertyOf ec:hasDate ;
+                             rdfs:range time:Instant ;
+                             dcterms:description "Das Datum, an dem ein Artefakt gekauft wurde. ."@de ,
+                                                 "La date à laquelle un artefact a été acheté. ."@fr ,
+                                                 "The date when an Artefact was purchased. ."@en ;
+                             rdfs:label "Artefact date of purchase"@en ,
+                                        "Date d'achat de l'artefact"@fr ,
+                                        "Kaufdatum des Artefakts"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasArtefactDateOfSale
+ec:hasArtefactDateOfSale rdf:type owl:ObjectProperty ;
+                         rdfs:subPropertyOf ec:hasDate ;
+                         rdfs:range time:Instant ;
+                         dcterms:description "Das Datum, an dem ein Artefakt verkauft wurde."@de ,
+                                             "La date à laquelle un artefact a été vendu."@fr ,
+                                             "The date when an Artefact was sold."@en ;
+                         rdfs:label "Artefact date of sale"@en ,
+                                    "Date de vente de l'artefact"@fr ,
+                                    "Verkaufsdatum des Artefakts"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasArtefactOwner
@@ -1082,6 +867,16 @@ ec:hasAssetValue rdf:type owl:ObjectProperty ;
                  rdfs:label "Asset value"@en ,
                             "Valeur de l'actif"@fr ,
                             "Vermögenswert"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAssetValueCurrency
+ec:hasAssetValueCurrency rdf:type owl:ObjectProperty ;
+                         dcterms:description "Pour fournir la devise dans laquelle la valeur de l'actif est donnée."@fr ,
+                                             "To provide the currency in which the assetValue is given."@en ,
+                                             "Zur Angabe der Währung, in der der assetValue angegeben wird. gegeben ist."@de ;
+                         rdfs:label "Asset value currency"@en ,
+                                    "Devise de la valeur de l'actif"@fr ,
+                                    "Vermögenswert Währung"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAssociatedArtefact
@@ -1218,6 +1013,28 @@ ec:hasAuditJobRelatedAuditReport rdf:type owl:ObjectProperty ;
                                  rdfs:label "Rapport d'audit connexe"@fr ,
                                             "Related audit report"@en ,
                                             "Zugehöriger Prüfbericht"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAuditReportDate
+ec:hasAuditReportDate rdf:type owl:ObjectProperty ;
+                      dcterms:description "Das Datum der Veröffentlichung eines AuditReports."@de ,
+                                          "La date de publication d'un rapport d'audit."@fr ,
+                                          "The date of release of an AuditReport."@en ;
+                      rdfs:label "Audit report date"@en ,
+                                 "Date du rapport d'audit"@fr ,
+                                 "Datum des Prüfungsberichts"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAwardDate
+ec:hasAwardDate rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf ec:hasDate ;
+                rdfs:range time:Instant ;
+                dcterms:description "Pour fournir une date à laquelle un prix a été livré."@fr ,
+                                    "To provide an date when an Award was delivered."@en ,
+                                    "Zur Angabe des Datums, an dem ein Award zugestellt wurde."@de ;
+                rdfs:label "Award date"@en ,
+                           "Date d'attribution"@fr ,
+                           "Datum der Vergabe"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasBeenAwarded
@@ -1358,6 +1175,16 @@ ec:hasConsumptionCount rdf:type owl:ObjectProperty ;
                                   "hat den Verbrauch gezählt"@de .
 
 
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasConsumptionDeviceManufacturer
+ec:hasConsumptionDeviceManufacturer rdf:type owl:ObjectProperty ;
+                                    dcterms:description "Der Hersteller eines ConsumptionDevice."@de ,
+                                                        "Le fabricant d'un ConsumptionDevice."@fr ,
+                                                        "The manufacturer of a ConsumptionDevice."@en ;
+                                    rdfs:label "Consumption device manufacturer"@en ,
+                                               "Fabricant de dispositifs de consommation"@fr ,
+                                               "Hersteller von Verbrauchsgeräten"@de .
+
+
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasConsumptionEvent
 ec:hasConsumptionEvent rdf:type owl:ObjectProperty ;
                        dcterms:description "Pour identifier un ConsumptionEvent lié à un PublicationEvent."@fr ,
@@ -1366,6 +1193,26 @@ ec:hasConsumptionEvent rdf:type owl:ObjectProperty ;
                        rdfs:label "Consumption event"@en ,
                                   "Verbrauchsereignis"@de ,
                                   "Événement de consommation"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasConsumptionEventResumePoint
+ec:hasConsumptionEventResumePoint rdf:type owl:ObjectProperty ;
+                                  dcterms:description "Das Datum und der Zeitpunkt, zu dem der Konsum wieder aufgenommen wurde wiederaufgenommen wurde."@de ,
+                                                      "La date et l'heure à laquelle la consommation a repris."@fr ,
+                                                      "The date and time point at which consumption has resumed."@en ;
+                                  rdfs:label "Consumption event resume point"@en ,
+                                             "Point de reprise de l'événement de consommation"@fr ,
+                                             "Punkt für die Fortsetzung des Verbrauchsereignisses"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasConsumptionLicenceLink
+ec:hasConsumptionLicenceLink rdf:type owl:ObjectProperty ;
+                             dcterms:description "A link to the terms of a ConsumptionLicence."@en ,
+                                                 "Ein Link zu den Bedingungen einer ConsumptionLicence."@de ,
+                                                 "Un lien vers les conditions d'une licence de consommation."@fr ;
+                             rdfs:label "Consumption licence link"@en ,
+                                        "Lien vers le permis de consommation"@fr ,
+                                        "Link zur Verbrauchslizenz"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContact
@@ -1424,6 +1271,26 @@ ec:hasContentEditorialFormat rdf:type owl:ObjectProperty ;
                              rdfs:label "Editorial format"@en ,
                                         "Format rédactionnel"@fr ,
                                         "Redaktionelles Format"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContractCostAmountCurrency
+ec:hasContractCostAmountCurrency rdf:type owl:ObjectProperty ;
+                                 dcterms:description "Die Währung des Betrags der ContractCost."@de ,
+                                                     "La devise du montant du ContractCost."@fr ,
+                                                     "The currency of the amount of the ContractCost."@en ;
+                                 rdfs:label "Cost currency"@en ,
+                                            "Devise de coût"@fr ,
+                                            "Kostenwährung"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContractLink
+ec:hasContractLink rdf:type owl:ObjectProperty ;
+                   dcterms:description "A link to a location where information can be found about a Contract."@en ,
+                                       "Ein Link zu einem Ort, an dem Sie Informationen über einen Vertrag."@de ,
+                                       "Un lien vers un emplacement où l'on peut trouver des informations sur un contrat."@fr ;
+                   rdfs:label "Contract link"@en ,
+                              "Lien vers le contrat"@fr ,
+                              "Vertrag Link"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContractRelatedCost
@@ -1602,9 +1469,22 @@ ec:hasDataTrack rdf:type owl:ObjectProperty ;
                            "Suivi des données"@fr .
 
 
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDate
+ec:hasDate rdf:type owl:ObjectProperty ;
+           rdfs:range time:Instant ;
+           dc:description "Range: Litteral, on the instance level, this can be restricted to dateTime, date or another suitable format."@en ;
+           dcterms:description "A date associated to an Asset. Range: Litteral, on the instance level, this can be restricted to dateTime, date or another suitable format."@en ,
+                               "Ein Datum, das mit einem Asset verbunden ist. Range: Litteral, auf Instanzebene kann dies auf dateTime, Datum oder ein anderes geeignetes Format beschränkt werden."@de ,
+                               "Une date associée à un actif. Range : Litteral, au niveau de l'instance, cela peut être limité à dateTime, date ou un autre format approprié."@fr ;
+           rdfs:isDefinedBy dc:date ;
+           rdfs:label "Date"@en ,
+                      "Date"@fr ,
+                      "Datum"@de .
+
+
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateArchived
 ec:hasDateArchived rdf:type owl:ObjectProperty ;
-                   rdfs:subPropertyOf ec:date ;
+                   rdfs:subPropertyOf ec:hasDate ;
                    rdfs:range time:Instant ;
                    dcterms:description "Das Datum, an dem das Asset archiviert wurde."@de ,
                                        "La date à laquelle l'actif a été archivé."@fr ,
@@ -1616,7 +1496,7 @@ ec:hasDateArchived rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateBroadcast
 ec:hasDateBroadcast rdf:type owl:ObjectProperty ;
-                    rdfs:subPropertyOf ec:date ;
+                    rdfs:subPropertyOf ec:hasDate ;
                     rdfs:range time:Instant ;
                     dcterms:description "Das Datum, an dem der Asset zum ersten Mal öffentlich im Fernsehen, Radio oder per Streaming ausgestrahlt wurde."@de ,
                                         "La date à laquelle l'actif a été diffusé pour la première fois en public à la télévision ou à la radio ou par streaming."@fr ,
@@ -1628,7 +1508,7 @@ ec:hasDateBroadcast rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateCreated
 ec:hasDateCreated rdf:type owl:ObjectProperty ;
-                  rdfs:subPropertyOf ec:date ;
+                  rdfs:subPropertyOf ec:hasDate ;
                   rdfs:range time:Instant ;
                   dcterms:description "Das Datum der Erstellung des Assets."@de ,
                                       "La date de création de l'actif."@fr ,
@@ -1640,7 +1520,7 @@ ec:hasDateCreated rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateDeleted
 ec:hasDateDeleted rdf:type owl:ObjectProperty ;
-                  rdfs:subPropertyOf ec:date ;
+                  rdfs:subPropertyOf ec:hasDate ;
                   rdfs:range time:Instant ;
                   dcterms:description "Das Datum, an dem die Ressource gelöscht wurde."@de ,
                                       "La date à laquelle la ressource a été supprimée."@fr ,
@@ -1652,7 +1532,7 @@ ec:hasDateDeleted rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateDigitised
 ec:hasDateDigitised rdf:type owl:ObjectProperty ;
-                    rdfs:subPropertyOf ec:date ;
+                    rdfs:subPropertyOf ec:hasDate ;
                     rdfs:range time:Instant ;
                     dcterms:description "Das Datum, an dem die Ressource digitalisiert wurde."@de ,
                                         "La date à laquelle la ressource a été numérisée."@fr ,
@@ -1664,7 +1544,7 @@ ec:hasDateDigitised rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateDistributed
 ec:hasDateDistributed rdf:type owl:ObjectProperty ;
-                      rdfs:subPropertyOf ec:date ;
+                      rdfs:subPropertyOf ec:hasDate ;
                       rdfs:range time:Instant ;
                       dcterms:description "Das Datum, an dem die Ressource erstmals der Öffentlichkeit zum Kauf, Download oder Online-Zugriff zur Verfügung gestellt wurde."@de ,
                                           "La date à laquelle la ressource a été mise pour la première fois à la disposition du public pour l'achat, le téléchargement ou l'accès en ligne."@fr ,
@@ -1676,7 +1556,7 @@ ec:hasDateDistributed rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateIngested
 ec:hasDateIngested rdf:type owl:ObjectProperty ;
-                   rdfs:subPropertyOf ec:date ;
+                   rdfs:subPropertyOf ec:hasDate ;
                    rdfs:range time:Instant ;
                    dcterms:description "Das Datum, an dem die Ressource in den institutionellen Bestand aufgenommen/erworben wurde."@de ,
                                        "La date à laquelle la ressource a été ingérée/acquise dans les fonds institutionnels."@fr ,
@@ -1688,7 +1568,7 @@ ec:hasDateIngested rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateIssued
 ec:hasDateIssued rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf ec:date ;
+                 rdfs:subPropertyOf ec:hasDate ;
                  rdfs:range time:Instant ;
                  dcterms:description "Das Datum, an dem das Asset ausgegeben wurde."@de ,
                                      "La date à laquelle l'actif a été émis."@fr ,
@@ -1700,7 +1580,7 @@ ec:hasDateIssued rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateLicenseEnd
 ec:hasDateLicenseEnd rdf:type owl:ObjectProperty ;
-                     rdfs:subPropertyOf ec:date ;
+                     rdfs:subPropertyOf ec:hasDate ;
                      rdfs:range time:Instant ;
                      dcterms:description "Das Datum, an dem die Lizenz für das Asset endet."@de ,
                                          "La date à laquelle la licence de l'actif prend fin."@fr ,
@@ -1710,9 +1590,21 @@ ec:hasDateLicenseEnd rdf:type owl:ObjectProperty ;
                                 "Licence end date"@en .
 
 
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateLicensedStart
+ec:hasDateLicensedStart rdf:type owl:ObjectProperty ;
+                        rdfs:subPropertyOf ec:hasDate ;
+                        rdfs:range time:Instant ;
+                        dcterms:description "Das Datum, an dem die Lizenz für das Asset beginnt."@de ,
+                                            "La date à laquelle la licence pour le bien commence."@fr ,
+                                            "The date when the licence for the Asset begins."@en ;
+                        rdfs:label "Date de début de la licence"@fr ,
+                                   "Licence start date"@en ,
+                                   "Startdatum der Lizenz"@de .
+
+
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateMigrated
 ec:hasDateMigrated rdf:type owl:ObjectProperty ;
-                   rdfs:subPropertyOf ec:date ;
+                   rdfs:subPropertyOf ec:hasDate ;
                    rdfs:range time:Instant ;
                    dcterms:description "Das Datum, an dem die Ressource kopiert oder von einem veralteten oder gefährdeten Originalformat in ein aktuelleres Format zur Aufbewahrung konvertiert wurde."@de ,
                                        "La date à laquelle la ressource a été copiée ou convertie d'un format original obsolète ou menacé à un format plus actualisé pour la conservation."@fr ,
@@ -1720,6 +1612,114 @@ ec:hasDateMigrated rdf:type owl:ObjectProperty ;
                    rdfs:label "Date de migration"@fr ,
                               "Datum der Migration"@de ,
                               "Migration date"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateModified
+ec:hasDateModified rdf:type owl:ObjectProperty ;
+                   rdfs:subPropertyOf ec:hasDate ;
+                   rdfs:range time:Instant ;
+                   dcterms:description "Pour indiquer la date à laquelle l'actif a été modifié."@fr ,
+                                       "To indicate the date at which the Asset has been modified."@en ,
+                                       "Zur Angabe des Datums, an dem das Asset geändert wurde."@de ;
+                   rdfs:label "Date/heure de modification"@fr ,
+                              "Datum/Uhrzeit der Änderung"@de ,
+                              "Modification date/time"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateNormalized
+ec:hasDateNormalized rdf:type owl:ObjectProperty ;
+                     rdfs:subPropertyOf ec:hasDate ;
+                     rdfs:range time:Instant ;
+                     dcterms:description "Das Datum, an dem die Ressource aus ihrem ursprünglichen Format in ein von der Institution für die Aufbewahrung ausgewähltes Format konvertiert wurde."@de ,
+                                         "La date à laquelle la ressource a été convertie de son format original en un format présélectionné par l'institution pour la préservation."@fr ,
+                                         "The date when the Resource was converted from its original format into a format pre-selected by the institution for preservation."@en ;
+                     rdfs:label "Date de normalisation"@fr ,
+                                "Datum der Normalisierung"@de ,
+                                "Normalization date"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateOfBirth
+ec:hasDateOfBirth rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf ec:hasDate ;
+                  rdfs:range time:Instant ;
+                  dcterms:description "Das Datum, an dem ein Kontakt/eine Person geboren wird."@de ,
+                                      "La date de naissance d'un contact/personne."@fr ,
+                                      "The date when a Contact/Person is born."@en ;
+                  rdfs:label "Date de naissance"@fr ,
+                             "Date of birth"@en ,
+                             "Geburtsdatum"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateOfDeath
+ec:hasDateOfDeath rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf ec:hasDate ;
+                  rdfs:range time:Instant ;
+                  dcterms:description "Das Datum, an dem ein Kontakt/eine Person verstorben ist."@de ,
+                                      "La date à laquelle un contact/personne est décédé."@fr ,
+                                      "The date when a Contact/Person has passed away."@en ;
+                  rdfs:label "Date du décès"@fr ,
+                             "Date of death"@en ,
+                             "Datum des Todes"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateOfRetirement
+ec:hasDateOfRetirement rdf:type owl:ObjectProperty ;
+                       rdfs:subPropertyOf ec:hasDate ;
+                       rdfs:range time:Instant ;
+                       dcterms:description "Das Datum, an dem ein Kontakt/eine Person in den Ruhestand getreten ist."@de ,
+                                           "La date à laquelle un contact/personne a pris sa retraite."@fr ,
+                                           "The date when a Contact/Person has retired."@en ;
+                       rdfs:label "Date de la retraite"@fr ,
+                                  "Date of retirement"@en ,
+                                  "Datum der Pensionierung"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateProduced
+ec:hasDateProduced rdf:type owl:ObjectProperty ;
+                   rdfs:subPropertyOf ec:hasDate ;
+                   rdfs:range time:Instant ;
+                   dcterms:description "Das Datum der Produktion des Assets."@de ,
+                                       "La date de production de l'actif."@fr ,
+                                       "The date of production of the Asset."@en ;
+                   rdfs:label "Produktionsdatum"@de ,
+                              "date de production"@fr ,
+                              "production date"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateReleased
+ec:hasDateReleased rdf:type owl:ObjectProperty ;
+                   rdfs:subPropertyOf ec:hasDate ;
+                   rdfs:range time:Instant ;
+                   dcterms:description "Das Datum, an dem die Ressource erstmals der Öffentlichkeit zum Kauf, Download oder Online-Zugriff zur Verfügung gestellt wurde."@de ,
+                                       "La date à laquelle la ressource a été mise pour la première fois à la disposition du public pour l'achat, le téléchargement ou l'accès en ligne."@fr ,
+                                       "The date when the Resource was first made available to the public for purchase, download, or online access."@en ;
+                   rdfs:label "Date de sortie"@fr ,
+                              "Datum der Veröffentlichung"@de ,
+                              "Release date"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateTransferred
+ec:hasDateTransferred rdf:type owl:ObjectProperty ;
+                      rdfs:subPropertyOf ec:hasDate ;
+                      rdfs:range time:Instant ;
+                      dcterms:description "Das Datum, an dem das Asset von einem digitalen oder physischen Ort zu einem anderen verschoben wurde."@de ,
+                                          "La date à laquelle l'actif a été déplacé d'un emplacement numérique ou physique à un autre."@fr ,
+                                          "The date when the Asset was moved from one digital or physical location to another."@en ;
+                      rdfs:label "Date de transfert"@fr ,
+                                 "Datum der Übertragung"@de ,
+                                 "Transfer date"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateValidated
+ec:hasDateValidated rdf:type owl:ObjectProperty ;
+                    rdfs:subPropertyOf ec:hasDate ;
+                    rdfs:range time:Instant ;
+                    dcterms:description "Das letzte Datum, an dem die Ressource durch manuelle oder digitale QC als gültig bestätigt wurde."@de ,
+                                        "La date la plus récente à laquelle la validité de la ressource a été confirmée par un CQ manuel ou numérique."@fr ,
+                                        "The most recent date when the Resource was confirmed to be valid through manual or digital QC."@en ;
+                    rdfs:label "Date de validation"@fr ,
+                               "Datum der Validierung"@de ,
+                               "Validation date"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDepartment
@@ -2943,6 +2943,37 @@ ec:hasRightsTargetService rdf:type owl:ObjectProperty ;
                                      "Zielservice"@de .
 
 
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRightsTerritoryIncludes
+ec:hasRightsTerritoryIncludes rdf:type owl:ObjectProperty ;
+                              rdfs:range ec:CountryCode ;
+                              dcterms:description "A list of country or region codes to which Rights apply."@en ,
+                                                  "Eine Liste der Länder- oder Regionencodes, für die Rechte gelten."@de ,
+                                                  "Une liste des codes de pays ou de région auxquels les droits s'appliquent."@fr ;
+                              rdfs:label "Enthaltene Territorien"@de ,
+                                         "Included territories"@en ,
+                                         "Territoires inclus"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRulePriority
+ec:hasRulePriority rdf:type owl:ObjectProperty ;
+                   dcterms:description "Pour définir la priorité associée à une règle."@fr ,
+                                       "To define the priority associated to a Rule."@en ,
+                                       "Um die Priorität einer Regel zu definieren."@de ;
+                   rdfs:label "Priorität der Regel"@de ,
+                              "Priorité de la règle"@fr ,
+                              "Rule priority"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRuleReference
+ec:hasRuleReference rdf:type owl:ObjectProperty ;
+                    dcterms:description "Pour fournir des références à une règle."@fr ,
+                                        "To provide references to a Rule."@en ,
+                                        "Um Hinweise auf eine Regel zu geben."@de ;
+                    rdfs:label "Regel-Referenz"@de ,
+                               "Rule reference"@en ,
+                               "Référence de la règle"@fr .
+
+
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasScene
 ec:hasScene rdf:type owl:ObjectProperty ;
             rdfs:subPropertyOf ec:hasPart ;
@@ -3080,6 +3111,26 @@ ec:hasStandard rdf:type owl:ObjectProperty ;
                rdfs:label "Standard"@de ,
                           "Standard"@en ,
                           "Standard"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasStart
+ec:hasStart rdf:type owl:ObjectProperty ;
+            rdfs:range ec:TimelinePoint ;
+            rdfs:label "Début"@fr ,
+                       "Start"@de ,
+                       "Start"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasStartDateTime
+ec:hasStartDateTime rdf:type owl:ObjectProperty ;
+                    rdfs:subPropertyOf ec:hasDate ;
+                    rdfs:range time:Instant ;
+                    dcterms:description "A point of time or start of an interval"@en ,
+                                        "Ein Zeitpunkt oder der Beginn eines Intervalls"@de ,
+                                        "Un instant ou l'nstant de départ d'un intervalle"@fr ;
+                    rdfs:label "Date de début"@fr ,
+                               "Start date time"@en ,
+                               "Startdatum Uhrzeit"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasStorageId
@@ -3378,6 +3429,16 @@ ec:hasVersion rdf:type owl:ObjectProperty ;
               rdfs:label "Version"@de ,
                          "Version"@en ,
                          "Version"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasVersionType
+ec:hasVersionType rdf:type owl:ObjectProperty ;
+                  dcterms:description "Pour spécifier un type de version pour un EditorialObject."@fr ,
+                                      "To specify a type of version for an EditorialObject."@en ,
+                                      "Um eine Art von Version für ein EditorialObject anzugeben."@de ;
+                  rdfs:label "Type de version"@fr ,
+                             "Version Typ"@de ,
+                             "Version type"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasVideoCodec
@@ -4374,57 +4435,6 @@ ec:rightsTerritoryExcludes rdf:type owl:ObjectProperty ;
                                       "Territoires exclus"@fr .
 
 
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#rightsTerritoryIncludes
-ec:rightsTerritoryIncludes rdf:type owl:ObjectProperty ;
-                           rdfs:range ec:CountryCode ;
-                           dcterms:description "A list of country or region codes to which Rights apply."@en ,
-                                               "Eine Liste der Länder- oder Regionencodes, für die Rechte gelten."@de ,
-                                               "Une liste des codes de pays ou de région auxquels les droits s'appliquent."@fr ;
-                           rdfs:label "Enthaltene Territorien"@de ,
-                                      "Included territories"@en ,
-                                      "Territoires inclus"@fr .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#rulePriority
-ec:rulePriority rdf:type owl:ObjectProperty ;
-                dcterms:description "Pour définir la priorité associée à une règle."@fr ,
-                                    "To define the priority associated to a Rule."@en ,
-                                    "Um die Priorität einer Regel zu definieren."@de ;
-                rdfs:label "Priorität der Regel"@de ,
-                           "Priorité de la règle"@fr ,
-                           "Rule priority"@en .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ruleReference
-ec:ruleReference rdf:type owl:ObjectProperty ;
-                 dcterms:description "Pour fournir des références à une règle."@fr ,
-                                     "To provide references to a Rule."@en ,
-                                     "Um Hinweise auf eine Regel zu geben."@de ;
-                 rdfs:label "Regel-Referenz"@de ,
-                            "Rule reference"@en ,
-                            "Référence de la règle"@fr .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#start
-ec:start rdf:type owl:ObjectProperty ;
-         rdfs:range ec:TimelinePoint ;
-         rdfs:label "Début"@fr ,
-                    "Start"@de ,
-                    "Start"@en .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#startDateTime
-ec:startDateTime rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf ec:date ;
-                 rdfs:range time:Instant ;
-                 dcterms:description "A point of time or start of an interval"@en ,
-                                     "Ein Zeitpunkt oder der Beginn eines Intervalls"@de ,
-                                     "Un instant ou l'nstant de départ d'un intervalle"@fr ;
-                 rdfs:label "Date de début"@fr ,
-                            "Start date time"@en ,
-                            "Startdatum Uhrzeit"@de .
-
-
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#supportsConsumptionDeviceProfile
 ec:supportsConsumptionDeviceProfile rdf:type owl:ObjectProperty ;
                                     dcterms:description "Pour définir le profil d'un ConsumptionDevice."@fr ,
@@ -4470,16 +4480,6 @@ ec:usesProductionDevice rdf:type owl:ObjectProperty ;
                         rdfs:label "Dispositif de production"@fr ,
                                    "Production device"@en ,
                                    "Produktionsgerät"@de .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#versionType
-ec:versionType rdf:type owl:ObjectProperty ;
-               dcterms:description "Pour spécifier un type de version pour un EditorialObject."@fr ,
-                                   "To specify a type of version for an EditorialObject."@en ,
-                                   "Um eine Art von Version für ein EditorialObject anzugeben."@de ;
-               rdfs:label "Type de version"@fr ,
-                          "Version Typ"@de ,
-                          "Version type"@en .
 
 
 ###  http://www.w3.org/2000/01/rdf-schema#related
@@ -7430,7 +7430,7 @@ ec:Action rdf:type owl:Class ;
                             owl:allValuesFrom skos:Concept
                           ] ,
                           [ rdf:type owl:Restriction ;
-                            owl:onProperty ec:start ;
+                            owl:onProperty ec:hasStart ;
                             owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                             owl:onClass ec:TimelinePoint
                           ] ,
@@ -7498,7 +7498,7 @@ ec:Affiliation rdf:type owl:Class ;
                                  owl:onClass time:Instant
                                ] ,
                                [ rdf:type owl:Restriction ;
-                                 owl:onProperty ec:startDateTime ;
+                                 owl:onProperty ec:hasStartDateTime ;
                                  owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                  owl:onClass time:Instant
                                ] ,
@@ -7740,7 +7740,7 @@ ec:AlternativeTitle rdf:type owl:Class ;
                                       owl:onClass time:Instant
                                     ] ,
                                     [ rdf:type owl:Restriction ;
-                                      owl:onProperty ec:startDateTime ;
+                                      owl:onProperty ec:hasStartDateTime ;
                                       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                       owl:onClass time:Instant
                                     ] ,
@@ -7838,12 +7838,12 @@ ec:Animal rdf:type owl:Class ;
                             owl:allValuesFrom ec:Character
                           ] ,
                           [ rdf:type owl:Restriction ;
-                            owl:onProperty ec:dateOfBirth ;
+                            owl:onProperty ec:hasDateOfBirth ;
                             owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                             owl:onClass time:Instant
                           ] ,
                           [ rdf:type owl:Restriction ;
-                            owl:onProperty ec:dateOfDeath ;
+                            owl:onProperty ec:hasDateOfDeath ;
                             owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                             owl:onClass time:Instant
                           ] ,
@@ -7932,7 +7932,7 @@ ec:Annotation rdf:type owl:Class ;
                                 owl:allValuesFrom skos:Concept
                               ] ,
                               [ rdf:type owl:Restriction ;
-                                owl:onProperty ec:annotationCurationDateTime ;
+                                owl:onProperty ec:hasAnnotationCurationDateTime ;
                                 owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                 owl:onClass time:Instant
                               ] ,
@@ -8041,12 +8041,12 @@ ec:Artefact rdf:type owl:Class ;
                               owl:allValuesFrom skos:Concept
                             ] ,
                             [ rdf:type owl:Restriction ;
-                              owl:onProperty ec:artefactDateOfPurchase ;
+                              owl:onProperty ec:hasArtefactDateOfPurchase ;
                               owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                               owl:onClass time:Instant
                             ] ,
                             [ rdf:type owl:Restriction ;
-                              owl:onProperty ec:artefactDateOfSell ;
+                              owl:onProperty ec:hasArtefactDateOfSale ;
                               owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                               owl:onClass time:Instant
                             ] ,
@@ -8269,26 +8269,6 @@ ec:Asset rdf:type owl:Class ;
                            owl:allValuesFrom ec:Asset
                          ] ,
                          [ rdf:type owl:Restriction ;
-                           owl:onProperty ec:dateModified ;
-                           owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                           owl:onClass time:Instant
-                         ] ,
-                         [ rdf:type owl:Restriction ;
-                           owl:onProperty ec:dateProduced ;
-                           owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                           owl:onClass time:Instant
-                         ] ,
-                         [ rdf:type owl:Restriction ;
-                           owl:onProperty ec:dateReleased ;
-                           owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                           owl:onClass time:Instant
-                         ] ,
-                         [ rdf:type owl:Restriction ;
-                           owl:onProperty ec:datelicensedStart ;
-                           owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                           owl:onClass time:Instant
-                         ] ,
-                         [ rdf:type owl:Restriction ;
                            owl:onProperty ec:hasDateArchived ;
                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                            owl:onClass time:Instant
@@ -8310,6 +8290,26 @@ ec:Asset rdf:type owl:Class ;
                          ] ,
                          [ rdf:type owl:Restriction ;
                            owl:onProperty ec:hasDateLicenseEnd ;
+                           owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                           owl:onClass time:Instant
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasDateLicensedStart ;
+                           owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                           owl:onClass time:Instant
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasDateModified ;
+                           owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                           owl:onClass time:Instant
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasDateProduced ;
+                           owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                           owl:onClass time:Instant
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasDateReleased ;
                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                            owl:onClass time:Instant
                          ] ,
@@ -8363,7 +8363,7 @@ ec:Asset rdf:type owl:Class ;
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AssetValue
 ec:AssetValue rdf:type owl:Class ;
               rdfs:subClassOf [ rdf:type owl:Restriction ;
-                                owl:onProperty ec:assetValueCurrency ;
+                                owl:onProperty ec:hasAssetValueCurrency ;
                                 owl:allValuesFrom skos:Concept
                               ] ,
                               [ rdf:type owl:Restriction ;
@@ -8787,7 +8787,7 @@ ec:AuditJob rdf:type owl:Class ;
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AuditReport
 ec:AuditReport rdf:type owl:Class ;
                rdfs:subClassOf [ rdf:type owl:Restriction ;
-                                 owl:onProperty ec:auditReportDate ;
+                                 owl:onProperty ec:hasAuditReportDate ;
                                  owl:allValuesFrom time:Instant
                                ] ,
                                [ rdf:type owl:Restriction ;
@@ -8868,7 +8868,7 @@ ec:Award rdf:type owl:Class ;
                            owl:allValuesFrom skos:Concept
                          ] ,
                          [ rdf:type owl:Restriction ;
-                           owl:onProperty ec:awardDate ;
+                           owl:onProperty ec:hasAwardDate ;
                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                            owl:onClass time:Instant
                          ] ,
@@ -9342,12 +9342,12 @@ ec:ConsumptionCount rdf:type owl:Class ;
                                       owl:onClass time:Instant
                                     ] ,
                                     [ rdf:type owl:Restriction ;
-                                      owl:onProperty ec:start ;
+                                      owl:onProperty ec:hasStart ;
                                       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                       owl:onClass ec:TimelinePoint
                                     ] ,
                                     [ rdf:type owl:Restriction ;
-                                      owl:onProperty ec:startDateTime ;
+                                      owl:onProperty ec:hasStartDateTime ;
                                       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                       owl:onClass time:Instant
                                     ] ,
@@ -9396,7 +9396,7 @@ ec:ConsumptionDevice rdf:type owl:Class ;
                                        owl:allValuesFrom ec:ConsumptionDeviceProfile
                                      ] ,
                                      [ rdf:type owl:Restriction ;
-                                       owl:onProperty ec:consumptionDeviceManufacturer ;
+                                       owl:onProperty ec:hasConsumptionDeviceManufacturer ;
                                        owl:allValuesFrom ec:Agent
                                      ] ,
                                      [ rdf:type owl:Restriction ;
@@ -9555,7 +9555,7 @@ ec:ConsumptionEvent rdf:type owl:Class ;
                                       owl:allValuesFrom ec:Essence
                                     ] ,
                                     [ rdf:type owl:Restriction ;
-                                      owl:onProperty ec:consumptionEventResumePoint ;
+                                      owl:onProperty ec:hasConsumptionEventResumePoint ;
                                       owl:allValuesFrom ec:TimelinePoint
                                     ] ,
                                     [ rdf:type owl:Restriction ;
@@ -9593,12 +9593,12 @@ ec:ConsumptionEvent rdf:type owl:Class ;
                                       owl:onClass time:Instant
                                     ] ,
                                     [ rdf:type owl:Restriction ;
-                                      owl:onProperty ec:start ;
+                                      owl:onProperty ec:hasStart ;
                                       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                       owl:onClass ec:TimelinePoint
                                     ] ,
                                     [ rdf:type owl:Restriction ;
-                                      owl:onProperty ec:startDateTime ;
+                                      owl:onProperty ec:hasStartDateTime ;
                                       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                       owl:onClass time:Instant
                                     ] ,
@@ -9645,7 +9645,7 @@ ec:ConsumptionLicence rdf:type owl:Class ;
                                         owl:allValuesFrom skos:Concept
                                       ] ,
                                       [ rdf:type owl:Restriction ;
-                                        owl:onProperty ec:consumptionLicenceLink ;
+                                        owl:onProperty ec:hasConsumptionLicenceLink ;
                                         owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                         owl:onClass ec:Contract
                                       ] ,
@@ -9772,7 +9772,7 @@ ec:ContentEditorialFormat rdf:type owl:Class ;
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Contract
 ec:Contract rdf:type owl:Class ;
             rdfs:subClassOf [ rdf:type owl:Restriction ;
-                              owl:onProperty ec:contractLink ;
+                              owl:onProperty ec:hasContractLink ;
                               owl:allValuesFrom ec:Resource
                             ] ,
                             [ rdf:type owl:Restriction ;
@@ -9823,7 +9823,7 @@ ec:Contract rdf:type owl:Class ;
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ContractCost
 ec:ContractCost rdf:type owl:Class ;
                 rdfs:subClassOf [ rdf:type owl:Restriction ;
-                                  owl:onProperty ec:contractCostAmountCurrency ;
+                                  owl:onProperty ec:hasContractCostAmountCurrency ;
                                   owl:allValuesFrom skos:Concept
                                 ] ,
                                 [ rdf:type owl:Restriction ;
@@ -10386,6 +10386,10 @@ ec:EditorialObject rdf:type owl:Class ;
                                      owl:allValuesFrom ec:EditorialObject
                                    ] ,
                                    [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasVersionType ;
+                                     owl:allValuesFrom skos:Concept
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
                                      owl:onProperty ec:isBrand ;
                                      owl:allValuesFrom ec:Brand
                                    ] ,
@@ -10454,10 +10458,6 @@ ec:EditorialObject rdf:type owl:Class ;
                                      owl:allValuesFrom ec:EditorialObject
                                    ] ,
                                    [ rdf:type owl:Restriction ;
-                                     owl:onProperty ec:versionType ;
-                                     owl:allValuesFrom skos:Concept
-                                   ] ,
-                                   [ rdf:type owl:Restriction ;
                                      owl:onProperty ec:duration ;
                                      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                      owl:onClass ec:TimelinePoint
@@ -10483,6 +10483,11 @@ ec:EditorialObject rdf:type owl:Class ;
                                      owl:onClass ec:Location
                                    ] ,
                                    [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasStart ;
+                                     owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                     owl:onClass ec:TimelinePoint
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
                                      owl:onProperty ec:isNextInSequence ;
                                      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                      owl:onClass ec:EditorialObject
@@ -10494,11 +10499,6 @@ ec:EditorialObject rdf:type owl:Class ;
                                    ] ,
                                    [ rdf:type owl:Restriction ;
                                      owl:onProperty ec:resourceOffset ;
-                                     owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                                     owl:onClass ec:TimelinePoint
-                                   ] ,
-                                   [ rdf:type owl:Restriction ;
-                                     owl:onProperty ec:start ;
                                      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                      owl:onClass ec:TimelinePoint
                                    ] ,
@@ -10774,7 +10774,7 @@ ec:Emotion rdf:type owl:Class ;
                              owl:allValuesFrom skos:Concept
                            ] ,
                            [ rdf:type owl:Restriction ;
-                             owl:onProperty ec:start ;
+                             owl:onProperty ec:hasStart ;
                              owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                              owl:onClass ec:TimelinePoint
                            ] ,
@@ -10887,7 +10887,7 @@ ec:Event rdf:type owl:Class ;
                            owl:onClass ec:Location
                          ] ,
                          [ rdf:type owl:Restriction ;
-                           owl:onProperty ec:startDateTime ;
+                           owl:onProperty ec:hasStartDateTime ;
                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                            owl:onClass time:Instant
                          ] ,
@@ -11733,10 +11733,6 @@ ec:MediaResource rdf:type owl:Class ;
                                    owl:allValuesFrom ec:VideoTrack
                                  ] ,
                                  [ rdf:type owl:Restriction ;
-                                   owl:onProperty ec:isClonedFrom ;
-                                   owl:allValuesFrom ec:MediaResource
-                                 ] ,
-                                 [ rdf:type owl:Restriction ;
                                    owl:onProperty ec:isMasterOf ;
                                    owl:allValuesFrom ec:MediaResource
                                  ] ,
@@ -11747,16 +11743,6 @@ ec:MediaResource rdf:type owl:Class ;
                                  [ rdf:type owl:Restriction ;
                                    owl:onProperty ec:requires ;
                                    owl:allValuesFrom ec:MediaResource
-                                 ] ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty ec:dateNormalized ;
-                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                                   owl:onClass time:Instant
-                                 ] ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty ec:dateTransferred ;
-                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                                   owl:onClass time:Instant
                                  ] ,
                                  [ rdf:type owl:Restriction ;
                                    owl:onProperty ec:displayAspectRatio ;
@@ -11815,6 +11801,16 @@ ec:MediaResource rdf:type owl:Class ;
                                  ] ,
                                  [ rdf:type owl:Restriction ;
                                    owl:onProperty ec:hasDateMigrated ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass time:Instant
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasDateNormalized ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass time:Instant
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasDateTransferred ;
                                    owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                    owl:onClass time:Instant
                                  ] ,
@@ -12297,7 +12293,7 @@ ec:Organisation rdf:type owl:Class ;
                                   owl:onClass time:Instant
                                 ] ,
                                 [ rdf:type owl:Restriction ;
-                                  owl:onProperty ec:startDateTime ;
+                                  owl:onProperty ec:hasStartDateTime ;
                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                   owl:onClass time:Instant
                                 ] ;
@@ -12386,21 +12382,6 @@ ec:Person rdf:type owl:Class ;
                             owl:allValuesFrom ec:KeyPersonalEvent
                           ] ,
                           [ rdf:type owl:Restriction ;
-                            owl:onProperty ec:dateOfBirth ;
-                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                            owl:onClass time:Instant
-                          ] ,
-                          [ rdf:type owl:Restriction ;
-                            owl:onProperty ec:dateOfDeath ;
-                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                            owl:onClass time:Instant
-                          ] ,
-                          [ rdf:type owl:Restriction ;
-                            owl:onProperty ec:dateOfRetirement ;
-                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                            owl:onClass time:Instant
-                          ] ,
-                          [ rdf:type owl:Restriction ;
                             owl:onProperty ec:hasCountryOfBirth ;
                             owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                             owl:onClass ec:CountryCode
@@ -12409,6 +12390,21 @@ ec:Person rdf:type owl:Class ;
                             owl:onProperty ec:hasCountryOfDeath ;
                             owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                             owl:onClass ec:CountryCode
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasDateOfBirth ;
+                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                            owl:onClass time:Instant
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasDateOfDeath ;
+                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                            owl:onClass time:Instant
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasDateOfRetirement ;
+                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                            owl:onClass time:Instant
                           ] ,
                           [ rdf:type owl:Restriction ;
                             owl:onProperty ec:hasPlaceOfBirth ;
@@ -12774,7 +12770,7 @@ ec:ProductionJob rdf:type owl:Class ;
                                    owl:onClass time:Instant
                                  ] ,
                                  [ rdf:type owl:Restriction ;
-                                   owl:onProperty ec:startDateTime ;
+                                   owl:onProperty ec:hasStartDateTime ;
                                    owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                    owl:onClass time:Instant
                                  ] ,
@@ -12967,12 +12963,12 @@ ec:Provenance rdf:type owl:Class ;
                                 owl:allValuesFrom skos:Concept
                               ] ,
                               [ rdf:type owl:Restriction ;
-                                owl:onProperty ec:dateModified ;
+                                owl:onProperty ec:hasDateCreated ;
                                 owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                 owl:onClass time:DateTimeDescription
                               ] ,
                               [ rdf:type owl:Restriction ;
-                                owl:onProperty ec:hasDateCreated ;
+                                owl:onProperty ec:hasDateModified ;
                                 owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                 owl:onClass time:DateTimeDescription
                               ] ,
@@ -13066,7 +13062,7 @@ ec:PublicationChannel rdf:type owl:Class ;
                                         owl:onClass time:Instant
                                       ] ,
                                       [ rdf:type owl:Restriction ;
-                                        owl:onProperty ec:startDateTime ;
+                                        owl:onProperty ec:hasStartDateTime ;
                                         owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                         owl:onClass time:Instant
                                       ] ,
@@ -13190,7 +13186,7 @@ ec:PublicationEvent rdf:type owl:Class ;
                                       owl:allValuesFrom ec:EditorialObject
                                     ] ,
                                     [ rdf:type owl:Restriction ;
-                                      owl:onProperty ec:startDateTime ;
+                                      owl:onProperty ec:hasStartDateTime ;
                                       owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                       owl:onClass time:Instant
                                     ] ,
@@ -13295,14 +13291,14 @@ ec:PublicationLog rdf:type owl:Class ;
                                     owl:someValuesFrom ec:TimelinePoint
                                   ] ,
                                   [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:hasStartDateTime ;
+                                    owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                    owl:onClass time:Instant
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
                                     owl:onProperty ec:loggsPublicationEvent ;
                                     owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                     owl:onClass ec:PublicationEvent
-                                  ] ,
-                                  [ rdf:type owl:Restriction ;
-                                    owl:onProperty ec:startDateTime ;
-                                    owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                                    owl:onClass time:Instant
                                   ] ,
                                   [ rdf:type owl:Restriction ;
                                     owl:onProperty ec:endDateTime ;
@@ -13385,14 +13381,14 @@ ec:PublicationPlan rdf:type owl:Class ;
                                      owl:onClass time:Instant
                                    ] ,
                                    [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasStartDateTime ;
+                                     owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                     owl:onClass time:Instant
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
                                      owl:onProperty ec:publicationPlanStatus ;
                                      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                      owl:onClass skos:Collection
-                                   ] ,
-                                   [ rdf:type owl:Restriction ;
-                                     owl:onProperty ec:startDateTime ;
-                                     owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                                     owl:onClass time:Instant
                                    ] ,
                                    [ rdf:type owl:Restriction ;
                                      owl:onProperty ec:description ;
@@ -13503,7 +13499,7 @@ ec:PublicationPlatform rdf:type owl:Class ;
                                          owl:onClass time:Instant
                                        ] ,
                                        [ rdf:type owl:Restriction ;
-                                         owl:onProperty ec:startDateTime ;
+                                         owl:onProperty ec:hasStartDateTime ;
                                          owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                          owl:onClass time:Instant
                                        ] ,
@@ -13590,7 +13586,7 @@ ec:PublicationService rdf:type owl:Class ;
                                         owl:onClass time:Instant
                                       ] ,
                                       [ rdf:type owl:Restriction ;
-                                        owl:onProperty ec:startDateTime ;
+                                        owl:onProperty ec:hasStartDateTime ;
                                         owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                         owl:onClass time:Instant
                                       ] ,
@@ -13968,12 +13964,12 @@ ec:Resource rdf:type owl:Class ;
                               owl:allValuesFrom skos:Concept
                             ] ,
                             [ rdf:type owl:Restriction ;
-                              owl:onProperty ec:dateValidated ;
+                              owl:onProperty ec:hasDateDeleted ;
                               owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                               owl:onClass time:Instant
                             ] ,
                             [ rdf:type owl:Restriction ;
-                              owl:onProperty ec:hasDateDeleted ;
+                              owl:onProperty ec:hasDateValidated ;
                               owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                               owl:onClass time:Instant
                             ] ,
@@ -14085,6 +14081,10 @@ ec:Rights rdf:type owl:Class ;
                             owl:allValuesFrom ec:PublicationService
                           ] ,
                           [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasRightsTerritoryIncludes ;
+                            owl:allValuesFrom ec:CountryCode
+                          ] ,
+                          [ rdf:type owl:Restriction ;
                             owl:onProperty ec:objectType ;
                             owl:allValuesFrom skos:Concept
                           ] ,
@@ -14094,10 +14094,6 @@ ec:Rights rdf:type owl:Class ;
                           ] ,
                           [ rdf:type owl:Restriction ;
                             owl:onProperty ec:rightsTerritoryExcludes ;
-                            owl:allValuesFrom ec:CountryCode
-                          ] ,
-                          [ rdf:type owl:Restriction ;
-                            owl:onProperty ec:rightsTerritoryIncludes ;
                             owl:allValuesFrom ec:CountryCode
                           ] ,
                           [ rdf:type owl:Restriction ;
@@ -14111,7 +14107,7 @@ ec:Rights rdf:type owl:Class ;
                             owl:onClass time:Instant
                           ] ,
                           [ rdf:type owl:Restriction ;
-                            owl:onProperty ec:startDateTime ;
+                            owl:onProperty ec:hasStartDateTime ;
                             owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                             owl:onClass time:Instant
                           ] ,
@@ -14176,20 +14172,20 @@ ec:Rule rdf:type owl:Class ;
                           owl:allValuesFrom ec:Identifier
                         ] ,
                         [ rdf:type owl:Restriction ;
+                          owl:onProperty ec:hasRulePriority ;
+                          owl:allValuesFrom skos:Concept
+                        ] ,
+                        [ rdf:type owl:Restriction ;
+                          owl:onProperty ec:hasRuleReference ;
+                          owl:allValuesFrom ec:Rule
+                        ] ,
+                        [ rdf:type owl:Restriction ;
                           owl:onProperty ec:isDefinedBy ;
                           owl:allValuesFrom ec:Contract
                         ] ,
                         [ rdf:type owl:Restriction ;
                           owl:onProperty ec:objectType ;
                           owl:allValuesFrom skos:Concept
-                        ] ,
-                        [ rdf:type owl:Restriction ;
-                          owl:onProperty ec:rulePriority ;
-                          owl:allValuesFrom skos:Concept
-                        ] ,
-                        [ rdf:type owl:Restriction ;
-                          owl:onProperty ec:ruleReference ;
-                          owl:allValuesFrom ec:Rule
                         ] ,
                         [ rdf:type owl:Restriction ;
                           owl:onProperty ec:description ;
@@ -14683,6 +14679,11 @@ ec:TextLine rdf:type owl:Class ;
                               owl:onClass ec:TimelinePoint
                             ] ,
                             [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasStart ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onClass ec:TimelinePoint
+                            ] ,
+                            [ rdf:type owl:Restriction ;
                               owl:onProperty ec:hasTextLineSource ;
                               owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                               owl:onClass ec:Agent
@@ -14691,11 +14692,6 @@ ec:TextLine rdf:type owl:Class ;
                               owl:onProperty ec:objectType ;
                               owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                               owl:onClass skos:Concept
-                            ] ,
-                            [ rdf:type owl:Restriction ;
-                              owl:onProperty ec:start ;
-                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                              owl:onClass ec:TimelinePoint
                             ] ,
                             [ rdf:type owl:Restriction ;
                               owl:onProperty ec:artefactBoxHeight ;
@@ -15032,14 +15028,14 @@ ec:UncertainDate rdf:type owl:Class ;
                                    owl:onClass time:Instant
                                  ] ,
                                  [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasStartDateTime ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass time:Instant
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
                                    owl:onProperty ec:objectType ;
                                    owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                    owl:onClass skos:Concept
-                                 ] ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty ec:startDateTime ;
-                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                                   owl:onClass time:Instant
                                  ] ,
                                  [ rdf:type owl:Restriction ;
                                    owl:onProperty ec:description ;


### PR DESCRIPTION
In this pull request, I have standardized the naming of ten object properties by adding a 'has' prefix.

- `dateArchived` to `hasDateArchived`
- `dateBroadcast` to `hasDateBroadcast`
- `dateCreated` to `hasDateCreated`
- `dateDeleted` to `hasDateDeleted`
- `dateDigitised` to `hasDateDigitised`
- `dateDistributed` to `hasDateDistributed`
- `dateIngested` to `hasDateIngested`
- `dateIssued` to `hasDateIssued`
- `dateLicenseEnd` to `hasDateLicenseEnd`
- `dateMigrated` to `hasDateMigrated`


**Reviewers**
- @JuergenGrupp 
- @aro-max 