### PR TITLE
Fix "isClonedFrom" duplication

### DIFF
--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -11733,10 +11733,6 @@ ec:MediaResource rdf:type owl:Class ;
                                    owl:allValuesFrom ec:VideoTrack
                                  ] ,
                                  [ rdf:type owl:Restriction ;
-                                   owl:onProperty ec:isClonedFrom ;
-                                   owl:allValuesFrom ec:MediaResource
-                                 ] ,
-                                 [ rdf:type owl:Restriction ;
                                    owl:onProperty ec:isMasterOf ;
                                    owl:allValuesFrom ec:MediaResource
                                  ] ,


### PR DESCRIPTION
The property "isClonedFrom" was duplicated. Removed one and kept the other pointing to  "max 1" MediaResource.