### PR TITLE
Fix #276-range-for-hasbeenawarded

### DIFF
--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -1340,17 +1340,6 @@ ec:hasAuditJobRelatedAuditReport rdf:type owl:ObjectProperty ;
                                             "Zugehöriger Prüfbericht"@de .
 
 
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasBeenAwarded
-ec:hasBeenAwarded rdf:type owl:ObjectProperty ;
-                  rdfs:range ec:Award ;
-                  dcterms:description "Der an einen Agenten verliehene Preis"@de ,
-                                      "Le prix décerné à un agent"@fr ,
-                                      "The Award gievn to an Agent"@en ;
-                  rdfs:label "Agent"@de ,
-                             "Agent"@en ,
-                             "Agent"@fr .
-
-
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasBusinessContract
 ec:hasBusinessContract rdf:type owl:ObjectProperty ;
                        dcterms:description "Pour identifier les Contrats associés à un Plan de publication."@fr ,
@@ -3426,6 +3415,13 @@ ec:hasWrappingType rdf:type owl:ObjectProperty ;
                               "Wrapping type"@en .
 
 
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#holdsAward
+ec:holdsAward rdf:type owl:ObjectProperty ;
+              rdfs:label "erhält"@de ,
+                         "holds"@en ,
+                         "reçoit"@fr .
+
+
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#holdsLicence
 ec:holdsLicence rdf:type owl:ObjectProperty ;
                 dcterms:description "Die Bedingungen einer ConsumptionLicence, die mit einem Vertrag."@de ,
@@ -3555,6 +3551,13 @@ ec:isAttributedTo rdf:type owl:ObjectProperty ;
                   rdfs:label "Cible de provenance"@fr ,
                              "Provenance target"@en ,
                              "Ziel Provenienz"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isAwardedTo
+ec:isAwardedTo rdf:type owl:ObjectProperty ;
+               rdfs:label "awarded to"@en ,
+                          "décerné à"@fr ,
+                          "vergeben an"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isBrand
@@ -7558,10 +7561,6 @@ ec:Agent rdf:type owl:Class ;
                            owl:allValuesFrom ec:Artefact
                          ] ,
                          [ rdf:type owl:Restriction ;
-                           owl:onProperty ec:hasBeenAwarded ;
-                           owl:allValuesFrom ec:Agent
-                         ] ,
-                         [ rdf:type owl:Restriction ;
                            owl:onProperty ec:hasContact ;
                            owl:allValuesFrom ec:Contact
                          ] ,
@@ -7576,6 +7575,10 @@ ec:Agent rdf:type owl:Class ;
                          [ rdf:type owl:Restriction ;
                            owl:onProperty ec:hasRelatedPicture ;
                            owl:allValuesFrom ec:Picture
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:holdsAward ;
+                           owl:allValuesFrom ec:Award
                          ] ,
                          [ rdf:type owl:Restriction ;
                            owl:onProperty ec:isAgent ;
@@ -8844,10 +8847,6 @@ ec:AuditReport rdf:type owl:Class ;
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Award
 ec:Award rdf:type owl:Class ;
          rdfs:subClassOf [ rdf:type owl:Restriction ;
-                           owl:onProperty ec:hasBeenAwarded ;
-                           owl:allValuesFrom ec:Agent
-                         ] ,
-                         [ rdf:type owl:Restriction ;
                            owl:onProperty ec:hasIdentifier ;
                            owl:allValuesFrom ec:Identifier
                          ] ,
@@ -8862,6 +8861,10 @@ ec:Award rdf:type owl:Class ;
                          [ rdf:type owl:Restriction ;
                            owl:onProperty ec:hasRelatedEvent ;
                            owl:allValuesFrom ec:Event
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:isAwardedTo ;
+                           owl:allValuesFrom ec:Agent
                          ] ,
                          [ rdf:type owl:Restriction ;
                            owl:onProperty ec:objectType ;


### PR DESCRIPTION
Following our new naming conventions, I have split the property `hasBeenAwardedTo` into:
`Award` `isAwardedTo` `Agent`
`Agent` `holdsAward` `Award`