### PR TITLE
299 refactoring renaming property cluster 02

### DIFF
--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -2307,6 +2307,17 @@ ec:hasOutputResource rdf:type owl:ObjectProperty ;
                                 "Ressource de sortie"@fr .
 
 
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasOwner
+ec:hasOwner rdf:type owl:ObjectProperty ;
+            rdfs:range ec:Agent ;
+            dcterms:description "Pour identifier le propriétaire d'un animal."@fr ,
+                                "To identify the owner of an animal."@en ,
+                                "Um den Besitzer eines Tieres zu identifizieren."@de ;
+            rdfs:label "Animal owner"@en ,
+                       "Propriétaire d'animaux"@fr ,
+                       "Tierhalter"@de .
+
+
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasParentEditorialObject
 ec:hasParentEditorialObject rdf:type owl:ObjectProperty ;
                             rdfs:range ec:EditorialObject ;
@@ -3672,17 +3683,6 @@ ec:isAffiliatedTo rdf:type owl:ObjectProperty ;
                   rdfs:label "est affilié à"@fr ,
                              "is affiliated to"@en ,
                              "ist angegliedert an"@de .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isAnimalOwner
-ec:isAnimalOwner rdf:type owl:ObjectProperty ;
-                 rdfs:range ec:Agent ;
-                 dcterms:description "Pour identifier le propriétaire d'un animal."@fr ,
-                                     "To identify the owner of an animal."@en ,
-                                     "Um den Besitzer eines Tieres zu identifizieren."@de ;
-                 rdfs:label "Animal owner"@en ,
-                            "Propriétaire d'animaux"@fr ,
-                            "Tierhalter"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isAnimatedBy
@@ -7811,7 +7811,7 @@ ec:Animal rdf:type owl:Class ;
                             owl:allValuesFrom skos:Concept
                           ] ,
                           [ rdf:type owl:Restriction ;
-                            owl:onProperty ec:isAnimalOwner ;
+                            owl:onProperty ec:hasOwner ;
                             owl:allValuesFrom ec:Agent
                           ] ,
                           [ rdf:type owl:Restriction ;

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -969,6 +969,17 @@ ec:hasBeenAwarded rdf:type owl:ObjectProperty ;
                              "Agent"@fr .
 
 
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasBrand
+ec:hasBrand rdf:type owl:ObjectProperty ;
+            rdfs:range ec:Brand ;
+            dcterms:description "Pour identifier une Marque."@fr ,
+                                "To identify a Brand."@en ,
+                                "Um eine Marke zu identifizieren."@de ;
+            rdfs:label "Brand"@en ,
+                       "Marke"@de ,
+                       "Marque"@fr .
+
+
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasBusinessContract
 ec:hasBusinessContract rdf:type owl:ObjectProperty ;
                        dcterms:description "Pour identifier les Contrats associés à un Plan de publication."@fr ,
@@ -3737,17 +3748,6 @@ ec:isAttributedTo rdf:type owl:ObjectProperty ;
                   rdfs:label "Cible de provenance"@fr ,
                              "Provenance target"@en ,
                              "Ziel Provenienz"@de .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isBrand
-ec:isBrand rdf:type owl:ObjectProperty ;
-           rdfs:range ec:Brand ;
-           dcterms:description "Pour identifier une Marque."@fr ,
-                               "To identify a Brand."@en ,
-                               "Um eine Marke zu identifizieren."@de ;
-           rdfs:label "Brand"@en ,
-                      "Marke"@de ,
-                      "Marque"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isCharacter
@@ -10187,6 +10187,10 @@ ec:EditorialObject rdf:type owl:Class ;
                                      owl:allValuesFrom ec:AudioDescription
                                    ] ,
                                    [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasBrand ;
+                                     owl:allValuesFrom ec:Brand
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
                                      owl:onProperty ec:hasCaptioning ;
                                      owl:allValuesFrom ec:Captioning
                                    ] ,
@@ -10369,10 +10373,6 @@ ec:EditorialObject rdf:type owl:Class ;
                                    [ rdf:type owl:Restriction ;
                                      owl:onProperty ec:hasVersionType ;
                                      owl:allValuesFrom skos:Concept
-                                   ] ,
-                                   [ rdf:type owl:Restriction ;
-                                     owl:onProperty ec:isBrand ;
-                                     owl:allValuesFrom ec:Brand
                                    ] ,
                                    [ rdf:type owl:Restriction ;
                                      owl:onProperty ec:isCommissionedBy ;

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -925,6 +925,17 @@ ec:hasAuditReportDate rdf:type owl:ObjectProperty ;
                                  "Datum des Prüfungsberichts"@de .
 
 
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAuthor
+ec:hasAuthor rdf:type owl:ObjectProperty ;
+             rdfs:range ec:Agent ;
+             dcterms:description "Pour lier une annotation à l'agent qui l'a créée."@fr ,
+                                 "So verknüpfen Sie eine Anmerkung mit einem Agenten, der sie erstellt hat."@de ,
+                                 "To link an Annotation to an Agent who created it."@en ;
+             rdfs:label "Agent"@de ,
+                        "Agent"@en ,
+                        "Agent"@fr .
+
+
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAwardDate
 ec:hasAwardDate rdf:type owl:ObjectProperty ;
                 rdfs:subPropertyOf ec:hasDate ;
@@ -3705,17 +3716,6 @@ ec:isAnnotatedMediaResource rdf:type owl:ObjectProperty ;
                             rdfs:label "Media resource"@en ,
                                        "Medienressource"@de ,
                                        "Ressource médiatique"@fr .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isAnnotationBy
-ec:isAnnotationBy rdf:type owl:ObjectProperty ;
-                  rdfs:range ec:Agent ;
-                  dcterms:description "Pour lier une annotation à l'agent qui l'a créée."@fr ,
-                                      "So verknüpfen Sie eine Anmerkung mit einem Agenten, der sie erstellt hat."@de ,
-                                      "To link an Annotation to an Agent who created it."@en ;
-                  rdfs:label "Agent"@de ,
-                             "Agent"@en ,
-                             "Agent"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isApprovedBy
@@ -7918,6 +7918,11 @@ ec:Annotation rdf:type owl:Class ;
                                 owl:onClass time:Instant
                               ] ,
                               [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:hasAuthor ;
+                                owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                owl:onClass ec:Agent
+                              ] ,
+                              [ rdf:type owl:Restriction ;
                                 owl:onProperty ec:hasLocation ;
                                 owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                 owl:onClass ec:Location
@@ -7926,11 +7931,6 @@ ec:Annotation rdf:type owl:Class ;
                                 owl:onProperty ec:isAnnotatedMediaResource ;
                                 owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                 owl:onClass ec:MediaResource
-                              ] ,
-                              [ rdf:type owl:Restriction ;
-                                owl:onProperty ec:isAnnotationBy ;
-                                owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                                owl:onClass ec:Agent
                               ] ,
                               [ rdf:type owl:Restriction ;
                                 owl:onProperty ec:description ;

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -1806,6 +1806,17 @@ ec:hasEditorialWork rdf:type owl:ObjectProperty ;
                                "hat redaktionelle Arbeit"@de .
 
 
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasEmbodyingArtefact
+ec:hasEmbodyingArtefact rdf:type owl:ObjectProperty ;
+                        rdfs:range ec:Artefact ;
+                        dcterms:description "Character depicted by an Artifact"@en ,
+                                            "Personnage représenté par un artefact"@fr ,
+                                            "Von einem Artefakt dargestellter Charakter"@de ;
+                        rdfs:label "est incarné par"@fr ,
+                                   "is embodied by"@en ,
+                                   "wird verkörpert durch"@de .
+
+
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasEncodingFormat
 ec:hasEncodingFormat rdf:type owl:ObjectProperty ;
                      rdfs:subPropertyOf ec:hasFormat ;
@@ -3853,17 +3864,6 @@ ec:isDubOf rdf:type owl:ObjectProperty ;
            rdfs:label "Doublé de"@fr ,
                       "Dubbed from"@en ,
                       "Synchronisiert von"@de .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isEmbodiedBy
-ec:isEmbodiedBy rdf:type owl:ObjectProperty ;
-                rdfs:range ec:Artefact ;
-                dcterms:description "Character depicted by an Artifact"@en ,
-                                    "Personnage représenté par un artefact"@fr ,
-                                    "Von einem Artefakt dargestellter Charakter"@de ;
-                rdfs:label "est incarné par"@fr ,
-                           "is embodied by"@en ,
-                           "wird verkörpert durch"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isEpisodeOf
@@ -9109,12 +9109,12 @@ ec:CastMember rdf:type owl:Class ;
 ec:Character rdf:type owl:Class ;
              rdfs:subClassOf ec:Person ,
                              [ rdf:type owl:Restriction ;
-                               owl:onProperty ec:isAnimatedBy ;
-                               owl:allValuesFrom ec:Person
+                               owl:onProperty ec:hasEmbodyingArtefact ;
+                               owl:allValuesFrom ec:Artefact
                              ] ,
                              [ rdf:type owl:Restriction ;
-                               owl:onProperty ec:isEmbodiedBy ;
-                               owl:allValuesFrom ec:Artefact
+                               owl:onProperty ec:isAnimatedBy ;
+                               owl:allValuesFrom ec:Person
                              ] ,
                              [ rdf:type owl:Restriction ;
                                owl:onProperty ec:isPlayedBy ;

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -1778,6 +1778,18 @@ ec:hasDuration rdf:type owl:ObjectProperty ;
                rdfs:range ec:TimelinePoint .
 
 
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasEditorialFormatOf
+ec:hasEditorialFormatOf rdf:type owl:ObjectProperty ;
+                        rdfs:range ec:EditorialObject ;
+                        dcterms:description "Pour identifier un objet éditorial basé sur le même format éditorial"@fr ,
+                                            "So identifizieren Sie ein redaktionelles Objekt, das auf demselben redaktionellen Format basiert"@de ,
+                                            "To identify an Editorial Object based on the same Editorial format"@en ;
+                        rdfs:comment "*** Bad description ***"@en ;
+                        rdfs:label "Gleiches redaktionelles Format"@de ,
+                                   "Même format éditorial"@fr ,
+                                   "Same editorial format"@en .
+
+
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasEditorialGroup
 ec:hasEditorialGroup rdf:type owl:ObjectProperty ;
                      rdfs:subPropertyOf ec:isMemberOf ;
@@ -3841,18 +3853,6 @@ ec:isDubOf rdf:type owl:ObjectProperty ;
            rdfs:label "Doublé de"@fr ,
                       "Dubbed from"@en ,
                       "Synchronisiert von"@de .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isEditorialFormatOf
-ec:isEditorialFormatOf rdf:type owl:ObjectProperty ;
-                       rdfs:range ec:EditorialObject ;
-                       dcterms:description "Pour identifier un objet éditorial basé sur le même format éditorial"@fr ,
-                                           "So identifizieren Sie ein redaktionelles Objekt, das auf demselben redaktionellen Format basiert"@de ,
-                                           "To identify an Editorial Object based on the same Editorial format"@en ;
-                       rdfs:comment "*** Bad description ***"@en ;
-                       rdfs:label "Gleiches redaktionelles Format"@de ,
-                                  "Même format éditorial"@fr ,
-                                  "Same editorial format"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isEmbodiedBy
@@ -10226,6 +10226,10 @@ ec:EditorialObject rdf:type owl:Class ;
                                      owl:allValuesFrom ec:Language
                                    ] ,
                                    [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasEditorialFormatOf ;
+                                     owl:allValuesFrom ec:EditorialObject
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
                                      owl:onProperty ec:hasGenre ;
                                      owl:allValuesFrom skos:Concept
                                    ] ,
@@ -10376,10 +10380,6 @@ ec:EditorialObject rdf:type owl:Class ;
                                    [ rdf:type owl:Restriction ;
                                      owl:onProperty ec:isDistributedOn ;
                                      owl:allValuesFrom ec:PublicationService
-                                   ] ,
-                                   [ rdf:type owl:Restriction ;
-                                     owl:onProperty ec:isEditorialFormatOf ;
-                                     owl:allValuesFrom ec:EditorialObject
                                    ] ,
                                    [ rdf:type owl:Restriction ;
                                      owl:onProperty ec:isExtractOf ;

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -1038,12 +1038,18 @@ ec:hasCastMember rdf:type owl:ObjectProperty ;
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasCharacter
 ec:hasCharacter rdf:type owl:ObjectProperty ;
                 rdfs:range ec:Character ;
-                dcterms:description "Pour énumérer les personnages d'une fiction."@fr ,
+                dcterms:description "Pour identifier un personnage."@fr ,
+                                    "Pour énumérer les personnages d'une fiction."@fr ,
+                                    "To identify a character."@en ,
                                     "To list characters in a fiction."@en ,
+                                    "Um einen Charakter zu identifizieren."@de ,
                                     "Zum Auflisten von Figuren in einer Fiktion."@de ;
                 rdfs:label "Caractère"@fr ,
                            "Character"@en ,
-                           "Charakter"@de .
+                           "Charakter"@de ,
+                           "Fictional character."@en ,
+                           "Fiktiver Charakter."@de ,
+                           "Personnage fictif."@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasClip
@@ -3748,17 +3754,6 @@ ec:isAttributedTo rdf:type owl:ObjectProperty ;
                   rdfs:label "Cible de provenance"@fr ,
                              "Provenance target"@en ,
                              "Ziel Provenienz"@de .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isCharacter
-ec:isCharacter rdf:type owl:ObjectProperty ;
-               rdfs:range ec:Character ;
-               dcterms:description "Pour identifier un personnage."@fr ,
-                                   "To identify a character."@en ,
-                                   "Um einen Charakter zu identifizieren."@de ;
-               rdfs:label "Fictional character."@en ,
-                          "Fiktiver Charakter."@de ,
-                          "Personnage fictif."@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isChildOf
@@ -7543,6 +7538,10 @@ ec:Agent rdf:type owl:Class ;
                            owl:allValuesFrom ec:Agent
                          ] ,
                          [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasCharacter ;
+                           owl:allValuesFrom ec:Character
+                         ] ,
+                         [ rdf:type owl:Restriction ;
                            owl:onProperty ec:hasContact ;
                            owl:allValuesFrom ec:Contact
                          ] ,
@@ -7565,10 +7564,6 @@ ec:Agent rdf:type owl:Class ;
                          [ rdf:type owl:Restriction ;
                            owl:onProperty ec:hasRelatedPicture ;
                            owl:allValuesFrom ec:Picture
-                         ] ,
-                         [ rdf:type owl:Restriction ;
-                           owl:onProperty ec:isCharacter ;
-                           owl:allValuesFrom ec:Character
                          ] ,
                          [ rdf:type owl:Restriction ;
                            owl:onProperty ec:agentDbpedia ;

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -1869,6 +1869,17 @@ ec:hasExploitationIssues rdf:type owl:ObjectProperty ;
                                     "Problèmes d'exploitation"@fr .
 
 
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasFictitiousPerson
+ec:hasFictitiousPerson rdf:type owl:ObjectProperty ;
+                       rdfs:range ec:Person ;
+                       dcterms:description "Pour identifier un contact/personne fictive."@fr ,
+                                           "To identify a Contact/Person being fictitious."@en ,
+                                           "Um einen Kontakt/eine Person als fiktiv zu identifizieren."@de ;
+                       rdfs:label "Contact fictif"@fr ,
+                                  "Fictitious contact"@en ,
+                                  "Fiktiver Kontakt"@de .
+
+
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasFileFormat
 ec:hasFileFormat rdf:type owl:ObjectProperty ;
                  rdfs:range ec:FileFormat ;
@@ -3914,17 +3925,6 @@ ec:isExtractOf rdf:type owl:ObjectProperty ;
                rdfs:label "est un extrait de"@fr ,
                           "is extract of"@en ,
                           "ist ein Auszug aus"@de .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isFictitiousPerson
-ec:isFictitiousPerson rdf:type owl:ObjectProperty ;
-                      rdfs:range ec:Person ;
-                      dcterms:description "Pour identifier un contact/personne fictive."@fr ,
-                                          "To identify a Contact/Person being fictitious."@en ,
-                                          "Um einen Kontakt/eine Person als fiktiv zu identifizieren."@de ;
-                      rdfs:label "Contact fictif"@fr ,
-                                 "Fictitious contact"@en ,
-                                 "Fiktiver Kontakt"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isInstantiatedBy
@@ -9125,7 +9125,7 @@ ec:Character rdf:type owl:Class ;
                                owl:allValuesFrom ec:Animal
                              ] ,
                              [ rdf:type owl:Restriction ;
-                               owl:onProperty ec:isFictitiousPerson ;
+                               owl:onProperty ec:hasFictitiousPerson ;
                                owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                owl:onClass ec:Person
                              ] ;

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -2078,6 +2078,17 @@ ec:hasInputResource rdf:type owl:ObjectProperty ;
                                "Ressourceneinsatz"@de .
 
 
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasIssuer
+ec:hasIssuer rdf:type owl:ObjectProperty ;
+             rdfs:range ec:Agent ;
+             dcterms:description "Pour identifier l'émetteur d'un identifiant."@fr ,
+                                 "To identify the issuer of an identifier."@en ,
+                                 "Zur Identifizierung des Ausstellers eines Identifikators."@de ;
+             rdfs:label "Emittent"@de ,
+                        "Issuer"@en ,
+                        "Émetteur"@fr .
+
+
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasKeyCareerEvent
 ec:hasKeyCareerEvent rdf:type owl:ObjectProperty ;
                      rdfs:range ec:KeyCareerEvent ;
@@ -3936,17 +3947,6 @@ ec:isInstantiatedBy rdf:type owl:ObjectProperty ;
                     rdfs:label "Media Resource"@en ,
                                "Medien Ressource"@de ,
                                "Ressource médiatique"@fr .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isIssuedBy
-ec:isIssuedBy rdf:type owl:ObjectProperty ;
-              rdfs:range ec:Agent ;
-              dcterms:description "Pour identifier l'émetteur d'un identifiant."@fr ,
-                                  "To identify the issuer of an identifier."@en ,
-                                  "Zur Identifizierung des Ausstellers eines Identifikators."@de ;
-              rdfs:label "Emittent"@de ,
-                         "Issuer"@en ,
-                         "Émetteur"@fr .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isMasterOf
@@ -11076,12 +11076,12 @@ ec:IPRRestrictions rdf:type owl:Class ;
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Identifier
 ec:Identifier rdf:type owl:Class ;
               rdfs:subClassOf [ rdf:type owl:Restriction ;
-                                owl:onProperty ec:hasObjectType ;
-                                owl:allValuesFrom skos:Concept
+                                owl:onProperty ec:hasIssuer ;
+                                owl:allValuesFrom ec:Agent
                               ] ,
                               [ rdf:type owl:Restriction ;
-                                owl:onProperty ec:isIssuedBy ;
-                                owl:allValuesFrom ec:Agent
+                                owl:onProperty ec:hasObjectType ;
+                                owl:allValuesFrom skos:Concept
                               ] ,
                               [ rdf:type owl:Restriction ;
                                 owl:onProperty ec:hasDateCreated ;

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -1105,6 +1105,16 @@ ec:hasColourSpace rdf:type owl:ObjectProperty ;
                              "Farbraum"@de .
 
 
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasCommissioningContract
+ec:hasCommissioningContract rdf:type owl:ObjectProperty ;
+                            dcterms:description "Der Vertrag, durch den ein EditorialObject in Auftrag gegeben wird."@de ,
+                                                "Le contrat par lequel un objet éditorial est commissionné."@fr ,
+                                                "The Contract through which an EditorialObject is commissioned."@en ;
+                            rdfs:label "Contract"@en ,
+                                       "Contrat"@fr ,
+                                       "Vertrag"@de .
+
+
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasConsumptionContract
 ec:hasConsumptionContract rdf:type owl:ObjectProperty ;
                           dcterms:description "Pour identifier un ConsumptionContract lié à un compte."@fr ,
@@ -3777,16 +3787,6 @@ ec:isCloneOf rdf:type owl:ObjectProperty ;
              rdfs:label "Clone source"@en ,
                         "Cloner la source"@fr ,
                         "Quelle klonen"@de .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isCommissionedBy
-ec:isCommissionedBy rdf:type owl:ObjectProperty ;
-                    dcterms:description "Der Vertrag, durch den ein EditorialObject in Auftrag gegeben wird."@de ,
-                                        "Le contrat par lequel un objet éditorial est commissionné."@fr ,
-                                        "The Contract through which an EditorialObject is commissioned."@en ;
-                    rdfs:label "Contract"@en ,
-                               "Contrat"@fr ,
-                               "Vertrag"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isComposedOf
@@ -10198,6 +10198,10 @@ ec:EditorialObject rdf:type owl:Class ;
                                      owl:allValuesFrom ec:Character
                                    ] ,
                                    [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasCommissioningContract ;
+                                     owl:allValuesFrom ec:Contract
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
                                      owl:onProperty ec:hasContentEditorialFormat ;
                                      owl:allValuesFrom ec:ContentEditorialFormat
                                    ] ,
@@ -10368,10 +10372,6 @@ ec:EditorialObject rdf:type owl:Class ;
                                    [ rdf:type owl:Restriction ;
                                      owl:onProperty ec:hasVersionType ;
                                      owl:allValuesFrom skos:Concept
-                                   ] ,
-                                   [ rdf:type owl:Restriction ;
-                                     owl:onProperty ec:isCommissionedBy ;
-                                     owl:allValuesFrom ec:Contract
                                    ] ,
                                    [ rdf:type owl:Restriction ;
                                      owl:onProperty ec:isDistributedOn ;

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -640,6 +640,16 @@ ec:hasAnnotationTarget rdf:type owl:ObjectProperty ;
                                   "Ziel der Annotation"@de .
 
 
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasApprover
+ec:hasApprover rdf:type owl:ObjectProperty ;
+               dcterms:description "Pour identifier un agent qui a approuvé un rapport d'audit."@fr ,
+                                   "To identify an Agent who approved an AuditReport."@en ,
+                                   "Um einen Agenten zu identifizieren, der einen AuditReport genehmigt hat."@de ;
+               rdfs:label "Approuvé par"@fr ,
+                          "Approved by"@en ,
+                          "Genehmigt von"@de .
+
+
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasArtefactBuyer
 ec:hasArtefactBuyer rdf:type owl:ObjectProperty ;
                     rdfs:range ec:Agent ;
@@ -3716,16 +3726,6 @@ ec:isAnnotatedMediaResource rdf:type owl:ObjectProperty ;
                             rdfs:label "Media resource"@en ,
                                        "Medienressource"@de ,
                                        "Ressource médiatique"@fr .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isApprovedBy
-ec:isApprovedBy rdf:type owl:ObjectProperty ;
-                dcterms:description "Pour identifier un agent qui a approuvé un rapport d'audit."@fr ,
-                                    "To identify an Agent who approved an AuditReport."@en ,
-                                    "Um einen Agenten zu identifizieren, der einen AuditReport genehmigt hat."@de ;
-                rdfs:label "Approuvé par"@fr ,
-                           "Approved by"@en ,
-                           "Genehmigt von"@de .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isAttributedTo
@@ -8768,6 +8768,10 @@ ec:AuditJob rdf:type owl:Class ;
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AuditReport
 ec:AuditReport rdf:type owl:Class ;
                rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                 owl:onProperty ec:hasApprover ;
+                                 owl:allValuesFrom ec:Agent
+                               ] ,
+                               [ rdf:type owl:Restriction ;
                                  owl:onProperty ec:hasAuditReportDate ;
                                  owl:allValuesFrom time:Instant
                                ] ,
@@ -8782,10 +8786,6 @@ ec:AuditReport rdf:type owl:Class ;
                                [ rdf:type owl:Restriction ;
                                  owl:onProperty ec:hasRelatedAuditJob ;
                                  owl:allValuesFrom ec:AuditJob
-                               ] ,
-                               [ rdf:type owl:Restriction ;
-                                 owl:onProperty ec:isApprovedBy ;
-                                 owl:allValuesFrom ec:Agent
                                ] ,
                                [ rdf:type owl:Restriction ;
                                  owl:onProperty ec:referencesRule ;


### PR DESCRIPTION
This pull request includes the renaming of ten object properties.

- 'isAnimalOwner' to 'hasOwner'
- 'isAnnotationBy' to 'hasAuthor'
- 'isApprovedBy' to 'hasApprover'
- 'isBrand' to 'hasBrand'
- 'isCharacter' to 'hasCharacter'.
- 'isCommissionedBy' to 'hasCommissioningContract'
-  'isEditorialFormatOf' to 'hasEditorialFormatOf'
- 'isEmbodiedBy' to 'hasEmbodyingArtefact'
- 'isFictitiousPerson' to 'hasFictitiousPerson'
- 'isIssuedBy' to 'hasIssuer'

**Reviewers:**
- @JuergenGrupp
- @aro-max