### PR TITLE
299 refactoring removing range cluster 02

### DIFF
--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -668,7 +668,6 @@ ec:hasArtefactDateOfSale rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasArtefactOwner
 ec:hasArtefactOwner rdf:type owl:ObjectProperty ;
-                    rdfs:range ec:Agent ;
                     dcterms:description "Pour identifier le propriétaire d'un artefact."@fr ,
                                         "To identify the owner of an Artefact."@en ,
                                         "Um den Besitzer eines Artefakts zu identifizieren."@de ;


### PR DESCRIPTION
This pull request removes range constraints from ten object properties in ebucoreplus ontology. 
#### Changes
- Removed the range "AncillaryData" from the property "hasAncillaryData".
- Removed the range "AnimalBreedCode" from the property "hasAnimalBreedCode".
- Removed the range "AnimalColourCode" from the property "hasAnimalColourCode".
- Removed the range "Agent" from the property "hasAnimalGroom".
- Removed the range "Involvement" from the property "hasAnimalRole".
- Removed the range "Agent" from the property "hasAnnotationAgent".
- Removed the range "time:Instance" from the property "hasAnnotationCurationDateTime".
- Removed the range "owl:Thing" from the property "hasAnnotationTarget".
- Removed the range "Agent" from the property "hasArtefactBuyer".
- Removed the range "Agent" from the property "hasArtefactOwner".
#### Reviewer
@aro-max 
@JuergenGrupp 