### PR TITLE
299 refactoring removing range cluster 04

### DIFF
--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -876,7 +876,6 @@ ec:hasAudioEncodingFormat rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAudioTrack
 ec:hasAudioTrack rdf:type owl:ObjectProperty ;
-                 rdfs:range ec:AudioTrack ;
                  dcterms:description "Pour identifier les AudioTracks dans la ressource."@fr ,
                                      "So identifizieren Sie Audiospuren in der Ressource."@de ,
                                      "To identify AudioTracks in the Resource."@en ;

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -1024,7 +1024,6 @@ ec:hasClone rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasCodec
 ec:hasCodec rdf:type owl:ObjectProperty ;
-            rdfs:range ec:Codec ;
             dcterms:description "Pour identifier un Codec utilisé pour créer une ressource."@fr ,
                                 "To identify a Codec used to create a resource."@en ,
                                 "Um einen Codec zu identifizieren, der zur Erstellung einer Ressource verwendet wird."@de ;

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -980,7 +980,6 @@ ec:hasCaptioningSource rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasCastMember
 ec:hasCastMember rdf:type owl:ObjectProperty ;
-                 rdfs:range ec:CastMember ;
                  dcterms:description "A member of the cast."@en ,
                                      "Ein Mitglied der Besetzung."@de ,
                                      "Un membre de la distribution."@fr ;

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -1014,7 +1014,6 @@ ec:hasClip rdf:type owl:ObjectProperty ;
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasClone
 ec:hasClone rdf:type owl:ObjectProperty ;
             owl:inverseOf ec:isCloneOf ;
-            rdfs:range ec:MediaResource ;
             dcterms:description "Identifie la relation entre une instanciation numérique d'une MediaResource et sa copie directe, sans perte de génération."@fr ,
                                 "Identifies relationship between a digital instantiation of a MediaResource and its direct copy, with no generational loss."@en ,
                                 "Identifiziert die Beziehung zwischen einer digitalen Instanziierung einer MediaResource und ihrer direkten Kopie, ohne Generationsverlust."@de ;

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -928,7 +928,6 @@ ec:hasAwardDate rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasBrand
 ec:hasBrand rdf:type owl:ObjectProperty ;
-            rdfs:range ec:Brand ;
             dcterms:description "Pour identifier une Marque."@fr ,
                                 "To identify a Brand."@en ,
                                 "Um eine Marke zu identifizieren."@de ;

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -948,7 +948,6 @@ ec:hasBusinessContract rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasCaptioning
 ec:hasCaptioning rdf:type owl:ObjectProperty ;
-                 rdfs:range ec:Captioning ;
                  dcterms:description "Pour signaler la présence de sous-titres."@fr ,
                                      "To signal the presence of Captioning."@en ,
                                      "Zum Signalisieren der Anwesenheit von Untertitel."@de ;

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -970,7 +970,6 @@ ec:hasCaptioningFormat rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasCaptioningSource
 ec:hasCaptioningSource rdf:type owl:ObjectProperty ;
-                       rdfs:range ec:Agent ;
                        dcterms:description "Fournir des informations sur la source du sous-titrage."@fr ,
                                            "To provide information on the source of Captioning."@en ,
                                            "Um Informationen über die Quelle der Untertitelung bereitzustellen."@de ;

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -990,7 +990,6 @@ ec:hasCastMember rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasCharacter
 ec:hasCharacter rdf:type owl:ObjectProperty ;
-                rdfs:range ec:Character ;
                 dcterms:description "Pour identifier un personnage."@fr ,
                                     "Pour énumérer les personnages d'une fiction."@fr ,
                                     "To identify a character."@en ,

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -906,7 +906,6 @@ ec:hasAuditReportDate rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAuthor
 ec:hasAuthor rdf:type owl:ObjectProperty ;
-             rdfs:range ec:Agent ;
              dcterms:description "Pour lier une annotation à l'agent qui l'a créée."@fr ,
                                  "So verknüpfen Sie eine Anmerkung mit einem Agenten, der sie erstellt hat."@de ,
                                  "To link an Annotation to an Agent who created it."@en ;

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -843,7 +843,6 @@ ec:hasAudienceScoreRecordingTechnique rdf:type owl:ObjectProperty ;
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAudioCodec
 ec:hasAudioCodec rdf:type owl:ObjectProperty ;
                  rdfs:subPropertyOf ec:hasCodec ;
-                 rdfs:range ec:AudioCodec ;
                  dcterms:description "Pour identifier le Codec audio"@fr ,
                                      "So identifizieren Sie den Audio Codec"@de ,
                                      "To identify the audio Codec"@en ;


### PR DESCRIPTION
This pull request removes range constraints from ten object properties in ebucoreplus ontology. 
#### Changes
- Removed the range "AudioTrack" from the property "hasAudioTrack".
- Removed the range "Agent" from the property "hasAuthor".
- Removed the range "Brand" from the property "hasBrand".
- Removed the range "Captioning" from the property "hasCaptioning".
- Removed the range "Agent" from the property "hasCaptioningSource".
- Removed the range "CastMember" from the property "hasCastMember".
- Removed the range "Character" from the property "hasCharacter".
- Removed the range "MediaResource" from the property "hasClone".
- Removed the range "Codec" from the property "hasCodec".
- Removed the range "AudioCodec" from the property "hasAudioCodec".
#### Reviewer
@aro-max 
@JuergenGrupp 