### PR TITLE
299 refactoring inverse property cluster 1

### DIFF
--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -1983,6 +1983,7 @@ ec:hasInputResource rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasIssuer
 ec:hasIssuer rdf:type owl:ObjectProperty ;
+             owl:inverseOf ec:isIssuedBy ;
              dcterms:description "Pour identifier l'émetteur d'un identifiant."@fr ,
                                  "To identify the issuer of an identifier."@en ,
                                  "Zur Identifizierung des Ausstellers eines Identifikators."@de ;
@@ -3766,6 +3767,10 @@ ec:isInstantiatedBy rdf:type owl:ObjectProperty ;
                     rdfs:label "Media Resource"@en ,
                                "Medien Ressource"@de ,
                                "Ressource médiatique"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isIssuedBy
+ec:isIssuedBy rdf:type owl:ObjectProperty .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isMasterOf

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -251,6 +251,11 @@ ec:accountingTo rdf:type owl:ObjectProperty ;
                            "Konto"@de .
 
 
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#animates
+ec:animates rdf:type owl:ObjectProperty ;
+            owl:inverseOf ec:isAnimatedBy .
+
+
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#applyTo
 ec:applyTo rdf:type owl:ObjectProperty ;
            owl:inverseOf ec:hasRights ;

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -427,6 +427,11 @@ ec:existsAs rdf:type owl:ObjectProperty ;
                        "Redaktionelles Objekt"@de .
 
 
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#grantsApproval
+ec:grantsApproval rdf:type owl:ObjectProperty ;
+                  owl:inverseOf ec:hasApprover .
+
+
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAccessConditions
 ec:hasAccessConditions rdf:type owl:ObjectProperty ;
                        rdfs:subPropertyOf ec:hasRights ;

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -1724,6 +1724,7 @@ ec:hasEditorialWork rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasEmbodyingArtefact
 ec:hasEmbodyingArtefact rdf:type owl:ObjectProperty ;
+                        owl:inverseOf ec:isEmbodiedBy ;
                         dcterms:description "Character depicted by an Artifact"@en ,
                                             "Personnage représenté par un artefact"@fr ,
                                             "Von einem Artefakt dargestellter Charakter"@de ;
@@ -3698,6 +3699,10 @@ ec:isDubOf rdf:type owl:ObjectProperty ;
            rdfs:label "Doublé de"@fr ,
                       "Dubbed from"@en ,
                       "Synchronisiert von"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isEmbodiedBy
+ec:isEmbodiedBy rdf:type owl:ObjectProperty .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isEpisodeOf

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -435,6 +435,7 @@ ec:hasAccessConditions rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAffiliation
 ec:hasAffiliation rdf:type owl:ObjectProperty ;
+                  owl:inverseOf ec:isAffiliationFor ;
                   dcterms:description "A property to establish the relation between a Contact/Person and an Organisation."@en ,
                                       "Eine Eigenschaft, die die Beziehung zwischen einem Kontakt/Person und einer Organisation."@de ,
                                       "Une propriété permettant d'établir la relation entre un contact/personne et une organisation."@fr ;
@@ -3555,6 +3556,10 @@ ec:isAffiliatedTo rdf:type owl:ObjectProperty ;
                   rdfs:label "est affilié à"@fr ,
                              "is affiliated to"@en ,
                              "ist angegliedert an"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isAffiliationFor
+ec:isAffiliationFor rdf:type owl:ObjectProperty .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isAnimatedBy

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -1983,7 +1983,6 @@ ec:hasInputResource rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasIssuer
 ec:hasIssuer rdf:type owl:ObjectProperty ;
-             owl:inverseOf ec:isIssuedBy ;
              dcterms:description "Pour identifier l'émetteur d'un identifiant."@fr ,
                                  "To identify the issuer of an identifier."@en ,
                                  "Zur Identifizierung des Ausstellers eines Identifikators."@de ;
@@ -3768,10 +3767,6 @@ ec:isInstantiatedBy rdf:type owl:ObjectProperty ;
                     rdfs:label "Media Resource"@en ,
                                "Medien Ressource"@de ,
                                "Ressource médiatique"@fr .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isIssuedBy
-ec:isIssuedBy rdf:type owl:ObjectProperty .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isMasterOf

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -1761,6 +1761,7 @@ ec:hasEndDateTime rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasEpisode
 ec:hasEpisode rdf:type owl:ObjectProperty ;
+              owl:inverseOf ec:isEpisodeOf ;
               dcterms:description "Pour identifier les épisodes d'une série"@fr ,
                                   "So identifizieren Sie Episoden einer Serie"@de ,
                                   "To identify Episodes in a Series"@en ;

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -324,6 +324,11 @@ platform"""@en ,
                                            "peut accéder à la plateforme de publication"@fr .
 
 
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#commissions
+ec:commissions rdf:type owl:ObjectProperty ;
+               owl:inverseOf ec:hasCommissioningContract .
+
+
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#compilesResonanceEvents
 ec:compilesResonanceEvents rdf:type owl:ObjectProperty ;
                            dcterms:description "Eines der ResonanceEvents, die zu einem aussagekräftigen Satz von Resonanzdaten."@de ,

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -1781,11 +1781,6 @@ ec:hasExploitationIssues rdf:type owl:ObjectProperty ;
                                     "Problèmes d'exploitation"@fr .
 
 
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasExtract
-ec:hasExtract rdf:type owl:ObjectProperty ;
-              owl:inverseOf ec:isExtractOf .
-
-
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasFictitiousPerson
 ec:hasFictitiousPerson rdf:type owl:ObjectProperty ;
                        dcterms:description "Pour identifier un contact/personne fictive."@fr ,

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -2113,6 +2113,7 @@ ec:hasManifestation rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasMaster
 ec:hasMaster rdf:type owl:ObjectProperty ;
+             owl:inverseOf ec:isMasterOf ;
              dcterms:description "Pour identifier le maître d'une ressource"@fr ,
                                  "So identifizieren Sie den Master einer Ressource"@de ,
                                  "To identify the master of a Resource"@en ;

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -401,6 +401,11 @@ ec:createsMetadata rdf:type owl:ObjectProperty ;
                               "erstellt Metadaten"@de .
 
 
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#defines
+ec:defines rdf:type owl:ObjectProperty ;
+           owl:inverseOf ec:isDefinedBy .
+
+
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#derivedTo
 ec:derivedTo rdf:type owl:ObjectProperty ;
              owl:inverseOf ec:isDerivedFrom ;

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -1781,6 +1781,11 @@ ec:hasExploitationIssues rdf:type owl:ObjectProperty ;
                                     "Problèmes d'exploitation"@fr .
 
 
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasExtract
+ec:hasExtract rdf:type owl:ObjectProperty ;
+              owl:inverseOf ec:isExtractOf .
+
+
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasFictitiousPerson
 ec:hasFictitiousPerson rdf:type owl:ObjectProperty ;
                        dcterms:description "Pour identifier un contact/personne fictive."@fr ,


### PR DESCRIPTION
This pull request adds new object properties and defines them as inverses of existing properties in the EBUCorePlus ontology.

#### Changes
- Created a new object property 'isAffiliationFor' and added it as the inverse of 'hasAffiliation'.
- Created a new object property 'animates' and added it as the inverse of 'isAnimatedBy'.
- Created a new object property 'grantsApproval' and added it as the inverse of 'hasApprover'.
- Created a new object property 'commissions ' and added it as the inverse of 'hasCommissioningContract'.
- Created a new object property 'defines' and added it as the inverse of 'isDefinedBy'.
- Created a new object property 'isEmbodiedBy' and added it as the inverse of 'hasEmbodyingArtefact'.
- Added 'isEpisodeOf' as the inverse of 'hasEpisode'.
- Created a new object property 'hasExtract' and added it as the inverse of 'isExtractOf'.
- Created a new object property 'isIssuedBy' and added it as the inverse of 'hasIssuer'.
- Added 'isMasterOf' as the inverse of 'hasMaster'.
#### Reviewer
@aro-max 
@JuergenGrupp 