### PR TITLE
299 refactoring inverse property cluster 2

### DIFF
--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -3618,10 +3618,6 @@ ec:isAnnotatedMediaResource rdf:type owl:ObjectProperty ;
                                        "Ressource médiatique"@fr .
 
 
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isAnnotationFor
-ec:isAnnotationFor rdf:type owl:ObjectProperty .
-
-
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isAttributedTo
 ec:isAttributedTo rdf:type owl:ObjectProperty ;
                   dcterms:description "Pour associer un agent à une instance de Provenance."@fr ,

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -3905,6 +3905,7 @@ ec:isPartOf rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isPlayedBy
 ec:isPlayedBy rdf:type owl:ObjectProperty ;
+              owl:inverseOf ec:playsCharacter ;
               owl:propertyDisjointWith ec:isPortrayedBy ;
               dcterms:description "Beziehung zwischen einer fiktiven Figur und dem Schauspieler, der die Rolle spielt."@de ,
                                   "Relation entre un personnage fictif et l'acteur qui joue le rôle."@fr ,

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -3843,6 +3843,7 @@ ec:isNextInSequence rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isOfferedBy
 ec:isOfferedBy rdf:type owl:ObjectProperty ;
+               owl:inverseOf ec:offers ;
                dcterms:description "Pour identifier un service associé à un PublicationEvent."@fr ,
                                    "To identify a Service associated to a PublicationEvent."@en ,
                                    "Um einen Dienst zu identifizieren, der einem PublicationEvent zugeordnet ist."@de ;

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -3905,7 +3905,6 @@ ec:isPartOf rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isPlayedBy
 ec:isPlayedBy rdf:type owl:ObjectProperty ;
-              owl:inverseOf ec:plays ;
               owl:propertyDisjointWith ec:isPortrayedBy ;
               dcterms:description "Beziehung zwischen einer fiktiven Figur und dem Schauspieler, der die Rolle spielt."@de ,
                                   "Relation entre un personnage fictif et l'acteur qui joue le rôle."@fr ,
@@ -4087,10 +4086,6 @@ ec:originatesFrom rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#owns
 ec:owns rdf:type owl:ObjectProperty .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#plays
-ec:plays rdf:type owl:ObjectProperty .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#playsCharacter

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -3883,6 +3883,7 @@ ec:isPartOf rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isPlayedBy
 ec:isPlayedBy rdf:type owl:ObjectProperty ;
+              owl:inverseOf ec:plays ;
               owl:propertyDisjointWith ec:isPortrayedBy ;
               dcterms:description "Beziehung zwischen einer fiktiven Figur und dem Schauspieler, der die Rolle spielt."@de ,
                                   "Relation entre un personnage fictif et l'acteur qui joue le rôle."@fr ,
@@ -4055,6 +4056,10 @@ ec:originatesFrom rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#owns
 ec:owns rdf:type owl:ObjectProperty .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#plays
+ec:plays rdf:type owl:ObjectProperty .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#playsCharacter

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -4219,10 +4219,6 @@ ec:transports rdf:type owl:ObjectProperty ;
                          "Transports"@fr .
 
 
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#uses
-ec:uses rdf:type owl:ObjectProperty .
-
-
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#usesConsumptionDevice
 ec:usesConsumptionDevice rdf:type owl:ObjectProperty ;
                          dcterms:description "Bereich: string oder ConsumptionDevice"@de ,

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -3852,6 +3852,7 @@ ec:isOrderedBy rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isOwnedBy
 ec:isOwnedBy rdf:type owl:ObjectProperty ;
+             owl:inverseOf ec:owns ;
              dcterms:description "Pour identifier l'agent (contact/personne ou Organisation) qui possède un Service exploitant un PublicationChannel."@fr ,
                                  "To identify the Agent (Contact/person or Organisation) who owns a Service operating a PublicationChannel."@en ,
                                  "Zur Identifizierung des Agenten (Kontakt/Person oder Organisation), der Eigentümer eines Dienstes ist, der einen PublicationChannel betreibt."@de ;
@@ -4050,6 +4051,10 @@ ec:originatesFrom rdf:type owl:ObjectProperty ;
                   rdfs:label "Contract"@en ,
                              "Contrat"@fr ,
                              "Vertrag"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#owns
+ec:owns rdf:type owl:ObjectProperty .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#playsCharacter

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -609,6 +609,11 @@ ec:hasAnimalRole rdf:type owl:ObjectProperty ;
                             "Tierische Rolle"@de .
 
 
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAnnotation
+ec:hasAnnotation rdf:type owl:ObjectProperty ;
+                 owl:inverseOf ec:isAnnotationFor .
+
+
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAnnotationAgent
 ec:hasAnnotationAgent rdf:type owl:ObjectProperty ;
                       dcterms:description "Pour définir l'instance d'annotation d'un agent."@fr ,
@@ -3609,6 +3614,10 @@ ec:isAnnotatedMediaResource rdf:type owl:ObjectProperty ;
                             rdfs:label "Media resource"@en ,
                                        "Medienressource"@de ,
                                        "Ressource médiatique"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isAnnotationFor
+ec:isAnnotationFor rdf:type owl:ObjectProperty .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isAttributedTo

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -3410,6 +3410,7 @@ ec:hasTrack rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasTrackPart
 ec:hasTrackPart rdf:type owl:ObjectProperty ;
+                owl:inverseOf ec:isTrackPartOf ;
                 dcterms:description "An element to identify a part of a track by a title, a start time and an end time in both the media source and media destinationn."@en ,
                                     "Ein Element zur Identifizierung eines Teils eines Titels durch einen Titel, eine Startzeit und eine Endzeit sowohl in der Medienquelle als auch im Medienziel."@de ,
                                     "Un élément pour identifier une partie d'une piste par un titre, une heure de début et une heure de fin dans la source du média et la destination du médian."@fr ;

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -8926,7 +8926,7 @@ ec:Character rdf:type owl:Class ;
                              ] ,
                              [ rdf:type owl:Restriction ;
                                owl:onProperty ec:isPlayedBy ;
-                               owl:allValuesFrom ec:Person
+                               owl:allValuesFrom ec:Involvement
                              ] ,
                              [ rdf:type owl:Restriction ;
                                owl:onProperty ec:isPortrayedBy ;

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -4015,11 +4015,6 @@ ec:isTrackPartOf rdf:type owl:ObjectProperty ;
                             "Track part source"@en .
 
 
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isUsedBy
-ec:isUsedBy rdf:type owl:ObjectProperty ;
-            owl:inverseOf ec:uses .
-
-
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isVersionOf
 ec:isVersionOf rdf:type owl:ObjectProperty ;
                dcterms:description "Pour identifier les versions connexes."@fr ,

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -2615,6 +2615,7 @@ ec:hasRelatedAccount rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedAgent
 ec:hasRelatedAgent rdf:type owl:ObjectProperty ;
+                   owl:inverseOf ec:isRelatedAgent ;
                    dcterms:description "Pour associer un concept à un agent (par exemple, une personne ou un personnage)."@fr ,
                                        "To associate a concept with an Agent (e.g. Person or Character)."@en ,
                                        "Um ein Konzept mit einem Agenten (z.B. einer Person oder einem Charakter) zu verknüpfen."@de ;
@@ -3949,6 +3950,10 @@ ec:isReferencedBy rdf:type owl:ObjectProperty ;
                   rdfs:label "Reference source"@en ,
                              "Referenzquelle"@de ,
                              "Source de référence"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isRelatedAgent
+ec:isRelatedAgent rdf:type owl:ObjectProperty .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isReplacedBy

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -1986,6 +1986,11 @@ ec:hasIssuer rdf:type owl:ObjectProperty ;
                         "Émetteur"@fr .
 
 
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasJob
+ec:hasJob rdf:type owl:ObjectProperty ;
+          owl:inverseOf ec:isOrderedBy .
+
+
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasKeyCareerEvent
 ec:hasKeyCareerEvent rdf:type owl:ObjectProperty ;
                      dcterms:description "Die wichtigsten Karriereereignisse einer Person zu identifizieren."@de ,

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -919,6 +919,7 @@ ec:hasAuditReportDate rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAuthor
 ec:hasAuthor rdf:type owl:ObjectProperty ;
+             owl:inverseOf ec:isAuthorOf ;
              dcterms:description "Pour lier une annotation à l'agent qui l'a créée."@fr ,
                                  "So verknüpfen Sie eine Anmerkung mit einem Agenten, der sie erstellt hat."@de ,
                                  "To link an Annotation to an Agent who created it."@en ;
@@ -3618,6 +3619,10 @@ ec:isAttributedTo rdf:type owl:ObjectProperty ;
                   rdfs:label "Cible de provenance"@fr ,
                              "Provenance target"@en ,
                              "Ziel Provenienz"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isAuthorOf
+ec:isAuthorOf rdf:type owl:ObjectProperty .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isAwardedTo

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -4023,6 +4023,11 @@ ec:isTrackPartOf rdf:type owl:ObjectProperty ;
                             "Track part source"@en .
 
 
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isUsedBy
+ec:isUsedBy rdf:type owl:ObjectProperty ;
+            owl:inverseOf ec:uses .
+
+
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isVersionOf
 ec:isVersionOf rdf:type owl:ObjectProperty ;
                dcterms:description "Pour identifier les versions connexes."@fr ,
@@ -4229,6 +4234,10 @@ ec:transports rdf:type owl:ObjectProperty ;
               rdfs:label "Transporte"@de ,
                          "Transports"@en ,
                          "Transports"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#uses
+ec:uses rdf:type owl:ObjectProperty .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#usesConsumptionDevice

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -591,6 +591,7 @@ ec:hasAnimalColourCode rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAnimalGroom
 ec:hasAnimalGroom rdf:type owl:ObjectProperty ;
+                  owl:inverseOf ec:isAnimalGroomFor ;
                   dcterms:description "Identifier le palefrenier / le soigneur d'un animal."@fr ,
                                       "To identify the groom / care taker of an animal."@en ,
                                       "Zur Identifizierung des Pflegers / Betreuers eines Tieres."@de ;
@@ -3596,6 +3597,10 @@ ec:isAffiliatedTo rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isAffiliationFor
 ec:isAffiliationFor rdf:type owl:ObjectProperty .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isAnimalGroomFor
+ec:isAnimalGroomFor rdf:type owl:ObjectProperty .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isAnimatedBy

--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -610,11 +610,6 @@ ec:hasAnimalRole rdf:type owl:ObjectProperty ;
                             "Tierische Rolle"@de .
 
 
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAnnotation
-ec:hasAnnotation rdf:type owl:ObjectProperty ;
-                 owl:inverseOf ec:isAnnotationFor .
-
-
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAnnotationAgent
 ec:hasAnnotationAgent rdf:type owl:ObjectProperty ;
                       dcterms:description "Pour définir l'instance d'annotation d'un agent."@fr ,


### PR DESCRIPTION
This pull request adds new object properties and defines them as inverses of existing properties in the EBUCorePlus ontology.

#### Changes
- Created a new object property 'hasJob' and added it as the inverse of 'isOrderedBy'.
- Created a new object property 'owns' and added it as the inverse of 'isOwnedBy'.
- Created a new object property 'plays' and added it as the inverse of 'isPlayedBy'.
- Created a new object property 'isAuthorOf' and added it as the inverse of 'hasAuthor'.
- Created a new object property 'isAnnotationFor' and  'hasAnnotation and added 'isAnnotationFor' as the inverse of 'hasAnnotation'.
- Added 'isTrackPartOf' as the inverse of 'hasTrackPart'.
- Created a new object property 'isRelatedAgent' and added it as the inverse of 'hasRelatedAgent'.
- Created a new object property 'isAnimalGroomFor' and added it as the inverse of 'hasAnimalGroom'.
- Created a new object property 'isUsedBy' and  'uses and added 'isUsedBy' as the inverse of 'uses'.
- Added 'isOfferedBy' as the inverse of 'offerse'.

#### Reviewer
@aro-max 
@JuergenGrupp 