### PR TITLE
fix for #277 - property references on dev

### DIFF
--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -3818,8 +3818,7 @@ ec:isMediaFragmentOf rdf:type owl:ObjectProperty ;
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isMemberOf
 ec:isMemberOf rdf:type owl:ObjectProperty ;
-              dcterms:description 
-                                  "Pour identifier un groupe dont un objet éditorial est membre."@fr ,
+              dcterms:description "Pour identifier un groupe dont un objet éditorial est membre."@fr ,
                                   "So identifizieren Sie einen übergeordneten Veröffentlichungsplan"@de ,
                                   "To identify a Group to which an EditorialObject is a member of."@en ;
               rdfs:label "Member of"@en ,
@@ -8706,20 +8705,14 @@ ec:BehindTheScenes rdf:type owl:Class ;
 ec:BibliographicalObject rdf:type owl:Class ;
                          rdfs:subClassOf ec:Asset ,
                                          [ rdf:type owl:Restriction ;
-                                           owl:onProperty ec:isReferencedBy ;
-                                           owl:allValuesFrom ec:BibliographicalObject
-                                         ] ,
-                                         [ rdf:type owl:Restriction ;
-                                           owl:onProperty ec:isReferencedBy ;
-                                           owl:allValuesFrom ec:EditorialObject
+                                           owl:onProperty ec:references ;
+                                           owl:minQualifiedCardinality "0"^^xsd:nonNegativeInteger ;
+                                           owl:onClass ec:BibliographicalObject
                                          ] ,
                                          [ rdf:type owl:Restriction ;
                                            owl:onProperty ec:references ;
-                                           owl:allValuesFrom ec:BibliographicalObject
-                                         ] ,
-                                         [ rdf:type owl:Restriction ;
-                                           owl:onProperty ec:references ;
-                                           owl:allValuesFrom ec:EditorialObject
+                                           owl:minQualifiedCardinality "0"^^xsd:nonNegativeInteger ;
+                                           owl:onClass ec:EditorialObject
                                          ] ;
                          dcterms:description "Documents de nature diverse."@fr ,
                                              "Documents of various nature."@en ,
@@ -10210,14 +10203,6 @@ ec:EditorialObject rdf:type owl:Class ;
                                      owl:allValuesFrom ec:PublicationEvent
                                    ] ,
                                    [ rdf:type owl:Restriction ;
-                                     owl:onProperty ec:isReferencedBy ;
-                                     owl:allValuesFrom ec:BibliographicalObject
-                                   ] ,
-                                   [ rdf:type owl:Restriction ;
-                                     owl:onProperty ec:isReferencedBy ;
-                                     owl:allValuesFrom ec:EditorialObject
-                                   ] ,
-                                   [ rdf:type owl:Restriction ;
                                      owl:onProperty ec:isRequiredBy ;
                                      owl:allValuesFrom ec:EditorialObject
                                    ] ,
@@ -10230,20 +10215,22 @@ ec:EditorialObject rdf:type owl:Class ;
                                      owl:allValuesFrom ec:EditorialObject
                                    ] ,
                                    [ rdf:type owl:Restriction ;
-                                     owl:onProperty ec:references ;
-                                     owl:allValuesFrom ec:BibliographicalObject
-                                   ] ,
-                                   [ rdf:type owl:Restriction ;
-                                     owl:onProperty ec:references ;
-                                     owl:allValuesFrom ec:EditorialObject
-                                   ] ,
-                                   [ rdf:type owl:Restriction ;
                                      owl:onProperty ec:represents ;
                                      owl:allValuesFrom ec:Asset
                                    ] ,
                                    [ rdf:type owl:Restriction ;
                                      owl:onProperty ec:requires ;
                                      owl:allValuesFrom ec:EditorialObject
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:references ;
+                                     owl:minQualifiedCardinality "0"^^xsd:nonNegativeInteger ;
+                                     owl:onClass ec:BibliographicalObject
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:references ;
+                                     owl:minQualifiedCardinality "0"^^xsd:nonNegativeInteger ;
+                                     owl:onClass ec:EditorialObject
                                    ] ,
                                    [ rdf:type owl:Restriction ;
                                      owl:onProperty ec:hasDateBroadcast ;
@@ -15064,8 +15051,8 @@ dcterms:contributor dcterms:description "Dans le contexte d'EBUCore, réservé �
                      rdfs:label "Beitragender"@de ;
                      dcterms:description "In the context of EBUCore, reserved for the annotation of RDF properties."@en ,
                                          "Im Kontext von EBUCore für die Annotation von RDF-Eigenschaften reserviert."@de ;
-                     rdfs:label "Contributor"@en ,
-                                "Contributeur"@fr .
+                     rdfs:label "Contributeur"@fr ,
+                                "Contributor"@en .
 
 
 ###  Generated by the OWL API (version 4.5.9.2019-02-01T07:24:44Z) https://github.com/owlcs/owlapi


### PR DESCRIPTION
- replaced reference cardinality by "min 0" as proposed by Tormod in #277 
- introduced "isReferencedBy" as inverse and  removed from EditorialObject and from BibliographicalObject.