### PR TITLE
Add rdfs:label to class ec:EditorialSegment

### DIFF
--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -10504,6 +10504,9 @@ ec:EditorialSegment rdf:type owl:Class ;
                                       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                       owl:onDataRange xsd:integer
                                     ] ;
+                    rdfs:label "Editorial Segment"@en ,
+                                "Segment éditorial"@fr ,
+                                "Redaktioneller Abschnitt"@de ;
                     skos:definition "Ein Medieninhalt, der einen Ausschnitt eines anderen Medieninhaltes darstellt"@de ,
                                     "an EditorialObject representing a fraction of an EditorialObject"@en ,
                                     "un objet éditorial représentant une fraction d'un objet éditorial"@fr ;


### PR DESCRIPTION
### Context
The class `ec:EditorialSegment` is missing a `rdfs:label`, even though it has SKOS metadata.

### Fix
This PR adds a `rdfs:label` in English, French, and German:
