### PR TITLE
Normalize ebucoreplus.owl as the English reference and generate translated versions

### DIFF
--- a/ontology/EBUCorePlus/ebucoreplus.owl
+++ b/ontology/EBUCorePlus/ebucoreplus.owl
@@ -86,83 +86,51 @@ cc:licence rdf:type owl:AnnotationProperty .
 
 ###  http://purl.org/dc/elements/1.1/contributor
 dc:contributor rdf:type owl:AnnotationProperty ;
-               dcterms:description "An Agent who has participated in any phase of management of an Asset."@en ,
-                                   "Ein Agent, der in irgendeiner Phase der Verwaltung eines Assets mitgewirkt hat."@de ,
-                                   "Un agent qui a participé à une phase quelconque de la gestion d'un actif."@fr ;
-               rdfs:label "Beitragender"@de ,
-                          "Contributeur"@fr ,
-                          "Contributor"@en .
+               dcterms:description "An Agent who has participated in any phase of management of an Asset."@en ;
+               rdfs:label "Contributor"@en .
 
 
 ###  http://purl.org/dc/elements/1.1/creator
 dc:creator rdf:type owl:AnnotationProperty ;
-           dcterms:description "Pour identifier le créateur d'un actif."@fr ,
-                               "So identifizieren Sie den Ersteller eines Assets."@de ,
-                               "To identify the creator of an Asset."@en ;
-           rdfs:label "Creator"@en ,
-                      "Créateur"@fr ,
-                      "Schöpfer"@de .
+           dcterms:description "To identify the creator of an Asset."@en ;
+           rdfs:label "Creator"@en .
 
 
 ###  http://purl.org/dc/elements/1.1/date
 dc:date rdf:type owl:AnnotationProperty ;
-        dcterms:description "A date associated with a resource."@en ,
-                            "Ein Datum, das mit einer Resource verbunden ist."@de ,
-                            "Une date associée à une ressource."@fr ;
-        rdfs:label "Date"@en ,
-                   "Date"@fr ,
-                   "Datum"@de ;
+        dcterms:description "A date associated with a resource."@en ;
+        rdfs:label "Date"@en ;
         rdfs:range xsd:date .
 
 
 ###  http://purl.org/dc/elements/1.1/description
 dc:description rdf:type owl:AnnotationProperty ;
-               dcterms:description "A description of an Asset."@en ,
-                                   "Eine Beschreibung eines Assets."@de ,
-                                   "Une description d'un actif."@fr ;
-               rdfs:label "Beschreibung"@de ,
-                          "Description"@en ,
-                          "Description"@fr .
+               dcterms:description "A description of an Asset."@en ;
+               rdfs:label "Description"@en .
 
 
 ###  http://purl.org/dc/elements/1.1/format
 dc:format rdf:type owl:AnnotationProperty ;
-          dcterms:description "Information about the Format of a Resource."@en ,
-                              "Informationen über das Format einer Resource."@de ,
-                              "Informations sur le format d'une ressource."@fr ;
-          rdfs:label "Format"@de ,
-                     "Format"@en ,
-                     "Format"@fr .
+          dcterms:description "Information about the Format of a Resource."@en ;
+          rdfs:label "Format"@en .
 
 
 ###  http://purl.org/dc/elements/1.1/identifier
 dc:identifier rdf:type owl:AnnotationProperty ;
-              dcterms:description "Fournir un identifiant simple et non fortement structuré."@fr ,
-                                  "To provide a simple not strongly structured identifier."@en ,
-                                  "Um einen einfachen, nicht stark strukturierten Identifikator bereitzustellen."@de ;
-              rdfs:label "Identifiant"@fr ,
-                         "Identifier"@en ,
-                         "Kennung"@de .
+              dcterms:description "To provide a simple not strongly structured identifier."@en ;
+              rdfs:label "Identifier"@en .
 
 
 ###  http://purl.org/dc/elements/1.1/language
 dc:language rdf:type owl:AnnotationProperty ;
-            dcterms:description "Pour définir les langues associées à une ressource."@fr ,
-                                "To define languages associated with an Asset."@en ,
-                                "Zur Definition von Sprachen, die mit einem Asset verbunden sind."@de ;
-            rdfs:label "Language"@en ,
-                       "Langue"@fr ,
-                       "Sprache"@de .
+            dcterms:description "To define languages associated with an Asset."@en ;
+            rdfs:label "Language"@en .
 
 
 ###  http://purl.org/dc/elements/1.1/publisher
 dc:publisher rdf:type owl:AnnotationProperty ;
-             dcterms:description "An Agent involved in the distribution of content."@en ,
-                                 "Ein Agent, der an der Verbreitung von Inhalten beteiligt ist."@de ,
-                                 "Un agent impliqué dans la distribution de contenu."@fr ;
-             rdfs:label "Editeur"@fr ,
-                        "Herausgeber"@de ,
-                        "Publisher"@en .
+             dcterms:description "An Agent involved in the distribution of content."@en ;
+             rdfs:label "Publisher"@en .
 
 
 ###  http://purl.org/dc/elements/1.1/rights
@@ -171,22 +139,14 @@ dc:rights rdf:type owl:AnnotationProperty .
 
 ###  http://purl.org/dc/elements/1.1/title
 dc:title rdf:type owl:AnnotationProperty ;
-         dcterms:description "Der Titel, unter dem ein EditorialObject bekannt ist."@de ,
-                             "Le titre par lequel un EditorialObject est connu."@fr ,
-                             "The title by which a EditorialObject is known."@en ;
-         rdfs:label "Titel"@de ,
-                    "Title"@en ,
-                    "Titre"@fr .
+         dcterms:description "The title by which a EditorialObject is known."@en ;
+         rdfs:label "Title"@en .
 
 
 ###  http://purl.org/dc/elements/1.1/type
 dc:type rdf:type owl:AnnotationProperty ;
-        dcterms:description "A concept associated with a resource."@en ,
-                            "Ein Konzept, das mit einer Resource verbunden ist."@de ,
-                            "Un concept associé à une ressource."@fr ;
-        rdfs:label "Typ"@de ,
-                   "Type"@en ,
-                   "Type"@fr .
+        dcterms:description "A concept associated with a resource."@en ;
+        rdfs:label "Type"@en .
 
 
 ###  http://purl.org/dc/terms/description
@@ -243,4016 +203,2945 @@ xsd:time rdf:type rdfs:Datatype .
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#accountingTo
 ec:accountingTo rdf:type owl:ObjectProperty ;
-                dcterms:description "A Consumer Account for a particular Service."@en ,
-                                    "Ein Verbraucherkonto für einen bestimmten Dienst."@de ,
-                                    "Un compte de consommateur pour un service particulier."@fr ;
-                rdfs:label "Account"@en ,
-                           "Compte"@fr ,
-                           "Konto"@de .
+                dcterms:description "A Consumer Account for a particular Service."@en ;
+                rdfs:label "Account"@en ;
+                skos:definition "an owl:ObjectProperty relating an ec:ConsumptionEvent to an ec:Account"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#animates
 ec:animates rdf:type owl:ObjectProperty ;
             owl:inverseOf ec:isAnimatedBy ;
-            dcterms:description "Gibt an, dass eine Person eine Figur mithilfe eines Artefakts animiert, etwa einer Puppe oder einem Animationsgerät."@de ,
-                                "Indicates that a person animates a character through the use of an artefact, such as a puppet or animation rig."@en ,
-                                "Indique qu'une personne anime un personnage à l’aide d’un artefact, comme une marionnette ou un dispositif d’animation."@fr ;
-            rdfs:label "animates"@en ,
-                       "anime"@fr ,
-                       "animiert"@de .
+            dcterms:description "Indicates that a person animates a character through the use of an artefact, such as a puppet or animation rig."@en ;
+            rdfs:label "Animates"@en ;
+            skos:definition "an owl:ObjectProperty relating an ec:Person to an ec:Character"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#applyTo
 ec:applyTo rdf:type owl:ObjectProperty ;
-           dcterms:description "Das Asset, auf das sich die Rechte beziehen."@de ,
-                               "L'actif auquel les droits s'appliquent."@fr ,
-                               "The Asset to which Rights apply."@en ;
-           rdfs:label "Actif"@fr ,
-                      "Asset"@en ,
-                      "Vermögenswert"@de .
+           dcterms:description "The Asset to which Rights apply."@en ;
+           rdfs:label "Asset"@en ;
+           skos:definition "an owl:ObjectProperty relating an ec:Rights to an ec:Asset"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#approvedBy
 ec:approvedBy rdf:type owl:ObjectProperty ;
-              dcterms:description "Pour identifier l'agent qui a approuvé la publication de l'objet EditorialObject. La propriété, lorsqu'elle est présente, servira de déclencheur pour la publication de l'objet Editorial."@fr ,
-                                  "To identify the Agent who approved the EditorialObject for publishing. The property, when present, will act as a trigger for the publishing of the Editorial object."@en ,
-                                  "Zur Identifizierung des Agenten, der das EditorialObject zur Veröffentlichung freigegeben hat. Wenn diese Eigenschaft vorhanden ist, dient sie als Auslöser für die Veröffentlichung des Redaktionsobjekts."@de ;
-              rdfs:label "Agent"@de ,
-                         "Agent"@en ,
-                         "Agent"@fr .
+              dcterms:description "The Agent who approved the EditorialObject for publishing. When present, the property acts as a trigger for publishing the EditorialObject."@en ;
+              rdfs:label "Agent"@en ;
+              skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Agent"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#basedOn
 ec:basedOn rdf:type owl:ObjectProperty ;
-           dcterms:description "Pour identifier l'EditorialObject auquel se rapporte un ProductionJob à."@fr ,
-                               "So identifizieren Sie das EditorialObject, auf das sich ein ProductionJob bezieht zu."@de ,
-                               "To identify the EditorialObject a ProductionJob relates to."@en ;
-           rdfs:label "Objet éditorial connexe"@fr ,
-                      "Related Editorial Object"@en ,
-                      "Verwandtes redaktionelles Objekt"@de .
+           dcterms:description "The EditorialObject that the ProductionJob relates to."@en ;
+           rdfs:label "Related editorial object"@en ;
+           skos:definition "an owl:ObjectProperty relating an ec:ProductionJob to an ec:EditorialObject"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#belongsToAudience
 ec:belongsToAudience rdf:type owl:ObjectProperty ;
-                     dcterms:description "Die übergeordnete Hörergruppe, der ein Verbraucher angehört von."@de ,
-                                         "Le groupe d'audience parent auquel appartient un consommateur de."@fr ,
-                                         "The parent Audience group to which a Consumer is a member of."@en ;
-                     rdfs:label "Parent audience"@en ,
-                                "Public de parents"@fr ,
-                                "Publikum der Eltern"@de .
+                     dcterms:description "The parent Audience group to which a Consumer is a member of."@en ;
+                     rdfs:label "Parent audience"@en ;
+                     skos:definition "an owl:ObjectProperty relating an ec:Consumer to an ec:Audience"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#bringsRights
 ec:bringsRights rdf:type owl:ObjectProperty ;
-                dcterms:description "Die Rechte sind eine Folge des Engagements."@de ,
-                                    "Les droits apparaissent comme une conséquence de l'engagement."@fr ,
-                                    "The rights appear as a consequence of the engagement."@en ;
-                rdfs:label "Brings rights"@en ,
-                           "Bringt Rechte"@de ,
-                           "Donne des droits"@fr .
+                dcterms:description "The rights appear as a consequence of the engagement."@en ;
+                rdfs:label "Brings rights"@en ;
+                skos:definition "an owl:ObjectProperty relating an ec:Involvement to ec:Rights"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#canAccessPublicationChannel
 ec:canAccessPublicationChannel rdf:type owl:ObjectProperty ;
-                               rdfs:label "can access publication channel"@en ,
-                                          "kann auf den Publikationskanal zugreifen"@de ,
-                                          "peut accéder au canal de publication"@fr .
+                               dcterms:description "A property that indicates whether a consumption device profile can access a publication channel."@en ;
+                               rdfs:label "Can access publication channel"@en ;
+                               skos:definition "an owl:ObjectProperty relating an ec:ConsumptionDeviceProfile to an ec:PublicationChannel"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#canAccessPublicationPlatform
 ec:canAccessPublicationPlatform rdf:type owl:ObjectProperty ;
-                                rdfs:label "can access publication platform"@en ,
-                                           "kann auf die Publikationsplattform zugreifen"@de ,
-                                           "peut accéder à la plateforme de publication"@fr .
+                                dcterms:description "A property that indicates whether a consumption device profile can access a publication platform."@en ;
+                                rdfs:label "Can access publication platform"@en ;
+                                skos:definition "an owl:ObjectProperty relating an ec:ConsumptionDeviceProfile to an ec:PublicationPlatform"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#commissions
 ec:commissions rdf:type owl:ObjectProperty ;
-               owl:inverseOf ec:hasCommissioningContract .
+               owl:inverseOf ec:hasCommissioningContract ;
+               dcterms:description "Relates an EditorialObject to the Contract through which it is commissioned."@en ;
+               rdfs:label "Commissions"@en ;
+               skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Contract"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#compilesResonanceEvents
 ec:compilesResonanceEvents rdf:type owl:ObjectProperty ;
-                           dcterms:description "Eines der ResonanceEvents, die zu einem aussagekräftigen Satz von Resonanzdaten."@de ,
-                                               "One of the ResonanceEvents aggregated into a meaningful set of Resonance data."@en ,
-                                               "Un des ResonanceEvents agrégés en un ensemble significatif de données de résonance."@fr ;
-                           rdfs:label "Resonance"@en ,
-                                      "Resonanz"@de ,
-                                      "Résonance"@fr .
+                           dcterms:description "One of the ResonanceEvents aggregated into a meaningful set of Resonance data."@en ;
+                           rdfs:label "Resonance"@en ;
+                           skos:definition "an owl:ObjectProperty relating a ec:ResonanceCount to a ec:ResonanceEvent"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#compliesWith
 ec:compliesWith rdf:type owl:ObjectProperty ;
-                dcterms:description "Das Profil, dem ein ConsumptionDevice entspricht."@de ,
-                                    "Le profil auquel se conforme un ConsumptionDevice."@fr ,
-                                    "The profile a ConsumptionDevice complies with."@en ;
-                rdfs:label "Device profile"@en ,
-                           "Geräteprofil"@de ,
-                           "Profil de l'appareil"@fr .
+                dcterms:description "The profile a ConsumptionDevice complies with."@en ;
+                rdfs:label "Device profile"@en ;
+                skos:definition "an owl:ObjectProperty relating an ec:ConsumptionDevice to an ec:ConsumptionDeviceProfile"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#consumesEssence
 ec:consumesEssence rdf:type owl:ObjectProperty ;
-                   dcterms:description "die Essenz, die während eines ConsumptionEvent."@de ,
-                                       "l'Essence qui a été consommée lors d'un ConsumptionEvent."@fr ,
-                                       "the Essence that has been consumed during a ConsumptionEvent."@en ;
-                   rdfs:label "Essence"@en ,
-                              "Essence"@fr ,
-                              "Essenz"@de .
+                   dcterms:description "The Essence that has been consumed during a ConsumptionEvent."@en ;
+                   rdfs:label "Essence"@en ;
+                   skos:definition "an ec:ConsumptionEvent relating to an ec:Essence"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#coversConsumptionDevice
 ec:coversConsumptionDevice rdf:type owl:ObjectProperty ;
-                           dcterms:description "Pour identifier un appareil compatible avec le licence de consommation."@fr ,
-                                               "To identify a device compatible with the ConsumptionLicence."@en ,
-                                               "Um ein Gerät zu identifizieren, das mit der ConsumptionLicence."@de ;
-                           rdfs:label "Compatible consumption device"@en ,
-                                      "Dispositif de consommation compatible"@fr ,
-                                      "Kompatibles Verbrauchsgerät"@de .
+                           dcterms:description "A device compatible with the ConsumptionLicence."@en ;
+                           rdfs:label "Compatible consumption device"@en ;
+                           skos:definition "an owl:ObjectProperty relating an ec:ConsumptionLicence to an ec:ConsumptionDevice"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#coversEvent
 ec:coversEvent rdf:type owl:ObjectProperty ;
                rdfs:subPropertyOf ec:hasCoverage ;
-               dcterms:description "A property to identify the Events, all real or fictional, covered by the EditorialObject"@en ,
-                                   "Eine Eigenschaft zur Identifizierung der Ereignisse, alle real oder fiktiv, die vom EditorialObject abgedeckt werden"@de ,
-                                   "Une propriété pour identifier les événements, tous réels ou fictifs, couverts par l'EditorialObject."@fr ;
-               rdfs:label "Couvre l'événement"@fr ,
-                          "Covers event"@en ,
-                          "Deckt Ereignis"@de .
+               dcterms:description "A property to identify the Events, all real or fictional, covered by the EditorialObject."@en ;
+               rdfs:label "Covers event"@en ;
+               skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Event"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#coversLocation
 ec:coversLocation rdf:type owl:ObjectProperty ;
                   rdfs:subPropertyOf ec:hasCoverage ;
-                  dcterms:description "A property to identify the Locations, all real or fictional, covered by the EditorialObject"@en ,
-                                      "Eine Eigenschaft zur Identifizierung der realen oder fiktiven Orte, die von dem EditorialObject abgedeckt werden."@de ,
-                                      "Une propriété pour identifier les lieux, tous réels ou fictifs, couverts par l'EditorialObject."@fr ;
-                  rdfs:label "Couvre l'emplacement"@fr ,
-                             "Covers location"@en ,
-                             "Deckt den Standort ab"@de .
+                  dcterms:description "A property to identify the Locations, all real or fictional, covered by the EditorialObject."@en ;
+                  rdfs:label "Covers location"@en ;
+                  skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Location"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#createsMetadata
 ec:createsMetadata rdf:type owl:ObjectProperty ;
-                   dcterms:description "Used where a production job, e.g. a face recognition service, yields information that can be described using the EditorialObject class."@en ,
-                                       "Utilisé lorsqu'un travail de production, par exemple un service de reconnaissance des visages, produit des informations qui peuvent être décrites à l'aide de la classe EditorialObject."@fr ,
-                                       "Wird verwendet, wenn ein Produktionsauftrag, z. B. ein Gesichtserkennungsdienst, Informationen liefert, die mit der Klasse EditorialObject beschrieben werden können."@de ;
-                   rdfs:label "creates metadata"@en ,
-                              "crée des métadonnées"@fr ,
-                              "erstellt Metadaten"@de .
+                   dcterms:description "Used where a production job, e.g. a face recognition service, yields information that can be described using the EditorialObject class."@en ;
+                   rdfs:label "Creates metadata"@en ;
+                   skos:definition "an owl:ObjectProperty relating an ec:ProductionJob to an ec:EditorialObject"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#defines
 ec:defines rdf:type owl:ObjectProperty ;
-           owl:inverseOf ec:isDefinedBy .
+           owl:inverseOf ec:isDefinedBy ;
+           dcterms:description "Identifies the contract, agreement, or law that defines a rule."@en ;
+           rdfs:label "Defines"@en ;
+           skos:definition "an owl:ObjectProperty relating an ec:Rule to an ec:Contract"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#derivedTo
 ec:derivedTo rdf:type owl:ObjectProperty ;
              owl:inverseOf ec:isDerivedFrom ;
-             dcterms:description "Pour identifier une nouvelle version dérivée de l'original."@fr ,
-                                 "To identify a new version derived from the original."@en ,
-                                 "Um eine neue, vom Original abgeleitete Version zu identifizieren."@de ;
-             rdfs:label "Ableitung Ziel"@de ,
-                        "Derivation target"@en ,
-                        "Objectif de dérivation"@fr .
+             dcterms:description "A new version derived from the original asset."@en ;
+             rdfs:label "Derivation target"@en ;
+             skos:definition "an owl:ObjectProperty relating an ec:Asset to an ec:Asset"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#excludesAudience
 ec:excludesAudience rdf:type owl:ObjectProperty ;
-                    dcterms:description "A defined audience group that is excluded from the audience"@en ,
-                                        "Eine bestimmte Zielgruppe, die von der Zielgruppe ausgeschlossen ist"@de ,
-                                        "Un groupe d'audience défini qui est exclu de l'audience"@fr ;
-                    rdfs:label "Excludes audience"@en ,
-                               "Exclut le public"@fr ,
-                               "Schließt Publikum aus"@de .
+                    dcterms:description "A defined audience group that is excluded from the audience."@en ;
+                    rdfs:label "Excludes audience"@en ;
+                    skos:definition "an owl:ObjectProperty relating an ec:Audience to an ec:Audience"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#existsAs
 ec:existsAs rdf:type owl:ObjectProperty ;
-            dcterms:description "Identifier des objets éditoriaux alternatifs sous la forme desquels un objet éditorial peut exister."@fr ,
-                                "To identify alternative EditorialObjects in the form of which and EditorialObject may exists."@en ,
-                                "Um alternative EditorialObjects zu identifizieren, in deren Form und EditorialObject existieren können."@de ;
-            rdfs:label "Editorial object"@en ,
-                       "Objet de la rédaction"@fr ,
-                       "Redaktionelles Objekt"@de .
+            dcterms:description "The relationship that links an EditorialObject to an alternative EditorialObject in which it may exist."@en ;
+            rdfs:label "Editorial object"@en ;
+            skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:EditorialObject"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#grantsApproval
 ec:grantsApproval rdf:type owl:ObjectProperty ;
-                  owl:inverseOf ec:hasApprover .
+                  owl:inverseOf ec:hasApprover ;
+                  dcterms:description "Indicates that an Agent grants approval for an Audit Report."@en ;
+                  rdfs:label "Grants approval"@en ;
+                  skos:definition "an owl:ObjectProperty relating an ec:AuditReport to an ec:Agent"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAccessConditions
 ec:hasAccessConditions rdf:type owl:ObjectProperty ;
                        rdfs:subPropertyOf ec:hasRights ;
-                       dcterms:description "Pour exprimer les conditions/restrictions d'accès."@fr ,
-                                           "To express access conditions/restrictions."@en ,
-                                           "Um Zugangsbedingungen/Einschränkungen auszudrücken."@de ;
-                       rdfs:label "Access conditions"@en ,
-                                  "Conditions d'accès"@fr ,
-                                  "Zugangsbedingungen"@de .
+                       dcterms:description "Access conditions or restrictions under which access to content or its publication is granted."@en ;
+                       rdfs:label "Access conditions"@en ;
+                       skos:definition "an owl:ObjectProperty relating an ec:Asset or ec:PublicationEvent to ec:AccessConditions"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAffiliation
 ec:hasAffiliation rdf:type owl:ObjectProperty ;
                   owl:inverseOf ec:isAffiliationFor ;
-                  dcterms:description "A property to establish the relation between a Contact/Person and an Organisation."@en ,
-                                      "Eine Eigenschaft, die die Beziehung zwischen einem Kontakt/Person und einer Organisation."@de ,
-                                      "Une propriété permettant d'établir la relation entre un contact/personne et une organisation."@fr ;
-                  rdfs:label "Affiliation"@en ,
-                             "Affiliation"@fr ,
-                             "Zugehörigkeit"@de .
+                  dcterms:description "A property to establish the relation between a Contact/Person and an Organisation."@en ;
+                  rdfs:label "Affiliation"@en ;
+                  skos:definition "an owl:ObjectProperty relating an ec:Person to an ec:Affiliation"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAgent
 ec:hasAgent rdf:type owl:ObjectProperty ;
-            rdfs:label "a un agent"@fr ,
-                       "has agent"@en ,
-                       "hat Agent"@de .
+            dcterms:description "Relates an involvement to the agent who participates in it."@en ;
+            rdfs:label "Has agent"@en ;
+            skos:definition "an owl:ObjectProperty relating an ec:Involvement to an ec:Agent"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAgentBiography
 ec:hasAgentBiography rdf:type owl:ObjectProperty ;
-                     dcterms:description "Fournir la biographie d'un agent."@fr ,
-                                         "To provide a biography of an Agent."@en ,
-                                         "Um eine Biographie eines Agenten zu erstellen."@de ;
-                     rdfs:label "Biographie"@de ,
-                                "Biographie"@fr ,
-                                "Biography"@en .
+                     dcterms:description "A biography of an Agent."@en ;
+                     rdfs:label "Biography"@en ;
+                     skos:definition "an owl:ObjectProperty relating an ec:Agent to an ec:Biography"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAgentCountryOfResidence
 ec:hasAgentCountryOfResidence rdf:type owl:ObjectProperty ;
-                              dcterms:description "Pour indiquer le lieu de résidence d'un agent."@fr ,
-                                                  "To indicate the place of residence of an Agent."@en ,
-                                                  "Zur Angabe des Wohnsitzes eines Agenten."@de ;
-                              rdfs:label "Country of residence"@en ,
-                                         "Land des Wohnsitzes"@de ,
-                                         "Pays de résidence"@fr .
+                              dcterms:description "The country of residence of an Agent."@en ;
+                              rdfs:label "Country of residence"@en ;
+                              skos:definition "an owl:ObjectProperty relating an ec:Agent to an ec:CountryCode"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAgentLanguage
 ec:hasAgentLanguage rdf:type owl:ObjectProperty ;
-                    dcterms:description "Pour fournir la ou les langues d'un contact/personne."@fr ,
-                                        "To provide the language(s) of a Contact/person."@en ,
-                                        "Zur Angabe der Sprache(n) eines Kontakts/einer Person."@de ;
-                    rdfs:label "Language"@en ,
-                               "Langue"@fr ,
-                               "Sprache"@de .
+                    dcterms:description "The language or languages associated with an Agent."@en ;
+                    rdfs:label "Language"@en ;
+                    skos:definition "an owl:ObjectProperty relating an ec:Agent to an ec:Language"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAgentMember
 ec:hasAgentMember rdf:type owl:ObjectProperty ;
-                  dcterms:description "Pour associer un agent à un autre agent, par exemple une équipe."@fr ,
-                                      "So verknüpfen Sie einen Agenten mit einem anderen Agenten, z.B. einem Team."@de ,
-                                      "To associate an Agent to another Agent e.g. a Team."@en ;
-                  rdfs:label "Agent Mitglied"@de ,
-                             "Agent member"@en ,
-                             "Membre agent"@fr .
+                  dcterms:description "The Agent that is a member of another Agent, such as a Team."@en ;
+                  rdfs:label "Agent member"@en ;
+                  skos:definition "an owl:ObjectProperty relating an ec:Agent to an ec:Agent"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAgentNationality
 ec:hasAgentNationality rdf:type owl:ObjectProperty ;
-                       dcterms:description "Pour fournir la nationalité d'un agent."@fr ,
-                                           "To provide the nationality of an Agent."@en ,
-                                           "Zur Angabe der Nationalität eines Agenten."@de ;
-                       rdfs:label "Nationality"@en ,
-                                  "Nationalität"@de ,
-                                  "Nationalité"@fr .
+                       dcterms:description "The nationality associated with an Agent."@en ;
+                       rdfs:label "Nationality"@en ;
+                       skos:definition "an owl:ObjectProperty relating an ec:Agent to an ec:CountryCode"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAgentOnStagePosition
 ec:hasAgentOnStagePosition rdf:type owl:ObjectProperty ;
-                           dcterms:description "Pour spécifier la position d'un agent sur la scène."@fr ,
-                                               "To specify the position of an Agent on Stage."@en ,
-                                               "Zur Angabe der Position eines Agenten auf der Bühne."@de ;
-                           rdfs:label "On stage position"@en ,
-                                      "Position auf der Bühne"@de ,
-                                      "Position sur scène"@fr .
+                           dcterms:description "The position of an agent on stage."@en ;
+                           rdfs:label "On stage position"@en ;
+                           skos:definition "an owl:ObjectProperty relating an ec:Involvement to an ec:OnStagePosition"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAgentPlaceOfResidence
 ec:hasAgentPlaceOfResidence rdf:type owl:ObjectProperty ;
-                            dcterms:description "Pour indiquer le lieu de résidence d'un agent."@fr ,
-                                                "To indicate the place of residence of an Agent."@en ,
-                                                "Zur Angabe des Wohnsitzes eines Agenten."@de ;
-                            rdfs:label "Lieu de résidence"@fr ,
-                                       "Ort des Wohnsitzes"@de ,
-                                       "Place of residence"@en .
+                            dcterms:description "The place where an Agent resides."@en ;
+                            rdfs:label "Place of residence"@en ;
+                            skos:definition "an owl:ObjectProperty relating an ec:Agent to an ec:Location"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAlternativeTitle
 ec:hasAlternativeTitle rdf:type owl:ObjectProperty ;
-                       rdfs:label "a un titre alternatif"@fr ,
-                                  "has alternative title"@en ,
-                                  "hat einen alternativen Titel"@de .
+                       dcterms:description "Links an editorial object to one of its alternative titles."@en ;
+                       rdfs:label "Has alternative title"@en ;
+                       skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:AlternativeTitle"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAncillaryData
 ec:hasAncillaryData rdf:type owl:ObjectProperty ;
-                    dcterms:description "Pour identifier les données auxiliaires dans la ressource média."@fr ,
-                                        "To identify ancillary data in the media resource."@en ,
-                                        "Zur Identifizierung von Zusatzdaten in der MedienResource."@de ;
-                    rdfs:label "Ancillary data"@en ,
-                               "Données auxiliaires"@fr ,
-                               "Ergänzende Daten"@de .
+                    dcterms:description "The ancillary data contained in the media resource."@en ;
+                    rdfs:label "Ancillary data"@en ;
+                    skos:definition "an owl:ObjectProperty relating an ec:Resource to an ec:AncillaryData"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAncillaryDataFormat
 ec:hasAncillaryDataFormat rdf:type owl:ObjectProperty ;
                           rdfs:subPropertyOf ec:hasFormat ;
-                          dcterms:description "das Format der Zusatzdaten."@de ,
-                                              "le format des données auxiliaires."@fr ,
-                                              "the format of ancillary data."@en ;
-                          rdfs:label "Ancillary data format"@en ,
-                                     "Format der Zusatzdaten"@de ,
-                                     "Format des données auxiliaires"@fr .
+                          dcterms:description "The format of ancillary data."@en ;
+                          rdfs:label "Ancillary data format"@en ;
+                          skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:AncillaryDataFormat"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAnimalBreedCode
 ec:hasAnimalBreedCode rdf:type owl:ObjectProperty ;
-                      dcterms:description "Pour associer un code de race à un animal."@fr ,
-                                          "To associate a breed code with an animal."@en ,
-                                          "Um einen Rassencode mit einem Tier zu verknüpfen."@de ;
-                      rdfs:label "Animal breed code"@en ,
-                                 "Code de la race de l'animal"@fr ,
-                                 "Code der Tierrasse"@de .
+                      dcterms:description "The breed code associated with an animal."@en ;
+                      rdfs:label "Animal breed code"@en ;
+                      skos:definition "an owl:ObjectProperty relating an ec:Animal to an ec:AnimalBreedCode"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAnimalColourCode
 ec:hasAnimalColourCode rdf:type owl:ObjectProperty ;
-                       dcterms:description "Pour associer un code de couleur à un animal."@fr ,
-                                           "To associate a colour code with an animal."@en ,
-                                           "Um einen Farbcode mit einem Tier zu verbinden."@de ;
-                       rdfs:label "Animal colour code"@en ,
-                                  "Code couleur des animaux"@fr ,
-                                  "Farbcode für Tiere"@de .
+                       dcterms:description "The animal colour code associated with an animal."@en ;
+                       rdfs:label "Animal colour code"@en ;
+                       skos:definition "an owl:ObjectProperty relating an ec:Animal to an ec:AnimalColourCode"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAnimalGroom
 ec:hasAnimalGroom rdf:type owl:ObjectProperty ;
                   owl:inverseOf ec:isAnimalGroomFor ;
-                  dcterms:description "Identifier le palefrenier / le soigneur d'un animal."@fr ,
-                                      "To identify the groom / care taker of an animal."@en ,
-                                      "Zur Identifizierung des Pflegers / Betreuers eines Tieres."@de ;
-                  rdfs:label "Animal groom"@en ,
-                             "Tierpfleger"@de ,
-                             "Toilette pour animaux"@fr .
+                  dcterms:description "The person or agent who grooms and cares for an animal."@en ;
+                  rdfs:label "Animal groom"@en ;
+                  skos:definition "an owl:ObjectProperty relating an ec:Animal to an ec:Agent"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAnimalRole
 ec:hasAnimalRole rdf:type owl:ObjectProperty ;
-                 dcterms:description "Die Rolle eines Tieres zu identifizieren."@de ,
-                                     "Identifier le rôle d'un animal."@fr ,
-                                     "To identify the role of an animal."@en ;
-                 rdfs:label "Animal role"@en ,
-                            "Rôle des animaux"@fr ,
-                            "Tierische Rolle"@de .
+                 dcterms:description "The role of an animal in an involvement."@en ;
+                 rdfs:label "Animal role"@en ;
+                 skos:definition "an owl:ObjectProperty relating an ec:Animal to an ec:Involvement"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAnnotationAgent
 ec:hasAnnotationAgent rdf:type owl:ObjectProperty ;
-                      dcterms:description "Pour définir l'instance d'annotation d'un agent."@fr ,
-                                          "So definieren Sie die Annotation-Instanz eines Agenten."@de ,
-                                          "To define the Annotation instance of an Agent."@en ;
-                      rdfs:label "Agent d'annotation"@fr ,
-                                 "Agent für Anmerkungen"@de ,
-                                 "Annotation agent"@en .
+                      dcterms:description "The Agent associated with the annotation."@en ;
+                      rdfs:label "Annotation agent"@en ;
+                      skos:definition "an owl:ObjectProperty relating an ec:Annotation to an ec:Agent"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAnnotationCurationDateTime
 ec:hasAnnotationCurationDateTime rdf:type owl:ObjectProperty ;
-                                 dcterms:description "Pour fournir la date et l'heure auxquelles une Annotation a été révisée."@fr ,
-                                                     "To provide the date and time when an Annotation has been reviewed."@en ,
-                                                     "Um das Datum und die Uhrzeit anzugeben, zu der eine Anmerkung überprüft wurde."@de ;
-                                 rdfs:label "Annotation curation date & time"@en ,
-                                            "Date et heure de la curation des annotations"@fr ,
-                                            "Datum und Uhrzeit der Kommentarkuration"@de .
+                                 dcterms:description "The date and time when an Annotation was reviewed."@en ;
+                                 rdfs:label "Annotation curation date & time"@en ;
+                                 skos:definition "an owl:ObjectProperty relating an ec:Annotation to a time:Instant"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAnnotationTarget
 ec:hasAnnotationTarget rdf:type owl:ObjectProperty ;
-                       dcterms:description "Pour définir l'objet cible auquel l'annotation s'applique."@fr ,
-                                           "To define the target object to which the Annotation applies."@en ,
-                                           "Zur Definition des Zielobjekts, auf das sich die Anmerkung bezieht."@de ;
-                       rdfs:label "Annotation target"@en ,
-                                  "Cible d'annotation"@fr ,
-                                  "Ziel der Annotation"@de .
+                       dcterms:description "The target object to which the annotation applies."@en ;
+                       rdfs:label "Annotation target"@en ;
+                       skos:definition "an owl:ObjectProperty relating an ec:Annotation to an owl:Thing"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasApprover
 ec:hasApprover rdf:type owl:ObjectProperty ;
-               dcterms:description "Pour identifier un agent qui a approuvé un rapport d'audit."@fr ,
-                                   "To identify an Agent who approved an AuditReport."@en ,
-                                   "Um einen Agenten zu identifizieren, der einen AuditReport genehmigt hat."@de ;
-               rdfs:label "Approuvé par"@fr ,
-                          "Approved by"@en ,
-                          "Genehmigt von"@de .
+               dcterms:description "An Agent who approved an AuditReport."@en ;
+               rdfs:label "Approved by"@en ;
+               skos:definition "an owl:ObjectProperty relating an ec:AuditReport to an ec:Agent"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasArtefactBuyer
 ec:hasArtefactBuyer rdf:type owl:ObjectProperty ;
-                    dcterms:description "Der Agent, der das Artefakt gekauft hat."@de ,
-                                        "L'agent qui a acheté l'Artefact."@fr ,
-                                        "The Agent who bought the Artefact."@en ;
-                    rdfs:label "Acheteur"@fr ,
-                               "Buyer"@en ,
-                               "Käufer"@de .
+                    dcterms:description "The Agent who bought the Artefact."@en ;
+                    rdfs:label "Buyer"@en ;
+                    skos:definition "an owl:ObjectProperty relating an ec:Artefact to an ec:Agent"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasArtefactDateOfPurchase
 ec:hasArtefactDateOfPurchase rdf:type owl:ObjectProperty ;
                              rdfs:subPropertyOf ec:hasDate ;
-                             dcterms:description "Das Datum, an dem ein Artefakt gekauft wurde. ."@de ,
-                                                 "La date à laquelle un artefact a été acheté. ."@fr ,
-                                                 "The date when an Artefact was purchased. ."@en ;
-                             rdfs:label "Artefact date of purchase"@en ,
-                                        "Date d'achat de l'artefact"@fr ,
-                                        "Kaufdatum des Artefakts"@de .
+                             dcterms:description "The date when an Artefact was purchased. ."@en ;
+                             rdfs:label "Artefact date of purchase"@en ;
+                             skos:definition "an owl:ObjectProperty relating an ec:Artefact to a time:Instant"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasArtefactDateOfSale
 ec:hasArtefactDateOfSale rdf:type owl:ObjectProperty ;
                          rdfs:subPropertyOf ec:hasDate ;
-                         dcterms:description "Das Datum, an dem ein Artefakt verkauft wurde."@de ,
-                                             "La date à laquelle un artefact a été vendu."@fr ,
-                                             "The date when an Artefact was sold."@en ;
-                         rdfs:label "Artefact date of sale"@en ,
-                                    "Date de vente de l'artefact"@fr ,
-                                    "Verkaufsdatum des Artefakts"@de .
+                         dcterms:description "The date when an Artefact was sold."@en ;
+                         rdfs:label "Artefact date of sale"@en ;
+                         skos:definition "an owl:ObjectProperty relating an ec:Artefact to a time:Instant"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasArtefactOwner
 ec:hasArtefactOwner rdf:type owl:ObjectProperty ;
-                    dcterms:description "Pour identifier le propriétaire d'un artefact."@fr ,
-                                        "To identify the owner of an Artefact."@en ,
-                                        "Um den Besitzer eines Artefakts zu identifizieren."@de ;
-                    rdfs:label "Eigentümer"@de ,
-                               "Owner"@en ,
-                               "Propriétaire"@fr .
+                    dcterms:description "The person or organisation that owns an Artefact."@en ;
+                    rdfs:label "Owner"@en ;
+                    skos:definition "an owl:ObjectProperty relating an ec:Artefact to an ec:Agent"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasArtefactPriceCurrency
 ec:hasArtefactPriceCurrency rdf:type owl:ObjectProperty ;
-                            dcterms:description "Pour spécifier la devise dans laquelle le prix d'un artefact est exprimé."@fr ,
-                                                "To specify the currency into which the price of an Artefact is expressed."@en ,
-                                                "Zur Angabe der Währung, in der der Preis eines Artefakts ausgedrückt wird."@de ;
-                            rdfs:label "Artefact price currency"@en ,
-                                       "Artefakt Preis Währung"@de ,
-                                       "Devise du prix de l'artefact"@fr .
+                            dcterms:description "The currency in which an Artefact’s price is expressed."@en ;
+                            rdfs:label "Artefact price currency"@en ;
+                            skos:definition "an owl:ObjectProperty relating an ec:Artefact to an ec:CurrencyCode"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasArtefactRelatedLocation
 ec:hasArtefactRelatedLocation rdf:type owl:ObjectProperty ;
-                              dcterms:description "Pour associer un Artefact/Prop ou autre à un Lieu."@fr ,
-                                                  "To associate an Artefact/Prop or else with a Location."@en ,
-                                                  "Um ein Artefakt/eine Requisite oder einen anderen Ort zuzuordnen."@de ;
-                              rdfs:label "Associated location"@en ,
-                                         "Assoziierter Standort"@de ,
-                                         "Emplacement associé"@fr .
+                              dcterms:description "Associates an Artefact with a Location."@en ;
+                              rdfs:label "Associated location"@en ;
+                              skos:definition "an owl:ObjectProperty relating an ec:Artefact to an ec:Location"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasArtefactRelatedPhysicalResource
 ec:hasArtefactRelatedPhysicalResource rdf:type owl:ObjectProperty ;
-                                      dcterms:description "Pour associer un Artefact/Prop ou autre à une ressource physique."@fr ,
-                                                          "To associate an Artefact/Prop or else with a physical resource."@en ,
-                                                          "Um ein Artefakt/Prop oder eine andere physische Resource zu verknüpfen."@de ;
-                                      rdfs:label "Associated physical resource"@en ,
-                                                 "Assoziierte physische Resource"@de ,
-                                                 "Ressource physique associée"@fr .
+                                      dcterms:description "Associates an artefact or prop with a physical resource."@en ;
+                                      rdfs:label "Associated physical resource"@en ;
+                                      skos:definition "an owl:ObjectProperty relating an ec:Artefact to an ec:PhysicalResource"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasArtefactRetailer
 ec:hasArtefactRetailer rdf:type owl:ObjectProperty ;
-                       dcterms:description "Identifier le détaillant d'un artefact."@fr ,
-                                           "To identify the retailer of an Artefact."@en ,
-                                           "Zur Identifizierung des Händlers eines Artefakts."@de ;
-                       rdfs:label "Détaillant"@fr ,
-                                  "Einzelhändler"@de ,
-                                  "Retailer"@en .
+                       dcterms:description "The retailer of an Artefact."@en ;
+                       rdfs:label "Retailer"@en ;
+                       skos:definition "an owl:ObjectProperty relating an ec:Artefact to an ec:Agent"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasArtefactSupplier
 ec:hasArtefactSupplier rdf:type owl:ObjectProperty ;
-                       dcterms:description "Pour identifier le fournisseur d'un artefact."@fr ,
-                                           "To identify a supplier of an Artefact."@en ,
-                                           "Um einen Anbieter eines Artefakts zu identifizieren."@de ;
-                       rdfs:label "Anbieter"@de ,
-                                  "Fournisseur"@fr ,
-                                  "Supplier"@en .
+                       dcterms:description "The supplier of an Artefact."@en ;
+                       rdfs:label "Supplier"@en ;
+                       skos:definition "an owl:ObjectProperty relating an ec:Artefact to an ec:Agent"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasArticle
 ec:hasArticle rdf:type owl:ObjectProperty ;
-              rdfs:label "a article"@fr ,
-                         "has article"@en ,
-                         "hat Artikel"@de .
+              dcterms:description "Indicates that an Item has an associated Article. It is used to link content intended for incorporation into an article with the resulting article resource."@en ;
+              rdfs:label "Has article"@en ;
+              skos:definition "an owl:ObjectProperty relating an ec:Item to an ec:Article"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAsset
 ec:hasAsset rdf:type owl:ObjectProperty ;
-            dcterms:description "Pour identifier les actifs liés à un PublicationPlan."@fr ,
-                                "To identify the Assets related to a PublicationPlan."@en ,
-                                "Um die Assets zu identifizieren, die mit einem PublicationPlan verbunden sind."@de ;
-            rdfs:label "Actif"@fr ,
-                       "Asset"@en ,
-                       "Vermögenswert"@de .
+            dcterms:description "The assets related to a PublicationPlan."@en ;
+            rdfs:label "Asset"@en ;
+            skos:definition "an owl:ObjectProperty relating an ec:PublicationPlan to an ec:Asset"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAssetValue
 ec:hasAssetValue rdf:type owl:ObjectProperty ;
-                 dcterms:description "Pour associer un actif à sa valeur d'actif."@fr ,
-                                     "So verknüpfen Sie ein Asset mit seinem AssetWert."@de ,
-                                     "To associate an Asset with its AssetValue."@en ;
-                 rdfs:label "Asset value"@en ,
-                            "Valeur de l'actif"@fr ,
-                            "Vermögenswert"@de .
+                 dcterms:description "Associates an Asset with its AssetValue."@en ;
+                 rdfs:label "Asset value"@en ;
+                 skos:definition "an owl:ObjectProperty relating an ec:Asset to an ec:AssetValue"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAssetValueCurrency
 ec:hasAssetValueCurrency rdf:type owl:ObjectProperty ;
-                         dcterms:description "Pour fournir la devise dans laquelle la valeur de l'actif est donnée."@fr ,
-                                             "To provide the currency in which the assetValue is given."@en ,
-                                             "Zur Angabe der Währung, in der der assetValue angegeben wird. gegeben ist."@de ;
-                         rdfs:label "Asset value currency"@en ,
-                                    "Devise de la valeur de l'actif"@fr ,
-                                    "Vermögenswert Währung"@de .
+                         dcterms:description "The currency in which the asset value is given."@en ;
+                         rdfs:label "Asset value currency"@en ;
+                         skos:definition "an owl:ObjectProperty relating an ec:AssetValue to a skos:Concept"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAssociatedArtefact
 ec:hasAssociatedArtefact rdf:type owl:ObjectProperty ;
-                         dcterms:description "An Artefact related to an Agent."@en ,
-                                             "Ein Artefakt, das mit einem Agent verbunden ist."@de ,
-                                             "Un artefact lié à un agent."@fr ;
-                         rdfs:label "Artefact connexe"@fr ,
-                                    "Related Artefact"@en ,
-                                    "Verwandtes Artefakt"@de .
+                         dcterms:description "An Artefact related to an Agent."@en ;
+                         rdfs:label "Related artefact"@en ;
+                         skos:definition "an owl:ObjectProperty relating an ec:Agent to an ec:Artefact"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAssociatedConsumer
 ec:hasAssociatedConsumer rdf:type owl:ObjectProperty ;
-                         dcterms:description "Pour associer un consommateur à un ResonanceEvent."@fr ,
-                                             "To associate a consumer with a ResonanceEvent."@en ,
-                                             "Um einen Verbraucher mit einem ResonanceEvent zu verknüpfen."@de ;
-                         rdfs:label "Associated consumer"@en ,
-                                    "Assoziierter Verbraucher"@de ,
-                                    "Consommateur associé"@fr .
+                         dcterms:description "A consumer associated with a ResonanceEvent."@en ;
+                         rdfs:label "Associated consumer"@en ;
+                         skos:definition "an owl:ObjectProperty relating an ec:ResonanceEvent to an ec:Consumer"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAssociatedConsumptionEvent
 ec:hasAssociatedConsumptionEvent rdf:type owl:ObjectProperty ;
-                                 dcterms:description "Pour identifier les ConsumptionEvents associés à un consommateur."@fr ,
-                                                     "To identify ConsumptionEvents associated with a Consumer."@en ,
-                                                     "Um ConsumptionEvents zu identifizieren, die mit einem Verbraucher."@de ;
-                                 rdfs:label "Consumption event"@en ,
-                                            "Verbrauchsereignis"@de ,
-                                            "Événement de consommation"@fr .
+                                 dcterms:description "The ConsumptionEvent associated with a Consumer."@en ;
+                                 rdfs:label "Consumption event"@en ;
+                                 skos:definition "an owl:ObjectProperty relating an ec:Consumer to an ec:ConsumptionEvent"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAssociatedProductionJob
 ec:hasAssociatedProductionJob rdf:type owl:ObjectProperty ;
-                              dcterms:description "Pour identifier un ProductionJob associé à la réalisation d'un EditorialObject."@fr ,
-                                                  "To identify a ProductionJob associated with the realisation of an EditorialObject."@en ,
-                                                  "Um einen ProductionJob zu identifizieren, der mit der Realisierung eines EditorialObjects verbunden ist."@de ;
-                              rdfs:label "Job in der Produktion"@de ,
-                                         "Poste de production"@fr ,
-                                         "Production job"@en .
+                              dcterms:description "An associated ProductionJob for the realisation of an EditorialObject."@en ;
+                              rdfs:label "Production job"@en ;
+                              skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:ProductionJob"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAssociatedProductionOrder
 ec:hasAssociatedProductionOrder rdf:type owl:ObjectProperty ;
-                                dcterms:description "Pour identifier les ProductionOrders associés à PublicationPlan."@fr ,
-                                                    "To identify the productionOrders associated with PublicationPlan."@en ,
-                                                    "Um die productionOrders zu identifizieren, die mit VeröffentlichungPan."@de ;
-                                rdfs:label "Ordre de production"@fr ,
-                                           "Production order"@en ,
-                                           "Produktionsauftrag"@de .
+                                dcterms:description "The production order associated with a publication plan."@en ;
+                                rdfs:label "Production order"@en ;
+                                skos:definition "an owl:ObjectProperty relating an ec:PublicationPlan to an ec:ProductionOrder"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAssociatedRelation
 ec:hasAssociatedRelation rdf:type owl:ObjectProperty ;
-                         dcterms:description "Pour définir une Relation."@fr ,
-                                             "To define a Relation."@en ,
-                                             "Um eine Relation zu definieren."@de ;
-                         rdfs:label "Beziehung"@de ,
-                                    "Relation"@en ,
-                                    "Relation"@fr .
+                         dcterms:description "A relation associated with the resource."@en ;
+                         rdfs:label "Relation"@en ;
+                         skos:definition "an owl:ObjectProperty relating an ec:Resource to an ec:Relation"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAudience
 ec:hasAudience rdf:type owl:ObjectProperty ;
-               rdfs:label "a un public"@fr ,
-                          "has audience"@en ,
-                          "hat Publikum"@de .
+               dcterms:description "Indicates the audience associated with a consumption count."@en ;
+               rdfs:label "Has audience"@en ;
+               skos:definition "an owl:ObjectProperty relating an ec:ConsumptionCount to an ec:Audience"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAudienceScoreRecordingTechnique
 ec:hasAudienceScoreRecordingTechnique rdf:type owl:ObjectProperty ;
-                                      dcterms:description "Die Technik zu identifizieren, die zur Messung eines Publikums verwendet wird."@de ,
-                                                          "Identifier la technique utilisée pour mesurer une audience."@fr ,
-                                                          "To identify the technique used to measure an audience."@en ;
-                                      rdfs:label "Audience score recording technique"@en ,
-                                                 "Aufnahmetechnik für Publikumspartituren"@de ,
-                                                 "Technique d'enregistrement des partitions d'audience"@fr .
+                                      dcterms:description "The technique used to measure an audience score."@en ;
+                                      rdfs:label "Audience score recording technique"@en ;
+                                      skos:definition "an owl:ObjectProperty relating an ec:AudienceRating to a skos:Concept"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAudioCodec
 ec:hasAudioCodec rdf:type owl:ObjectProperty ;
                  rdfs:subPropertyOf ec:hasCodec ;
-                 dcterms:description "Pour identifier le Codec audio"@fr ,
-                                     "So identifizieren Sie den Audio Codec"@de ,
-                                     "To identify the audio Codec"@en ;
-                 rdfs:label "Audio Codec"@de ,
-                            "Audio codec"@en ,
-                            "Codec audio"@fr .
+                 dcterms:description "The audio codec associated with the media resource."@en ;
+                 rdfs:label "Audio codec"@en ;
+                 skos:definition "an ec:ObjectProperty relating an ec:MediaResource to an ec:AudioCodec"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAudioDescription
 ec:hasAudioDescription rdf:type owl:ObjectProperty ;
-                       dcterms:description "Pour signaler la présence de l'AudioDescription."@fr ,
-                                           "To signal the presence of AudioDescription."@en ,
-                                           "Um das Vorhandensein von AudioDescription zu signalisieren."@de ;
-                       rdfs:label "Audio description"@en ,
-                                  "Audio-Beschreibung"@de ,
-                                  "Description audio"@fr .
+                       dcterms:description "Signals the presence of audio description."@en ;
+                       rdfs:label "Audio description"@en ;
+                       skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:AudioDescription"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAudioEncodingFormat
 ec:hasAudioEncodingFormat rdf:type owl:ObjectProperty ;
                           rdfs:subPropertyOf ec:hasFormat ;
-                          dcterms:description "Pour spécifier le format d'encodage audio."@fr ,
-                                              "To specify the audio encoding format."@en ,
-                                              "Zur Angabe des Audio-Codierungsformats."@de ;
-                          rdfs:label "Audio encoding format"@en ,
-                                     "Format d'encodage audio"@fr ,
-                                     "Format der Audiokodierung"@de .
+                          dcterms:description "An audio encoding format associated with a media resource."@en ;
+                          rdfs:label "Audio encoding format"@en ;
+                          skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:AudioEncodingFormat"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAudioTrack
 ec:hasAudioTrack rdf:type owl:ObjectProperty ;
-                 dcterms:description "Pour identifier les AudioTracks dans la ressource."@fr ,
-                                     "So identifizieren Sie Audiospuren in der Resource."@de ,
-                                     "To identify AudioTracks in the Resource."@en ;
-                 rdfs:label "Audio track"@en ,
-                            "Audiospur"@de ,
-                            "Piste audio"@fr .
+                 dcterms:description "A property that identifies the audio track associated with a media resource."@en ;
+                 rdfs:label "Audio track"@en ;
+                 skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:AudioTrack"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAuditJobRelatedAuditReport
 ec:hasAuditJobRelatedAuditReport rdf:type owl:ObjectProperty ;
-                                 dcterms:description "Pour associer un AuditReport à un AuditJob."@fr ,
-                                                     "So verknüpfen Sie einen AuditReport mit einem AuditJob."@de ,
-                                                     "To associate an AuditReport with an AuditJob."@en ;
-                                 rdfs:label "Rapport d'audit connexe"@fr ,
-                                            "Related audit report"@en ,
-                                            "Zugehöriger Prüfbericht"@de .
+                                 dcterms:description "An audit report associated with an audit job."@en ;
+                                 rdfs:label "Related audit report"@en ;
+                                 skos:definition "an owl:ObjectProperty relating an ec:AuditJob to an ec:AuditReport"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAuditReportDate
 ec:hasAuditReportDate rdf:type owl:ObjectProperty ;
-                      dcterms:description "Das Datum der Veröffentlichung eines AuditReports."@de ,
-                                          "La date de publication d'un rapport d'audit."@fr ,
-                                          "The date of release of an AuditReport."@en ;
-                      rdfs:label "Audit report date"@en ,
-                                 "Date du rapport d'audit"@fr ,
-                                 "Datum des Prüfungsberichts"@de .
+                      dcterms:description "The date of release of an AuditReport."@en ;
+                      rdfs:label "Audit report date"@en ;
+                      skos:definition "an owl:ObjectProperty relating an ec:AuditReport to a time:Instant"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAuthor
 ec:hasAuthor rdf:type owl:ObjectProperty ;
              owl:inverseOf ec:isAuthorOf ;
-             dcterms:description "Pour lier une annotation à l'agent qui l'a créée."@fr ,
-                                 "So verknüpfen Sie eine Anmerkung mit einem Agenten, der sie erstellt hat."@de ,
-                                 "To link an Annotation to an Agent who created it."@en ;
-             rdfs:label "Agent"@de ,
-                        "Agent"@en ,
-                        "Agent"@fr .
+             dcterms:description "Links an Annotation to the Agent who created it."@en ;
+             rdfs:label "Agent"@en ;
+             skos:definition "an owl:ObjectProperty relating an ec:Annotation to an ec:Agent"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAwardDate
 ec:hasAwardDate rdf:type owl:ObjectProperty ;
                 rdfs:subPropertyOf ec:hasDate ;
-                dcterms:description "Pour fournir une date à laquelle un prix a été livré."@fr ,
-                                    "To provide an date when an Award was delivered."@en ,
-                                    "Zur Angabe des Datums, an dem ein Award zugestellt wurde."@de ;
-                rdfs:label "Award date"@en ,
-                           "Date d'attribution"@fr ,
-                           "Datum der Vergabe"@de .
+                dcterms:description "The date when an Award was delivered."@en ;
+                rdfs:label "Award date"@en ;
+                skos:definition "an ec:hasDate relating an ec:Award to a time:Instant"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasBrand
 ec:hasBrand rdf:type owl:ObjectProperty ;
-            dcterms:description "Pour identifier une Marque."@fr ,
-                                "To identify a Brand."@en ,
-                                "Um eine Marke zu identifizieren."@de ;
-            rdfs:label "Brand"@en ,
-                       "Marke"@de ,
-                       "Marque"@fr .
+            dcterms:description "A brand associated with the editorial object or publication service."@en ;
+            rdfs:label "Brand"@en ;
+            skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:MarketingBrand"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasBusinessContract
 ec:hasBusinessContract rdf:type owl:ObjectProperty ;
-                       dcterms:description "Pour identifier les Contrats associés à un Plan de publication."@fr ,
-                                           "To identify the Contracts associated with a PublicationPlan."@en ,
-                                           "Zur Identifizierung der Verträge, die mit einem PublicationPlan."@de ;
-                       rdfs:label "Business contract"@en ,
-                                  "Contrat d'affaires"@fr ,
-                                  "Geschäftsvertrag"@de .
+                       dcterms:description "The contract associated with a publication plan."@en ;
+                       rdfs:label "Business contract"@en ;
+                       skos:definition "an owl:ObjectProperty relating an ec:PublicationPlan to an ec:Contract"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasCaptioning
 ec:hasCaptioning rdf:type owl:ObjectProperty ;
-                 dcterms:description "Pour signaler la présence de sous-titres."@fr ,
-                                     "To signal the presence of Captioning."@en ,
-                                     "Zum Signalisieren der Anwesenheit von Untertitel."@de ;
-                 rdfs:label "Captioning"@en ,
-                            "Sous-titrage"@fr ,
-                            "Untertitel"@de .
+                 dcterms:description "A captioning track for transcribed dialogue or audio descriptions for the hard of hearing."@en ;
+                 rdfs:label "Captioning"@en ;
+                 skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Captioning"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasCaptioningFormat
 ec:hasCaptioningFormat rdf:type owl:ObjectProperty ;
                        rdfs:subPropertyOf ec:hasFormat ;
-                       dcterms:description "Das Format der Untertitelung."@de ,
-                                           "Le format du sous-titrage."@fr ,
-                                           "The format of Captioning."@en ;
-                       rdfs:label "Captioning format"@en ,
-                                  "Format de sous-titrage"@fr ,
-                                  "Format der Untertitel"@de .
+                       dcterms:description "The format of Captioning."@en ;
+                       rdfs:label "Captioning format"@en ;
+                       skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:CaptioningFormat"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasCaptioningSource
 ec:hasCaptioningSource rdf:type owl:ObjectProperty ;
-                       dcterms:description "Fournir des informations sur la source du sous-titrage."@fr ,
-                                           "To provide information on the source of Captioning."@en ,
-                                           "Um Informationen über die Quelle der Untertitelung bereitzustellen."@de ;
-                       rdfs:label "Captioning source"@en ,
-                                  "Quelle für Untertitel"@de ,
-                                  "Source de sous-titrage"@fr .
+                       dcterms:description "The source of the captioning associated with the media resource."@en ;
+                       rdfs:label "Captioning source"@en ;
+                       skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:Agent"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasCastMember
 ec:hasCastMember rdf:type owl:ObjectProperty ;
-                 dcterms:description "A member of the cast."@en ,
-                                     "Ein Mitglied der Besetzung."@de ,
-                                     "Un membre de la distribution."@fr ;
-                 rdfs:label "Cast member"@en ,
-                            "Membre de la distribution"@fr ,
-                            "Mitglied der Besetzung"@de .
+                 dcterms:description "A member of the cast."@en ;
+                 rdfs:label "Cast member"@en ;
+                 skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:CastMember"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasCharacter
 ec:hasCharacter rdf:type owl:ObjectProperty ;
-                dcterms:description "Pour identifier un personnage."@fr ,
-                                    "Pour énumérer les personnages d'une fiction."@fr ,
-                                    "To identify a character."@en ,
-                                    "To list characters in a fiction."@en ,
-                                    "Um einen Charakter zu identifizieren."@de ,
-                                    "Zum Auflisten von Figuren in einer Fiktion."@de ;
-                rdfs:label "Caractère"@fr ,
-                           "Character"@en ,
-                           "Charakter"@de ,
-                           "Fictional character."@en ,
-                           "Fiktiver Charakter."@de ,
-                           "Personnage fictif."@fr .
+                dcterms:description "Identifies one or more fictional characters associated with an editorial object."@en ;
+                rdfs:label "Character"@en ;
+                skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Character"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasChild
 ec:hasChild rdf:type owl:ObjectProperty ;
             owl:inverseOf ec:isChildOf ;
-            dcterms:description "Pour lier un actif à un actif parent."@fr ,
-                                "So verknüpfen Sie ein Asset mit einem übergeordneten Asset."@de ,
-                                "To link a Asset to a parent Asset."@en ;
-            rdfs:label "Child"@en ,
-                       "Enfant"@fr ,
-                       "Kind"@de .
+            dcterms:description "Links an Asset to its parent Asset."@en ;
+            rdfs:label "Child"@en ;
+            skos:definition "an owl:ObjectProperty relating an ec:Asset to an ec:Asset"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasClip
 ec:hasClip rdf:type owl:ObjectProperty ;
-           rdfs:label "a un clip"@fr ,
-                      "has clip"@en ,
-                      "hat Clip"@de .
+           dcterms:description "Indicates a clip associated with the resource."@en ;
+           rdfs:label "Has clip"@en ;
+           skos:definition "an owl:ObjectProperty relating a resource to an associated clip"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasClone
 ec:hasClone rdf:type owl:ObjectProperty ;
             owl:inverseOf ec:isCloneOf ;
-            dcterms:description "Identifie la relation entre une instanciation numérique d'une Mediaressource et sa copie directe, sans perte de génération."@fr ,
-                                "Identifies relationship between a digital instantiation of a MediaResource and its direct copy, with no generational loss."@en ,
-                                "Identifiziert die Beziehung zwischen einer digitalen Instanziierung einer MediaResource und ihrer direkten Kopie, ohne Generationsverlust."@de ;
-            rdfs:label "Cloned to"@en ,
-                       "Cloné en"@fr ,
-                       "Geklont auf"@de .
+            dcterms:description "Identifies relationship between a digital instantiation of a MediaResource and its direct copy, with no generational loss."@en ;
+            rdfs:label "Cloned to"@en ;
+            skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:MediaResource"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasCodec
 ec:hasCodec rdf:type owl:ObjectProperty ;
-            dcterms:description "Pour identifier un Codec utilisé pour créer une ressource."@fr ,
-                                "To identify a Codec used to create a resource."@en ,
-                                "Um einen Codec zu identifizieren, der zur Erstellung einer Resource verwendet wird."@de ;
-            rdfs:label "Codec"@de ,
-                       "Codec"@en ,
-                       "Codec"@fr .
+            dcterms:description "The codec used to create a resource."@en ;
+            rdfs:label "Codec"@en ;
+            skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:Codec"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasCodecVendor
 ec:hasCodecVendor rdf:type owl:ObjectProperty ;
-                  dcterms:description "Pour fournir un nom pour le vendeur du Codec."@fr ,
-                                      "To provide a name for the vendor of the Codec."@en ,
-                                      "Um einen Namen für den Anbieter des Codecs anzugeben."@de ;
-                  rdfs:label "Codec vendor"@en ,
-                             "Codec-Anbieter"@de ,
-                             "Fournisseur de codecs"@fr .
+                  dcterms:description "The vendor of the codec."@en ;
+                  rdfs:label "Codec vendor"@en ;
+                  skos:definition "an owl:ObjectProperty relating an ec:Codec to an ec:Agent"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasColourSpace
 ec:hasColourSpace rdf:type owl:ObjectProperty ;
                   rdfs:subPropertyOf ec:hasFormat ;
-                  dcterms:description "Pour décrire l'espace couleur."@fr ,
-                                      "To describe the colour space."@en ,
-                                      "Zur Beschreibung des Farbraums."@de ;
-                  rdfs:label "Colour space"@en ,
-                             "Espace couleur"@fr ,
-                             "Farbraum"@de .
+                  dcterms:description "The colour space associated with the media resource."@en ;
+                  rdfs:label "Colour space"@en ;
+                  skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:ColourSpace"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasCommissioningContract
 ec:hasCommissioningContract rdf:type owl:ObjectProperty ;
-                            dcterms:description "Der Vertrag, durch den ein EditorialObject in Auftrag gegeben wird."@de ,
-                                                "Le contrat par lequel un objet éditorial est commissionné."@fr ,
-                                                "The Contract through which an EditorialObject is commissioned."@en ;
-                            rdfs:label "Contract"@en ,
-                                       "Contrat"@fr ,
-                                       "Vertrag"@de .
+                            dcterms:description "The Contract through which an EditorialObject is commissioned."@en ;
+                            rdfs:label "Contract"@en ;
+                            skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Contract"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasConsumer
 ec:hasConsumer rdf:type owl:ObjectProperty ;
-               dcterms:description "Links a ConsumptionEvent to the consumer."@en ,
-                                   "Relie un ConsumptionEvent au consommateur."@fr ,
-                                   "Verknüpft ein ConsumptionEvent mit dem Nutzer."@de ;
-               rdfs:label "a un consommateur"@fr ,
-                          "has consumer"@en ,
-                          "hat Nutzer"@de .
+               dcterms:description "Links a ConsumptionEvent to the consumer."@en ;
+               rdfs:label "Has consumer"@en ;
+               skos:definition "an owl:ObjectProperty relating a ec:ConsumptionEvent to a ec:Consumer"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasConsumptionContract
 ec:hasConsumptionContract rdf:type owl:ObjectProperty ;
-                          dcterms:description "Pour identifier un ConsumptionContract lié à un compte."@fr ,
-                                              "To identify a ConsumptionContract related to an Account."@en ,
-                                              "Um einen ConsumptionContract zu identifizieren, der mit einem Konto."@de ;
-                          rdfs:label "Consumption Contract"@en ,
-                                     "Contrat de consommation"@fr ,
-                                     "Verbrauchsvertrag"@de .
+                          dcterms:description "A contract related to an account."@en ;
+                          rdfs:label "Consumption contract"@en ;
+                          skos:definition "an owl:ObjectProperty relating an ec:Account to an ec:Contract"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasConsumptionCount
 ec:hasConsumptionCount rdf:type owl:ObjectProperty ;
-                       dcterms:description "Die Anzahl und der Bezug zum echten Publikum."@de ,
-                                           "Le nombre et la relation avec le public réel."@fr ,
-                                           "The count of and relation to the real audience."@en ;
-                       rdfs:label "a compte de la consommation"@fr ,
-                                  "has consumption count"@en ,
-                                  "hat den Verbrauch gezählt"@de .
+                       dcterms:description "The count of and relation to the real audience."@en ;
+                       rdfs:label "Has consumption count"@en ;
+                       skos:definition "an owl:ObjectProperty relating an ec:Campaign to an ec:ConsumptionCount"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasConsumptionDeviceManufacturer
 ec:hasConsumptionDeviceManufacturer rdf:type owl:ObjectProperty ;
-                                    dcterms:description "Der Hersteller eines ConsumptionDevice."@de ,
-                                                        "Le fabricant d'un ConsumptionDevice."@fr ,
-                                                        "The manufacturer of a ConsumptionDevice."@en ;
-                                    rdfs:label "Consumption device manufacturer"@en ,
-                                               "Fabricant de dispositifs de consommation"@fr ,
-                                               "Hersteller von Verbrauchsgeräten"@de .
+                                    dcterms:description "The manufacturer of a ConsumptionDevice."@en ;
+                                    rdfs:label "Consumption device manufacturer"@en ;
+                                    skos:definition "an owl:ObjectProperty relating an ec:ConsumptionDevice to an ec:Agent"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasConsumptionEvent
 ec:hasConsumptionEvent rdf:type owl:ObjectProperty ;
-                       dcterms:description "Pour identifier un ConsumptionEvent lié à un PublicationEvent."@fr ,
-                                           "To identify a ConsumptionEvent related to a PublicationEvent."@en ,
-                                           "Um ein ConsumptionEvent zu identifizieren, das mit einem PublikationsEreignis."@de ;
-                       rdfs:label "Consumption event"@en ,
-                                  "Verbrauchsereignis"@de ,
-                                  "Événement de consommation"@fr .
+                       dcterms:description "An event in which a consumer uses a device to consume an editorial object published in a publication event within a media service."@en ;
+                       rdfs:label "Consumption event"@en ;
+                       skos:definition "an owl:ObjectProperty relating an ec:ConsumptionCount to an ec:ConsumptionEvent"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasConsumptionEventResumePoint
 ec:hasConsumptionEventResumePoint rdf:type owl:ObjectProperty ;
-                                  dcterms:description "Das Datum und der Zeitpunkt, zu dem der Konsum wieder aufgenommen wurde wiederaufgenommen wurde."@de ,
-                                                      "La date et l'heure à laquelle la consommation a repris."@fr ,
-                                                      "The date and time point at which consumption has resumed."@en ;
-                                  rdfs:label "Consumption event resume point"@en ,
-                                             "Point de reprise de l'événement de consommation"@fr ,
-                                             "Punkt für die Fortsetzung des Verbrauchsereignisses"@de .
+                                  dcterms:description "The date and time point at which consumption has resumed."@en ;
+                                  rdfs:label "Consumption event resume point"@en ;
+                                  skos:definition "an owl:ObjectProperty relating an ec:ConsumptionEvent to an ec:TimelinePoint"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasConsumptionLicenceLink
 ec:hasConsumptionLicenceLink rdf:type owl:ObjectProperty ;
-                             dcterms:description "A link to the terms of a ConsumptionLicence."@en ,
-                                                 "Ein Link zu den Bedingungen einer ConsumptionLicence."@de ,
-                                                 "Un lien vers les conditions d'une licence de consommation."@fr ;
-                             rdfs:label "Consumption licence link"@en ,
-                                        "Lien vers le permis de consommation"@fr ,
-                                        "Link zur Verbrauchslizenz"@de .
+                             dcterms:description "A link to the terms of a ConsumptionLicence."@en ;
+                             rdfs:label "Consumption licence link"@en ;
+                             skos:definition "an owl:ObjectProperty relating an ec:ConsumptionLicence to an ec:Contract"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContact
 ec:hasContact rdf:type owl:ObjectProperty ;
-              dcterms:description "Pour fournir des informations sur un contact pour une Organisation ou une personne physique (par exemple, l'agent d'un acteur)."@fr ,
-                                  "To provide information on a Contact for an Organisation or a physical person (e.g. the agent of an actor)."@en ,
-                                  "Zur Bereitstellung von Informationen über einen Kontakt für eine Organisation oder eine natürliche Person (z.B. den Agenten eines Schauspielers)."@de ;
-              rdfs:label "Contact"@en ,
-                         "Contact"@fr ,
-                         "Kontakt"@de .
+              dcterms:description "Information about a contact for an organisation or a person, such as the agent of an actor."@en ;
+              rdfs:label "Contact"@en ;
+              skos:definition "an owl:ObjectProperty relating an ec:Agent to an ec:Contact"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContainerCodec
 ec:hasContainerCodec rdf:type owl:ObjectProperty ;
                      rdfs:subPropertyOf ec:hasCodec ;
-                     dcterms:description "Pour identifier un codec de conteneur."@fr ,
-                                         "To identify a container codec."@en ,
-                                         "Um einen Container-Codec zu identifizieren."@de ;
-                     rdfs:label "Codec de conteneur"@fr ,
-                                "Container Codec"@de ,
-                                "Container codec"@en .
+                     dcterms:description "The codec used in a content container."@en ;
+                     rdfs:label "Container codec"@en ;
+                     skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:ContainerCodec"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContainerEncodingFormat
 ec:hasContainerEncodingFormat rdf:type owl:ObjectProperty ;
                               rdfs:subPropertyOf ec:hasFormat ;
-                              dcterms:description "Pour décrire le format d'encodage du conteneur."@fr ,
-                                                  "To describe the container encoding format."@en ,
-                                                  "Zur Beschreibung des Container-Kodierungsformats."@de ;
-                              rdfs:label "Container encoding format"@en ,
-                                         "Container-Kodierungsformat"@de ,
-                                         "Format d'encodage du conteneur"@fr .
+                              dcterms:description "The container encoding format associated with the media resource."@en ;
+                              rdfs:label "Container encoding format"@en ;
+                              skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:ContainerEncodingFormat"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContainerMimeType
 ec:hasContainerMimeType rdf:type owl:ObjectProperty ;
                         rdfs:subPropertyOf ec:hasFormat ;
-                        dcterms:description "Pour fournir le type Mime de la ressource."@fr ,
-                                            "To provide the Mime type of the Resource."@en ,
-                                            "Zur Angabe des Mime-Typs der Resource."@de ;
-                        rdfs:label "Mime type"@en ,
-                                   "Mime-Typ"@de ,
-                                   "Type Mime"@fr .
+                        dcterms:description "The MIME type associated with the resource."@en ;
+                        rdfs:label "Mime type"@en ;
+                        skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:MimeType"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContentEditorialFormat
 ec:hasContentEditorialFormat rdf:type owl:ObjectProperty ;
-                             dcterms:description "Pour définir un format éditorial de contenu, par exemple un magazine."@fr ,
-                                                 "To define a content editorial format e.g. magazine."@en ,
-                                                 "Um ein redaktionelles Format zu definieren, z. B. ein Magazin."@de ;
-                             rdfs:label "Editorial format"@en ,
-                                        "Format rédactionnel"@fr ,
-                                        "Redaktionelles Format"@de .
+                             dcterms:description "Describes a content editorial format, such as magazine."@en ;
+                             rdfs:label "Editorial format"@en ;
+                             skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:ContentEditorialFormat"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContractCostAmountCurrency
 ec:hasContractCostAmountCurrency rdf:type owl:ObjectProperty ;
-                                 dcterms:description "Die Währung des Betrags der ContractCost."@de ,
-                                                     "La devise du montant du ContractCost."@fr ,
-                                                     "The currency of the amount of the ContractCost."@en ;
-                                 rdfs:label "Cost currency"@en ,
-                                            "Devise de coût"@fr ,
-                                            "Kostenwährung"@de .
+                                 dcterms:description "The currency of the amount of the ContractCost."@en ;
+                                 rdfs:label "Cost currency"@en ;
+                                 skos:definition "an owl:ObjectProperty relating an ec:ContractCost to a skos:Concept"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContractLink
 ec:hasContractLink rdf:type owl:ObjectProperty ;
-                   dcterms:description "A link to a location where information can be found about a Contract."@en ,
-                                       "Ein Link zu einem Ort, an dem Sie Informationen über einen Vertrag."@de ,
-                                       "Un lien vers un emplacement où l'on peut trouver des informations sur un contrat."@fr ;
-                   rdfs:label "Contract link"@en ,
-                              "Lien vers le contrat"@fr ,
-                              "Vertrag Link"@de .
+                   dcterms:description "A link to a location where information can be found about a Contract."@en ;
+                   rdfs:label "Contract link"@en ;
+                   skos:definition "an owl:ObjectProperty relating an ec:Contract to an ec:Resource"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContractRelatedCost
 ec:hasContractRelatedCost rdf:type owl:ObjectProperty ;
-                          dcterms:description "Pour identifier les coûts liés au contrat."@fr ,
-                                              "To identify Contract related costs."@en ,
-                                              "Um vertragsbezogene Kosten zu ermitteln."@de ;
-                          rdfs:label "Contract related cost"@en ,
-                                     "Coût lié au contrat"@fr ,
-                                     "Vertragsbezogene Kosten"@de .
+                          dcterms:description "The financial costs associated with a contract."@en ;
+                          rdfs:label "Contract related cost"@en ;
+                          skos:definition "an owl:ObjectProperty relating an ec:Contract to an ec:ContractCost"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContractTemplate
 ec:hasContractTemplate rdf:type owl:ObjectProperty ;
-                       dcterms:description "A Contract used as a template for another Contract."@en ,
-                                           "Ein Vertrag, der als Vorlage für einen anderen Vertrag dient."@de ,
-                                           "Un contrat utilisé comme modèle pour un autre contrat."@fr ;
-                       rdfs:label "Contract template"@en ,
-                                  "Modèle de contrat"@fr ,
-                                  "Vertragsvorlage"@de .
+                       dcterms:description "A Contract used as a template for another Contract."@en ;
+                       rdfs:label "Contract template"@en ;
+                       skos:definition "an owl:ObjectProperty relating an ec:Contract to an ec:Contract"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContractualParty
 ec:hasContractualParty rdf:type owl:ObjectProperty ;
-                       dcterms:description "Identifier les différentes parties impliquées mentionnées dans le contrat termes."@fr ,
-                                           "Identifizierung der verschiedenen Parteien, die im Vertrag erwähnt werden Bedingungen."@de ,
-                                           "To identify the different parties involved mentioned in Contract terms."@en ;
-                       rdfs:label "Contract party"@en ,
-                                  "Partie contractante"@fr ,
-                                  "Vertragspartner"@de .
+                       dcterms:description "The different parties involved in a contract."@en ;
+                       rdfs:label "Contract party"@en ;
+                       skos:definition "an owl:ObjectProperty relating an ec:Contract to an ec:Agent"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContributor
 ec:hasContributor rdf:type owl:ObjectProperty ;
-                  dcterms:description "Pour identifier un contributeur à une ressource, un EditorialObject, un Événement..."@fr ,
-                                      "To identify a contributor to a Resource, a EditorialObject, an Event..."@en ,
-                                      "Zur Identifizierung eines Mitwirkenden an einer Resource, einem Redaktionsobjekt, einem Ereignis..."@de ;
-                  rdfs:label "Beitragender"@de ,
-                             "Contributeur"@fr ,
-                             "Contributor"@en .
+                  dcterms:description "An agent or organization that contributes to a Resource, EditorialObject, or Event."@en ;
+                  rdfs:label "Contributor"@en ;
+                  skos:definition "an owl:ObjectProperty relating an ec:EditorialObject or ec:ProductionJob to an ec:Involvement"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasCopyright
 ec:hasCopyright rdf:type owl:ObjectProperty ;
                 rdfs:subPropertyOf ec:hasRights ;
-                dcterms:description "Pour exprimer le droit d'auteur."@fr ,
-                                    "To express copyright."@en ,
-                                    "Um das Urheberrecht auszudrücken."@de ;
-                rdfs:label "Copyright"@de ,
-                           "Copyright"@en ,
-                           "Copyright"@fr .
+                dcterms:description "The rights that define the conditions under which the associated asset may be copied."@en ;
+                rdfs:label "Copyright"@en ;
+                skos:definition "an owl:ObjectProperty relating an ec:Asset to an ec:Copyright"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasCountryOfBirth
 ec:hasCountryOfBirth rdf:type owl:ObjectProperty ;
-                     dcterms:description "Das Land, in dem eine Person geboren ist."@de ,
-                                         "Le pays où une personne est née."@fr ,
-                                         "The country where a person is born."@en ;
-                     rdfs:label "Country of birth"@en ,
-                                "Land der Geburt"@de ,
-                                "Pays de naissance"@fr .
+                     dcterms:description "The country where a person is born."@en ;
+                     rdfs:label "Country of birth"@en ;
+                     skos:definition "an owl:ObjectProperty relating an ec:Person to an ec:CountryCode"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasCountryOfDeath
 ec:hasCountryOfDeath rdf:type owl:ObjectProperty ;
-                     dcterms:description "Das Land, in dem die Person gestorben ist"@de ,
-                                         "Le pays où la personne est décédée"@fr ,
-                                         "The country where the person died"@en ;
-                     rdfs:label "Country of death"@en ,
-                                "Land des Todes"@de ,
-                                "Pays de décès"@fr .
+                     dcterms:description "The country where the person died."@en ;
+                     rdfs:label "Country of death"@en ;
+                     skos:definition "an owl:ObjectProperty relating an ec:Person to an ec:CountryCode"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasCoverage
 ec:hasCoverage rdf:type owl:ObjectProperty ;
-               dcterms:description "Pour fournir des informations sur la couverture."@fr ,
-                                   "To provide coverage information."@en ,
-                                   "Zur Bereitstellung von Informationen zum Versicherungsschutz."@de ;
-               rdfs:label "Couverture"@fr ,
-                          "Coverage"@en ,
-                          "Erfassungsbereich"@de .
+               dcterms:description "Coverage information associated with the editorial object."@en ;
+               rdfs:label "Coverage"@en ;
+               skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Event or ec:Location"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasCoverageRestrictions
 ec:hasCoverageRestrictions rdf:type owl:ObjectProperty ;
                            rdfs:subPropertyOf ec:hasRights ;
-                           dcterms:description "Pour exprimer les restrictions de couverture."@fr ,
-                                               "To express coverage restrictions."@en ,
-                                               "Um Einschränkungen der Deckung auszudrücken."@de ;
-                           rdfs:label "Coverage restrictions"@en ,
-                                      "Einschränkungen der Deckung"@de ,
-                                      "Restrictions de couverture"@fr .
+                           dcterms:description "The limitations on coverage for an asset or publication event, such as time or spatial coverage."@en ;
+                           rdfs:label "Coverage restrictions"@en ;
+                           skos:definition "an owl:ObjectProperty relating an ec:Asset to an ec:CoverageRestrictions"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasCreativeCommons
 ec:hasCreativeCommons rdf:type owl:ObjectProperty ;
                       rdfs:subPropertyOf ec:hasRights ;
-                      dcterms:description "Pour exprimer Creative Commons."@fr ,
-                                          "To express Creative Commons."@en ,
-                                          "Um Creative Commons auszudrücken."@de ;
-                      rdfs:label "Creative Commons"@de ,
-                                 "Creative Commons"@en ,
-                                 "Creative Commons"@fr .
+                      dcterms:description "A property linking an asset to its Creative Commons license or licensing conditions."@en ;
+                      rdfs:label "Creative commons"@en ;
+                      skos:definition "an owl:ObjectProperty relating an ec:Asset to ec:CreativeCommons"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasCreator
 ec:hasCreator rdf:type owl:ObjectProperty ;
-              dcterms:description "Pour identifier un agent impliqué dans la création de la ressource ou de l'objet éditorial."@fr ,
-                                  "To identify an Agent involved in the creation of the Resource or EditorialObject."@en ,
-                                  "Zur Identifizierung eines Agenten, der an der Erstellung der Resource oder des Redaktionsobjekts beteiligt war."@de ;
-              rdfs:label "Creator"@en ,
-                         "Créateur"@fr ,
-                         "Schöpfer"@de .
+              dcterms:description "An Agent involved in the creation of the Resource or EditorialObject."@en ;
+              rdfs:label "Creator"@en ;
+              skos:definition "an owl:ObjectProperty relating an ec:Artefact or ec:EditorialObject to an ec:Involvement"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasCrewMember
 ec:hasCrewMember rdf:type owl:ObjectProperty ;
-                 dcterms:description "A member of the crew."@en ,
-                                     "Ein Mitglied der Besatzung."@de ,
-                                     "Un membre de l'équipage."@fr ;
-                 rdfs:label "Besatzungsmitglied"@de ,
-                            "Crew member"@en ,
-                            "Membre de l'équipage"@fr .
+                 dcterms:description "A member of the crew."@en ;
+                 rdfs:label "Crew member"@en ;
+                 skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:CrewMember"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasCuisineOrigin
 ec:hasCuisineOrigin rdf:type owl:ObjectProperty ;
-                    dcterms:description "Das Land/die Region, aus dem/der die Küche stammt"@de ,
-                                        "Le pays/la région d'origine de la cuisine"@fr ,
-                                        "The country/region of origin of the cuisine"@en ;
-                    rdfs:label "Cuisine origin"@en ,
-                               "Herkunft der Küche"@de ,
-                               "Origine de la cuisine"@fr .
+                    dcterms:description "The country/region of origin of the cuisine."@en ;
+                    rdfs:label "Cuisine origin"@en ;
+                    skos:definition "an owl:ObjectProperty relating an ec:Food to an ec:CountryCode"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasCuisineStyle
 ec:hasCuisineStyle rdf:type owl:ObjectProperty ;
-                   dcterms:description "Der Stil der Küche"@de ,
-                                       "Le style de la cuisine"@fr ,
-                                       "The style of the cuisine"@en ;
-                   rdfs:label "Cuisine style"@en ,
-                              "Stil der Küche"@de ,
-                              "Style de cuisine"@fr .
+                   dcterms:description "The style of the cuisine."@en ;
+                   rdfs:label "Cuisine style"@en ;
+                   skos:definition "an owl:ObjectProperty relating an ec:Food to an ec:CuisineStyle"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDataFormat
 ec:hasDataFormat rdf:type owl:ObjectProperty ;
                  rdfs:subPropertyOf ec:hasFormat ;
-                 dcterms:description "Pour décrire le format des données transportées dans une ressource."@fr ,
-                                     "To describe the format of data carried in a resource."@en ,
-                                     "Zur Beschreibung des Formats der in einer Resource enthaltenen Daten."@de ;
-                 rdfs:label "Data format"@en ,
-                            "Datenformat"@de ,
-                            "Format des données"@fr .
+                 dcterms:description "The format of data carried in a resource."@en ;
+                 rdfs:label "Data format"@en ;
+                 skos:definition "an owl:ObjectProperty relating an ec:DataTrack to an ec:DataFormat"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDataTrack
 ec:hasDataTrack rdf:type owl:ObjectProperty ;
-                dcterms:description "Pour identifier les DataTracks dans la ressource."@fr ,
-                                    "To identify DataTracks in the Resource."@en ,
-                                    "Um DataTracks in der Resource zu identifizieren."@de ;
-                rdfs:label "Data track"@en ,
-                           "Daten verfolgen"@de ,
-                           "Suivi des données"@fr .
+                dcterms:description "The data track associated with the resource."@en ;
+                rdfs:label "Data track"@en ;
+                skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:DataTrack"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDate
 ec:hasDate rdf:type owl:ObjectProperty ;
            dc:description "Range: Litteral, on the instance level, this can be restricted to dateTime, date or another suitable format."@en ;
-           dcterms:description "A date associated with an Asset. Range: Litteral, on the instance level, this can be restricted to dateTime, date or another suitable format."@en ,
-                               "Ein Datum, das mit einem Asset verbunden ist. Range: Litteral, auf Instanzebene kann dies auf dateTime, Datum oder ein anderes geeignetes Format beschränkt werden."@de ,
-                               "Une date associée à un actif. Range : Litteral, au niveau de l'instance, cela peut être limité à dateTime, date ou un autre format approprié."@fr ;
+           dcterms:description "A date associated with an Asset. Range: Literal, on the instance level, this can be restricted to dateTime, date or another suitable format."@en ;
            rdfs:isDefinedBy dc:date ;
-           rdfs:label "Date"@en ,
-                      "Date"@fr ,
-                      "Datum"@de .
+           rdfs:label "Date"@en ;
+           skos:definition "an owl:ObjectProperty relating an ec:Asset to a time:Instant"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateArchived
 ec:hasDateArchived rdf:type owl:ObjectProperty ;
                    rdfs:subPropertyOf ec:hasDate ;
-                   dcterms:description "Das Datum, an dem das Asset archiviert wurde."@de ,
-                                       "La date à laquelle l'actif a été archivé."@fr ,
-                                       "The date when the Asset was archived."@en ;
-                   rdfs:label "Archiving date"@en ,
-                              "Date d'archivage"@fr ,
-                              "Datum der Archivierung"@de .
+                   dcterms:description "The date when the Asset was archived."@en ;
+                   rdfs:label "Archiving date"@en ;
+                   skos:definition "an owl:ObjectProperty relating an ec:Asset to a time:Instant"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateBroadcast
 ec:hasDateBroadcast rdf:type owl:ObjectProperty ;
                     rdfs:subPropertyOf ec:hasDate ;
-                    dcterms:description "Das Datum, an dem der Asset zum ersten Mal öffentlich im Fernsehen, Radio oder per Streaming ausgestrahlt wurde."@de ,
-                                        "La date à laquelle l'actif a été diffusé pour la première fois en public à la télévision ou à la radio ou par streaming."@fr ,
-                                        "The date when the Asset was first broadcast publicly on television or radio or via streaming."@en ;
-                    rdfs:label "Broadcast date"@en ,
-                               "Date de diffusion"@fr ,
-                               "Datum der Ausstrahlung"@de .
+                    dcterms:description "The date when the Asset was first broadcast publicly on television or radio or via streaming."@en ;
+                    rdfs:label "Broadcast date"@en ;
+                    skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to a time:Instant"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateCreated
 ec:hasDateCreated rdf:type owl:ObjectProperty ;
                   rdfs:subPropertyOf ec:hasDate ;
-                  dcterms:description "Das Datum der Erstellung des Assets."@de ,
-                                      "La date de création de l'actif."@fr ,
-                                      "The date of creation of the Asset."@en ;
-                  rdfs:label "Creation date/time"@en ,
-                             "Date/heure de création"@fr ,
-                             "Erstellungsdatum/-zeit"@de .
+                  dcterms:description "The date of creation of the Asset."@en ;
+                  rdfs:label "Creation date/time"@en ;
+                  skos:definition "an owl:ObjectProperty relating an ec:Asset to a time:Instant"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateDeleted
 ec:hasDateDeleted rdf:type owl:ObjectProperty ;
                   rdfs:subPropertyOf ec:hasDate ;
-                  dcterms:description "Das Datum, an dem die Resource gelöscht wurde."@de ,
-                                      "La date à laquelle la ressource a été supprimée."@fr ,
-                                      "The date when the Resource was deleted."@en ;
-                  rdfs:label "Date de suppression"@fr ,
-                             "Datum der Löschung"@de ,
-                             "Deletion date"@en .
+                  dcterms:description "The date when the Resource was deleted."@en ;
+                  rdfs:label "Deletion date"@en ;
+                  skos:definition "an owl:ObjectProperty relating an ec:Asset to a time:Instant"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateDigitised
 ec:hasDateDigitised rdf:type owl:ObjectProperty ;
                     rdfs:subPropertyOf ec:hasDate ;
-                    dcterms:description "Das Datum, an dem die Resource digitalisiert wurde."@de ,
-                                        "La date à laquelle la ressource a été numérisée."@fr ,
-                                        "The date when the Resource was digitised."@en ;
-                    rdfs:label "Date de numérisation"@fr ,
-                               "Datum der Digitalisierung"@de ,
-                               "Digitisation date"@en .
+                    dcterms:description "The date when the Resource was digitised."@en ;
+                    rdfs:label "Digitisation date"@en ;
+                    skos:definition "an owl:ObjectProperty relating an ec:MediaResource to a time:Instant"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateDistributed
 ec:hasDateDistributed rdf:type owl:ObjectProperty ;
                       rdfs:subPropertyOf ec:hasDate ;
-                      dcterms:description "Das Datum, an dem die Resource erstmals der Öffentlichkeit zum Kauf, Download oder Online-Zugriff zur Verfügung gestellt wurde."@de ,
-                                          "La date à laquelle la ressource a été mise pour la première fois à la disposition du public pour l'achat, le téléchargement ou l'accès en ligne."@fr ,
-                                          "The date when the Resource was first made available to the public for purchase, download, or online access."@en ;
-                      rdfs:label "Date de distribution"@fr ,
-                                 "Datum der Verteilung"@de ,
-                                 "Distribution date"@en .
+                      dcterms:description "The date when the Resource was first made available to the public for purchase, download, or online access."@en ;
+                      rdfs:label "Distribution date"@en ;
+                      skos:definition "an ec:hasDate relation relating an ec:Asset to a time:Instant"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateIngested
 ec:hasDateIngested rdf:type owl:ObjectProperty ;
                    rdfs:subPropertyOf ec:hasDate ;
-                   dcterms:description "Das Datum, an dem die Resource in den institutionellen Bestand aufgenommen/erworben wurde."@de ,
-                                       "La date à laquelle la ressource a été ingérée/acquise dans les fonds institutionnels."@fr ,
-                                       "The date when the Resource was ingested/acquired in institutional holdings."@en ;
-                   rdfs:label "Date d'ingestion"@fr ,
-                              "Ingest date"@en ,
-                              "Ingest-Datum"@de .
+                   dcterms:description "The date when the Resource was ingested/acquired in institutional holdings."@en ;
+                   rdfs:label "Ingest date"@en ;
+                   skos:definition "an owl:ObjectProperty relating an ec:MediaResource to a time:Instant"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateIssued
 ec:hasDateIssued rdf:type owl:ObjectProperty ;
                  rdfs:subPropertyOf ec:hasDate ;
-                 dcterms:description "Das Datum, an dem das Asset ausgegeben wurde."@de ,
-                                     "La date à laquelle l'actif a été émis."@fr ,
-                                     "The date when the Asset was issued."@en ;
-                 rdfs:label "Date d'émission"@fr ,
-                            "Date issued"@en ,
-                            "Datum der Ausstellung"@de .
+                 dcterms:description "The date when the Asset was issued."@en ;
+                 rdfs:label "Date issued"@en ;
+                 skos:definition "an ec:hasDate relation relating an ec:EditorialObject to a time:Instant"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateLicenseEnd
 ec:hasDateLicenseEnd rdf:type owl:ObjectProperty ;
                      rdfs:subPropertyOf ec:hasDate ;
-                     dcterms:description "Das Datum, an dem die Lizenz für das Asset endet."@de ,
-                                         "La date à laquelle la licence de l'actif prend fin."@fr ,
-                                         "The date when the licence for the Asset ends."@en ;
-                     rdfs:label "Date de fin de licence"@fr ,
-                                "Enddatum der Lizenz"@de ,
-                                "Licence end date"@en .
+                     dcterms:description "The date when the licence for the Asset ends."@en ;
+                     rdfs:label "Licence end date"@en ;
+                     skos:definition "an owl:ObjectProperty relating an ec:Asset to a time:Instant"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateLicensedStart
 ec:hasDateLicensedStart rdf:type owl:ObjectProperty ;
                         rdfs:subPropertyOf ec:hasDate ;
-                        dcterms:description "Das Datum, an dem die Lizenz für das Asset beginnt."@de ,
-                                            "La date à laquelle la licence pour le bien commence."@fr ,
-                                            "The date when the licence for the Asset begins."@en ;
-                        rdfs:label "Date de début de la licence"@fr ,
-                                   "Licence start date"@en ,
-                                   "Startdatum der Lizenz"@de .
+                        dcterms:description "The date when the licence for the Asset begins."@en ;
+                        rdfs:label "Licence start date"@en ;
+                        skos:definition "an owl:ObjectProperty relating an ec:Asset to a time:Instant"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateMigrated
 ec:hasDateMigrated rdf:type owl:ObjectProperty ;
                    rdfs:subPropertyOf ec:hasDate ;
-                   dcterms:description "Das Datum, an dem die Resource kopiert oder von einem veralteten oder gefährdeten Originalformat in ein aktuelleres Format zur Aufbewahrung konvertiert wurde."@de ,
-                                       "La date à laquelle la ressource a été copiée ou convertie d'un format original obsolète ou menacé à un format plus actualisé pour la conservation."@fr ,
-                                       "The date when the Resource was copied or converted from an obsolete or endangered original format to a more updated format for preservation."@en ;
-                   rdfs:label "Date de migration"@fr ,
-                              "Datum der Migration"@de ,
-                              "Migration date"@en .
+                   dcterms:description "The date when the Resource was copied or converted from an obsolete or endangered original format to a more updated format for preservation."@en ;
+                   rdfs:label "Migration date"@en ;
+                   skos:definition "an owl:ObjectProperty relating an ec:MediaResource to a time:Instant"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateModified
 ec:hasDateModified rdf:type owl:ObjectProperty ;
                    rdfs:subPropertyOf ec:hasDate ;
-                   dcterms:description "Pour indiquer la date à laquelle l'actif a été modifié."@fr ,
-                                       "To indicate the date at which the Asset has been modified."@en ,
-                                       "Zur Angabe des Datums, an dem das Asset geändert wurde."@de ;
-                   rdfs:label "Date/heure de modification"@fr ,
-                              "Datum/Uhrzeit der Änderung"@de ,
-                              "Modification date/time"@en .
+                   dcterms:description "The date and time when the Asset was modified."@en ;
+                   rdfs:label "Modification date/time"@en ;
+                   skos:definition "an owl:ObjectProperty relating an ec:Asset to a time:Instant"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateNormalized
 ec:hasDateNormalized rdf:type owl:ObjectProperty ;
                      rdfs:subPropertyOf ec:hasDate ;
-                     dcterms:description "Das Datum, an dem die Resource aus ihrem ursprünglichen Format in ein von der Institution für die Aufbewahrung ausgewähltes Format konvertiert wurde."@de ,
-                                         "La date à laquelle la ressource a été convertie de son format original en un format présélectionné par l'institution pour la préservation."@fr ,
-                                         "The date when the Resource was converted from its original format into a format pre-selected by the institution for preservation."@en ;
-                     rdfs:label "Date de normalisation"@fr ,
-                                "Datum der Normalisierung"@de ,
-                                "Normalization date"@en .
+                     dcterms:description "The date when the Resource was converted from its original format into a format selected by the institution for preservation."@en ;
+                     rdfs:label "Normalization date"@en ;
+                     skos:definition "an ec:hasDate relation relating an ec:MediaResource to a time:Instant"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateOfBirth
 ec:hasDateOfBirth rdf:type owl:ObjectProperty ;
                   rdfs:subPropertyOf ec:hasDate ;
-                  dcterms:description "Das Datum, an dem ein Kontakt/eine Person geboren wird."@de ,
-                                      "La date de naissance d'un contact/personne."@fr ,
-                                      "The date when a Contact/Person is born."@en ;
-                  rdfs:label "Date de naissance"@fr ,
-                             "Date of birth"@en ,
-                             "Geburtsdatum"@de .
+                  dcterms:description "The date when a Contact/Person is born."@en ;
+                  rdfs:label "Date of birth"@en ;
+                  skos:definition "an owl:ObjectProperty relating an ec:Person to a time:Instant"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateOfDeath
 ec:hasDateOfDeath rdf:type owl:ObjectProperty ;
                   rdfs:subPropertyOf ec:hasDate ;
-                  dcterms:description "Das Datum, an dem ein Kontakt/eine Person verstorben ist."@de ,
-                                      "La date à laquelle un contact/personne est décédé."@fr ,
-                                      "The date when a Contact/Person has passed away."@en ;
-                  rdfs:label "Date du décès"@fr ,
-                             "Date of death"@en ,
-                             "Datum des Todes"@de .
+                  dcterms:description "The date when a Contact/Person has passed away."@en ;
+                  rdfs:label "Date of death"@en ;
+                  skos:definition "an owl:ObjectProperty relating an ec:Person to a time:Instant"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateOfRetirement
 ec:hasDateOfRetirement rdf:type owl:ObjectProperty ;
                        rdfs:subPropertyOf ec:hasDate ;
-                       dcterms:description "Das Datum, an dem ein Kontakt/eine Person in den Ruhestand getreten ist."@de ,
-                                           "La date à laquelle un contact/personne a pris sa retraite."@fr ,
-                                           "The date when a Contact/Person has retired."@en ;
-                       rdfs:label "Date de la retraite"@fr ,
-                                  "Date of retirement"@en ,
-                                  "Datum der Pensionierung"@de .
+                       dcterms:description "The date when a Contact/Person has retired."@en ;
+                       rdfs:label "Date of retirement"@en ;
+                       skos:definition "an owl:ObjectProperty relating an ec:Person to a time:Instant"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateProduced
 ec:hasDateProduced rdf:type owl:ObjectProperty ;
                    rdfs:subPropertyOf ec:hasDate ;
-                   dcterms:description "Das Datum der Produktion des Assets."@de ,
-                                       "La date de production de l'actif."@fr ,
-                                       "The date of production of the Asset."@en ;
-                   rdfs:label "Produktionsdatum"@de ,
-                              "date de production"@fr ,
-                              "production date"@en .
+                   dcterms:description "The date of production of the Asset."@en ;
+                   rdfs:label "Production date"@en ;
+                   skos:definition "an owl:ObjectProperty relating an ec:Asset to a time:Instant"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateReleased
 ec:hasDateReleased rdf:type owl:ObjectProperty ;
                    rdfs:subPropertyOf ec:hasDate ;
-                   dcterms:description "Das Datum, an dem die Resource erstmals der Öffentlichkeit zum Kauf, Download oder Online-Zugriff zur Verfügung gestellt wurde."@de ,
-                                       "La date à laquelle la ressource a été mise pour la première fois à la disposition du public pour l'achat, le téléchargement ou l'accès en ligne."@fr ,
-                                       "The date when the Resource was first made available to the public for purchase, download, or online access."@en ;
-                   rdfs:label "Date de sortie"@fr ,
-                              "Datum der Veröffentlichung"@de ,
-                              "Release date"@en .
+                   dcterms:description "The date when the Resource was first made available to the public for purchase, download, or online access."@en ;
+                   rdfs:label "Release date"@en ;
+                   skos:definition "an owl:ObjectProperty relating an ec:Asset to a time:Instant"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateTransferred
 ec:hasDateTransferred rdf:type owl:ObjectProperty ;
                       rdfs:subPropertyOf ec:hasDate ;
-                      dcterms:description "Das Datum, an dem das Asset von einem digitalen oder physischen Ort zu einem anderen verschoben wurde."@de ,
-                                          "La date à laquelle l'actif a été déplacé d'un emplacement numérique ou physique à un autre."@fr ,
-                                          "The date when the Asset was moved from one digital or physical location to another."@en ;
-                      rdfs:label "Date de transfert"@fr ,
-                                 "Datum der Übertragung"@de ,
-                                 "Transfer date"@en .
+                      dcterms:description "The date when the Asset was moved from one digital or physical location to another."@en ;
+                      rdfs:label "Transfer date"@en ;
+                      skos:definition "an ec:hasDate relation relating an ec:MediaResource to a time:Instant"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateValidated
 ec:hasDateValidated rdf:type owl:ObjectProperty ;
                     rdfs:subPropertyOf ec:hasDate ;
-                    dcterms:description "Das letzte Datum, an dem die Resource durch manuelle oder digitale QC als gültig bestätigt wurde."@de ,
-                                        "La date la plus récente à laquelle la validité de la ressource a été confirmée par un CQ manuel ou numérique."@fr ,
-                                        "The most recent date when the Resource was confirmed to be valid through manual or digital QC."@en ;
-                    rdfs:label "Date de validation"@fr ,
-                               "Datum der Validierung"@de ,
-                               "Validation date"@en .
+                    dcterms:description "The most recent date when the Resource was confirmed to be valid through manual or digital QC."@en ;
+                    rdfs:label "Validation date"@en ;
+                    skos:definition "an owl:ObjectProperty relating an ec:Resource to a time:Instant"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDepartment
 ec:hasDepartment rdf:type owl:ObjectProperty ;
-                 dcterms:description "Pour identifier un département dans une organisation."@fr ,
-                                     "To identify a department in an organisation."@en ,
-                                     "Zur Identifizierung einer Abteilung in einer Organisation."@de ;
-                 rdfs:label "Abteilung"@de ,
-                            "Department"@en ,
-                            "Département"@fr .
+                 dcterms:description "The department associated with an organisation."@en ;
+                 rdfs:label "Department"@en ;
+                 skos:definition "an owl:ObjectProperty relating an ec:Organisation to an ec:Department"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDevice
 ec:hasDevice rdf:type owl:ObjectProperty ;
-             dcterms:description "Das ConsumptionDevice, das während eines ConsumptionEvents verwendet wird."@de ,
-                                 "Le ConsumptionDevice utilisé pendant un ConsumptionEvent."@fr ,
-                                 "The ConsumptionDevice used during a ConsumptionEvent."@en ;
-             rdfs:label "a un dispositif"@fr ,
-                        "has device"@en ,
-                        "hat Gerät"@de .
+             dcterms:description "The ConsumptionDevice used during a ConsumptionEvent."@en ;
+             rdfs:label "Has device"@en ;
+             skos:definition "an owl:ObjectProperty relating an ec:ConsumptionEvent to an ec:ConsumptionDevice"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDisclaimer
 ec:hasDisclaimer rdf:type owl:ObjectProperty ;
                  rdfs:subPropertyOf ec:hasRights ;
-                 dcterms:description "Pour exprimer le désistement."@fr ,
-                                     "To express Disclaimer."@en ,
-                                     "Zum Ausdruck bringen Disclaimer."@de ;
-                 rdfs:label "Avis de non-responsabilité"@fr ,
-                            "Disclaimer"@en ,
-                            "Haftungsausschluss"@de .
+                 dcterms:description "A right or claim that is intentionally waived for an asset."@en ;
+                 rdfs:label "Disclaimer"@en ;
+                 skos:definition "an owl:ObjectProperty relating an ec:Asset to an ec:Disclaimer"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDisplayAspectRatio
 ec:hasDisplayAspectRatio rdf:type owl:ObjectProperty ;
-                         dcterms:description "Das Seitenverhältnis bei der Anzeige."@de ,
-                                             "Le rapport d'aspect lors de l'affichage."@fr ,
-                                             "The aspect ratio when displayed."@en ;
-                         rdfs:label "Display aspect ratio"@en ,
-                                    "Rapport d'aspect de l'écran"@fr ,
-                                    "Seitenverhältnis der Anzeige"@de .
+                         dcterms:description "The aspect ratio when displayed."@en ;
+                         rdfs:label "Display aspect ratio"@en ;
+                         skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:ActiveFormatDescriptorCode"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDocumentFormat
 ec:hasDocumentFormat rdf:type owl:ObjectProperty ;
                      rdfs:subPropertyOf ec:hasFormat ;
-                     dcterms:description "Pour décrire le format d'un document."@fr ,
-                                         "To describe the format of a Document."@en ,
-                                         "Zur Beschreibung des Formats eines Dokuments."@de ;
-                     rdfs:label "Document format"@en ,
-                                "Format des Dokuments"@de ,
-                                "Format du document"@fr .
+                     dcterms:description "The format of a document."@en ;
+                     rdfs:label "Document format"@en ;
+                     skos:definition "an owl:ObjectProperty relating an ec:Document to an ec:DocumentFormat"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDopesheet
 ec:hasDopesheet rdf:type owl:ObjectProperty ;
-                dcterms:description "Das Dossier eines NewsItems."@de ,
-                                    "La feuille de dopage d'un NewsItem."@fr ,
-                                    "The dopesheet of a NewsItem."@en ;
-                rdfs:label "Dopesheet"@de ,
-                           "Dopesheet"@en ,
-                           "Dopesheet"@fr .
+                dcterms:description "The dopesheet of a NewsItem."@en ;
+                rdfs:label "Dopesheet"@en ;
+                skos:definition "an ec:ObjectProperty relating an ec:Item to an ec:Dopesheet"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDub
 ec:hasDub rdf:type owl:ObjectProperty ;
           owl:inverseOf ec:isDubOf ;
-          dcterms:description "die Resource eine andere Sprachversion hat"@de ,
-                              "la ressource a une autre version linguistique"@fr ,
-                              "the resource have another languageversion"@en ;
-          rdfs:label "Doublé à"@fr ,
-                     "Dubbed to"@en ,
-                     "Synchronisiert auf"@de .
+          dcterms:description "The resource have another language version."@en ;
+          rdfs:label "Dubbed to"@en ;
+          skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:MediaResource"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDubbedLanguage
 ec:hasDubbedLanguage rdf:type owl:ObjectProperty ;
                      rdfs:subPropertyOf ec:hasLanguage ;
-                     dcterms:description "Pour identifier les langues doublées disponibles."@fr ,
-                                         "To identify available dubbed languages."@en ,
-                                         "Um die verfügbaren Synchronsprachen zu identifizieren."@de ;
-                     rdfs:label "Dubbed language"@en ,
-                                "Langue doublée"@fr ,
-                                "Synchronisierte Sprache"@de .
+                     dcterms:description "The dubbed languages available for the asset."@en ;
+                     rdfs:label "Dubbed language"@en ;
+                     skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Language"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDuration
-ec:hasDuration rdf:type owl:ObjectProperty .
+ec:hasDuration rdf:type owl:ObjectProperty ;
+               dcterms:description "A property that links an editorial object to its duration on a timeline."@en ;
+               rdfs:label "Has duration"@en ;
+               skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:TimelinePoint"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasEditorialFormat
-ec:hasEditorialFormat rdf:type owl:ObjectProperty .
+ec:hasEditorialFormat rdf:type owl:ObjectProperty ;
+                      dcterms:description "Relates an EditorialObject to the EditorialFormat it uses."@en ;
+                      rdfs:label "Has editorial format"@en ;
+                      skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:EditorialFormat"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasEditorialFormatOf
 ec:hasEditorialFormatOf rdf:type owl:ObjectProperty ;
-                        dcterms:description "Pour identifier un objet éditorial basé sur le même format éditorial"@fr ,
-                                            "So identifizieren Sie ein redaktionelles Objekt, das auf demselben redaktionellen Format basiert"@de ,
-                                            "To identify an Editorial Object based on the same Editorial format"@en ;
-                        rdfs:label "Gleiches redaktionelles Format"@de ,
-                                   "Même format éditorial"@fr ,
-                                   "Same editorial format"@en .
+                        dcterms:description "An editorial object based on the same editorial format."@en ;
+                        rdfs:label "Same editorial format"@en ;
+                        skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:EditorialObject with the same editorial format"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasEditorialGroup
 ec:hasEditorialGroup rdf:type owl:ObjectProperty ;
                      rdfs:subPropertyOf ec:isMemberOf ;
-                     rdfs:label "a groupe de rédaction"@fr ,
-                                "has editorial group"@en ,
-                                "hat eine Redaktionsgruppe"@de .
+                     dcterms:description "This property identifies an editorial group that an editorial object belongs to."@en ;
+                     rdfs:label "Has editorial group"@en ;
+                     skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:EditorialGroup"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasEditorialWork
 ec:hasEditorialWork rdf:type owl:ObjectProperty ;
                     rdfs:subPropertyOf ec:isMemberOf ;
-                    rdfs:label "a un travail éditorial"@fr ,
-                               "has editorial work"@en ,
-                               "hat redaktionelle Arbeit"@de .
+                    dcterms:description "Identifies an editorial work associated with this property, typically an ec:EditorialWork linked from an ec:EditorialSegment."@en ;
+                    rdfs:label "Has editorial work"@en ;
+                    skos:definition "an owl:ObjectProperty relating an ec:EditorialSegment to an ec:EditorialWork"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasEmbodyingArtefact
 ec:hasEmbodyingArtefact rdf:type owl:ObjectProperty ;
                         owl:inverseOf ec:isEmbodiedBy ;
-                        dcterms:description "Character depicted by an Artifact"@en ,
-                                            "Personnage représenté par un artefact"@fr ,
-                                            "Von einem Artefakt dargestellter Charakter"@de ;
-                        rdfs:label "est incarné par"@fr ,
-                                   "is embodied by"@en ,
-                                   "wird verkörpert durch"@de .
+                        dcterms:description "Character depicted by an Artifact."@en ;
+                        rdfs:label "Is embodied by"@en ;
+                        skos:definition "an owl:ObjectProperty relating an ec:Character to an ec:Artefact"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasEncodingFormat
 ec:hasEncodingFormat rdf:type owl:ObjectProperty ;
                      rdfs:subPropertyOf ec:hasFormat ;
-                     dcterms:description "Pour décrire tout format d'encodage utilisé pour produire du contenu."@fr ,
-                                         "To describe any encoding format use to produce content."@en ,
-                                         "Zur Beschreibung eines beliebigen Kodierungsformats, das zur Erstellung von Inhalten verwendet wird."@de ;
-                     rdfs:label "Encoding format"@en ,
-                                "Format de codage"@fr ,
-                                "Format der Kodierung"@de .
+                     dcterms:description "An encoding format used to produce content."@en ;
+                     rdfs:label "Encoding format"@en ;
+                     skos:definition "an owl:ObjectProperty relating an ec:Document, ec:MediaResource, or ec:Picture to an ec:EncodingFormat"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasEnd
-ec:hasEnd rdf:type owl:ObjectProperty .
+ec:hasEnd rdf:type owl:ObjectProperty ;
+          dcterms:description "A property that links an action or content-related entity to its ending timeline point."@en ;
+          rdfs:label "Has end"@en ;
+          skos:definition "an owl:ObjectProperty relating an ec:Action to an ec:TimelinePoint"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasEndDateTime
 ec:hasEndDateTime rdf:type owl:ObjectProperty ;
                   rdfs:subPropertyOf ec:hasDate ;
-                  dcterms:description "Das Ende eines Intervalls beschreiben"@de ,
-                                      "Describing an end of an interval"@en ,
-                                      "Décrit la fin d'un intervalle"@fr ;
-                  rdfs:label "End date time"@en ,
-                             "Enddatum Uhrzeit"@de ,
-                             "Instant de fin"@fr .
+                  dcterms:description "Describing an end of an interval."@en ;
+                  rdfs:label "End date time"@en ;
+                  skos:definition "an owl:ObjectProperty relating an ec:Affiliation to a time:Instant"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasEpisode
 ec:hasEpisode rdf:type owl:ObjectProperty ;
-              dcterms:description "Pour identifier les épisodes d'une série"@fr ,
-                                  "So identifizieren Sie Episoden einer Serie"@de ,
-                                  "To identify Episodes in a Series"@en ;
-              rdfs:label "Episode"@de ,
-                         "Episode"@en ,
-                         "Episode"@fr .
+              dcterms:description "Identifies episodes in a series."@en ;
+              rdfs:label "Episode"@en ;
+              skos:definition "an owl:ObjectProperty relating an ec:Season, ec:Serial or ec:Series to an ec:Programme"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasExploitationIssues
 ec:hasExploitationIssues rdf:type owl:ObjectProperty ;
                          rdfs:subPropertyOf ec:hasRights ;
-                         dcterms:description "Pour exprimer les problèmes d'exploitation."@fr ,
-                                             "To express Exploitation Issues."@en ,
-                                             "Zum Ausdruck bringen von Ausbeutungsproblemen."@de ;
-                         rdfs:label "Exploitation Issues"@en ,
-                                    "Fragen der Ausbeutung"@de ,
-                                    "Problèmes d'exploitation"@fr .
+                         dcterms:description "A potential problem arising from the use of a work."@en ;
+                         rdfs:label "Exploitation issues"@en ;
+                         skos:definition "an owl:ObjectProperty relating an ec:Asset to ec:ExploitationIssues"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasFictitiousPerson
 ec:hasFictitiousPerson rdf:type owl:ObjectProperty ;
-                       dcterms:description "Pour identifier un contact/personne fictive."@fr ,
-                                           "To identify a Contact/Person being fictitious."@en ,
-                                           "Um einen Kontakt/eine Person als fiktiv zu identifizieren."@de ;
-                       rdfs:label "Contact fictif"@fr ,
-                                  "Fictitious contact"@en ,
-                                  "Fiktiver Kontakt"@de .
+                       dcterms:description "Indicates that the associated person is fictitious."@en ;
+                       rdfs:label "Fictitious contact"@en ;
+                       skos:definition "an owl:ObjectProperty relating an ec:Character to an ec:Person"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasFileFormat
 ec:hasFileFormat rdf:type owl:ObjectProperty ;
-                 dcterms:description "Das Format einer Datei."@de ,
-                                     "Le format d'un fichier."@fr ,
-                                     "The format of a file."@en ;
-                 rdfs:label "Dateiformat"@de ,
-                            "File format"@en ,
-                            "Format de fichier"@fr .
+                 dcterms:description "The format of a file."@en ;
+                 rdfs:label "File format"@en ;
+                 skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:FileFormat"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasFoodStyle
 ec:hasFoodStyle rdf:type owl:ObjectProperty ;
-                dcterms:description "Der Stil des Essens."@de ,
-                                    "Le style de la nourriture."@fr ,
-                                    "The style of Food."@en ;
-                rdfs:label "Essen Stil"@de ,
-                           "Food style"@en ,
-                           "Style alimentaire"@fr .
+                dcterms:description "The style of Food."@en ;
+                rdfs:label "Food style"@en ;
+                skos:definition "an owl:ObjectProperty relating an ec:Food to an ec:FoodStyle"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasFormat
 ec:hasFormat rdf:type owl:ObjectProperty ;
-             dcterms:description "Pour identifier un format"@fr ,
-                                 "So identifizieren Sie ein Format"@de ,
-                                 "To identify a Format"@en ;
-             rdfs:label "Format"@de ,
-                        "Format"@en ,
-                        "Format"@fr .
+             dcterms:description "The format associated with a resource."@en ;
+             rdfs:label "Format"@en ;
+             skos:definition "an owl:ObjectProperty relating an ec:Resource to an ec:Format"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasFormatId
 ec:hasFormatId rdf:type owl:ObjectProperty ;
-               dcterms:description "An identifier attributed to a Format."@en ,
-                                   "Ein Identifikator, der einem Format zugeordnet ist."@de ,
-                                   "Un identifiant attribué à un format."@fr ;
-               rdfs:label "Format Kennung"@de ,
-                          "Format identifier"@en ,
-                          "Identificateur de format"@fr .
+               dcterms:description "An identifier attributed to a Format."@en ;
+               rdfs:label "Format identifier"@en ;
+               skos:definition "an owl:ObjectProperty relating an ec:Format to an ec:Identifier"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasFormatVersionId
 ec:hasFormatVersionId rdf:type owl:ObjectProperty ;
-                      dcterms:description "A version identifier attributed to a Format."@en ,
-                                          "Ein Versionsbezeichner, der einem Format zugeordnet ist."@de ,
-                                          "Un identifiant de version attribué à un format."@fr ;
-                      rdfs:label "Format version identifier"@en ,
-                                 "Identifiant de la version du format"@fr ,
-                                 "Kennung der Formatversion"@de .
+                      dcterms:description "A version identifier attributed to a Format."@en ;
+                      rdfs:label "Format version identifier"@en ;
+                      skos:definition "an owl:ObjectProperty relating an ec:Format to an ec:Identifier"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasGeneration
 ec:hasGeneration rdf:type owl:ObjectProperty ;
-                 dcterms:description "Identifie la génération d'une version d'une ressource, c'est-à-dire master, maître de modification, copie de distribution, etc."@fr ,
-                                     "Identifies the generation of a version of a resource, i.e. master, edit master, distribution copy, etc."@en ,
-                                     "Identifiziert die Erzeugung einer Version einer Resource, d.h. Master, Master bearbeiten, Verteilungskopie, etc."@de ;
-                 rdfs:label "Generation"@de ,
-                            "Generation"@en ,
-                            "Génération"@fr .
+                 dcterms:description "Identifies the generation of a version of a resource, i.e. master, edit master, distribution copy, etc."@en ;
+                 rdfs:label "Generation"@en ;
+                 skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:MediaResource"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasGenre
 ec:hasGenre rdf:type owl:ObjectProperty ;
-            dcterms:description "Pour définir un Genre/catégorie associé à l'objet EditorialObject."@fr ,
-                                "To define a Genre/category associated with the EditorialObject."@en ,
-                                "Um ein Genre/eine Kategorie zu definieren, das/die dem EditorialObject zugeordnet ist."@de ;
-            rdfs:label "Genre"@de ,
-                       "Genre"@en ,
-                       "Genre"@fr .
+            dcterms:description "The genre or category associated with the EditorialObject."@en ;
+            rdfs:label "Genre"@en ;
+            skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to a skos:Concept"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasGeoBlockingBlacklist
 ec:hasGeoBlockingBlacklist rdf:type owl:ObjectProperty ;
-                           dcterms:description "checking a users IP-address against a blacklist"@en ,
-                                               "vérification de l'adresse IP d'un utilisateur par rapport à une liste noire"@fr ,
-                                               "Überprüfung der IP-Adresse eines Benutzers anhand einer schwarzen Liste"@de ;
-                           rdfs:label "Schwarze Liste für Geoblockierung"@de ,
-                                      "geo-blocking blacklist"@en ,
-                                      "liste noire de géoblocage"@fr .
+                           dcterms:description "Checking a users IP-address against a blacklist."@en ;
+                           rdfs:label "Geo-blocking blacklist"@en ;
+                           skos:definition "an owl:ObjectProperty relating an ec:AccessConditions to a skos:Concept"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasGeoBlockingWhitelist
 ec:hasGeoBlockingWhitelist rdf:type owl:ObjectProperty ;
-                           dcterms:description "checking a users IP-address against a whitelist"@en ,
-                                               "vérification de l'adresse IP d'un utilisateur par rapport à une liste blanche"@fr ,
-                                               "Überprüfung der IP-Adresse eines Benutzers anhand einer Whitelist"@de ;
-                           rdfs:label "Geoblocking-Whitelist"@de ,
-                                      "geo-blocking whitelist"@en ,
-                                      "liste blanche de géo-blocage"@fr .
+                           dcterms:description "Checking a users IP-address against a whitelist."@en ;
+                           rdfs:label "Geo-blocking whitelist"@en ;
+                           skos:definition "an owl:ObjectProperty relating an ec:AccessConditions to a skos:Concept"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasGeoLocation
 ec:hasGeoLocation rdf:type owl:ObjectProperty ;
-                  dcterms:description "Der Standort eines ConsumptionDevice."@de ,
-                                      "L'emplacement d'un ConsumptionDevice."@fr ,
-                                      "The Location of a ConsumptionDevice."@en ;
-                  rdfs:label "Device location"@en ,
-                             "Emplacement du dispositif"@fr ,
-                             "Standort des Geräts"@de .
+                  dcterms:description "The Location of a ConsumptionDevice."@en ;
+                  rdfs:label "Device location"@en ;
+                  skos:definition "an owl:ObjectProperty relating an ec:ConsumptionDeviceProfile to an ec:Location"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasGroupMember
-ec:hasGroupMember rdf:type owl:ObjectProperty .
+ec:hasGroupMember rdf:type owl:ObjectProperty ;
+                  dcterms:description "Relates an Agent to another Agent that is a member of the same group."@en ;
+                  rdfs:label "Group member"@en ;
+                  skos:definition "an owl:ObjectProperty relating an ec:Agent to an ec:Agent"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasIPRRestrictions
 ec:hasIPRRestrictions rdf:type owl:ObjectProperty ;
                       rdfs:subPropertyOf ec:hasRights ;
-                      dcterms:description "Pour exprimer les restrictions en matière de DPI."@fr ,
-                                          "To express IPR Restrictions."@en ,
-                                          "Um IPR-Einschränkungen auszudrücken."@de ;
-                      rdfs:label "IPR restrictions"@en ,
-                                 "IPR-Beschränkungen"@de ,
-                                 "Restrictions DPI"@fr .
+                      dcterms:description "A property that links an asset to its intellectual property restrictions."@en ;
+                      rdfs:label "IPR restrictions"@en ;
+                      skos:definition "an owl:ObjectProperty relating an ec:Asset to an ec:IPRRestrictions"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasIdPicture
 ec:hasIdPicture rdf:type owl:ObjectProperty ;
-                dcterms:description "Fournir un lien vers une photo d'identification."@fr ,
-                                    "To provide a link to an identification picture."@en ,
-                                    "Um einen Link zu einem Identifikationsbild bereitzustellen."@de ;
-                rdfs:label "Bild zur Identifizierung"@de ,
-                           "Identification picture"@en ,
-                           "Photo d'identification"@fr .
+                dcterms:description "A link to an identification picture associated with a person."@en ;
+                rdfs:label "Identification picture"@en ;
+                skos:definition "an owl:ObjectProperty relating an ec:Person to an ec:Picture"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasIdentifier
 ec:hasIdentifier rdf:type owl:ObjectProperty ;
-                 dcterms:description "Pour associer un identifiant à un bien."@fr ,
-                                     "So verknüpfen Sie einen Identifier mit einem Asset."@de ,
-                                     "To associate an Identifier with an Asset."@en ;
-                 rdfs:label "Identifiant"@fr ,
-                            "Identifier"@en ,
-                            "Kennung"@de .
+                 dcterms:description "An identifier associated with an asset."@en ;
+                 rdfs:label "Identifier"@en ;
+                 skos:definition "an owl:ObjectProperty relating an ec:Asset to an ec:Identifier"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasImageCodec
 ec:hasImageCodec rdf:type owl:ObjectProperty ;
-                 dcterms:description "Pour spécifier le codec d'une image."@fr ,
-                                     "To specify the codec of an Image."@en ,
-                                     "Um den Codec eines Bildes anzugeben."@de ;
-                 rdfs:label "Bild-Codec"@de ,
-                            "Codec d'image"@fr ,
-                            "Image codec"@en .
+                 dcterms:description "The codec used for an image."@en ;
+                 rdfs:label "Image codec"@en ;
+                 skos:definition "an owl:ObjectProperty relating an ec:MediaResource or ec:Picture to an ec:ImageCodec"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasImageFormat
 ec:hasImageFormat rdf:type owl:ObjectProperty ;
-                  dcterms:description "Pour spécifier le format d'une image."@fr ,
-                                      "To specify the format of an Image."@en ,
-                                      "Um das Format eines Bildes festzulegen."@de ;
-                  rdfs:label "Bildformat"@de ,
-                             "Format d'image"@fr ,
-                             "Image format"@en .
+                  dcterms:description "The format of an image, such as an image aspect ratio."@en ;
+                  rdfs:label "Image format"@en ;
+                  skos:definition "an owl:ObjectProperty relating an ec:MediaResource or ec:Picture to an ec:ImageFormat"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasInputMediaResource
 ec:hasInputMediaResource rdf:type owl:ObjectProperty ;
-                         dcterms:description "Pour identifier une MediaResource utilisée comme entrée d'un ProductionJob / processus."@fr ,
-                                             "To identify a MediaResource used as an input to a ProductionJob / process."@en ,
-                                             "Zur Identifizierung einer MediaResource, die als Input für einen ProductionJob / Prozess."@de ;
-                         rdfs:label "Entrée des ressources"@fr ,
-                                    "Resource input"@en ,
-                                    "Resourceneinsatz"@de .
+                         dcterms:description "The MediaResource used as an input to a ProductionJob or process."@en ;
+                         rdfs:label "Resource input"@en ;
+                         skos:definition "an owl:ObjectProperty relating an ec:ProductionJob to an ec:MediaResource"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasInputResonance
 ec:hasInputResonance rdf:type owl:ObjectProperty ;
-                     dcterms:description "A set of Resonance data used as input to influence the definition of a better targeted Campaign."@en ,
-                                         "Ein Satz von Resonanzdaten, die als Input für die Definition einer einer besser ausgerichteten Kampagne."@de ,
-                                         "Un ensemble de données de résonance utilisé comme entrée pour influencer la définition d'une d'une campagne mieux ciblée."@fr ;
-                     rdfs:label "Eingangsresonanz"@de ,
-                                "Input resonance"@en ,
-                                "Résonance d'entrée"@fr .
+                     dcterms:description "A set of Resonance data used as input to influence the definition of a better targeted Campaign."@en ;
+                     rdfs:label "Input resonance"@en ;
+                     skos:definition "an owl:ObjectProperty relating an ec:Campaign to an ec:ResonanceCount"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasInputResource
 ec:hasInputResource rdf:type owl:ObjectProperty ;
-                    dcterms:description "Pour identifier une ressource utilisée comme entrée d'un ProductionJob / processus."@fr ,
-                                        "To identify a Resource used as an input to a ProductionJob / process."@en ,
-                                        "Zur Identifizierung einer Resource, die als Input für einen ProductionJob / Prozess verwendet wird."@de ;
-                    rdfs:label "Entrée des ressources"@fr ,
-                               "Resource input"@en ,
-                               "Resourceneinsatz"@de .
+                    dcterms:description "A resource used as an input to a production job or process."@en ;
+                    rdfs:label "Resource input"@en ;
+                    skos:definition "an owl:ObjectProperty relating an ec:ProductionJob to an ec:Resource"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasIssuer
 ec:hasIssuer rdf:type owl:ObjectProperty ;
-             dcterms:description "Pour identifier l'émetteur d'un identifiant."@fr ,
-                                 "To identify the issuer of an identifier."@en ,
-                                 "Zur Identifizierung des Ausstellers eines Identifikators."@de ;
-             rdfs:label "Emittent"@de ,
-                        "Issuer"@en ,
-                        "Émetteur"@fr .
+             dcterms:description "The issuer of an identifier."@en ;
+             rdfs:label "Issuer"@en ;
+             skos:definition "an owl:ObjectProperty relating an ec:Identifier to an ec:Agent"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasJob
 ec:hasJob rdf:type owl:ObjectProperty ;
-          owl:inverseOf ec:isOrderedBy .
+          owl:inverseOf ec:isOrderedBy ;
+          dcterms:description "A property that links a production job to the contract by which it is ordered."@en ;
+          rdfs:label "Has job"@en ;
+          skos:definition "an owl:ObjectProperty relating a ec:Contract to an ec:ProductionJob"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasKeyCareerEvent
 ec:hasKeyCareerEvent rdf:type owl:ObjectProperty ;
-                     dcterms:description "Die wichtigsten Karriereereignisse einer Person zu identifizieren."@de ,
-                                         "Identifier les événements clés de la carrière d'une personne."@fr ,
-                                         "To identify the key career events of a Person."@en ;
-                     rdfs:label "Career event"@en ,
-                                "Karriere-Veranstaltung"@de ,
-                                "Événement de carrière"@fr .
+                     dcterms:description "The key career events associated with a person."@en ;
+                     rdfs:label "Career event"@en ;
+                     skos:definition "an owl:ObjectProperty relating an ec:Person to an ec:KeyCareerEvent"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasKeyPersonalEvent
 ec:hasKeyPersonalEvent rdf:type owl:ObjectProperty ;
-                       dcterms:description "Identifier les événements personnels clés d'une personne."@fr ,
-                                           "To identify the key personal events of a Person."@en ,
-                                           "Um die wichtigsten persönlichen Ereignisse einer Person zu identifizieren."@de ;
-                       rdfs:label "Personal event"@en ,
-                                  "Persönliches Ereignis"@de ,
-                                  "Événement personnel"@fr .
+                       dcterms:description "The key personal events associated with a Person."@en ;
+                       rdfs:label "Personal event"@en ;
+                       skos:definition "an owl:ObjectProperty relating an ec:Person to an ec:KeyPersonalEvent"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasKeyword
 ec:hasKeyword rdf:type owl:ObjectProperty ;
-              dcterms:description "Pour associer un concept, une phrase descriptive ou un mot-clé qui spécifie le sujet de l'EditorialObject."@fr ,
-                                  "To associate a concept, descriptive phrase or Keyword that specifies the topic of the EditorialObject."@en ,
-                                  "Um ein Konzept, eine beschreibende Phrase oder ein Schlüsselwort zuzuordnen, das das Thema des EditorialObjects angibt."@de ;
-              rdfs:label "Keyword"@en ,
-                         "Mot-clé"@fr ,
-                         "Schlüsselwort"@de .
+              dcterms:description "Associates a concept, descriptive phrase, or keyword that specifies the topic of an editorial object."@en ;
+              rdfs:label "Keyword"@en ;
+              skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Keyword"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasLanguage
 ec:hasLanguage rdf:type owl:ObjectProperty ;
-               dcterms:description "Pour associer une langue à un actif. Un vocabulaire contrôlé basé sur le BCP 47 est recommandé. Cette propriété peut également être utilisée pour identifier la présence d'une langue des signes (RFC 5646). Par héritage, la propriété hasLanguage s'applique indifféremment aux niveaux MediaResource / Fragment / Piste aux niveaux desquels l'usage est défini. Les meilleures pratiques recommandent de d'utiliser le meilleur niveau de granularité possible pour décrire l'utilisation de la langue dans une ressource multimédia, y compris au niveau des fragments. MediaResource, y compris aux niveaux Fragment et Track."@fr ,
-                                   "So verknüpfen Sie eine Sprache mit einem Asset. Es wird ein kontrolliertes Vokabular auf der Grundlage von BCP 47 empfohlen. Diese Eigenschaft kann auch verwendet werden, um das Vorhandensein von Zeichensprache zu identifizieren (RFC 5646). Durch Vererbung gilt die Eigenschaft hasLanguage gleichgültig auf den Ebenen MediaResource / Fragment / Track-Ebene, auf der die Verwendung definiert wird. Die beste Praxis empfiehlt, dass die bestmögliche Granularität zu verwenden, um die Verwendung der Sprache innerhalb einer MediaResource zu beschreiben, auch auf Fragment- und Trackebene."@de ,
-                                   "To associate a Language to an Asset. A controlled vocabulary based on BCP 47 is recommended. This property can also be used to identify the presence of sign language (RFC 5646). By inheritance, the hasLanguage property applies indifferently at the MediaResource / Fragment / Track levels at which the usage is being defined. Best practice recommends to use to best possible level of granularity fo describe the usage of language within a MediaResource including at Fragment and Track levels."@en ;
-               rdfs:label "Language"@en ,
-                          "Langue"@fr ,
-                          "Sprache"@de .
+               dcterms:description "The language associated with an editorial object. A controlled vocabulary based on BCP 47 is recommended. This property can also be used to indicate the presence of sign language (RFC 5646). By inheritance, it applies at the MediaResource, Fragment, and Track levels where language usage is defined. Best practice is to use the most specific level of granularity possible to describe language usage within a MediaResource, including Fragment and Track levels."@en ;
+               rdfs:label "Language"@en ;
+               skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Language"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasLicensing
 ec:hasLicensing rdf:type owl:ObjectProperty ;
                 rdfs:subPropertyOf ec:hasRights ;
-                dcterms:description "Pour exprimer l'autorisation."@fr ,
-                                    "To express Licensing."@en ,
-                                    "Um die Lizenzierung auszudrücken."@de ;
-                rdfs:label "Licences"@fr ,
-                           "Licensing"@en ,
-                           "Lizenzierung"@de .
+                dcterms:description "Links an asset to the licensing conditions that apply to it."@en ;
+                rdfs:label "Licensing"@en ;
+                skos:definition "an owl:ObjectProperty relating an ec:Asset to an ec:Licensing"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasLocation
 ec:hasLocation rdf:type owl:ObjectProperty ;
-               dcterms:description "A location associated with the object or concept"@en ,
-                                   "Ein Ort, der mit dem Objekt oder Gegenstand verbunden ist"@de ,
-                                   "Un emplacement associé à l'objet ou au concept."@fr ;
+               dcterms:description "A location associated with the object or concept."@en ;
                rdfs:example "The Location where content has been captured."@en ;
-               rdfs:label "Emplacement"@fr ,
-                          "Location"@en ,
-                          "Standort"@de .
+               rdfs:label "Location"@en ;
+               skos:definition "an owl:ObjectProperty relating an ec:Annotation to an ec:Location"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasLocationCode
 ec:hasLocationCode rdf:type owl:ObjectProperty ;
-                   dcterms:description "Pour donner le code d'un emplacement."@fr ,
-                                       "To give the code of a Location."@en ,
-                                       "Um den Code eines Ortes anzugeben."@de ;
-                   rdfs:label "Code de localisation"@fr ,
-                              "Locationcode"@en ,
-                              "Standortcode"@de .
+                   dcterms:description "To give the code of a Location."@en ;
+                   rdfs:label "Locationcode"@en ;
+                   skos:definition "an owl:ObjectProperty relating an ec:Location to an ec:LocationCode"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasLocationPicture
 ec:hasLocationPicture rdf:type owl:ObjectProperty ;
-                      dcterms:description "A picture associated with a Location."@en ,
-                                          "Ein Bild, das mit einem Ort verbunden ist."@de ,
-                                          "Une image associée à un emplacement."@fr ;
-                      rdfs:label "Bild"@de ,
-                                 "Photo"@fr ,
-                                 "Picture"@en .
+                      dcterms:description "A picture associated with a Location."@en ;
+                      rdfs:label "Picture"@en ;
+                      skos:definition "an owl:ObjectProperty relating an ec:Location to an ec:Picture"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasLocator
 ec:hasLocator rdf:type owl:ObjectProperty ;
-              dcterms:description "A locator from where the Resource can be accessed."@en ,
-                                  "Ein Locator, von dem aus auf die Resource zugegriffen werden kann."@de ,
-                                  "Un localisateur à partir duquel la ressource est accessible."@fr ;
-              rdfs:label "Localisateur"@fr ,
-                         "Locator"@de ,
-                         "Locator"@en .
+              dcterms:description "A locator from where the Resource can be accessed."@en ;
+              rdfs:label "Locator"@en ;
+              skos:definition "an owl:ObjectProperty relating an ec:Resource to an ec:Locator"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasLogo
 ec:hasLogo rdf:type owl:ObjectProperty ;
-           dcterms:description "Les logos peuvent être utilisés dans une variété de contextes. Le logo peut être associé à une organisation, un service ou un canal de publication."@fr ,
-                               "Logos can be used in a variety of contexts. Logo can be associated with an Organisation or a Service or a PublicationChannel."@en ,
-                               "Logos können in einer Vielzahl von Kontexten verwendet werden. Ein Logo kann mit einer Organisation, einem Dienst oder einem Publikationskanal verbunden sein."@de ,
-                               "Pour fournir un lien vers un logo"@fr ,
-                               "So erstellen Sie einen Link zu einem Logo"@de ,
-                               "To provide a link to a Logo"@en ;
-           rdfs:label "Lien vers le logo"@fr ,
-                      "Link to logo"@en ,
-                      "Link zum Logo"@de ,
-                      "Logo"@de ,
-                      "Logo"@en ,
-                      "Logo"@fr .
+           dcterms:description "A link to a logo representing an organisation, award, brand, publication platform, publication channel, publication service, or rating."@en ;
+           rdfs:label "Logo"@en ;
+           skos:definition "an owl:ObjectProperty relating an ec:Award, ec:Costume, ec:MarketingBrand, ec:Organisation, ec:PublicationChannel, ec:PublicationPlatform, ec:PublicationService, or ec:Rating to an ec:Logo"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasManifestation
 ec:hasManifestation rdf:type owl:ObjectProperty ;
-                    dcterms:description "A manifestation is the physical embodiment of work e.g. a tape, a file..."@en ,
-                                        "Eine Manifestation ist die physische Verkörperung der Arbeit, z. B. ein Band, eine Datei..."@de ,
-                                        "Une manifestation est l'incarnation physique du travail, par exemple une bande, un fichier..."@fr ;
-                    rdfs:label "Manifestation"@de ,
-                               "Manifestation"@en ,
-                               "Manifestation"@fr .
+                    dcterms:description "A manifestation is the physical embodiment of work e.g. a tape, a file..."@en ;
+                    rdfs:label "Manifestation"@en ;
+                    skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Resource"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasMaster
 ec:hasMaster rdf:type owl:ObjectProperty ;
              owl:inverseOf ec:isMasterOf ;
-             dcterms:description "Pour identifier le maître d'une ressource"@fr ,
-                                 "So identifizieren Sie den Master einer Resource"@de ,
-                                 "To identify the master of a Resource"@en ;
-             rdfs:label "Master"@en ,
-                        "Maître"@fr ,
-                        "Meister"@de .
+             dcterms:description "The master associated with a media resource."@en ;
+             rdfs:label "Master"@en ;
+             skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:MediaResource"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasMeasurementAgent
 ec:hasMeasurementAgent rdf:type owl:ObjectProperty ;
-                       dcterms:description "Der Agent, der Daten analysiert, um eine Resonanz zu definieren."@de ,
-                                           "L'agent qui analyse les données pour définir une résonance."@fr ,
-                                           "The Agent who analyses data to define a Resonance."@en ;
-                       rdfs:label "Gemessen an"@de ,
-                                  "Measured by"@en ,
-                                  "Mesuré par"@fr .
+                       dcterms:description "The Agent who analyses data to define a Resonance."@en ;
+                       rdfs:label "Measured by"@en ;
+                       skos:definition "an owl:ObjectProperty relating an ec:ResonanceCount to an ec:Agent"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasMediaFragment
 ec:hasMediaFragment rdf:type owl:ObjectProperty ;
                     owl:inverseOf ec:isMediaFragmentOf ;
-                    dcterms:description "Pour définir la relation avec les MediaFragments au sein d'une MediaResource."@fr ,
-                                        "So definieren Sie die Beziehung zu MediaFragmenten innerhalb einer MediaResource zu definieren."@de ,
-                                        "To define relation to MediaFragments withiin a MediaResource."@en ;
-                    rdfs:label "Fragment"@de ,
-                               "Fragment"@en ,
-                               "Fragment"@fr .
+                    dcterms:description "Relates a media resource to a media fragment contained within it."@en ;
+                    rdfs:label "Fragment"@en ;
+                    skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:MediaFragment"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasMedium
 ec:hasMedium rdf:type owl:ObjectProperty ;
              rdfs:subPropertyOf ec:hasFormat ;
-             dcterms:description "Pour spécifier le support sur lequel la ressource est disponible."@fr ,
-                                 "To specify the medium on which the Resource is available."@en ,
-                                 "Zur Angabe des Mediums, auf dem die Resource verfügbar ist."@de ;
-             rdfs:label "Medium"@de ,
-                        "Medium"@en ,
-                        "Moyen"@fr .
+             dcterms:description "The medium on which the resource is available."@en ;
+             rdfs:label "Medium"@en ;
+             skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:Medium"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasMember
 ec:hasMember rdf:type owl:ObjectProperty ;
              owl:inverseOf ec:isMemberOf ;
-             dcterms:description "Pour établir une relation de groupe/collection entre les EditorialObjects."@fr ,
-                                 "To establish group/collection relationship between EditorialObjects."@en ,
-                                 "Um eine Gruppen-/Sammlungsbeziehung zwischen EditorialObjects herzustellen."@de ;
-             rdfs:label "Member."@en ,
-                        "Membre."@fr ,
-                        "Mitglied."@de .
+             dcterms:description "To establish group/collection relationship between EditorialObjects."@en ;
+             rdfs:label "Member"@en ;
+             skos:definition "an owl:ObjectProperty relating an ec:EditorialGroup to an ec:EditorialObject"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasMemberAudience
 ec:hasMemberAudience rdf:type owl:ObjectProperty ;
-                     dcterms:description "Pour identifier un membre de l'audience de (inclus dans) l'actuel an groupe d'audience."@fr ,
-                                         "So identifizieren Sie ein Mitglied der (in der) aktuellen an Zuschauergruppe."@de ,
-                                         "To identify an Audience member of (included in) the current an Audience group."@en ;
-                     rdfs:label "Member audience"@en ,
-                                "Mitglied Publikum"@de ,
-                                "Public de membres"@fr .
+                     dcterms:description "An audience member included in the current audience group."@en ;
+                     rdfs:label "Member audience"@en ;
+                     skos:definition "an owl:ObjectProperty relating an ec:AudienceGroup to an ec:AudienceMember"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasMetadataTrack
 ec:hasMetadataTrack rdf:type owl:ObjectProperty ;
-                    dcterms:description "Pour identifier les MetadataTracks dans la ressource."@fr ,
-                                        "So identifizieren Sie MetadataTracks in der Resource."@de ,
-                                        "To identify MetadataTracks in the Resource."@en ;
-                    rdfs:label "Metadata track"@en ,
-                               "Metadaten Spur"@de ,
-                               "Piste de métadonnées"@fr .
+                    dcterms:description "The property that identifies the metadata track associated with a media resource."@en ;
+                    rdfs:label "Metadata track"@en ;
+                    skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:MetadataTrack"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasMimeType
 ec:hasMimeType rdf:type owl:ObjectProperty ;
                rdfs:subPropertyOf ec:hasFormat ;
-               dcterms:description "Pour spécifier le type Mime d'une ressource."@fr ,
-                                   "To specify the Mime type of a Resource."@en ,
-                                   "Um den Mime-Typ einer Resource anzugeben."@de ;
-               rdfs:label "Mime type"@en ,
-                          "Mime-Typ"@de ,
-                          "Type Mime"@fr .
+               dcterms:description "The MIME type of a media resource."@en ;
+               rdfs:label "Mime type"@en ;
+               skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:MimeType"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasObjectType
 ec:hasObjectType rdf:type owl:ObjectProperty ;
-                 dcterms:description "Die Art oder das Genre der Resource."@de ,
-                                     "Le type ou le genre de la ressource."@fr ,
-                                     "The kind or genre of the resource."@en ;
-                 rdfs:label "Typ"@de ,
-                            "type"@en ,
-                            "type"@fr .
+                 dcterms:description "The kind or genre of the resource."@en ;
+                 rdfs:label "Type"@en ;
+                 skos:definition "an owl:ObjectProperty relating a resource to a skos:Concept classifying its kind or genre"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasOrganisationStaff
 ec:hasOrganisationStaff rdf:type owl:ObjectProperty ;
-                        dcterms:description "Pour identifier les membres du personnel d'une organisation."@fr ,
-                                            "To identify Staff members in an Organisation."@en ,
-                                            "Zur Identifizierung von Mitarbeitern in einer Organisation."@de ;
-                        rdfs:label "Personal"@de ,
-                                   "Personnel"@fr ,
-                                   "Staff"@en .
+                        dcterms:description "The staff members in an organisation."@en ;
+                        rdfs:label "Staff"@en ;
+                        skos:definition "an owl:ObjectProperty relating an ec:Organisation to an ec:StaffMember"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasOriginalLanguage
 ec:hasOriginalLanguage rdf:type owl:ObjectProperty ;
                        rdfs:subPropertyOf ec:hasLanguage ;
-                       dcterms:description "Pour définir la langue d'origine d'un actif."@fr ,
-                                           "So definieren Sie die Originalsprache eines Assets."@de ,
-                                           "To define the original language of an Asset."@en ;
-                       rdfs:label "Langue originale"@fr ,
-                                  "Original language"@en ,
-                                  "Originalsprache"@de .
+                       dcterms:description "The original language of an editorial object."@en ;
+                       rdfs:label "Original language"@en ;
+                       skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Language"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasOutputEssence
 ec:hasOutputEssence rdf:type owl:ObjectProperty ;
-                    dcterms:description "Pour identifier l'Essence résultant d'un ProductionJob."@fr ,
-                                        "To identify Essence resulting from a ProductionJob."@en ,
-                                        "Um die aus einem ProductionJob resultierende Essenz zu identifizieren."@de ;
-                    rdfs:label "Ausgabe Essenz"@de ,
-                               "Essence de sortie"@fr ,
-                               "Output essence"@en .
+                    dcterms:description "An Essence resulting from a ProductionJob."@en ;
+                    rdfs:label "Output essence"@en ;
+                    skos:definition "an owl:ObjectProperty relating an ec:ProductionJob to an ec:Essence"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasOutputMediaResource
 ec:hasOutputMediaResource rdf:type owl:ObjectProperty ;
-                          dcterms:description "Pour identifier une MediaResource résultant d'un ProductionJob."@fr ,
-                                              "So identifizieren Sie eine MediaResource, die aus einem ProductionJob."@de ,
-                                              "To identify a MediaResource resulting from a ProductionJob."@en ;
-                          rdfs:label "MedienResource ausgeben"@de ,
-                                     "Output media resource"@en ,
-                                     "Resource média de sortie"@fr .
+                          dcterms:description "A media resource resulting from a production job."@en ;
+                          rdfs:label "Output media resource"@en ;
+                          skos:definition "an owl:ObjectProperty relating an ec:ProductionJob to an ec:MediaResource"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasOutputResource
 ec:hasOutputResource rdf:type owl:ObjectProperty ;
-                     dcterms:description "Pour identifier une ressource résultant d'un ProductionJob."@fr ,
-                                         "To identify a Resource resulting from a ProductionJob."@en ,
-                                         "Um eine Resource zu identifizieren, die aus einem ProduktionsJob."@de ;
-                     rdfs:label "Output resource"@en ,
-                                "Resource ausgeben"@de ,
-                                "Resource de sortie"@fr .
+                     dcterms:description "A resource resulting from a ProductionJob."@en ;
+                     rdfs:label "Output resource"@en ;
+                     skos:definition "an owl:ObjectProperty relating an ec:ProductionJob to an ec:Resource"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasOwner
 ec:hasOwner rdf:type owl:ObjectProperty ;
-            dcterms:description "Pour identifier le propriétaire d'un animal."@fr ,
-                                "To identify the owner of an animal."@en ,
-                                "Um den Besitzer eines Tieres zu identifizieren."@de ;
-            rdfs:label "Animal owner"@en ,
-                       "Propriétaire d'animaux"@fr ,
-                       "Tierhalter"@de .
+            dcterms:description "The owner of an animal."@en ;
+            rdfs:label "Animal owner"@en ;
+            skos:definition "an owl:ObjectProperty relating an ec:Animal to an ec:Agent"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasParentEditorialObject
 ec:hasParentEditorialObject rdf:type owl:ObjectProperty ;
-                            dcterms:description "Pour lier un ÉditorialOject à un parent."@fr ,
-                                                "To link a EditorialObject to a parent."@en ,
-                                                "Um ein EditorialObject mit einem Parent zu verknüpfen."@de ;
-                            rdfs:label "Objet éditorial parent"@fr ,
-                                       "Parent editorial object"@en ,
-                                       "Übergeordnetes redaktionelles Objekt"@de .
+                            dcterms:description "Links an EditorialObject to its parent editorial object."@en ;
+                            rdfs:label "Parent editorial object"@en ;
+                            skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:EditorialObject"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasParentEditorialSegment
 ec:hasParentEditorialSegment rdf:type owl:ObjectProperty ;
-                             rdfs:label "a un segment éditorial parent"@fr ,
-                                        "has parent editorial segment"@en ,
-                                        "hat ein übergeordnetes redaktionelles Segment"@de .
+                             dcterms:description "Links an editorial segment to its parent editorial segment."@en ;
+                             rdfs:label "Has parent editorial segment"@en ;
+                             skos:definition "an owl:ObjectProperty relating an ec:EditorialSegment to an ec:EditorialSegment"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasParentMediaResource
 ec:hasParentMediaResource rdf:type owl:ObjectProperty ;
-                          dcterms:description "Pour lier une MediaResource à un parent."@fr ,
-                                              "To link a MediaResource to a parent."@en ,
-                                              "Um eine MediaResource mit einer übergeordneten Resource zu verknüpfen."@de ;
-                          rdfs:label "Parent resource"@en ,
-                                     "Resource für Eltern"@de ,
-                                     "Resource pour les parents"@fr .
+                          dcterms:description "Links a media resource to its parent media resource."@en ;
+                          rdfs:label "Parent resource"@en ;
+                          skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:MediaResource"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasPart
 ec:hasPart rdf:type owl:ObjectProperty ;
            owl:inverseOf ec:isPartOf ;
-           dcterms:description "Pour définir des parties (segments, fragments, plans, etc.) au sein d'un EditorialObject."@fr ,
-                               "To define Parts (segments, fragments, shots, etc.) within an EditorialObject."@en ,
-                               "Zur Definition von Teilen (Segmente, Fragmente, Aufnahmen usw.) innerhalb eines EditorialObjects."@de ;
-           rdfs:label "Part"@en ,
-                      "Partie"@fr ,
-                      "Teil"@de .
+           dcterms:description "Defines Parts (segments, fragments, shots, etc.) within an EditorialObject."@en ;
+           rdfs:label "Part"@en ;
+           skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:EditorialSegment"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasParticipatingAgent
 ec:hasParticipatingAgent rdf:type owl:ObjectProperty ;
-                         dcterms:description "Pour identifier les agents participants."@fr ,
-                                             "To identify participating Agents."@en ,
-                                             "Um teilnehmende Agenten zu identifizieren."@de ;
-                         rdfs:label "Agent participant"@fr ,
-                                    "Beteiligter Agent"@de ,
-                                    "Participating agent"@en .
+                         dcterms:description "Identifies the agent participating in the asset."@en ;
+                         rdfs:label "Participating agent"@en ;
+                         skos:definition "an owl:ObjectProperty relating an ec:Asset to an ec:Agent"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasPictogram
 ec:hasPictogram rdf:type owl:ObjectProperty ;
-                dcterms:description "Für eine visuelle Darstellung eines Ratings / AufdienceRating / AudienceLevel."@de ,
-                                    "Pour fournir une représentation visuelle d'un Rating / AufdienceRating / AudienceLevel."@fr ,
-                                    "To provide a visual representation of a Rating / AufdienceRating / AudienceLevel."@en ;
-                rdfs:label "Pictogram"@en ,
-                           "Pictogramme"@fr ,
-                           "Piktogramm"@de .
+                dcterms:description "A visual representation used for a Rating, AudienceRating, or AudienceLevel."@en ;
+                rdfs:label "Pictogram"@en ;
+                skos:definition "an owl:ObjectProperty relating an ec:Rating to an ec:Picture"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasPlaceOfBirth
 ec:hasPlaceOfBirth rdf:type owl:ObjectProperty ;
-                   dcterms:description "Pour identifier le lieu de naissance."@fr ,
-                                       "To identify the place of birth."@en ,
-                                       "Zur Identifizierung des Geburtsortes."@de ;
-                   rdfs:label "Birth place"@en ,
-                              "Geburtsort"@de ,
-                              "Lieu de naissance"@fr .
+                   dcterms:description "The place where a person was born."@en ;
+                   rdfs:label "Birth place"@en ;
+                   skos:definition "an owl:ObjectProperty relating an ec:Person to an ec:Location"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasPlaceOfDeath
 ec:hasPlaceOfDeath rdf:type owl:ObjectProperty ;
-                   dcterms:description "Pour identifier le lieu du décès."@fr ,
-                                       "To identify the place of death."@en ,
-                                       "Um den Ort des Todes zu identifizieren."@de ;
-                   rdfs:label "Death place"@en ,
-                              "Lieu de décès"@fr ,
-                              "Ort des Todes"@de .
+                   dcterms:description "The place where a person died."@en ;
+                   rdfs:label "Death place"@en ;
+                   skos:definition "an owl:ObjectProperty relating an ec:Person to an ec:Location"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasPost
 ec:hasPost rdf:type owl:ObjectProperty ;
-           rdfs:label "a un poste"@fr ,
-                      "has post"@en ,
-                      "hat Post"@de .
+           dcterms:description "Connects an item to a post it is associated with or incorporated into."@en ;
+           rdfs:label "Has post"@en ;
+           skos:definition "an owl:ObjectProperty relating an ec:Item to an ec:Post"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasPreviousRelated
 ec:hasPreviousRelated rdf:type owl:ObjectProperty ;
-                      dcterms:description "Pour identifier un ProductionJob associé précédent"@fr ,
-                                          "So identifizieren Sie einen früheren zugehörigen ProductionJob"@de ,
-                                          "To identify a previous associated ProductionJob"@en ;
-                      rdfs:label "Emploi précédent"@fr ,
-                                 "Previous job"@en ,
-                                 "Vorheriger Job"@de .
+                      dcterms:description "The previous associated ProductionJob."@en ;
+                      rdfs:label "Previous job"@en ;
+                      skos:definition "an owl:ObjectProperty relating an ec:ProductionJob to an ec:ProductionJob"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasPriority
 ec:hasPriority rdf:type owl:ObjectProperty ;
-               dcterms:description "Pour définir la priorité associée à une règle."@fr ,
-                                   "To define the priority associated with a Rule."@en ,
-                                   "Um die Priorität einer Regel zu definieren."@de ;
-               rdfs:label "Priorität der Regel"@de ,
-                          "Priorité de la règle"@fr ,
-                          "Rule priority"@en .
+               dcterms:description "The priority associated with a Rule."@en ;
+               rdfs:label "Rule priority"@en ;
+               skos:definition "an owl:ObjectProperty relating an ec:Rule to a skos:Concept"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasProducer
 ec:hasProducer rdf:type owl:ObjectProperty ;
-               dcterms:description "Pour identifier un agent impliqué dans la production de la ressource ou de l'objet éditorial."@fr ,
-                                   "To identify an Agent involved in the production of the Resource or EditorialObject."@en ,
-                                   "Zur Identifizierung eines Agenten, der an der Produktion der Resource oder des Redaktionsobjekts beteiligt ist."@de ;
-               rdfs:label "Producer"@en ,
-                          "Producteur"@fr ,
-                          "Produzent"@de .
+               dcterms:description "The Agent involved in the production of the Resource or EditorialObject."@en ;
+               rdfs:label "Producer"@en ;
+               skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Agent"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasProductionContract
 ec:hasProductionContract rdf:type owl:ObjectProperty ;
-                         dcterms:description "Pour identifier les Contarcts associés à un ordre de production."@fr ,
-                                             "To identify Contarcts associated witha ProductionOrder."@en ,
-                                             "Zur Identifizierung von Kontakten, die mit einem ProduktionsAuftrag."@de ;
-                         rdfs:label "Contract"@en ,
-                                    "Contrat"@fr ,
-                                    "Vertrag"@de .
+                         dcterms:description "This property links a production order to the contracts associated with it."@en ;
+                         rdfs:label "Contract"@en ;
+                         skos:definition "an owl:ObjectProperty relating an ec:ProductionOrder to an ec:Contract"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasProductionDevice
 ec:hasProductionDevice rdf:type owl:ObjectProperty ;
-                       dcterms:description "Pour identifier un ProductionDevice associé à une MediaResource."@fr ,
-                                           "To identify a ProductionDevice associated with a MediaResource."@en ,
-                                           "Um ein ProductionDevice zu identifizieren, das mit einer MediaResource."@de ;
-                       rdfs:label "Dispositif de production"@fr ,
-                                  "Production device"@en ,
-                                  "Produktionsgerät"@de .
+                       dcterms:description "A production device associated with a media resource."@en ;
+                       rdfs:label "Production device"@en ;
+                       skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:ProductionDevice"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasProductionDeviceOnStagePosition
 ec:hasProductionDeviceOnStagePosition rdf:type owl:ObjectProperty ;
-                                      dcterms:description "Pour identifier la OnStagePosition d'un ProductionDevice sur la scène."@fr ,
-                                                          "So identifizieren Sie die OnStagePosition eines ProductionDevice auf Bühne."@de ,
-                                                          "To identify the OnStagePosition of a ProductionDevice on Stage."@en ;
-                                      rdfs:label "Dispositif de production"@fr ,
-                                                 "Production device"@en ,
-                                                 "Produktionsgerät"@de .
+                                      dcterms:description "The OnStagePosition of a ProductionDevice on Stage."@en ;
+                                      rdfs:label "Production device"@en ;
+                                      skos:definition "an owl:ObjectProperty relating an ec:ProductionDevice to an ec:OnStagePosition"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasProductionJobEvent
 ec:hasProductionJobEvent rdf:type owl:ObjectProperty ;
-                         dcterms:description "Pour définir un événement associé à un ProductionJob."@fr ,
-                                             "So definieren Sie ein Ereignis, das mit einem ProductionJob verbunden ist."@de ,
-                                             "To define an Event associated with a ProductionJob."@en ;
-                         rdfs:label "Production job event"@en ,
-                                    "Produktion Job Event"@de ,
-                                    "Événement de travail de production"@fr .
+                         dcterms:description "An event associated with a production job."@en ;
+                         rdfs:label "Production job event"@en ;
+                         skos:definition "an owl:ObjectProperty relating an ec:ProductionJob to an ec:Event"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasProductionJobLocation
 ec:hasProductionJobLocation rdf:type owl:ObjectProperty ;
-                            dcterms:description "Pour définir un lieu où un ProductionJob a eu ou est prévu d'avoir lieu. de se dérouler."@fr ,
-                                                "To define a Location where a ProductionJob has taken or is scheduled to take place."@en ,
-                                                "Um einen Ort zu definieren, an dem ein ProductionJob stattgefunden hat oder geplant ist stattfinden soll."@de ;
-                            rdfs:label "Arbeitsort Produktion"@de ,
-                                       "Lieu de travail de la production"@fr ,
-                                       "Production job location"@en .
+                            dcterms:description "The location where a ProductionJob has taken place or is scheduled to take place."@en ;
+                            rdfs:label "Production job location"@en ;
+                            skos:definition "an owl:ObjectProperty relating an ec:ProductionJob to an ec:Location"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasProgramme
 ec:hasProgramme rdf:type owl:ObjectProperty ;
-                rdfs:label "a un programme"@fr ,
-                           "has programme"@en ,
-                           "hat Programm"@de .
+                dcterms:description "Relates a resource to a programme it has or includes as part of its content. It is used for editorial extras, items, and scenes that are associated with a programme."@en ;
+                rdfs:label "Has programme"@en ;
+                skos:definition "an owl:ObjectProperty relating an ec:EditorialExtra, ec:Item or ec:Scene to an ec:Programme"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasPromotion
 ec:hasPromotion rdf:type owl:ObjectProperty ;
-                rdfs:label "a la promotion"@fr ,
-                           "has promotion"@en ,
-                           "hat Förderung"@de .
+                dcterms:description "A reminder that refers to a previous promotion and helps remind the consumer of the advertised object."@en ;
+                rdfs:label "Has promotion"@en ;
+                skos:definition "an owl:ObjectProperty relating an ec:Reminder to an ec:Promotion"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasProvenance
 ec:hasProvenance rdf:type owl:ObjectProperty ;
                  owl:inverseOf ec:hasProvenanceTarget ;
-                 dcterms:description "Bereich: String, anyURI oder Konzept."@de ,
-                                     "Die Person oder Firma, die die Metadaten zur Verfügung stellt."@de ,
-                                     "La personne ou l'entreprise qui fournit les métadonnées."@fr ,
-                                     "Plage : chaîne, anyURI ou Concept."@fr ,
-                                     "The person or company that is providing the metadata."@en ,
-                                     "To associate information on Provenance to an EBUCore class. Range: string, anyURI or Concept."@en ;
-                 rdfs:label "Provenance"@en ,
-                            "Provenance"@fr ,
-                            "Provenienz"@de .
+                 dcterms:description "The person or company providing the metadata."@en ;
+                 rdfs:label "Provenance"@en ;
+                 skos:definition "an owl:ObjectProperty relating an ec:Provenance to an owl:Thing"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasProvenanceTarget
 ec:hasProvenanceTarget rdf:type owl:ObjectProperty ;
-                       dcterms:description "Die Instanz eines Objekts, das von der Provenance bezogen wird."@de ,
-                                           "L'instance d'un objet sourcé par la Provenance."@fr ,
-                                           "The instance of an object sourced by the Provenance."@en ;
-                       rdfs:label "Cible de provenance"@fr ,
-                                  "Provenance target"@en ,
-                                  "Ziel Provenienz"@de .
+                       dcterms:description "The instance of an object sourced by the Provenance."@en ;
+                       rdfs:label "Provenance target"@en ;
+                       skos:definition "an owl:ObjectProperty relating an ec:Provenance to an owl:Thing"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasPublication
 ec:hasPublication rdf:type owl:ObjectProperty ;
                   owl:inverseOf ec:publishes ;
-                  dcterms:description "Pour associer un PublicationEvent à un EditorialObject."@fr ,
-                                      "So assoziieren Sie ein PublicationEvent mit einem EditorialObject."@de ,
-                                      "To associatre a PublicationEvent with an EditorialObject."@en ;
-                  rdfs:label "Ereignis der Veröffentlichung"@de ,
-                             "Publication event"@en ,
-                             "Événement de publication"@fr .
+                  dcterms:description "The PublicationEvent in which an EditorialObject is made available for consumption."@en ;
+                  rdfs:label "Publication event"@en ;
+                  skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:PublicationEvent"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasPublicationChannel
 ec:hasPublicationChannel rdf:type owl:ObjectProperty ;
-                         rdfs:label "a un canal de publication"@fr ,
-                                    "has publication channel"@en ,
-                                    "hat Publikationskanal"@de .
+                         dcterms:description "An object property that links a publication event or publication platform to a publication channel used for technical access to a service."@en ;
+                         rdfs:label "Has publication channel"@en ;
+                         skos:definition "an owl:ObjectProperty relating an ec:PublicationEvent or ec:PublicationPlatform to an ec:PublicationChannel"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasPublicationEvent
 ec:hasPublicationEvent rdf:type owl:ObjectProperty ;
-                       dcterms:description "Pour associer les PublicationEvents à canaux de publication ou en tant qu'éléments d'une PublicationHistory ou d'une PublicationPlanning."@fr ,
-                                           "To associate PublicationEvents with PublicationChannels or as elements of a PublicationHistory or PublicationPlanning."@en ,
-                                           "Um PublicationEvents zu verknüpfen mit PublicationChannels oder als Elemente einer PublicationHistory oder PublicationPlanning."@de ;
-                       rdfs:label "Ereignis der Veröffentlichung"@de ,
-                                  "Publication event"@en ,
-                                  "Événement de publication"@fr .
+                       dcterms:description "Associates publication events with publication channels, publication histories, or publication plans."@en ;
+                       rdfs:label "Publication event"@en ;
+                       skos:definition "an owl:ObjectProperty relating an ec:PublicationEvent to an ec:PublicationEvent"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasPublicationHistory
 ec:hasPublicationHistory rdf:type owl:ObjectProperty ;
-                         dcterms:description "Pour fournir l'historique de publication d'un EditorailObject ou d'un MediaResource."@fr ,
-                                             "To provide the history of publication of an EditorailObject or MediaResource."@en ,
-                                             "Um den Verlauf der Veröffentlichung eines EditorailObjects oder einer MediaResource anzuzeigen."@de ;
-                         rdfs:label "Geschichte der Veröffentlichung"@de ,
-                                    "Historique de la publication"@fr ,
-                                    "Publication history"@en .
+                         dcterms:description "The publication history of an EditorialObject or MediaResource."@en ;
+                         rdfs:label "Publication history"@en ;
+                         skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:PublicationHistory"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasPublicationMedium
 ec:hasPublicationMedium rdf:type owl:ObjectProperty ;
-                        dcterms:description "Pour identifier le support de publication."@fr ,
-                                            "To identify the publication medium."@en ,
-                                            "Um das Publikationsmedium zu identifizieren."@de ;
-                        rdfs:label "Medium der Veröffentlichung"@de ,
-                                   "Publication medium"@en ,
-                                   "Support de publication"@fr .
+                        dcterms:description "The publication medium associated with the publication event."@en ;
+                        rdfs:label "Publication medium"@en ;
+                        skos:definition "an owl:ObjectProperty relating an ec:PublicationEvent to an ec:PublicationMedium"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasPublicationPlan
 ec:hasPublicationPlan rdf:type owl:ObjectProperty ;
-                      dcterms:description "A PublicationPlan associated with a Campaign."@en ,
-                                          "Ein Publikationsplan, der mit einer Kampagne verknüpft ist."@de ,
-                                          "Un PublicationPlan associé à une campagne."@fr ;
-                      rdfs:label "Plan de publication"@fr ,
-                                 "Plan zur Veröffentlichung"@de ,
-                                 "Publication plan"@en .
+                      dcterms:description "A PublicationPlan associated with a Campaign."@en ;
+                      rdfs:label "Publication plan"@en ;
+                      skos:definition "an owl:ObjectProperty relating an ec:Campaign to an ec:PublicationPlan"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasPublicationPlanMember
 ec:hasPublicationPlanMember rdf:type owl:ObjectProperty ;
-                            dcterms:description "Pour identifier un sous-plan d'un plan de publication."@fr ,
-                                                "To identify a subplan of a publication plan."@en ,
-                                                "Um einen Teilplan eines Veröffentlichungsplans zu identifizieren."@de ;
-                            rdfs:label "Mitglied des Veröffentlichungsplans."@de ,
-                                       "Participant au plan de publication."@fr ,
-                                       "Publication plan member."@en .
+                            dcterms:description "Identifies a sub-plan of a publication plan."@en ;
+                            rdfs:label "Publication plan member"@en ;
+                            skos:definition "an owl:ObjectProperty relating an ec:PublicationPlan to an ec:PublicationPlan"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasPublicationPlanStatus
 ec:hasPublicationPlanStatus rdf:type owl:ObjectProperty ;
-                            dcterms:description "Pour fournir un statut concernant le PublicationPlan."@fr ,
-                                                "To provide a status regarding the PublicationPlan."@en ,
-                                                "Um einen Status bezüglich des PublicationPlan zu liefern."@de ;
-                            rdfs:label "PublicationPlan status"@en ,
-                                       "Statut du plan de publication"@fr ,
-                                       "VeröffentlichungPlan Status"@de .
+                            dcterms:description "The status associated with a publication plan."@en ;
+                            rdfs:label "PublicationPlan status"@en ;
+                            skos:definition "an owl:ObjectProperty relating an ec:PublicationPlan to a skos:Collection"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasPublicationRegion
 ec:hasPublicationRegion rdf:type owl:ObjectProperty ;
-                        dcterms:description "Die Region, in der die Veröffentlichung stattfindet."@de ,
-                                            "La région où la publication a lieu."@fr ,
-                                            "The region where the publication takes place."@en ;
-                        rdfs:label "Publication region"@en ,
-                                   "Region der Veröffentlichung"@de ,
-                                   "Région de publication"@fr .
+                        dcterms:description "The region where the publication takes place."@en ;
+                        rdfs:label "Publication region"@en ;
+                        skos:definition "an owl:ObjectProperty relating an ec:PublicationEvent to an ec:Location"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasPublisher
 ec:hasPublisher rdf:type owl:ObjectProperty ;
-                dcterms:description "Pour identifier un agent impliqué dans la publication de l'EditorialObject."@fr ,
-                                    "To identify an Agent involved in the publication of the EditorialObject."@en ,
-                                    "Zur Identifizierung eines Agenten, der an der Veröffentlichung des EditorialObjects beteiligt ist."@de ;
-                rdfs:label "Editeur"@fr ,
-                           "Herausgeber"@de ,
-                           "Publisher"@en .
+                dcterms:description "An agent involved in the publication of an editorial object."@en ;
+                rdfs:label "Publisher"@en ;
+                skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Involvement"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRating
 ec:hasRating rdf:type owl:ObjectProperty ;
-             dcterms:description "Pour identifier la présence de Rating attribué à un EditorialObject."@fr ,
-                                 "To identify the presence of Rating attributed to a EditorialObject."@en ,
-                                 "Um das Vorhandensein von Bewertungen zu identifizieren, die einem EditorialObject zugeordnet sind."@de ;
-             rdfs:label "Bewertung"@de ,
-                        "Classement"@fr ,
-                        "Rating"@en .
+             dcterms:description "The presence of a Rating attributed to an EditorialObject."@en ;
+             rdfs:label "Rating"@en ;
+             skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Rating"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRatingProvider
 ec:hasRatingProvider rdf:type owl:ObjectProperty ;
-                     dcterms:description "Pour identifier un agent qui a fourni un classement."@fr ,
-                                         "To identify an Agent who has provided a Rating."@en ,
-                                         "Zur Identifizierung eines Agenten, der eine Bewertung abgegeben hat."@de ;
-                     rdfs:label "Quelle der Bewertung / Agent"@de ,
-                                "Rating source / agent"@en ,
-                                "Source de notation / agent"@fr .
+                     dcterms:description "An Agent who provided the Rating."@en ;
+                     rdfs:label "Rating source / agent"@en ;
+                     skos:definition "an owl:ObjectProperty relating an ec:Rating to an ec:Agent"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRegionCode
 ec:hasRegionCode rdf:type owl:ObjectProperty ;
-                 dcterms:description "Eine Beschreibung einer bestimmten Region, die mit dem Ort verbunden ist."@de ,
-                                     "Fournir une description d'une région particulière associée à l'emplacement."@fr ,
-                                     "To provide a description of a particular region associated with the Location."@en ;
-                 rdfs:label "Region"@de ,
-                            "Region"@en ,
-                            "Région"@fr .
+                 dcterms:description "A region code associated with a location."@en ;
+                 rdfs:label "Region"@en ;
+                 skos:definition "an owl:ObjectProperty relating an ec:Location to an ec:RegionCode"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRegistration
 ec:hasRegistration rdf:type owl:ObjectProperty ;
-                   dcterms:description "Pour fournir les détails du compte d'un consommateur."@fr ,
-                                       "To provide the Account details of a registered Consumer."@en ,
-                                       "Zur Angabe der Kontodaten eines registrierten Verbrauchers."@de ;
-                   rdfs:label "Anmeldung"@de ,
-                              "Inscription"@fr ,
-                              "Registration"@en .
+                   dcterms:description "The account details of a registered consumer."@en ;
+                   rdfs:label "Registration"@en ;
+                   skos:definition "an owl:ObjectProperty relating an ec:Consumer to an ec:Account"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedAccount
 ec:hasRelatedAccount rdf:type owl:ObjectProperty ,
                               owl:IrreflexiveProperty ;
-                     dcterms:description "Pour lier des comptes connexes."@fr ,
-                                         "To link related Accounts."@en ,
-                                         "Um verwandte Konten zu verknüpfen."@de ;
-                     rdfs:label "Compte connexe"@fr ,
-                                "Related account"@en ,
-                                "Verwandtes Konto"@de .
+                     dcterms:description "Links one account to related accounts."@en ;
+                     rdfs:label "Related account"@en ;
+                     skos:definition "an owl:ObjectProperty relating an ec:Account to an ec:Account"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedAgent
 ec:hasRelatedAgent rdf:type owl:ObjectProperty ;
                    owl:inverseOf ec:isRelatedAgent ;
                    rdf:type owl:IrreflexiveProperty ;
-                   dcterms:description "Pour associer un concept à un agent (par exemple, une personne ou un personnage)."@fr ,
-                                       "To associate a concept with an Agent (e.g. Person or Character)."@en ,
-                                       "Um ein Konzept mit einem Agenten (z.B. einer Person oder einem Charakter) zu verknüpfen."@de ;
-                   rdfs:label "Agent connexe"@fr ,
-                              "Related agent"@en ,
-                              "Verwandter Agent"@de .
+                   dcterms:description "Links an entity to a related Agent, such as a Person or Character."@en ;
+                   rdfs:label "Related agent"@en ;
+                   skos:definition "an owl:ObjectProperty relating an ec:Action to an ec:Agent"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedAnimal
 ec:hasRelatedAnimal rdf:type owl:ObjectProperty ;
-                    dcterms:description "Identifier les animaux associés à un concept"@fr ,
-                                        "Tiere identifizieren, die mit einem Konzept verbunden sind"@de ,
-                                        "To identify animals associate with a concept"@en ;
-                    rdfs:label "Animal apparenté"@fr ,
-                               "Related animal"@en ,
-                               "Verwandtes Tier"@de .
+                    dcterms:description "Animals related to the editorial object or depicted in it."@en ;
+                    rdfs:label "Related animal"@en ;
+                    skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Animal"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedArtefact
 ec:hasRelatedArtefact rdf:type owl:ObjectProperty ;
-                      dcterms:description "Identifier un artefact lié à EditorialObject ou à un concept."@fr ,
-                                          "Identifizieren eines Artefakts mit Bezug zu einem EditorialObject oder einem Konzept"@de ,
-                                          "To identify and Artefact related to EditorialObject or a concept"@en ;
-                      rdfs:label "Artéfact connexe"@fr ,
-                                 "Related artefact"@en ,
-                                 "Verwandtes Artefakt"@de .
+                      dcterms:description "An artefact related to an annotation, asset, event, involvement, or location."@en ;
+                      rdfs:label "Related artefact"@en ;
+                      skos:definition "an owl:ObjectProperty relating an ec:Annotation or ec:Asset, ec:Event, ec:Involvement, or ec:Location to an ec:Artefact"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedAsset
 ec:hasRelatedAsset rdf:type owl:ObjectProperty ,
                             owl:IrreflexiveProperty ;
-                   dcterms:description "Pour identifier les actifs connexes."@fr ,
-                                       "Pour lier les actifs connexes."@fr ,
-                                       "To identify related Assets."@en ,
-                                       "To link related Assets."@en ,
-                                       "Um verwandte Assets zu identifizieren."@de ,
-                                       "Um verwandte Assets zu verlinken."@de ;
-                   rdfs:label "Bien connexe"@fr ,
-                              "Related asset"@en ,
-                              "Verwandter Vermögenswert"@de .
+                   dcterms:description "Links an Asset to another related Asset."@en ;
+                   rdfs:label "Related asset"@en ;
+                   skos:definition "an owl:ObjectProperty relating an ec:Asset to an ec:Asset"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedAudioContent
 ec:hasRelatedAudioContent rdf:type owl:ObjectProperty ,
                                    owl:IrreflexiveProperty ;
-                          dcterms:description "Pour identifier le contenu audio associé"@fr ,
-                                              "So identifizieren Sie verwandte Audioinhalte"@de ,
-                                              "To identify related Audio Content"@en ;
-                          rdfs:label "Audio content"@en ,
-                                     "Audio-Inhalt"@de ,
-                                     "Contenu audio"@fr .
+                          dcterms:description "Related audio content associated with the editorial object."@en ;
+                          rdfs:label "Audio content"@en ;
+                          skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:AudioContent"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedAudioObject
 ec:hasRelatedAudioObject rdf:type owl:ObjectProperty ;
-                         dcterms:description "Pour identifier les objets audio associés"@fr ,
-                                             "To identify related Audio Objects"@en ,
-                                             "Um verwandte Audio-Objekte zu identifizieren"@de ;
-                         rdfs:label "Audio object"@en ,
-                                    "Audio-Objekt"@de ,
-                                    "Objet audio"@fr .
+                         dcterms:description "A property that identifies a related audio object."@en ;
+                         rdfs:label "Audio object"@en ;
+                         skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:AudioObject"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedAudioProgramme
 ec:hasRelatedAudioProgramme rdf:type owl:ObjectProperty ,
                                      owl:IrreflexiveProperty ;
-                            dcterms:description "A related audio programme"@en ,
-                                                "Ein entsprechendes Audioprogramm"@de ,
-                                                "Un programme audio connexe"@fr ;
-                            rdfs:label "Audio Programm"@de ,
-                                       "Audio programme"@en ,
-                                       "Programme audio"@fr .
+                            dcterms:description "A related audio programme."@en ;
+                            rdfs:label "Audio programme"@en ;
+                            skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:AudioProgramme"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedAudioTrack
 ec:hasRelatedAudioTrack rdf:type owl:ObjectProperty ;
-                        dcterms:description "Pour identifier les pistes audio liées"@fr ,
-                                            "So identifizieren Sie verwandte Audiospuren"@de ,
-                                            "To identify related Audio Tracks"@en ;
-                        rdfs:label "Audio track"@en ,
-                                   "Audiospur"@de ,
-                                   "Piste audio"@fr .
+                        dcterms:description "A related audio track associated with the media resource."@en ;
+                        rdfs:label "Audio track"@en ;
+                        skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:AudioTrack"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedAuditJob
 ec:hasRelatedAuditJob rdf:type owl:ObjectProperty ;
-                      dcterms:description "Pour identifier les AuditJobs liés à un AuditReport."@fr ,
-                                          "To identify AuditJobs related to an AuditReport."@en ,
-                                          "Um AuditJobs zu identifizieren, die mit einem AuditReport verbunden sind."@de ;
-                      rdfs:label "Audit job(s)"@en ,
-                                 "Audit-Auftrag(e)"@de ,
-                                 "Poste(s) d'audit"@fr .
+                      dcterms:description "The AuditJob or AuditJobs related to an AuditReport."@en ;
+                      rdfs:label "Audit job(s)"@en ;
+                      skos:definition "an owl:ObjectProperty relating an ec:AuditReport to an ec:AuditJob"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedAuditReport
 ec:hasRelatedAuditReport rdf:type owl:ObjectProperty ;
-                         dcterms:description "Pour identifier les rapports d'audit associés à un actif, un objet éditorial ou une ressource."@fr ,
-                                             "To identify AuditReports associated with an Asset, EditorialObject or Resource."@en ,
-                                             "Um AuditReports zu identifizieren, die mit einem Asset, EditorialObject oder Resource."@de ;
-                         rdfs:label "Rapport d'audit connexe"@fr ,
-                                    "Related audit report"@en ,
-                                    "Zugehöriger Prüfbericht"@de .
+                         dcterms:description "An audit report associated with an asset."@en ;
+                         rdfs:label "Related audit report"@en ;
+                         skos:definition "an owl:ObjectProperty relating an ec:Asset to an ec:AuditReport"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedAward
 ec:hasRelatedAward rdf:type owl:ObjectProperty ;
-                   dcterms:description "Pour identifier une récompense liée à EditorialObject."@fr ,
-                                       "To identify an Award related to EditorialObject."@en ,
-                                       "Um einen Award zu identifizieren, der sich auf EditorialObject bezieht."@de ;
-                   rdfs:label "Prix connexe"@fr ,
-                              "Related award"@en ,
-                              "Verwandter Preis"@de .
+                   dcterms:description "An award related to an EditorialObject."@en ;
+                   rdfs:label "Related award"@en ;
+                   skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Award"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedCharacter
 ec:hasRelatedCharacter rdf:type owl:ObjectProperty ;
-                       dcterms:description "Pour identifier un caractère lié à un concept"@fr ,
-                                           "So identifizieren Sie ein Zeichen, das mit einem Konzept verbunden ist"@de ,
-                                           "To identify a Character related to a concept"@en ;
-                       rdfs:label "Caractère apparenté"@fr ,
-                                  "Related character"@en ,
-                                  "Verwandter Charakter"@de .
+                       dcterms:description "The Character related to the concept."@en ;
+                       rdfs:label "Related character"@en ;
+                       skos:definition "an owl:ObjectProperty relating an ec:TextLine to an ec:Character"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedConsumptionEvent
 ec:hasRelatedConsumptionEvent rdf:type owl:ObjectProperty ,
                                        owl:IrreflexiveProperty ;
-                              dcterms:description "Pour identifier les ConsumptionEvents liés."@fr ,
-                                                  "To identify related ConsumptionEvents."@en ,
-                                                  "Um verwandte ConsumptionEvents zu identifizieren."@de ;
-                              rdfs:label "Related consumption event"@en ,
-                                         "Veranstaltung zum Thema Konsum"@de ,
-                                         "Événement lié à la consommation"@fr .
+                              dcterms:description "A related consumption event."@en ;
+                              rdfs:label "Related consumption event"@en ;
+                              skos:definition "an owl:ObjectProperty relating an ec:ConsumptionEvent to an ec:ConsumptionEvent"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedEditorialObject
 ec:hasRelatedEditorialObject rdf:type owl:ObjectProperty ,
                                       owl:IrreflexiveProperty ;
-                             dcterms:description "Pour identifier les EditorialObjects connexes."@fr ,
-                                                 "To identify related EditorialObjects."@en ,
-                                                 "Um verwandte EditorialObjects zu identifizieren."@de ;
-                             rdfs:label "Objet éditorial connexe"@fr ,
-                                        "Related editorial object"@en ,
-                                        "Zugehöriges redaktionelles Objekt"@de .
+                             dcterms:description "Related editorial objects associated with this property."@en ;
+                             rdfs:label "Related editorial object"@en ;
+                             skos:definition "an owl:ObjectProperty relating an ec:Artefact, ec:Asset, or ec:EditorialObject to an ec:EditorialObject"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedEssence
 ec:hasRelatedEssence rdf:type owl:ObjectProperty ,
                               owl:IrreflexiveProperty ;
-                     dcterms:description "Pour établir une relation entre une MediaResource et une Essence."@fr ,
-                                         "To establish a relation between a MediaResource and an Essence."@en ,
-                                         "Um eine Beziehung zwischen einer MediaResource und einer Essenz herzustellen."@de ;
-                     rdfs:label "Essence apparentée"@fr ,
-                                "Related essence"@en ,
-                                "Verwandte Essenz"@de .
+                     dcterms:description "To establish a relation between a MediaResource and an Essence."@en ;
+                     rdfs:label "Related essence"@en ;
+                     skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:Essence"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedEvent
 ec:hasRelatedEvent rdf:type owl:ObjectProperty ,
                             owl:IrreflexiveProperty ;
-                   dcterms:description "an event associated with the concept"@en ,
-                                       "ein mit dem Konzept verbundenes Ereignis"@de ,
-                                       "un événement associé au concept"@fr ;
-                   rdfs:label "related event"@en ,
-                              "verwandtes Ereignis"@de ,
-                              "événement connexe"@fr .
+                   dcterms:description "An event associated with the concept."@en ;
+                   rdfs:label "Related event"@en ;
+                   skos:definition "an owl:ObjectProperty relating an ec:Annotation to an ec:Event"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedMediaFragment
 ec:hasRelatedMediaFragment rdf:type owl:ObjectProperty ,
                                     owl:IrreflexiveProperty ;
-                           dcterms:description "Pour associer une partie d'un objet éditorial à un MediaFragment au sein de l'association MediaResource instanciant l'objet éditorial."@fr ,
-                                               "So verknüpfen Sie einen Teil eines Redaktionsobjekts mit einem MediaFragment innerhalb der Assoziation MediaResource, die das Redaktionsobjekt instanziiert."@de ,
-                                               "To associate a Part of an Editorial Object with a MediaFragment within the association MediaResource instantiating the Editrial Object."@en ;
-                           rdfs:label "Fragment de média"@fr ,
-                                      "Media fragment"@en ,
-                                      "Medienfragment"@de .
+                           dcterms:description "Associates a resource with a related media fragment, such as a temporal or spatial segment of that resource."@en ;
+                           rdfs:label "Media fragment"@en ;
+                           skos:definition "an owl:ObjectProperty relating an ec:Resource to an ec:MediaFragment"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedMediaResource
 ec:hasRelatedMediaResource rdf:type owl:ObjectProperty ;
-                           dcterms:description "Pour identifier une MediaResource associée à un concept"@fr ,
-                                               "So identifizieren Sie eine mit einem Konzept verbundene MediaResource"@de ,
-                                               "To identify a MediaResource associated with a concept"@en ;
-                           rdfs:label "Related media resource"@en ,
-                                      "Resource médiatique connexe"@fr ,
-                                      "Verwandte MedienResourcen"@de .
+                           dcterms:description "A media resource associated with an editorial object."@en ;
+                           rdfs:label "Related media resource"@en ;
+                           skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:MediaResource"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedPicture
 ec:hasRelatedPicture rdf:type owl:ObjectProperty ;
-                     dcterms:description "Pour associer une image à un EditorialObject"@fr ,
-                                         "So verknüpfen Sie ein Bild mit einem EditorialObject"@de ,
-                                         "To associate a Picture with an EditorialObject"@en ;
-                     rdfs:label "Bild"@de ,
-                                "Photo"@fr ,
-                                "Picture"@en .
+                     dcterms:description "Associates a Picture with an EditorialObject."@en ;
+                     rdfs:label "Picture"@en ;
+                     skos:definition "an owl:ObjectProperty relating an ec:Asset to an ec:Picture"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedPublicationChannel
 ec:hasRelatedPublicationChannel rdf:type owl:ObjectProperty ,
                                          owl:IrreflexiveProperty ;
-                                dcterms:description "Pour identifier un canal de publication"@fr ,
-                                                    "So identifizieren Sie einen Publikationskanal"@de ,
-                                                    "To identify a Publication Channel"@en ;
-                                rdfs:label "Canal de publication"@fr ,
-                                           "Publication channel"@en ,
-                                           "Publikationskanal"@de .
+                                dcterms:description "A property that identifies a related publication channel."@en ;
+                                rdfs:label "Publication channel"@en ;
+                                skos:definition "an owl:ObjectProperty relating an ec:PublicationChannel to an ec:PublicationChannel"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedPublicationEvent
 ec:hasRelatedPublicationEvent rdf:type owl:ObjectProperty ,
                                        owl:IrreflexiveProperty ;
-                              dcterms:description "Pour identifier le PublicationEvent associé à la ressource."@fr ,
-                                                  "To identify the PublicationEvent associated with the resource."@en ,
-                                                  "Um das mit der Ressource verknüpfte Publikationsereignis zu identifizieren."@de ;
-                              rdfs:label "Ereignis der Veröffentlichung"@de ,
-                                         "Publication event"@en ,
-                                         "Événement de publication"@fr .
+                              dcterms:description "The PublicationEvent associated with the resource."@en ;
+                              rdfs:label "Publication event"@en ;
+                              skos:definition "an ec:ObjectProperty relating an ec:ConsumptionEvent or ec:Essence to an ec:PublicationEvent"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedPublicationService
 ec:hasRelatedPublicationService rdf:type owl:ObjectProperty ,
                                          owl:IrreflexiveProperty ;
-                                dcterms:description "To establish a relation to publication services."@en ,
-                                                    "Um eine Beziehung zu den Publikationsdiensten herzustellen."@de ,
-                                                    "Établir une relation avec les services de publication."@fr ;
-                                rdfs:label "Related publication service"@en ,
-                                           "Service de publication connexe"@fr ,
-                                           "Service für verwandte Publikationen"@de .
+                                dcterms:description "To establish a relation to publication services."@en ;
+                                rdfs:label "Related publication service"@en ;
+                                skos:definition "an owl:ObjectProperty relating an ec:PublicationPlatform to an ec:PublicationService"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedRecord
 ec:hasRelatedRecord rdf:type owl:ObjectProperty ,
                              owl:IrreflexiveProperty ;
-                    dcterms:description "Pour associer un Enregistrement à un Bien."@fr ,
-                                        "So verknüpfen Sie einen Datensatz mit einem Asset."@de ,
-                                        "To associate a Record with an Asset."@en ;
-                    rdfs:label "Dossier connexe"@fr ,
-                               "Related record"@en ,
-                               "Verwandter Datensatz"@de .
+                    dcterms:description "The record associated with an asset."@en ;
+                    rdfs:label "Related record"@en ;
+                    skos:definition "an owl:ObjectProperty relating an ec:Asset to an ec:Record"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedResonanceEvent
 ec:hasRelatedResonanceEvent rdf:type owl:ObjectProperty ;
-                            dcterms:description "Pour associer un ResonanceEvent à un EditorialObject."@fr ,
-                                                "So verknüpfen Sie ein ResonanceEvent mit einem EditorialObject."@de ,
-                                                "To associate a ResonanceEvent with an EditorialObject."@en ;
-                            rdfs:label "Related resonance event"@en ,
-                                       "Ähnliches Resonanzereignis"@de ,
-                                       "Événement de résonance connexe"@fr .
+                            dcterms:description "Associates a ResonanceEvent with an EditorialObject."@en ;
+                            rdfs:label "Related resonance event"@en ;
+                            skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:ResonanceEvent"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedResource
 ec:hasRelatedResource rdf:type owl:ObjectProperty ;
-                      dcterms:description "Pour identifier une ressource associée à un actif ou un EditorialObject ou un PublicationEvent ou une autre ressource."@fr ,
-                                          "To identify a Resource associated with an Asset or an EditorialObject or a PublicationEvent or another Resource."@en ,
-                                          "Um eine Resource zu identifizieren, die mit einem Asset oder einem EditorialObject oder einem PublicationEvent oder einer anderen Resource verbunden ist."@de ;
-                      rdfs:label "Related resource"@en ,
-                                 "Resource connexe"@fr ,
-                                 "Verwandte Resource"@de .
+                      dcterms:description "A resource associated with an asset, editorial object, publication event, or another resource."@en ;
+                      rdfs:label "Related resource"@en ;
+                      skos:definition "an owl:ObjectProperty relating an ec:Asset or ec:EditorialObject or ec:PublicationEvent or ec:Resource to an ec:Resource"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedRule
 ec:hasRelatedRule rdf:type owl:ObjectProperty ;
-                  dcterms:description "Pour fournir des références à une règle."@fr ,
-                                      "To provide references to a Rule."@en ,
-                                      "Um Hinweise auf eine Regel zu geben."@de ;
-                  rdfs:label "Regel-Referenz"@de ,
-                             "Rule reference"@en ,
-                             "Référence de la règle"@fr .
+                  dcterms:description "References to a Rule."@en ;
+                  rdfs:label "Rule reference"@en ;
+                  skos:definition "an owl:ObjectProperty relating an ec:Rule to an ec:Rule"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedScene
 ec:hasRelatedScene rdf:type owl:ObjectProperty ;
-                   dcterms:description "Pour associer un concept à une Scène"@fr ,
-                                       "So verknüpfen Sie ein Konzept mit einer Szene"@de ,
-                                       "To associate a concept with a Scene"@en ;
-                   rdfs:label "Related scene"@en ,
-                              "Scène connexe"@fr ,
-                              "Verwandte Szene"@de .
+                   dcterms:description "A property that associates a concept with a scene."@en ;
+                   rdfs:label "Related scene"@en ;
+                   skos:definition "an owl:ObjectProperty relating an ec:Action, ec:Emotion, or ec:TextLine to an ec:Scene"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedStage
 ec:hasRelatedStage rdf:type owl:ObjectProperty ;
-                   dcterms:description "Pour associer une scène à une position sur la scène."@fr ,
-                                       "To associate a stage with a position on stage."@en ,
-                                       "Um eine Bühne mit einer Position auf der Bühne zu verbinden."@de ;
-                   rdfs:label "Related stage"@en ,
-                              "Verwandte Etappe"@de ,
-                              "Étape connexe"@fr .
+                   dcterms:description "A relationship that links an on-stage position to the stage it is on."@en ;
+                   rdfs:label "Related stage"@en ;
+                   skos:definition "an owl:ObjectProperty relating an ec:OnStagePosition to an ec:Stage"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedTextLine
 ec:hasRelatedTextLine rdf:type owl:ObjectProperty ;
-                      dcterms:description "A TextLine or free text related to an EditorialObject."@en ,
-                                          "Eine Textzeile oder ein freier Text, der sich auf ein EditorialObject bezieht."@de ,
-                                          "Une TextLine ou un texte libre lié à un EditorialObject."@fr ;
-                      rdfs:label "Ligne de texte associée"@fr ,
-                                 "Related text line"@en ,
-                                 "Zugehörige Textzeile"@de .
+                      dcterms:description "A TextLine or free text related to an EditorialObject."@en ;
+                      rdfs:label "Related text line"@en ;
+                      skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:TextLine"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelationLink
 ec:hasRelationLink rdf:type owl:ObjectProperty ;
-                   dcterms:description "Pour définir un lien dans une Relation."@fr ,
-                                       "So definieren Sie eine Verknüpfung in einer Relation."@de ,
-                                       "To define a link in a Relation."@en ;
-                   rdfs:label "Lien"@fr ,
-                              "Link"@de ,
-                              "Link"@en .
+                   dcterms:description "A link within a Relation."@en ;
+                   rdfs:label "Link"@en ;
+                   skos:definition "an owl:ObjectProperty relating an ec:Relation to an owl:Thing"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelationSource
 ec:hasRelationSource rdf:type owl:ObjectProperty ;
-                     dcterms:description "Pour définir la source d'une Relation."@fr ,
-                                         "To define source of a Relation."@en ,
-                                         "Um die Quelle einer Relation zu definieren."@de ;
-                     rdfs:label "Relation Quelle"@de ,
-                                "Relation source"@en ,
-                                "Source de la relation"@fr .
+                     dcterms:description "The source of a relation."@en ;
+                     rdfs:label "Relation source"@en ;
+                     skos:definition "an owl:ObjectProperty relating an ec:Relation to an ec:Agent"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasResourceOffset
 ec:hasResourceOffset rdf:type owl:ObjectProperty ;
-                     dcterms:description "Der Start-Offset innerhalb einer Resource."@de ,
-                                         "Le décalage de départ dans une ressource."@fr ,
-                                         "The start offset within a Resource."@en ;
-                     rdfs:label "Compensation des ressources"@fr ,
-                                "Resource offset"@en ,
-                                "Resourcenausgleich"@de .
+                     dcterms:description "The start offset within a Resource."@en ;
+                     rdfs:label "Resource offset"@en ;
+                     skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:TimelinePoint"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRestrictedAudience
 ec:hasRestrictedAudience rdf:type owl:ObjectProperty ;
-                         dcterms:description "Pour identifier une audience pour laquelle l'accès est restreint."@fr ,
-                                             "To identify an Audience for which access is restricted."@en ,
-                                             "Um eine Zielgruppe zu identifizieren, für die der Zugriff eingeschränkt ist."@de ;
-                         rdfs:label "Eingeschränktes Publikum"@de ,
-                                    "Public restreint"@fr ,
-                                    "Restricted audience"@en .
+                         dcterms:description "An Audience for which access is restricted."@en ;
+                         rdfs:label "Restricted audience"@en ;
+                         skos:definition "an owl:ObjectProperty relating an ec:PublicationEvent to an ec:Audience"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasReview
 ec:hasReview rdf:type owl:ObjectProperty ;
-             dcterms:description "Pour fournir une revue."@fr ,
-                                 "To provide a review."@en ,
-                                 "Um einen Überblick zu geben."@de ;
-             rdfs:label "Consulter"@fr ,
-                        "Review"@en ,
-                        "Überprüfung"@de .
+             dcterms:description "An audio or audio-visual report in which somebody gives their opinion of a play, film, or other editorial object."@en ;
+             rdfs:label "Review"@en ;
+             skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Review"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRights
 ec:hasRights rdf:type owl:ObjectProperty ;
-             rdfs:label "Est couvert par"@fr ,
-                        "Is covered by"@en ,
-                        "Wird abgedeckt durch"@de .
+             dcterms:description "An object property that links an asset or publication event to the rights that cover it."@en ;
+             rdfs:label "Is covered by"@en ;
+             skos:definition "an owl:ObjectProperty relating an ec:Asset to ec:Rights"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRightsClearance
 ec:hasRightsClearance rdf:type owl:ObjectProperty ;
                       rdfs:subPropertyOf ec:hasRights ;
-                      dcterms:description "Pour exprimer l'autorisation des droits."@fr ,
-                                          "To express Rights Clearance."@en ,
-                                          "Zum Ausdruck bringen Rechte Clearance."@de ;
-                      rdfs:label "Apurement des droits"@fr ,
-                                 "Rechteklärung"@de ,
-                                 "Rights clearance"@en .
+                      dcterms:description "The rights clearance associated with an asset."@en ;
+                      rdfs:label "Rights clearance"@en ;
+                      skos:definition "an owl:ObjectProperty relating an ec:Asset to an ec:RightsClearance"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRightsHolder
 ec:hasRightsHolder rdf:type owl:ObjectProperty ;
-                   dcterms:description "Pour identifier un agent (contact/personne ou Organisation) ayant/gérant des droits."@fr ,
-                                       "To identify an Agent (Contact/person or Organisation) having/managing Rights."@en ,
-                                       "Zur Identifizierung eines Agenten (Kontaktperson/Person oder Organisation), der Rechte besitzt/verwaltet."@de ;
-                   rdfs:label "Rechteinhaber"@de ,
-                              "Rights holder"@en ,
-                              "Titulaire des droits"@fr .
+                   dcterms:description "The agent that holds or manages the rights associated with the resource."@en ;
+                   rdfs:label "Rights holder"@en ;
+                   skos:definition "an owl:ObjectProperty relating an ec:Rights to an ec:Agent"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRightsTargetService
 ec:hasRightsTargetService rdf:type owl:ObjectProperty ;
-                          dcterms:description "Pour identifier un service associé à des droits."@fr ,
-                                              "To identify a Service associated with Rights."@en ,
-                                              "Um einen mit Rechten verbundenen Service zu identifizieren."@de ;
-                          rdfs:label "Service cible"@fr ,
-                                     "Target service"@en ,
-                                     "Zielservice"@de .
+                          dcterms:description "The service associated with the rights."@en ;
+                          rdfs:label "Target service"@en ;
+                          skos:definition "an owl:ObjectProperty relating an ec:Rights to an ec:PublicationService"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRightsTerritoryExcludes
 ec:hasRightsTerritoryExcludes rdf:type owl:ObjectProperty ;
-                              dcterms:description "A list of country or region codes to which Rights do not apply."@en ,
-                                                  "Eine Liste von Länder- oder Regionencodes, für die die Rechte nicht gelten."@de ,
-                                                  "Une liste de codes de pays ou de régions auxquels les droits ne s'appliquent pas."@fr ;
-                              rdfs:label "Ausgeschlossene Territorien"@de ,
-                                         "Excluded territories"@en ,
-                                         "Territoires exclus"@fr .
+                              dcterms:description "A list of country or region codes to which Rights do not apply."@en ;
+                              rdfs:label "Excluded territories"@en ;
+                              skos:definition "an owl:ObjectProperty relating an ec:Rights to an ec:CountryCode"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRightsTerritoryIncludes
 ec:hasRightsTerritoryIncludes rdf:type owl:ObjectProperty ;
-                              dcterms:description "A list of country or region codes to which Rights apply."@en ,
-                                                  "Eine Liste der Länder- oder Regionencodes, für die Rechte gelten."@de ,
-                                                  "Une liste des codes de pays ou de région auxquels les droits s'appliquent."@fr ;
-                              rdfs:label "Enthaltene Territorien"@de ,
-                                         "Included territories"@en ,
-                                         "Territoires inclus"@fr .
+                              dcterms:description "A list of country or region codes to which Rights apply."@en ;
+                              rdfs:label "Included territories"@en ;
+                              skos:definition "an owl:ObjectProperty relating an ec:Rights to an ec:CountryCode"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasScene
 ec:hasScene rdf:type owl:ObjectProperty ;
             rdfs:subPropertyOf ec:hasPart ;
-            rdfs:label "a une scène"@fr ,
-                       "has scene"@en ,
-                       "hat Szene"@de .
+            dcterms:description "Identifies a scene that is part of a shot or take."@en ;
+            rdfs:label "Has scene"@en ;
+            skos:definition "an owl:ObjectProperty relating an ec:Shot or ec:Take to an ec:Scene"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasScheduleDate
 ec:hasScheduleDate rdf:type owl:ObjectProperty ;
-                   dcterms:description "Pour exprimer spécifiquement la date d'horaire à laquelle un PublicationEvent est associé en particulier si l'heure de broacdast est après minuit. Par exemple, la date du planning serait le 29 mai et le programme est publié à 1 heure du matin le 30 mai, tout en restant associé dans le planning à la nuit du 29 mai."@fr ,
-                                       "To express specifically the schedule date to which a PublicationEvent is related in particular if the broadcast time is after midnight. For example, the schedule date would be May 29th and the programme is published at 1 am on May 30th, while still associated in the schedule with the night of May 29th."@en ,
-                                       "Zur Angabe des spezifischen Termindatums, auf das sich ein PublicationEvent bezieht, insbesondere wenn die Broacdast-Zeit nach Mitternacht liegt. Zum Beispiel wäre das Programmdatum der 29. Mai und die Sendung wird um 1 Uhr morgens am 30. Mai veröffentlicht, während sie im Programm noch mit der Nacht des 29. Mai verbunden ist."@de ;
-                   rdfs:label "Date du calendrier"@fr ,
-                              "Schedule date"@en ,
-                              "Zeitplan Datum"@de .
+                   dcterms:description "The schedule date associated with a PublicationEvent, especially when the broadcast time is after midnight. For example, the schedule date may be May 29th while the programme is published at 1 am on May 30th, yet remains associated in the schedule with the night of May 29th."@en ;
+                   rdfs:label "Schedule date"@en ;
+                   skos:definition "an owl:ObjectProperty relating an ec:PublicationEvent to a time:Instant"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasSeason
 ec:hasSeason rdf:type owl:ObjectProperty ;
-             dcterms:description "Pour identifier les saisons d'une série."@fr ,
-                                 "To identiify Seasons in a Series."@en ,
-                                 "Zur Identifizierung von Jahreszeiten in einer Serie."@de ;
-             rdfs:label "Saison"@de ,
-                        "Saison"@fr ,
-                        "Season"@en .
+             dcterms:description "Associates a serial or series with a season."@en ;
+             rdfs:label "Season"@en ;
+             skos:definition "an owl:ObjectProperty relating an ec:Serial or ec:Series to an ec:Season"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasSerial
 ec:hasSerial rdf:type owl:ObjectProperty ;
-             rdfs:label "a une série"@fr ,
-                        "has serial"@en ,
-                        "hat serielle"@de .
+             dcterms:description "A property that links a season to the serial it contains or is associated with."@en ;
+             rdfs:label "Has serial"@en ;
+             skos:definition "an owl:ObjectProperty relating an ec:Season to an ec:Serial"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasServiceGenre
 ec:hasServiceGenre rdf:type owl:ObjectProperty ;
-                   dcterms:description "Das Genre des mit dem Dienst verbundenen Inhalts."@de ,
-                                       "Le genre de contenu associé au service."@fr ,
-                                       "The genre of content associated with the Service."@en ;
-                   rdfs:label "Genre Dienstleistung"@de ,
-                              "Genre de service"@fr ,
-                              "Service genre"@en .
+                   dcterms:description "The genre of content associated with the Service."@en ;
+                   rdfs:label "Service genre"@en ;
+                   skos:definition "an owl:ObjectProperty relating an ec:PublicationService to a skos:Concept"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasShot
 ec:hasShot rdf:type owl:ObjectProperty ;
            rdfs:subPropertyOf ec:hasPart ;
-           rdfs:label "a un plan"@fr ,
-                      "has shot"@en ,
-                      "hat geschossen"@de .
+           dcterms:description "Identifies a shot that is part of a scene."@en ;
+           rdfs:label "Has shot"@en ;
+           skos:definition "an owl:ObjectProperty relating an ec:Scene to an ec:Shot"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasSigning
 ec:hasSigning rdf:type owl:ObjectProperty ;
-              dcterms:description "Pour identifier la présence d'une signature associée à l'EditorialObject."@fr ,
-                                  "To identify the presence of Signing associated with the EditorialObject."@en ,
-                                  "Um das Vorhandensein von Signaturen im Zusammenhang mit dem EditorialObject festzustellen."@de ;
-              rdfs:label "Accessibility - signing"@en ,
-                         "Accessibilité - signature"@fr ,
-                         "Zugänglichkeit - Beschilderung"@de .
+              dcterms:description "Presence of signing associated with the editorial object."@en ;
+              rdfs:label "Accessibility - signing"@en ;
+              skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Signing"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasSigningFormat
 ec:hasSigningFormat rdf:type owl:ObjectProperty ;
-                    dcterms:description "Pour spécifier le format utilisé pour la signature."@fr ,
-                                        "To specify the format used for signing."@en ,
-                                        "Zur Angabe des für die Unterzeichnung verwendeten Formats."@de ;
-                    rdfs:label "Format de signature"@fr ,
-                               "Format der Unterschrift"@de ,
-                               "Signing format"@en .
+                    dcterms:description "The format used for sign language interpretation."@en ;
+                    rdfs:label "Signing format"@en ;
+                    skos:definition "an owl:ObjectProperty relating an ec:Signing to an ec:SigningFormat"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasSigningSource
 ec:hasSigningSource rdf:type owl:ObjectProperty ;
-                    dcterms:description "Pour spécifier la source de la signature."@fr ,
-                                        "So geben Sie die Quelle der Signierung an."@de ,
-                                        "To specify the source of signing."@en ;
-                    rdfs:label "Quelle der Signierung"@de ,
-                               "Signing source"@en ,
-                               "Source de signature"@fr .
+                    dcterms:description "The source used for signing."@en ;
+                    rdfs:label "Signing source"@en ;
+                    skos:definition "an owl:ObjectProperty relating an ec:Signing to an ec:Agent"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasSource
 ec:hasSource rdf:type owl:ObjectProperty ;
-             dcterms:description "Pour identifier la source d'une MediaResource."@fr ,
-                                 "To identify the source of a MediaResource."@en ,
-                                 "Um die Quelle einer MediaResource zu identifizieren."@de ;
-             rdfs:label "Quelle"@de ,
-                        "Source"@en ,
-                        "Source :"@fr .
+             dcterms:description "The source associated with a MediaResource."@en ;
+             rdfs:label "Source"@en ;
+             skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:MediaResource"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasStaffMember
 ec:hasStaffMember rdf:type owl:ObjectProperty ;
-                  dcterms:description "Pour identifier les membres du personnel d'une organisation."@fr ,
-                                      "To identify members of staff in an organisation."@en ,
-                                      "Zur Identifizierung von Mitarbeitern in einer Organisation."@de ;
-                  rdfs:label "Mitglied des Personals"@de ,
-                             "member of Staff"@en ,
-                             "membre du personnel"@fr .
+                  dcterms:description "A person who is a member of staff in an organisation."@en ;
+                  rdfs:label "Member of staff"@en ;
+                  skos:definition "an owl:ObjectProperty relating an ec:Organisation to an ec:StaffMember"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasStageLocation
 ec:hasStageLocation rdf:type owl:ObjectProperty ;
-                    dcterms:description "Pour associer un emplacement à une scène."@fr ,
-                                        "So verknüpfen Sie einen Ort mit einer Bühne."@de ,
-                                        "To associate a Location with a Stage."@en ;
-                    rdfs:label "Lieu de la scène"@fr ,
-                               "Stage location"@en ,
-                               "Standort der Bühne"@de .
+                    dcterms:description "The location associated with a stage."@en ;
+                    rdfs:label "Stage location"@en ;
+                    skos:definition "an owl:ObjectProperty relating an ec:Stage to an ec:Location"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasStakeholder
 ec:hasStakeholder rdf:type owl:ObjectProperty ;
-                  dcterms:description "An Agent related to the PublicationPlan."@en ,
-                                      "Ein Agent, der sich auf den PublicationPlan bezieht."@de ,
-                                      "Pour identifier les agents associés à un PublicationPlan."@fr ,
-                                      "To identify Agents associated with a PublicationPlan."@en ,
-                                      "Um Agenten zu identifizieren, die mit einem PublicationPlan verbunden sind."@de ,
-                                      "Un agent lié au PublicationPlan."@fr ;
-                  rdfs:label "Intervenant du plan de publication"@fr ,
-                             "Parties prenantes"@fr ,
-                             "Publication plan stakeholder"@en ,
-                             "Publikationsplan Stakeholder"@de ,
-                             "Stakeholder"@de ,
-                             "Stakeholder"@en .
+                  dcterms:description "An Agent related to a PublicationPlan."@en ;
+                  rdfs:label "Publication plan stakeholder"@en ;
+                  skos:definition "an owl:ObjectProperty relating an ec:PublicationPlan to an ec:Agent"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasStandard
 ec:hasStandard rdf:type owl:ObjectProperty ;
                rdfs:subPropertyOf ec:hasFormat ;
-               dcterms:description "Identifie la norme vidéo technique d'une MediaResource, c'est-à-dire NTSC ou PAL."@fr ,
-                                   "Identifies the technical video standard of a MediaResource, i.e. NTSC or PAL."@en ,
-                                   "Identifiziert den technischen Videostandard einer MediaResource, d.h. NTSC oder PAL."@de ;
-               rdfs:label "Standard"@de ,
-                          "Standard"@en ,
-                          "Standard"@fr .
+               dcterms:description "Identifies the technical video standard of a MediaResource, i.e. NTSC or PAL."@en ;
+               rdfs:label "Standard"@en ;
+               skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:Standard"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasStart
 ec:hasStart rdf:type owl:ObjectProperty ;
-            rdfs:label "Début"@fr ,
-                       "Start"@de ,
-                       "Start"@en .
+            dcterms:description "A property that links an action, event, or related content entity to its starting point on a timeline."@en ;
+            rdfs:label "Start"@en ;
+            skos:definition "an owl:ObjectProperty relating an ec:Action to an ec:TimelinePoint"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasStartDateTime
 ec:hasStartDateTime rdf:type owl:ObjectProperty ;
                     rdfs:subPropertyOf ec:hasDate ;
-                    dcterms:description "A point of time or start of an interval"@en ,
-                                        "Ein Zeitpunkt oder der Beginn eines Intervalls"@de ,
-                                        "Un instant ou l'nstant de départ d'un intervalle"@fr ;
-                    rdfs:label "Date de début"@fr ,
-                               "Start date time"@en ,
-                               "Startdatum Uhrzeit"@de .
+                    dcterms:description "A point of time or start of an interval."@en ;
+                    rdfs:label "Start date time"@en ;
+                    skos:definition "an owl:ObjectProperty relating an ec:Affiliation to a time:Instant"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasSticker
 ec:hasSticker rdf:type owl:ObjectProperty ;
-              dcterms:description "Pour fournir un lien vers un autocollant"@fr ,
-                                  "So erstellen Sie einen Link zu einem Sticker"@de ,
-                                  "To provide a link to a Sticker"@en ;
-              rdfs:label "Lien vers l'autocollant"@fr ,
-                         "Link to Sticker"@en ,
-                         "Link zum Aufkleber"@de .
+              dcterms:description "A link to a Sticker associated with a Costume."@en ;
+              rdfs:label "Link to sticker"@en ;
+              skos:definition "an owl:ObjectProperty relating an ec:Costume to an ec:Sticker"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasStorageId
 ec:hasStorageId rdf:type owl:ObjectProperty ;
-                dcterms:description "Identifier le stockage associé à un localisateur à partir duquel une ressource peut être accédée ou peut être récupérée."@fr ,
-                                    "To identify storage associated with a locator from which a Resource can be accessed or can be retrieved."@en ,
-                                    "Zur Identifizierung des mit einem Locator verbundenen Speichers, von dem aus auf eine Resource zugegriffen werden kann oder die abgerufen werden kann."@de ;
-                rdfs:label "Identifiant de stockage"@fr ,
-                           "Kennung des Speichers"@de ,
-                           "Storage identifier"@en .
+                dcterms:description "The storage associated with a locator from which a resource can be accessed or retrieved."@en ;
+                rdfs:label "Storage identifier"@en ;
+                skos:definition "an owl:ObjectProperty relating an ec:Resource to an ec:Identifier"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasStorageType
 ec:hasStorageType rdf:type owl:ObjectProperty ;
-                  dcterms:description "Définir un type de stockage associé à un localisateur à partir duquel une ressource peut être accédée ou peut être récupérée."@fr ,
-                                      "To define a type of storage associated with a locator from which a Resource can be accessed or can be retrieved."@en ,
-                                      "Zur Definition eines Speichertyps, der mit einem Locator verknüpft ist, von dem aus auf eine Resource zugegriffen werden kann oder die abgerufen werden kann."@de ;
-                  rdfs:label "Art der Lagerung"@de ,
-                             "Storage type"@en ,
-                             "Type de stockage"@fr .
+                  dcterms:description "A storage type associated with a locator from which a resource can be accessed or retrieved."@en ;
+                  rdfs:label "Storage type"@en ;
+                  skos:definition "an owl:ObjectProperty relating an ec:Resource to an ec:StorageType"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasSubJob
 ec:hasSubJob rdf:type owl:ObjectProperty ;
-             dcterms:description "Pour identifier un ProductionJob / processus comme faisant partie d'un complexe ProductionJob."@fr ,
-                                 "So identifizieren Sie einen ProductionJob / Prozess als Teil eines komplexen ProduktionsJob."@de ,
-                                 "To identify a ProductionJob / process as part of a complex ProductionJob."@en ;
-             rdfs:label "Job in der Produktion"@de ,
-                        "Poste de production"@fr ,
-                        "Production job"@en .
+             dcterms:description "A production job that is part of a complex production job."@en ;
+             rdfs:label "Production job"@en ;
+             skos:definition "an owl:ObjectProperty relating an ec:ProductionJob to an ec:ProductionJob"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasSubject
 ec:hasSubject rdf:type owl:ObjectProperty ;
-              dcterms:description "Cette propriété permet d'associer un actif à un sujet qui peut être une chaîne ou une URI pointant vers un terme d'un vocabulaire contrôlé."@fr ,
-                                  "Diese Eigenschaft ermöglicht es, ein Asset mit einem Betreff zu verknüpfen, der eine Zeichenkette oder ein URI sein kann, der auf einen Begriff aus einem kontrollierten Vokabular verweist."@de ,
-                                  "This property enables to associate an Asset with a subject which can be a string or a URI pointing to a term from a controlled vocabulary."@en ;
-              rdfs:label "Subject"@en ,
-                         "Sujet"@fr ,
-                         "Thema"@de .
+              dcterms:description "This property enables to associate an Asset with a subject which can be a string or a URI pointing to a term from a controlled vocabulary."@en ;
+              rdfs:label "Subject"@en ;
+              skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Subject"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasSubtitling
 ec:hasSubtitling rdf:type owl:ObjectProperty ;
-                 dcterms:description "Pour identifier le sous-titrage existant."@fr ,
-                                     "To identify existing subtitling."@en ,
-                                     "Um vorhandene Untertitel zu identifizieren."@de ;
-                 rdfs:label "Sous-titrage"@fr ,
-                            "Subtitling"@en ,
-                            "Untertitelung"@de .
+                 dcterms:description "Existing subtitling for the editorial object."@en ;
+                 rdfs:label "Subtitling"@en ;
+                 skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Subtitling"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasSubtitlingFormat
 ec:hasSubtitlingFormat rdf:type owl:ObjectProperty ;
                        rdfs:subPropertyOf ec:hasFormat ;
-                       dcterms:description "Das Format der Untertitelung."@de ,
-                                           "Le format du sous-titrage."@fr ,
-                                           "The format of Subtitling."@en ;
-                       rdfs:label "Format de sous-titrage"@fr ,
-                                  "Format der Untertitelung"@de ,
-                                  "Subtitling format"@en .
+                       dcterms:description "The format of Subtitling."@en ;
+                       rdfs:label "Subtitling format"@en ;
+                       skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:SubtitlingFormat"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasSubtitlingSource
 ec:hasSubtitlingSource rdf:type owl:ObjectProperty ;
-                       dcterms:description "Pour identifier la source du sous-titrage de la ressource."@fr ,
-                                           "To identify the source of the Subtitling resource."@en ,
-                                           "Um die Quelle der Untertitelung zu identifizieren Resource."@de ;
-                       rdfs:label "Quelle für die Untertitelung"@de ,
-                                  "Source de sous-titrage"@fr ,
-                                  "Subtitling source"@en .
+                       dcterms:description "The source of the subtitling resource."@en ;
+                       rdfs:label "Subtitling source"@en ;
+                       skos:definition "an owl:ObjectProperty relating an ec:Subtitling to an ec:Agent"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasTake
 ec:hasTake rdf:type owl:ObjectProperty ;
            rdfs:subPropertyOf ec:hasPart ;
-           rdfs:label "a des prises"@fr ,
-                      "has take"@en ,
-                      "hat angenommen"@de .
+           dcterms:description "This property relates a scene or shot to one of its takes. It is a sub-property of ec:hasPart and is used to identify repeated recordings of a scene or shot."@en ;
+           rdfs:label "Has take"@en ;
+           skos:definition "an owl:ObjectProperty relating an ec:Scene or ec:Shot to an ec:Take"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasTargetAudience
 ec:hasTargetAudience rdf:type owl:ObjectProperty ;
-                     dcterms:description "Pour associer une TargetAudience (par exemple, pour l'orientation parentale ou le ciblage d'un groupe social particulier) à un EditorialObject."@fr ,
-                                         "Pour identifier le public cible associé à un PublicationEvent."@fr ,
-                                         "To associate a TargetAudience (e.g. for parental guidance or targeting a particular social group) with a EditorialObject"@en ,
-                                         "To identify the target Audience associated with a PublicationEvent."@en ,
-                                         "Um das Zielpublikum zu identifizieren, das mit einem PublikationsEreignis."@de ,
-                                         "Um ein TargetAudience (z.B. für elterliche Ratschläge oder für eine bestimmte soziale Gruppe) mit einem EditorialObject zu verbinden"@de ;
-                     rdfs:label "Public cible"@fr ,
-                                "Target audience"@en ,
-                                "Zielpublikum"@de .
+                     dcterms:description "The target audience associated with an editorial object, campaign, publication event, publication channel, publication platform, or publication service."@en ;
+                     rdfs:label "Target audience"@en ;
+                     skos:definition "an owl:ObjectProperty relating an ec:EditorialObject or ec:Campaign to an ec:Audience"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasTargetChannel
 ec:hasTargetChannel rdf:type owl:ObjectProperty ;
-                    dcterms:description "Pour spécifier un canal de publication cible."@fr ,
-                                        "To specify the target Channel for publication."@en ,
-                                        "Um einen Zielkanal für die Publikation anzugeben."@de ;
-                    rdfs:label "Canal de publication cible"@fr ,
-                               "Has target channel"@en ,
-                               "Ziel-Kanal für Publikation"@de .
+                    dcterms:description "The target channel for publication."@en ;
+                    rdfs:label "Has target channel"@en ;
+                    skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:PublicationChannel"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasTargetPlatform
 ec:hasTargetPlatform rdf:type owl:ObjectProperty ;
-                     dcterms:description "Pour spécifier une plate-forme cible."@fr ,
-                                         "To specify a target platform."@en ,
-                                         "Um eine Zielplattform anzugeben."@de ;
-                     rdfs:label "Plate-forme cible"@fr ,
-                                "Target platform"@en ,
-                                "Ziel-Plattform"@de .
+                     dcterms:description "The platform used for publication or distribution of the editorial object."@en ;
+                     rdfs:label "Target platform"@en ;
+                     skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:PublicationPlatform"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasTargetService
 ec:hasTargetService rdf:type owl:ObjectProperty ;
-                    dcterms:description "Pour spécifier un service de publication cible."@fr ,
-                                        "To specify the target Service for publication."@en ,
-                                        "Um einen Ziel-Medienservice für die Publikation anzugeben."@de ;
-                    rdfs:label "Has target service"@en ,
-                               "Service de publication cible"@fr ,
-                               "Ziel-Medienservice"@de .
+                    dcterms:description "The target service for publication."@en ;
+                    rdfs:label "Has target service"@en ;
+                    skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:PublicationService"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasTeamMember
 ec:hasTeamMember rdf:type owl:ObjectProperty ;
-                 dcterms:description "Pour identifier les membres d'une équipe"@fr ,
-                                     "So identifizieren Sie die Mitglieder eines Teams"@de ,
-                                     "To identify the members of a Team"@en ;
-                 rdfs:label "Membre de l'équipe"@fr ,
-                            "Team member"@en ,
-                            "Teammitglied"@de .
+                 dcterms:description "The members of a Team."@en ;
+                 rdfs:label "Team member"@en ;
+                 skos:definition "an owl:ObjectProperty relating an ec:Team to an ec:Person"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasTerritoryExcludes
 ec:hasTerritoryExcludes rdf:type owl:ObjectProperty ;
-                        dcterms:description "Pour définir l'emplacement (par exemple, le pays, la région) auquel le classement et le public cible ne s'appliquent PAS."@fr ,
-                                            "To define the Location (e.g. country, region) to which Rating and TargetAudience do NOT apply."@en ,
-                                            "Zur Definition des Standorts (z.B. Land, Region), für den Rating und TargetAudience NICHT gelten."@de ;
-                        rdfs:label "Ausschlussgebiet"@de ,
-                                   "Exclusion area"@en ,
-                                   "Zone d'exclusion"@fr .
+                        dcterms:description "The location, such as a country or region, where the rating and target audience do not apply."@en ;
+                        rdfs:label "Exclusion area"@en ;
+                        skos:definition "an owl:ObjectProperty relating an ec:Rating to an ec:CountryCode"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasTerritoryIncludes
 ec:hasTerritoryIncludes rdf:type owl:ObjectProperty ;
-                        dcterms:description "Identifier l'actif auquel le Rating s'applique."@fr ,
-                                            "To identify the asset to which the Rating applies."@en ,
-                                            "Um den Vermögenswert zu identifizieren, für den das Rating gilt."@de ;
-                        rdfs:label "applies to"@en ,
-                                   "gilt für"@de ,
-                                   "s'applique à"@fr .
+                        dcterms:description "The asset to which the rating applies."@en ;
+                        rdfs:label "Applies to"@en ;
+                        skos:definition "an owl:ObjectProperty relating an ec:Rating to an ec:CountryCode"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasTextLineSource
 ec:hasTextLineSource rdf:type owl:ObjectProperty ;
-                     dcterms:description "Pour identifier la source d'un TextLine."@fr ,
-                                         "So identifizieren Sie die Quelle einer Textzeile."@de ,
-                                         "To identify the source of a TextLine."@en ;
-                     rdfs:label "Quelle der Textzeile"@de ,
-                                "Source de la ligne de texte"@fr ,
-                                "Text line source"@en .
+                     dcterms:description "The source of a TextLine."@en ;
+                     rdfs:label "Text line source"@en ;
+                     skos:definition "an owl:ObjectProperty relating an ec:TextLine to an ec:Agent"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasTheme
 ec:hasTheme rdf:type owl:ObjectProperty ;
-            dcterms:description "Cette propriété permet d'associer un actif à un thème qui peut être une chaîne ou un URI pointant vers un terme d'un vocabulaire contrôlé. Un exemple typique est la classification NACE d'Eurostats."@fr ,
-                                "Diese Eigenschaft ermöglicht es, ein Asset mit einem Thema zu verknüpfen, das eine Zeichenkette oder ein URI sein kann, der auf einen Begriff aus einem kontrollierten Vokabular verweist. Ein typisches Beispiel ist die NACE-Klassifizierung von Eurostats."@de ,
-                                "This property enables to associate an Asset with a theme which can be a string or a URI pointing to a term from a controlled vocabulary. A typical example is the Eurostats NACE classification."@en ;
-            rdfs:label "Thema"@de ,
-                       "Theme"@en ,
-                       "Thème"@fr .
+            dcterms:description "This property enables an Asset to be associated with a theme, which can be a string or a URI pointing to a term from a controlled vocabulary. A typical example is the Eurostat NACE classification."@en ;
+            rdfs:label "Theme"@en ;
+            skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Theme"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasTimecodeTrack
 ec:hasTimecodeTrack rdf:type owl:ObjectProperty ;
-                    dcterms:description "Pour identifier une piste de timecode avec une MediaResource."@fr ,
-                                        "So identifizieren Sie eine Timecode-Spur mit einer MediaResource."@de ,
-                                        "To identify a timecode track with a MediaResource."@en ;
-                    rdfs:label "Piste de timecode"@fr ,
-                               "Timecode track"@en ,
-                               "Timecode-Spur"@de .
+                    dcterms:description "A track that identifies the timecode track associated with a MediaResource."@en ;
+                    rdfs:label "Timecode track"@en ;
+                    skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:TimecodeTrack"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasTimelineTrack
 ec:hasTimelineTrack rdf:type owl:ObjectProperty ;
-                    dcterms:description "Pour associer un TimelineTrack à un EditorialObject"@fr ,
-                                        "So verknüpfen Sie einen TimelineTrack mit einem EditorialObject"@de ,
-                                        "To associate a TimelineTrack with an EditorialObject"@en ;
-                    rdfs:label "Piste chronologique"@fr ,
-                               "Timeline track"@en ,
-                               "Zeitleiste Spur"@de .
+                    dcterms:description "Associates a TimelineTrack with an EditorialObject."@en ;
+                    rdfs:label "Timeline track"@en ;
+                    skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:TimelineTrack"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasTimelineTrackPart
 ec:hasTimelineTrackPart rdf:type owl:ObjectProperty ;
                         owl:inverseOf ec:isTimelineTrackPartOf ;
-                        dcterms:description "Pour associer un EditorialObject à une TimelineTrack en tant que TimelineTrackpart"@fr ,
-                                            "So verknüpfen Sie ein EditorialObject mit einem TimelineTrack als TimelineTrackpart"@de ,
-                                            "To associate an EditorialObject to a TimelineTrack as an TimelineTrackpart"@en ;
-                        rdfs:label "Partie de la piste de la ligne de temps"@fr ,
-                                   "Teil der Zeitleiste"@de ,
-                                   "Timeline track part"@en .
+                        dcterms:description "An EditorialObject associated with a TimelineTrack as a TimelineTrack part."@en ;
+                        rdfs:label "Timeline track part"@en ;
+                        skos:definition "an owl:ObjectProperty relating an ec:TimelineTrack to an ec:EditorialObject"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasTopic
 ec:hasTopic rdf:type owl:ObjectProperty ;
-            dcterms:description "Cette propriété permet d'associer un actif à un sujet qui peut être une chaîne ou une URI pointant vers un terme d'un vocabulaire contrôlé. Un exemple typique est l'utilisation des sujets IPTC Media Topics définis sur http://cv.iptc.org/newscodes/mediatopic/."@fr ,
-                                "Mit dieser Eigenschaft können Sie ein Asset mit einem Thema verknüpfen, das eine Zeichenkette oder ein URI sein kann, der auf einen Begriff aus einem kontrollierten Vokabular verweist. Ein typisches Beispiel ist die Verwendung der IPTC-Medienthemen, die unter http://cv.iptc.org/newscodes/mediatopic/ definiert sind."@de ,
-                                "This property enables to associate an Asset with a topic which can be a string or a URI pointing to a term from a controlled vocabulary. A typical example is to make use of the IPTC Media Topics defined at http://cv.iptc.org/newscodes/mediatopic/."@en ;
-            rdfs:label "Sujet"@fr ,
-                       "Thema"@de ,
-                       "Topic"@en .
+            dcterms:description "This property enables to associate an Asset with a topic which can be a string or a URI pointing to a term from a controlled vocabulary. A typical example is to make use of the IPTC Media Topics defined at http://cv.iptc.org/newscodes/mediatopic/."@en ;
+            rdfs:label "Topic"@en ;
+            skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Topic"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasTrack
 ec:hasTrack rdf:type owl:ObjectProperty ;
-            dcterms:description "Pour associer des pistes audio/données/vidéo à une MediaResource."@fr ,
-                                "So verknüpfen Sie Audio-/Daten-/Videotracks mit einer MediaResource."@de ,
-                                "To associate audio/data/video tracks with a MediaResource."@en ;
-            rdfs:label "Piste"@fr ,
-                       "Spur"@de ,
-                       "Track"@en .
+            dcterms:description "Associates audio, video, or data tracks with a media resource."@en ;
+            rdfs:label "Track"@en ;
+            skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:Track"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasTrackPart
 ec:hasTrackPart rdf:type owl:ObjectProperty ;
                 owl:inverseOf ec:isTrackPartOf ;
-                dcterms:description "An element to identify a part of a track by a title, a start time and an end time in both the media source and media destinationn."@en ,
-                                    "Ein Element zur Identifizierung eines Teils eines Titels durch einen Titel, eine Startzeit und eine Endzeit sowohl in der Medienquelle als auch im Medienziel."@de ,
-                                    "Un élément pour identifier une partie d'une piste par un titre, une heure de début et une heure de fin dans la source du média et la destination du médian."@fr ;
-                rdfs:label "Quelle des Trackings"@de ,
-                           "Source de la partie de la voie"@fr ,
-                           "Track part source"@en .
+                dcterms:description "An element to identify a part of a track by a title, a start time and an end time in both the media source and media destination."@en ;
+                rdfs:label "Track part source"@en ;
+                skos:definition "an owl:ObjectProperty relating an ec:Track to an ec:MediaResource"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasTrackPurpose
 ec:hasTrackPurpose rdf:type owl:ObjectProperty ;
-                   dcterms:description "Der Zweck, für den der Track bereitgestellt wird."@de ,
-                                       "Le but pour lequel la piste est fournie."@fr ,
-                                       "The purpose for which the Track is provided."@en ;
-                   rdfs:label "Objectif de la voie"@fr ,
-                              "Track purpose"@en ,
-                              "Zweck der Spur"@de .
+                   dcterms:description "The purpose for which the Track is provided."@en ;
+                   rdfs:label "Track purpose"@en ;
+                   skos:definition "an owl:ObjectProperty relating an ec:Track to an ec:TrackPurpose"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasTrackType
 ec:hasTrackType rdf:type owl:ObjectProperty ;
-                dcterms:description "Der Typ, der einem Track zugeordnet ist."@de ,
-                                    "Le type attribué à une piste."@fr ,
-                                    "The type attributed to a Track."@en ;
-                rdfs:label "Name der Spur"@de ,
-                           "Nom de la piste"@fr ,
-                           "Track name"@en .
+                dcterms:description "The type attributed to a Track."@en ;
+                rdfs:label "Track name"@en ;
+                skos:definition "an owl:ObjectProperty relating an ec:Track to an ec:TrackType"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasUnit
 ec:hasUnit rdf:type owl:ObjectProperty ;
-           dcterms:description "Pour définir l'unité dans laquelle la valeur d'une mesure est exprimée, le cas échéant."@fr ,
-                               "To define the unit in which the value of a Measure is expressed, when applicable."@en ,
-                               "Zur Festlegung der Einheit, in der der Wert einer Kennzahl ausgedrückt wird, falls zutreffend."@de ;
-           rdfs:label "Einheit messen"@de ,
-                      "Measure unit"@en ,
-                      "Unité de mesure"@fr .
+           dcterms:description "The unit in which the value of a Measure is expressed, when applicable."@en ;
+           rdfs:label "Measure unit"@en ;
+           skos:definition "an owl:ObjectProperty relating an ec:Measure to a skos:Concept"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasUsageContract
 ec:hasUsageContract rdf:type owl:ObjectProperty ;
-                    dcterms:description "Die Vertragsbedingungen, unter denen ein ProductionDevice verwendet werden soll verwendet wird."@de ,
-                                        "Les conditions contractuelles selon lesquelles un ProductionDevice sera utilisé."@fr ,
-                                        "The contractual terms under which a ProductionDevice shall be used."@en ;
-                    rdfs:label "Contrat d'utilisation"@fr ,
-                               "Nutzungsvertrag"@de ,
-                               "Usage contract"@en .
+                    dcterms:description "The contractual terms under which a ProductionDevice shall be used."@en ;
+                    rdfs:label "Usage contract"@en ;
+                    skos:definition "an owl:ObjectProperty relating an ec:ProductionDevice to an ec:Contract"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasUsageRestrictions
 ec:hasUsageRestrictions rdf:type owl:ObjectProperty ;
                         rdfs:subPropertyOf ec:hasRights ;
-                        dcterms:description "Pour exprimer des restrictions d'utilisation."@fr ,
-                                            "To express usage restrictions."@en ,
-                                            "Um Nutzungseinschränkungen auszudrücken."@de ;
-                        rdfs:label "Einschränkungen bei der Verwendung"@de ,
-                                   "Restrictions d'utilisation"@fr ,
-                                   "Usage restrictions"@en .
+                        dcterms:description "The usage restrictions associated with an asset or publication event."@en ;
+                        rdfs:label "Usage restrictions"@en ;
+                        skos:definition "an owl:ObjectProperty relating an ec:Asset to ec:UsageRestrictions"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasUsageRights
 ec:hasUsageRights rdf:type owl:ObjectProperty ;
                   rdfs:subPropertyOf ec:hasRights ;
-                  dcterms:description "Pour exprimer les droits d'utilisation."@fr ,
-                                      "To express usage rights."@en ,
-                                      "Um Nutzungsrechte auszudrücken."@de ;
-                  rdfs:label "Droits d'utilisation"@fr ,
-                             "Nutzungsrechte"@de ,
-                             "Usage rights"@en .
+                  dcterms:description "The usage rights associated with an asset."@en ;
+                  rdfs:label "Usage rights"@en ;
+                  skos:definition "an owl:ObjectProperty relating an ec:Asset to an ec:UsageRights"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasVersion
 ec:hasVersion rdf:type owl:ObjectProperty ;
               owl:inverseOf ec:isVersionOf ;
-              dcterms:description "Pour identifier une autre version d'un actif, d'un objet éditorial ou d'une ressource."@fr ,
-                                  "To identify another version of an Asset, EditorialObject or Resource."@en ,
-                                  "Um eine andere Version eines Assets, Redaktionsobjekts oder einer Resource zu identifizieren."@de ;
-              rdfs:label "Version"@de ,
-                         "Version"@en ,
-                         "Version"@fr .
+              dcterms:description "An asset, editorial object, or resource that represents another version of the current entity."@en ;
+              rdfs:label "Version"@en ;
+              skos:definition "an owl:ObjectProperty relating an ec:Asset, ec:EditorialObject or resource to another version of that same entity"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasVersionType
 ec:hasVersionType rdf:type owl:ObjectProperty ;
-                  dcterms:description "Pour spécifier un type de version pour un EditorialObject."@fr ,
-                                      "To specify a type of version for an EditorialObject."@en ,
-                                      "Um eine Art von Version für ein EditorialObject anzugeben."@de ;
-                  rdfs:label "Type de version"@fr ,
-                             "Version Typ"@de ,
-                             "Version type"@en .
+                  dcterms:description "Specifies the type of version associated with an EditorialObject."@en ;
+                  rdfs:label "Version type"@en ;
+                  skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to a skos:Concept"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasVideoCodec
 ec:hasVideoCodec rdf:type owl:ObjectProperty ;
                  rdfs:subPropertyOf ec:hasCodec ;
-                 dcterms:description "Pour identifier un codec vidéo"@fr ,
-                                     "So identifizieren Sie einen Videocodec"@de ,
-                                     "To identify a video codec"@en ;
-                 rdfs:label "Codec vidéo"@fr ,
-                            "Video Codec"@de ,
-                            "Video codec"@en .
+                 dcterms:description "The video codec used to encode a media resource."@en ;
+                 rdfs:label "Video codec"@en ;
+                 skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:VideoCodec"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasVideoEncodingFormat
 ec:hasVideoEncodingFormat rdf:type owl:ObjectProperty ;
                           rdfs:subPropertyOf ec:hasFormat ;
-                          dcterms:description "Pour spécifier le format d'encodage vidéo."@fr ,
-                                              "To specify the video encoding format."@en ,
-                                              "Zur Angabe des Videocodierungsformats."@de ;
-                          rdfs:label "Audio encoding format"@en ,
-                                     "Format d'encodage audio"@fr ,
-                                     "Format der Audiokodierung"@de .
+                          dcterms:description "The video encoding format associated with a media resource."@en ;
+                          rdfs:label "Audio encoding format"@en ;
+                          skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:VideoEncodingFormat"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasVideoTrack
 ec:hasVideoTrack rdf:type owl:ObjectProperty ;
-                 dcterms:description "Pour identifier les VideoTracks dans la ressource."@fr ,
-                                     "So identifizieren Sie Videospuren in der Resource."@de ,
-                                     "To identify VideoTracks in the Resource."@en ;
-                 rdfs:label "Piste vidéo"@fr ,
-                            "Video track"@en ,
-                            "Video-Spur"@de .
+                 dcterms:description "A video track associated with the media resource."@en ;
+                 rdfs:label "Video track"@en ;
+                 skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:VideoTrack"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasWrappingType
 ec:hasWrappingType rdf:type owl:ObjectProperty ;
-                   dcterms:description "Pour spécifier le type d'emballage."@fr ,
-                                       "To specify the type of wrapping."@en ,
-                                       "Um die Art der Umhüllung festzulegen."@de ;
-                   rdfs:label "Art der Umhüllung"@de ,
-                              "Type d'emballage"@fr ,
-                              "Wrapping type"@en .
+                   dcterms:description "The type of wrapping associated with the resource."@en ;
+                   rdfs:label "Wrapping type"@en ;
+                   skos:definition "an owl:ObjectProperty relating an ec:AncillaryData to an ec:WrappingType"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#holdsAward
 ec:holdsAward rdf:type owl:ObjectProperty ;
               owl:inverseOf ec:isAwardedTo ;
-              rdfs:label "erhält"@de ,
-                         "holds"@en ,
-                         "reçoit"@fr .
+              dcterms:description "An Award held by an Agent, representing an award relationship from the agent to the award."@en ;
+              rdfs:label "Holds"@en ;
+              skos:definition "an owl:ObjectProperty relating an ec:Agent to an ec:Award"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#holdsLicence
 ec:holdsLicence rdf:type owl:ObjectProperty ;
-                dcterms:description "Die Bedingungen einer ConsumptionLicence, die mit einem Vertrag."@de ,
-                                    "Les termes d'une ConsumptionLicence associée à un contrat."@fr ,
-                                    "The terms of a ConsumptionLicence associated with a Contract."@en ;
-                rdfs:label "Consumption Licence"@en ,
-                           "Licence de consommation"@fr ,
-                           "Verbrauchslizenz"@de .
+                dcterms:description "The terms of a ConsumptionLicence associated with a Contract."@en ;
+                rdfs:label "Consumption licence"@en ;
+                skos:definition "an owl:ObjectProperty relating an ec:Account to an ec:ConsumptionLicence"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#includesAudience
 ec:includesAudience rdf:type owl:ObjectProperty ;
-                    dcterms:description "A defined audience group that is included in the audience"@en ,
-                                        "Eine definierte Zielgruppe, die in der Zielgruppe enthalten ist"@de ,
-                                        "Un groupe d'audience défini qui est inclus dans l'audience"@fr ;
-                    rdfs:label "Comprend le public"@fr ,
-                               "Includes audience"@en ,
-                               "Inklusive Publikum"@de .
+                    dcterms:description "A defined audience group that is included in the audience."@en ;
+                    rdfs:label "Includes audience"@en ;
+                    skos:definition "an owl:ObjectProperty relating an ec:Audience to an ec:Audience"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#instantiates
 ec:instantiates rdf:type owl:ObjectProperty ;
                 owl:inverseOf ec:isInstantiatedBy ;
-                dcterms:description "Pour lier une manifestation particulière d'un objet éditorial à la ressource correspondante."@fr ,
-                                    "To link a particular manifestation of an EditorialObject to the corresponding Resource."@en ,
-                                    "Um eine bestimmte Manifestation eines EditorialObjects mit der entsprechenden Resource zu verknüpfen."@de ;
-                rdfs:label "Editorial object"@en ,
-                           "Objet de la rédaction"@fr ,
-                           "Redaktionelles Objekt"@de .
+                dcterms:description "A particular manifestation of an EditorialObject linked to its corresponding Resource."@en ;
+                rdfs:label "Editorial object"@en ;
+                skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:EditorialObject"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isAbout
 ec:isAbout rdf:type owl:ObjectProperty ;
            rdfs:range ec:Asset ;
-           dcterms:description "Cette propriété est utilisée lorsqu'un autre objet éditorial, par exemple un livre, un film ou un programme, fait l'objet de l'objet éditorial."@fr ,
-                               "This property is used when another editorial object, e.g. a book, a movie or a programme is the topic of the editorial object."@en ,
-                               "Wird verwendet, wenn ein anderer Medieninhalt, z.b. ein Buch, ein Film oder eine Sendung das Thema des Medieninhaltes ist."@de ;
-           rdfs:label "est à propos"@fr ,
-                      "handelt von"@de ,
-                      "is about"@en .
+           dcterms:description "This property is used when another editorial object, e.g. a book, a movie or a programme is the topic of the editorial object."@en ;
+           rdfs:label "Is about"@en ;
+           skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Asset"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isAffiliatedTo
 ec:isAffiliatedTo rdf:type owl:ObjectProperty ;
-                  dcterms:description "Beziehung zu der Organisation, die der Verband vertritt"@de ,
-                                      "Relation avec l'organisation que l'affiliation représente"@fr ,
-                                      "Relation to the organisation the affiliation represents"@en ;
-                  rdfs:label "est affilié à"@fr ,
-                             "is affiliated to"@en ,
-                             "ist angegliedert an"@de .
+                  dcterms:description "Relation to the organisation the affiliation represents."@en ;
+                  rdfs:label "Is affiliated to"@en ;
+                  skos:definition "an owl:ObjectProperty relating an ec:Affiliation to an ec:Organisation"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isAffiliationFor
-ec:isAffiliationFor rdf:type owl:ObjectProperty .
+ec:isAffiliationFor rdf:type owl:ObjectProperty ;
+                    dcterms:description "A property that relates an Affiliation to the Person for whom it is valid."@en ;
+                    rdfs:label "Affiliation for"@en ;
+                    skos:definition "an owl:ObjectProperty relating an ec:Affiliation to an ec:Person"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isAnimalGroomFor
-ec:isAnimalGroomFor rdf:type owl:ObjectProperty .
+ec:isAnimalGroomFor rdf:type owl:ObjectProperty ;
+                    dcterms:description "The animal groomed or cared for by the associated agent."@en ;
+                    rdfs:label "Animal groom for"@en ;
+                    skos:definition "an owl:ObjectProperty inverse of ec:hasAnimalGroom relating an ec:Agent to an ec:Animal"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isAnimatedBy
 ec:isAnimatedBy rdf:type owl:ObjectProperty ;
-                dcterms:description "Character, animated by a person using an artifact"@en ,
-                                    "Charakter, der von einer Person mit Hilfe eines Artefakts animiert wird"@de ,
-                                    "Personnage, animé par une person utilisant un artefact"@fr ;
-                rdfs:label "est animé par"@fr ,
-                           "is animated by"@en ,
-                           "wird animiert von"@de .
+                dcterms:description "Character, animated by a person using an artifact."@en ;
+                rdfs:label "Is animated by"@en ;
+                skos:definition "an owl:ObjectProperty relating an ec:Character to an ec:Person"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isAnnotatedMediaResource
 ec:isAnnotatedMediaResource rdf:type owl:ObjectProperty ;
-                            dcterms:description "Pour lier une Annotation à une MediaResource."@fr ,
-                                                "So verknüpfen Sie eine Anmerkung mit einer MediaResource."@de ,
-                                                "To link an Annotation to a MediaResource."@en ;
-                            rdfs:label "Media resource"@en ,
-                                       "MedienResource"@de ,
-                                       "Resource médiatique"@fr .
+                            dcterms:description "Links an Annotation to a MediaResource."@en ;
+                            rdfs:label "Media resource"@en ;
+                            skos:definition "an owl:ObjectProperty relating an ec:Annotation to an ec:MediaResource"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isAttributedTo
 ec:isAttributedTo rdf:type owl:ObjectProperty ;
-                  dcterms:description "Pour associer un agent à une instance de Provenance."@fr ,
-                                      "So verknüpfen Sie einen Agenten mit einer Provenance-Instanz."@de ,
-                                      "To associate an Agent with a Provenance instance."@en ;
-                  rdfs:label "Cible de provenance"@fr ,
-                             "Provenance target"@en ,
-                             "Ziel Provenienz"@de .
+                  dcterms:description "An association between a Provenance instance and the Agent it is attributed to."@en ;
+                  rdfs:label "Provenance target"@en ;
+                  skos:definition "an owl:ObjectProperty relating an ec:Provenance to an ec:Agent"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isAuthorOf
-ec:isAuthorOf rdf:type owl:ObjectProperty .
+ec:isAuthorOf rdf:type owl:ObjectProperty ;
+              dcterms:description "An object property that links an Agent to the Annotation it authored."@en ;
+              rdfs:label "Author of"@en ;
+              skos:definition "an owl:ObjectProperty relating an ec:Agent to an ec:Annotation"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isAwardedTo
 ec:isAwardedTo rdf:type owl:ObjectProperty ;
-               rdfs:label "awarded to"@en ,
-                          "décerné à"@fr ,
-                          "verliehen an"@de .
+               dcterms:description "Identifies the agent to whom an award is given."@en ;
+               rdfs:label "Awarded to"@en ;
+               skos:definition "an owl:ObjectProperty relating an ec:Award to an ec:Agent"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isChildOf
 ec:isChildOf rdf:type owl:ObjectProperty ;
-             dcterms:description "Pour lier un concept à un parent."@fr ,
-                                 "To link a concept to a parent."@en ,
-                                 "Um ein Konzept mit einem übergeordneten Konzept zu verknüpfen."@de ;
-             rdfs:label "Eltern"@de ,
-                        "Parent"@en ,
-                        "Parent"@fr .
+             dcterms:description "The parent asset of this asset."@en ;
+             rdfs:label "Parent"@en ;
+             skos:definition "an owl:ObjectProperty relating an ec:Asset to an ec:Asset"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isCloneOf
 ec:isCloneOf rdf:type owl:ObjectProperty ;
-             dcterms:description "Pour identifier la source d'une MediaResource clonée"@fr ,
-                                 "So identifizieren Sie die Quelle einer geklonten MediaResource"@de ,
-                                 "To identify the source of a clone MediaResource"@en ;
-             rdfs:label "Clone source"@en ,
-                        "Cloner la source"@fr ,
-                        "Quelle klonen"@de .
+             dcterms:description "The source MediaResource of a clone."@en ;
+             rdfs:label "Clone source"@en ;
+             skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:MediaResource"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isCommissionedBy
 ec:isCommissionedBy rdf:type owl:ObjectProperty ;
-                    dcterms:description "Der Vertrag, durch den eine Resource in Auftrag gegeben wird."@de ,
-                                        "Le contrat par lequel une ressource est commandée."@fr ,
-                                        "The Contract through which a Resource is commissioned."@en ;
-                    rdfs:label "Contract"@en ,
-                               "Contrat"@fr ,
-                               "Vertrag"@de .
+                    dcterms:description "The Contract through which a Resource is commissioned."@en ;
+                    rdfs:label "Contract"@en ;
+                    skos:definition "an owl:ObjectProperty relating an ec:Resource to an ec:Contract"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isComposedOf
 ec:isComposedOf rdf:type owl:ObjectProperty ;
-                dcterms:description "Identifier les mediaResources utilisées pour composer une Essence."@fr ,
-                                    "To identify mediaResources used to compose an Essence."@en ,
-                                    "Zur Identifizierung von MedienResourcen, die zur Erstellung einer Essenz verwendet werden."@de ;
-                rdfs:label "Media Resource"@en ,
-                           "Medien Resource"@de ,
-                           "Resource médiatique"@fr .
+                dcterms:description "The media resources used to compose an Essence."@en ;
+                rdfs:label "Media resource"@en ;
+                skos:definition "an owl:ObjectProperty relating an ec:Essence to an ec:MediaResource"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isDefinedBy
 ec:isDefinedBy rdf:type owl:ObjectProperty ;
-               dcterms:description "Pour identifier le contrat par lequel une règle a été définie."@fr ,
-                                   "To identify the Contract by which a Rule has been defined."@en ,
-                                   "Um den Vertrag zu identifizieren, durch den eine Regel definiert wurde definiert wurde."@de ;
-               rdfs:label "Contrat connexe"@fr ,
-                          "Related contract"@en ,
-                          "Verwandter Vertrag"@de .
+               dcterms:description "The Contract by which a Rule has been defined."@en ;
+               rdfs:label "Related contract"@en ;
+               skos:definition "an owl:ObjectProperty relating an ec:Rule to an ec:Contract"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isDerivedFrom
 ec:isDerivedFrom rdf:type owl:ObjectProperty ;
-                 dcterms:description "Identifie une relation basée sur le contenu entre deux ressources."@fr ,
-                                     "Identifies a content-based relationship between two resources."@en ,
-                                     "Identifiziert eine inhaltsbezogene Beziehung zwischen zwei Resourcen."@de ;
-                 rdfs:label "Abgeleitet von"@de ,
-                            "Derived from"@en ,
-                            "Dérivé de"@fr .
+                 dcterms:description "Identifies a content-based relationship between two resources."@en ;
+                 rdfs:label "Derived from"@en ;
+                 skos:definition "an owl:ObjectProperty relating an ec:Asset to an ec:Asset"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isDistributedOn
 ec:isDistributedOn rdf:type owl:ObjectProperty ;
-                   dcterms:description "Pour identifier la plateforme sur laquelle le contenu est distribué."@fr ,
-                                       "To identify the platform on which content is distributed."@en ,
-                                       "Um die Plattform zu identifizieren, auf der die Inhalte verbreitet werden."@de ;
-                   rdfs:label "Plate-forme/Service/Canal de publication"@fr ,
-                              "Platform/Service/PublicationChannel"@en ,
-                              "Plattform/Dienstleistung/Veröffentlichungskanal"@de .
+                   dcterms:description "The platform on which the content is distributed."@en ;
+                   rdfs:label "Platform/service/publication channel"@en ;
+                   skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:PublicationService"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isDubOf
 ec:isDubOf rdf:type owl:ObjectProperty ;
-           dcterms:description "die Herkunft einer überspielten MediaResource."@de ,
-                               "l'origine d'une MediaResource doublée."@fr ,
-                               "the origin of a dubbed MediaResource."@en ;
-           rdfs:label "Doublé de"@fr ,
-                      "Dubbed from"@en ,
-                      "Synchronisiert von"@de .
+           dcterms:description "The origin of a dubbed MediaResource."@en ;
+           rdfs:label "Dubbed from"@en ;
+           skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:MediaResource"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isEmbodiedBy
-ec:isEmbodiedBy rdf:type owl:ObjectProperty .
+ec:isEmbodiedBy rdf:type owl:ObjectProperty ;
+                dcterms:description "Indicates that a character is embodied by an artefact in a production context."@en ;
+                rdfs:label "Is embodied by"@en ;
+                skos:definition "an owl:ObjectProperty relating an ec:Character to an ec:Artefact"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isEpisodeOfSeason
 ec:isEpisodeOfSeason rdf:type owl:ObjectProperty ;
-                     dcterms:description "Die Episode einer Saison."@de ,
-                                         "L'épisode d'une saison."@fr ,
-                                         "The Episode of a Season."@en ;
-                     rdfs:label "Parent season"@en ,
-                                "Saison der Eltern"@de ,
-                                "Saison des parents"@fr .
+                     dcterms:description "The Episode of a Season."@en ;
+                     rdfs:label "Parent season"@en ;
+                     skos:definition "an owl:ObjectProperty relating an ec:Programme to an ec:Season"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isEpisodeOfSerial
 ec:isEpisodeOfSerial rdf:type owl:ObjectProperty ;
-                     rdfs:label "est un épisode de la série"@fr ,
-                                "is episode of serial"@en ,
-                                "ist eine Folge der Serie"@de .
+                     dcterms:description "Indicates that a programme is an episode of a serial."@en ;
+                     rdfs:label "Is episode of serial"@en ;
+                     skos:definition "an owl:ObjectProperty relating an ec:Programme to an ec:Serial"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isEpisodeOfSeries
 ec:isEpisodeOfSeries rdf:type owl:ObjectProperty ;
-                     dcterms:description "Die Episode einer Serie."@de ,
-                                         "L'épisode d'une série."@fr ,
-                                         "The Episode of a Series."@en ;
-                     rdfs:label "Eltern-Serie"@de ,
-                                "Parent series"@en ,
-                                "Série sur les parents"@fr .
+                     dcterms:description "The Episode of a Series."@en ;
+                     rdfs:label "Parent series"@en ;
+                     skos:definition "an owl:ObjectProperty relating an ec:Programme to an ec:Series"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isExtractOf
 ec:isExtractOf rdf:type owl:ObjectProperty ;
-               dcterms:description "Dient zur Darstellung eines Auszugs, d. h. der Wiedergabe eines Teils oder des gesamten archivierten Materials auf dem Abspielgerät. Für Attribute wie Dauer und Start werden die Daten in der Instanz platziert, die den Auszug darstellt. Andere Metadaten werden aus der Originalinstanz gelesen, die extrahiert wird."@de ,
-                                   "Used for representing an extract, i. e. the playout of a part or the whole of some archived material on the playout. For attributes like duration and start, the data is placed in the instance representing the abstract. Other metadata is read from the original instance that is extracted."@en ,
-                                   "Utilisé pour représenter un extrait, c'est-à-dire la diffusion d'une partie ou de la totalité d'un matériel archivé sur le playout. Pour les attributs tels que la durée et le début, les données sont placées dans l'instance représentant l'extrait. Les autres métadonnées sont lues à partir de l'instance originale qui est extraite."@fr ;
-               rdfs:label "est un extrait de"@fr ,
-                          "is extract of"@en ,
-                          "ist ein Auszug aus"@de .
+               dcterms:description "Used for representing an extract, i. e. the playout of a part or the whole of some archived material on the playout. For attributes like duration and start, the data is placed in the instance representing the abstract. Other metadata is read from the original instance that is extracted."@en ;
+               rdfs:label "Is extract of"@en ;
+               skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:EditorialObject"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isInstantiatedBy
 ec:isInstantiatedBy rdf:type owl:ObjectProperty ;
-                    dcterms:description "Pour identifier une MediaResource instanciant un EditorialObject."@fr ,
-                                        "To identify a MediaResource instantiating an EditorialObject."@en ,
-                                        "Um eine MediaResource zu identifizieren, die ein EditorialObject instanziiert."@de ;
-                    rdfs:label "Media Resource"@en ,
-                               "Medien Resource"@de ,
-                               "Resource médiatique"@fr .
+                    dcterms:description "An object property that links an EditorialObject to the MediaResource it instantiates."@en ;
+                    rdfs:label "Media resource"@en ;
+                    skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:MediaResource"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isMasterOf
 ec:isMasterOf rdf:type owl:ObjectProperty ;
-              dcterms:description "Pour identifier le maître d'une ressource média dérivée."@fr ,
-                                  "To identify the master of a derived media resource."@en ,
-                                  "Um den Master einer abgeleiteten MedienResource zu identifizieren."@de ;
-              rdfs:label "Abgeleitete MedienResource"@de ,
-                         "Derived media resource"@en ,
-                         "Resource média dérivée"@fr .
+              dcterms:description "The master resource of a derived media resource."@en ;
+              rdfs:label "Derived media resource"@en ;
+              skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:MediaResource"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isMediaFragmentOf
 ec:isMediaFragmentOf rdf:type owl:ObjectProperty ;
-                     dcterms:description "Pour identifier la ressource média à laquelle appartient un fragment de média"@fr ,
-                                         "So identifizieren Sie die MedienResource, zu der ein Medienfragment gehört"@de ,
-                                         "To identify the Media Resource to which a Media Fragment belongs to"@en ;
-                     rdfs:label "Media fragment source"@en ,
-                                "Quelle des Medienfragments"@de ,
-                                "Source du fragment de média"@fr .
+                     dcterms:description "The Media Resource to which a Media Fragment belongs."@en ;
+                     rdfs:label "Media fragment source"@en ;
+                     skos:definition "an owl:ObjectProperty relating an ec:MediaFragment to an ec:MediaResource"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isMemberOf
 ec:isMemberOf rdf:type owl:ObjectProperty ;
-              dcterms:description "Pour identifier un groupe dont un objet éditorial est membre."@fr ,
-                                  "So identifizieren Sie einen übergeordneten Veröffentlichungsplan"@de ,
-                                  "To identify a Group to which an EditorialObject is a member of."@en ;
-              rdfs:label "Member of"@en ,
-                         "Membre de"@fr ,
-                         "Mitglied von"@de .
+              dcterms:description "A group to which an EditorialObject belongs."@en ;
+              rdfs:label "Member of"@en ;
+              skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:EditorialGroup"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isNextInSequence
 ec:isNextInSequence rdf:type owl:ObjectProperty ;
                     owl:inverseOf ec:isPreviousInSequence ;
-                    dcterms:description "A link to an Editorial Object following the current Editorial Object in an ordered sequence."@en ,
-                                        "Ein Link zu einem redaktionellen Objekt, das dem aktuellen redaktionellen Objekt in einer geordneten Reihenfolge folgt."@de ,
-                                        "Un lien vers un objet éditorial suivant l'objet éditorial actuel dans une séquence ordonnée."@fr ;
-                    rdfs:label "Next"@en ,
-                               "Nächste"@de ,
-                               "Suivant"@fr .
+                    dcterms:description "A link to an Editorial Object following the current Editorial Object in an ordered sequence."@en ;
+                    rdfs:label "Next"@en ;
+                    skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:EditorialObject"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isOfferedBy
 ec:isOfferedBy rdf:type owl:ObjectProperty ;
                owl:inverseOf ec:offers ;
-               dcterms:description "Pour identifier un service associé à un PublicationEvent."@fr ,
-                                   "To identify a Service associated with a PublicationEvent."@en ,
-                                   "Um einen Dienst zu identifizieren, der einem PublicationEvent zugeordnet ist."@de ;
-               rdfs:label "Service"@de ,
-                          "Service"@en ,
-                          "Service"@fr .
+               dcterms:description "Associates a PublicationEvent with the PublicationService that offers it."@en ;
+               rdfs:label "Service"@en ;
+               skos:definition "an owl:ObjectProperty relating an ec:PublicationEvent to an ec:PublicationService"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isOperatedBy
 ec:isOperatedBy rdf:type owl:ObjectProperty ;
-                dcterms:description "Pour identifier le service qui exploite le canal de publication."@fr ,
-                                    "To identify the Service that operates the PublicationChannel."@en ,
-                                    "Um den Dienst zu identifizieren, der den PublicationChannel."@de ;
-                rdfs:label "Betreiber, Eigentümer"@de ,
-                           "Operator, owner"@en ,
-                           "Opérateur, propriétaire"@fr .
+                dcterms:description "A service that operates the publication channel."@en ;
+                rdfs:label "Operator, owner"@en ;
+                skos:definition "an owl:ObjectProperty relating a ec:PublicationChannel to a ec:PublicationService"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isOrderedBy
 ec:isOrderedBy rdf:type owl:ObjectProperty ;
-               dcterms:description "Der Vertrag, über den ein ProductionJob bestellt wird bestellt wird."@de ,
-                                   "Le contrat par lequel un ProductionJob est commandée."@fr ,
-                                   "The Contract through which an ProductionJob is ordered."@en ;
-               rdfs:label "Contract"@en ,
-                          "Contrat"@fr ,
-                          "Vertrag"@de .
+               dcterms:description "The Contract through which an ProductionJob is ordered."@en ;
+               rdfs:label "Contract"@en ;
+               skos:definition "an owl:ObjectProperty relating an ec:ProductionJob to an ec:Contract"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isOwnedBy
 ec:isOwnedBy rdf:type owl:ObjectProperty ;
              owl:inverseOf ec:owns ;
-             dcterms:description "Pour identifier l’Agent (Contact, Personne ou Organisation) qui possède une Marque, un Canal de publication, une Plateforme de publication ou un Service de publication."@fr ,
-                                 "To identify the Agent (Contact, Person, or Organisation) who owns a MarketingBrand, PublicationChannel, PublicationPlatform, or PublicationService."@en ,
-                                 "Zur Identifizierung des Agenten (Kontakt, Person oder Organisation), der Eigentümer einer Marke, eines Veröffentlichungskanals, einer Veröffentlichungsplattform oder eines Veröffentlichungsdienstes ist."@de ;
-             rdfs:label "est possédé par"@fr ,
-                        "is owned by"@en ,
-                        "ist Eigentum von"@de .
+             dcterms:description "The Agent (Contact, Person, or Organisation) that owns a MarketingBrand, PublicationChannel, PublicationPlatform, or PublicationService."@en ;
+             rdfs:label "Is owned by"@en ;
+             skos:definition "an owl:ObjectProperty relating an ec:MarketingBrand, ec:PublicationChannel, ec:PublicationPlatform, or ec:PublicationService to an ec:Agent"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isPartOf
 ec:isPartOf rdf:type owl:ObjectProperty ;
-            dcterms:description "Pour identifier l'objet éditorial auquel appartient une partie."@fr ,
-                                "To identify the editorial object to which belongs a part."@en ,
-                                "Um das redaktionelle Objekt zu identifizieren, zu dem ein Teil gehört."@de ;
-            rdfs:label "Editorial object"@en ,
-                       "Objet de la rédaction"@fr ,
-                       "Redaktionelles Objekt"@de .
+            dcterms:description "The editorial object that contains a part."@en ;
+            rdfs:label "Editorial object"@en ;
+            skos:definition "an owl:ObjectProperty relating an ec:EditorialSegment to an ec:EditorialObject"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isPlayedBy
 ec:isPlayedBy rdf:type owl:ObjectProperty ;
               owl:inverseOf ec:playsCharacter ;
               owl:propertyDisjointWith ec:isPortrayedBy ;
-              dcterms:description "Beziehung zwischen einer fiktiven Figur und dem Schauspieler, der die Rolle spielt."@de ,
-                                  "Relation entre un personnage fictif et l'acteur qui joue le rôle."@fr ,
-                                  "Relationship between a fictional character and the actor playing the part."@en ;
-              rdfs:label "est joué par"@fr ,
-                         "is played by"@en ,
-                         "wird gespielt von"@de .
+              dcterms:description "Relationship between a fictional character and the actor playing the part."@en ;
+              rdfs:label "Is played by"@en ;
+              skos:definition "an owl:ObjectProperty relating an ec:Character to an ec:Involvement"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isPortrayedBy
 ec:isPortrayedBy rdf:type owl:ObjectProperty ;
                  owl:inverseOf ec:portrays ;
-                 dcterms:description "Beziehung zwischen einer fiktiven Figur und dem Tier, das in der Szene abgebildet ist."@de ,
-                                     "Relation entre un personnage fictif et l'animal qui est représenté dans la scène."@fr ,
-                                     "Relationship between a fictional character and the animal that is depicted in the scene."@en ;
-                 rdfs:label "est dépeint par"@fr ,
-                            "is portrayed by"@en ,
-                            "wird porträtiert von"@de .
+                 dcterms:description "Relationship between a fictional character and the animal that is depicted in the scene."@en ;
+                 rdfs:label "Is portrayed by"@en ;
+                 skos:definition "an owl:ObjectProperty relating an ec:Character to an ec:Animal"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isPreviousInSequence
 ec:isPreviousInSequence rdf:type owl:ObjectProperty ;
-                        dcterms:description "A link to an Editorial Object precedinging the current Editorial Object in an ordered sequence."@en ,
-                                            "Ein Link zu einem redaktionellen Objekt, das dem aktuellen redaktionellen Objekt in einer geordneten Reihenfolge vorausgeht."@de ,
-                                            "Un lien vers un objet éditorial précédant l'objet éditorial actuel dans une séquence ordonnée."@fr ;
-                        rdfs:label "Preceding"@en ,
-                                   "Précédant"@fr ,
-                                   "Vorangehend"@de .
+                        dcterms:description "A link to an Editorial Object preceding the current Editorial Object in an ordered sequence."@en ;
+                        rdfs:label "Preceding"@en ;
+                        skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:EditorialObject"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isReferencedBy
 ec:isReferencedBy rdf:type owl:ObjectProperty ;
                   owl:inverseOf ec:references ;
-                  dcterms:description "A related resource that references, cites, or otherwise points to the described resource."@en ,
-                                      "Eine verwandte Ressource, die auf die beschriebene Ressource verweist, sie zitiert oder anderweitig darauf verweist."@de ,
-                                      "Une ressource connexe qui fait référence, cite ou pointe d’une autre manière vers la ressource décrite."@fr ;
-                  rdfs:label "Reference source"@en ,
-                             "Referenzquelle"@de ,
-                             "Source de référence"@fr .
+                  dcterms:description "A related resource that references, cites, or otherwise points to the described resource."@en ;
+                  rdfs:label "Reference source"@en ;
+                  skos:definition "an owl:ObjectProperty relating a resource to a related resource that references, cites, or otherwise points to it"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isRelatedAgent
-ec:isRelatedAgent rdf:type owl:ObjectProperty .
+ec:isRelatedAgent rdf:type owl:ObjectProperty ;
+                  dcterms:description "To relate an Agent to a concept associated with it, such as a Person or Character."@en ;
+                  rdfs:label "Related agent"@en ;
+                  skos:definition "an owl:ObjectProperty relating an ec:Concept to an ec:Agent"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isReplacedBy
 ec:isReplacedBy rdf:type owl:ObjectProperty ;
                 owl:inverseOf ec:replaces ;
-                dcterms:description "Pour identifier les substitutions."@fr ,
-                                    "To identify substitutions."@en ,
-                                    "Um Substitutionen zu identifizieren."@de ;
-                rdfs:label "Ersatz"@de ,
-                           "Remplacement"@fr ,
-                           "Replacement"@en .
+                dcterms:description "Identifies an asset that is substituted by another asset."@en ;
+                rdfs:label "Replacement"@en ;
+                skos:definition "an owl:ObjectProperty relating an ec:Asset to an ec:Asset"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isRequiredBy
 ec:isRequiredBy rdf:type owl:ObjectProperty ;
                 owl:inverseOf ec:requires ;
-                dcterms:description "Pour exprimer des relations fortes entre les EditorialObjects"@fr ,
-                                    "To express strong relations between EditorialObjects"@en ,
-                                    "Um starke Beziehungen zwischen EditorialObjects auszudrücken"@de ;
-                rdfs:label "Erforderlich"@de ,
-                           "Required"@en ,
-                           "Requis"@fr .
+                dcterms:description "Strong relation between EditorialObjects."@en ;
+                rdfs:label "Required"@en ;
+                skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:EditorialObject"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isSeasonOf
 ec:isSeasonOf rdf:type owl:ObjectProperty ;
-              dcterms:description "Pour associer une Saison à une Série."@fr ,
-                                  "So ordnen Sie eine Saison einer Serie zu."@de ,
-                                  "To assoicate a Season with a Series."@en ;
-              rdfs:label "Serie"@de ,
-                         "Series"@en ,
-                         "Série"@fr .
+              dcterms:description "Associates a season with the series to which it belongs."@en ;
+              rdfs:label "Series"@en ;
+              skos:definition "an owl:ObjectProperty relating an ec:Season to an ec:Series"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isTimelineTrackPartOf
 ec:isTimelineTrackPartOf rdf:type owl:ObjectProperty ;
-                         dcterms:description "Pour associer un EditorialObject à une partie de la TimelineTrack."@fr ,
-                                             "So verknüpfen Sie ein EditorialObject mit einem Teil der TimelineTrack."@de ,
-                                             "To associate an EditorialObject with a part of the TimelineTrack."@en ;
-                         rdfs:label "Editorial Object"@en ,
-                                    "Objet de la rédaction"@fr ,
-                                    "Redaktionelles Objekt"@de .
+                         dcterms:description "Associates an EditorialObject with a part of a TimelineTrack."@en ;
+                         rdfs:label "Timeline track part"@en ;
+                         skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to a ec:TimelineTrack"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isTrackPartOf
 ec:isTrackPartOf rdf:type owl:ObjectProperty ;
-                 dcterms:description "An element to identify a part of a track by a title, a start time and an end time in both the media source and media destination."@en ,
-                                     "Ein Element zur Identifizierung eines Teils eines Titels durch einen Titel, eine Startzeit und eine Endzeit sowohl in der Medienquelle als auch im Medienziel."@de ,
-                                     "Un élément pour identifier une partie d'une piste par un titre, une heure de début et une heure de fin dans la source et la destination du média."@fr ;
-                 rdfs:label "Quelle des Trackings"@de ,
-                            "Source de la partie de la voie"@fr ,
-                            "Track part source"@en .
+                 dcterms:description "An element to identify a part of a track by a title, a start time and an end time in both the media source and media destination."@en ;
+                 rdfs:label "Track part source"@en ;
+                 skos:definition "an owl:ObjectProperty relating an ec:Track to an ec:MediaResource"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isVersionOf
 ec:isVersionOf rdf:type owl:ObjectProperty ;
-               dcterms:description "Pour identifier les versions connexes."@fr ,
-                                   "To identify related versions."@en ,
-                                   "Um verwandte Versionen zu identifizieren."@de ;
-               rdfs:label "Version de"@fr ,
-                          "Version of"@en ,
-                          "Version von"@de .
+               dcterms:description "Related versions of an EditorialObject or Resource."@en ;
+               rdfs:label "Version of"@en ;
+               skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:EditorialObject"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#logs
 ec:logs rdf:type owl:ObjectProperty ;
+        dcterms:description "Links a publication log to its publication events."@en ;
+        rdfs:label "Logs"@en ;
+        skos:definition "an owl:ObjectProperty relating an ec:PublicationLog to an ec:PublicationEvent"@en ;
         skos:note "logs publication event"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#measures
 ec:measures rdf:type owl:ObjectProperty ;
-            dcterms:description "Pour associer une règle à une mesure."@fr ,
-                                "So verknüpfen Sie eine Regel mit einer Kennzahl."@de ,
-                                "To associate a Rule with a Measure."@en ;
-            rdfs:label "Related Rule"@en ,
-                       "Règle connexe"@fr ,
-                       "Verwandte Regel"@de .
+            dcterms:description "Associates a Measure with a Rule."@en ;
+            rdfs:label "Related rule"@en ;
+            skos:definition "an owl:ObjectProperty relating an ec:Measure to an ec:Rule"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#occursIn
-ec:occursIn rdf:type owl:ObjectProperty .
+ec:occursIn rdf:type owl:ObjectProperty ;
+            dcterms:description "A property that links a consumption event to the publication channel or publication service in which it occurs."@en ;
+            rdfs:label "Occurs in"@en ;
+            skos:definition "an owl:ObjectProperty relating an ec:ConsumptionEvent to a ec:PublicationService or ec:PublicationChannel"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#occursOn
-ec:occursOn rdf:type owl:ObjectProperty .
+ec:occursOn rdf:type owl:ObjectProperty ;
+            dcterms:description "A property that links a consumption event to the publication platform on which it occurs."@en ;
+            rdfs:label "Occurs on"@en ;
+            skos:definition "an owl:ObjectProperty relating an ec:ConsumptionEvent to an ec:PublicationPlatform"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#offers
 ec:offers rdf:type owl:ObjectProperty ;
-          dcterms:description "Pour identifier les PublicationEvents disponibles via un service."@fr ,
-                              "To identify the PublicationEvents available through a Service."@en ,
-                              "Zur Identifizierung der PublicationEvents, die über einen Dienst."@de ;
-          rdfs:label "Angebote Service"@de ,
-                     "Offers service"@en ,
-                     "Offres de service"@fr ,
-                     "Publication events"@en ,
-                     "Veranstaltungen zur Veröffentlichung"@de ,
-                     "Événements de publication"@fr .
+          dcterms:description "The publication events available through a service."@en ;
+          rdfs:label "Offers service"@en ;
+          skos:definition "an owl:ObjectProperty relating an ec:PublicationPlatform to an ec:PublicationService"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#originatesFrom
 ec:originatesFrom rdf:type owl:ObjectProperty ;
-                  dcterms:description "Der Vertrag, aus dem die Rechte hervorgehen."@de ,
-                                      "Le contrat dont découlent les droits."@fr ,
-                                      "The Contract from which the Rights originate."@en ;
-                  rdfs:label "Contract"@en ,
-                             "Contrat"@fr ,
-                             "Vertrag"@de .
+                  dcterms:description "The Contract from which the Rights originate."@en ;
+                  rdfs:label "Contract"@en ;
+                  skos:definition "an owl:ObjectProperty relating an ec:Rights to an ec:Contract"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#owns
 ec:owns rdf:type owl:ObjectProperty ;
-        dcterms:description "Pour identifier la Marque, le Canal de publication, la Plateforme de publication ou le Service de publication possédé par un Agent (Contact, Personne ou Organisation)."@fr ,
-                            "To identify the MarketingBrand, PublicationChannel, PublicationPlatform, or PublicationService owned by a given Agent (Contact, Person, or Organisation)."@en ,
-                            "Zur Identifizierung der Marke, des Veröffentlichungskanals, der Veröffentlichungsplattform oder des Veröffentlichungsdienstes, die einem Agenten (Kontakt, Person oder Organisation) gehören."@de ;
-        rdfs:label "besitzt"@de ,
-                   "owns"@en ,
-                   "possède"@fr .
+        dcterms:description "The MarketingBrand, PublicationChannel, PublicationPlatform, or PublicationService owned by a given Agent (Contact, Person, or Organisation)."@en ;
+        rdfs:label "Owns"@en ;
+        skos:definition "an owl:ObjectProperty relating an ec:Agent to an ec:MarketingBrand, ec:PublicationChannel, ec:PublicationPlatform, or ec:PublicationService"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#playsCharacter
 ec:playsCharacter rdf:type owl:ObjectProperty ;
-                  dcterms:description "A character played by a person. The relationship implies that the person has intellectual rights to the performance of the character."@en ,
-                                      "Eine Figur, die von einer Person gespielt wird. Die Beziehung impliziert, dass die Person die geistigen Rechte an der Darstellung der Figur hat."@de ,
-                                      "Un personnage joué par une personne. La relation implique que la personne a des droits intellectuels sur l'interprétation du personnage."@fr ;
-                  rdfs:label "joue un personnage"@fr ,
-                             "plays character"@en ,
-                             "spielt Charakter"@de .
+                  dcterms:description "A character played by a person. The relationship implies that the person has intellectual rights to the performance of the character."@en ;
+                  rdfs:label "Plays character"@en ;
+                  skos:definition "an owl:ObjectProperty relating an ec:Involvement to an ec:Character"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#playsOut
 ec:playsOut rdf:type owl:ObjectProperty ;
-            dcterms:description "Pour identifier l'essence utilisée dans un PublicationEvent"@fr ,
-                                "So identifizieren Sie die in einem PublicationEvent verwendete Essenz"@de ,
-                                "To identify the Essence used in a PublicationEvent"@en ;
-            rdfs:label "Essence"@en ,
-                       "Essence"@fr ,
-                       "Essenz"@de .
+            dcterms:description "Describes the Essence used in a PublicationEvent."@en ;
+            rdfs:label "Essence"@en ;
+            skos:definition "an owl:ObjectProperty relating an ec:PublicationEvent to an ec:Essence"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#portrays
 ec:portrays rdf:type owl:ObjectProperty ;
-            dcterms:description "An animal that appears as a character other than itself."@en ,
-                                "Ein Tier, das als eine andere Figur als sich selbst erscheint."@de ,
-                                "Un animal qui apparaît comme un personnage autre que lui-même."@fr ;
-            rdfs:label "dépeint"@fr ,
-                       "portrays"@en ,
-                       "porträtiert"@de .
+            dcterms:description "An animal that appears as a character other than itself."@en ;
+            rdfs:label "Portrays"@en ;
+            skos:definition "an owl:ObjectProperty relating an ec:Animal to an ec:Character"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#promotes
 ec:promotes rdf:type owl:ObjectProperty ;
-            dcterms:description "Der Inhalt wirbt für einen anderen Inhalt"@de ,
-                                "Le contenu fait la promotion d'un autre contenu"@fr ,
-                                "The content promotes some other content"@en ;
-            rdfs:label "favorise"@fr ,
-                       "fördert"@de ,
-                       "promotes"@en .
+            dcterms:description "The content promotes some other content."@en ;
+            rdfs:label "Promotes"@en ;
+            skos:definition "an owl:ObjectProperty relating an ec:EditorialWork to an ec:EditorialGroup or ec:EditorialWork"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#publishes
 ec:publishes rdf:type owl:ObjectProperty ;
-             dcterms:description "Das redaktionelle Objekt, das mit einem PublicationEvent verbunden ist."@de ,
-                                 "L'objet éditorial associé à un PublicationEvent."@fr ,
-                                 "The editorial object associated with a PublicationEvent."@en ;
-             rdfs:label "Editorial object"@en ,
-                        "Objet de la rédaction"@fr ,
-                        "Redaktionelles Objekt"@de .
+             dcterms:description "The editorial object associated with a PublicationEvent."@en ;
+             rdfs:label "Editorial object"@en ;
+             skos:definition "an owl:ObjectProperty relating an ec:PublicationEvent to an ec:EditorialObject"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#references
 ec:references rdf:type owl:ObjectProperty ;
-              dcterms:description "A related resource that is referenced, cited, or otherwise pointed to by the described resource."@en ,
-                                  "Eine verwandte Ressource, auf die von der beschriebenen Ressource verwiesen, die sie zitiert oder auf die sie auf andere Weise verweist."@de ,
-                                  "Une ressource connexe qui est référencée, citée ou autrement pointée par la ressource décrite."@fr ;
-              rdfs:label "References"@en ,
-                         "Referenzen"@de ,
-                         "Références"@fr .
+              dcterms:description "A related resource that is referenced, cited, or otherwise pointed to by the described resource."@en ;
+              rdfs:label "References"@en ;
+              skos:definition "an owl:ObjectProperty relating a resource to a referenced resource"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#referencesRule
 ec:referencesRule rdf:type owl:ObjectProperty ;
-                  dcterms:description "Pour fournir une référence à une règle par rapport à laquelle un AuditJob a été effectué par le biais d'une mesure associée."@fr ,
-                                      "To provide a reference to a Rule against which an AuditJob has been performed through an associated Measure."@en ,
-                                      "Um einen Verweis auf eine Regel bereitzustellen, gegen die ein AuditJob durchgeführt wurde durch eine zugehörige Maßnahme durchgeführt wurde."@de ;
-                  rdfs:label "Referenced Rule"@en ,
-                             "Referenzierte Regel"@de ,
-                             "Règle référencée"@fr .
+                  dcterms:description "A reference to the rule against which an audit report was produced through an associated measure."@en ;
+                  rdfs:label "Referenced rule"@en ;
+                  skos:definition "an owl:ObjectProperty relating an ec:AuditReport to an ec:Rule"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#renders
 ec:renders rdf:type owl:ObjectProperty ;
-           rdfs:label "Ruft  auf."@de ,
-                      "rend"@fr ,
-                      "renders"@en .
+           dcterms:description "A property that relates a consumption device to the essence it renders."@en ;
+           rdfs:label "Renders"@en ;
+           skos:definition "an owl:ObjectProperty relating an ec:ConsumptionDevice to an ec:Essence"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#replaces
 ec:replaces rdf:type owl:ObjectProperty ;
-            dcterms:description "Pour identifier la substitution."@fr ,
-                                "To identify substitution."@en ,
-                                "Um die Substitution zu identifizieren."@de ;
-            rdfs:label "Ersetzt"@de ,
-                       "Remplace"@fr ,
-                       "Replaces"@en .
+            dcterms:description "Identifies that one asset replaces another."@en ;
+            rdfs:label "Replaces"@en ;
+            skos:definition "an owl:ObjectProperty relating an ec:Asset to an ec:Asset"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#represents
 ec:represents rdf:type owl:ObjectProperty ;
-              dcterms:description "Pour établir une relation entre un EditorialObject et un Asset."@fr ,
-                                  "To establish a relation between an EditorialObject and an Asset."@en ,
-                                  "Um eine Beziehung zwischen einem EditorialObject und einem Asset herzustellen."@de ;
-              rdfs:label "Bien connexe"@fr ,
-                         "Related asset"@en ,
-                         "Verwandter Vermögenswert"@de .
+              dcterms:description "To establish a relation between an EditorialObject and an Asset."@en ;
+              rdfs:label "Related asset"@en ;
+              skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Asset"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#requires
 ec:requires rdf:type owl:ObjectProperty ;
-            dcterms:description "Pour exprimer la dépendance."@fr ,
-                                "To express dependency."@en ,
-                                "Um eine Abhängigkeit auszudrücken."@de ;
-            rdfs:label "Benötigt"@de ,
-                       "Nécessite"@fr ,
-                       "Requires"@en .
+            dcterms:description "Indicates a dependency between an EditorialObject and the resource or object it requires."@en ;
+            rdfs:label "Requires"@en ;
+            skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:MediaResource"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#requiresLicence
 ec:requiresLicence rdf:type owl:ObjectProperty ;
-                   dcterms:description "Pour identifier une Licence de consommation requise par un ConsumptionEvent."@fr ,
-                                       "To identify a ConsumptionLicence required by a ConsumptionEvent."@en ,
-                                       "Zur Identifizierung einer ConsumptionLicence, die für ein VerbrauchsEreignis."@de ;
-                   rdfs:label "Erforderliche Lizenz"@de ,
-                              "Licence requise"@fr ,
-                              "Required licence"@en .
+                   dcterms:description "The ConsumptionLicence required by a ConsumptionEvent."@en ;
+                   rdfs:label "Required licence"@en ;
+                   skos:definition "an owl:ObjectProperty relating an ec:ConsumptionEvent to an ec:ConsumptionLicence"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#resultsIn
 ec:resultsIn rdf:type owl:ObjectProperty ;
-             dcterms:description "A link between a ResonanceEvent and a ConsumptionEvent."@en ,
-                                 "Eine Verbindung zwischen einem ResonanceEvent und einem VerbrauchsEreignis."@de ,
-                                 "Un lien entre un ResonanceEvent et un ConsumptionEvent."@fr ;
-             rdfs:label "Resonance event"@en ,
-                        "Resonanz Ereignis"@de ,
-                        "Événement de résonance"@fr .
+             dcterms:description "A link between a ResonanceEvent and a ConsumptionEvent."@en ;
+             rdfs:label "Resonance event"@en ;
+             skos:definition "an owl:ObjectProperty relating a ec:ConsumptionEvent to a ec:ResonanceEvent"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#supportsConsumptionDeviceProfile
 ec:supportsConsumptionDeviceProfile rdf:type owl:ObjectProperty ;
-                                    dcterms:description "Pour définir le profil d'un ConsumptionDevice."@fr ,
-                                                        "So definieren Sie das Profil eines ConsumptionDevice."@de ,
-                                                        "To define the profile of a ConsumptionDevice."@en ;
-                                    rdfs:label "Device profile"@en ,
-                                               "Geräteprofil"@de ,
-                                               "Profil de l'appareil"@fr .
+                                    dcterms:description "The profile of a consumption device."@en ;
+                                    rdfs:label "Device profile"@en ;
+                                    skos:definition "an owl:ObjectProperty relating an ec:PublicationPlatform to an ec:ConsumptionDeviceProfile"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#transports
 ec:transports rdf:type owl:ObjectProperty ;
-              rdfs:label "Transporte"@de ,
-                         "Transports"@en ,
-                         "Transports"@fr .
+              dcterms:description "A connection through which a publication service can be transported to a consumption device. For example, it may be a cable receiver, an FM receiver, a website, or an application used to access a service."@en ;
+              rdfs:label "Transports"@en ;
+              skos:definition "an owl:ObjectProperty relating an ec:PublicationChannel to an ec:PublicationService"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#usesConsumptionDevice
 ec:usesConsumptionDevice rdf:type owl:ObjectProperty ;
-                         dcterms:description "Bereich: string oder ConsumptionDevice"@de ,
-                                             "Plage : chaîne ou ConsumptionDevice"@fr ,
-                                             "To identify the ConsumptionDevices used by a Consumer. Range: string or ConsumptionDevice"@en ;
-                         rdfs:label "Consumption device"@en ,
-                                    "Dispositif de consommation"@fr ,
-                                    "Verbrauchsgerät"@de .
+                         dcterms:description "The Consumption devices used by a Consumer."@en ;
+                         rdfs:label "Consumption device"@en ;
+                         skos:definition "an owl:ObjectProperty relating an ec:Consumer to an ec:ConsumptionDevice"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#usesMeasure
 ec:usesMeasure rdf:type owl:ObjectProperty ;
-               dcterms:description "Pour associer une mesure à un AuditJob."@fr ,
-                                   "So verknüpfen Sie eine Maßnahme mit einem AuditJob."@de ,
-                                   "To associate a Measure with an AuditJob."@en ;
-               rdfs:label "Mesure connexe"@fr ,
-                          "Related measure"@en ,
-                          "Verwandte Maßnahme"@de .
+               dcterms:description "The measure associated with an audit job."@en ;
+               rdfs:label "Related measure"@en ;
+               skos:definition "an owl:ObjectProperty relating an ec:AuditJob to an ec:Measure"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#usesProductionDevice
 ec:usesProductionDevice rdf:type owl:ObjectProperty ;
-                        dcterms:description "Pour identifier un ProductionDevice associé à un ProductionJob."@fr ,
-                                            "To identify a ProductionDevice associated with a ProductionJob."@en ,
-                                            "Um ein ProductionDevice zu identifizieren, das mit einem ProduktionsJob."@de ;
-                        rdfs:label "Dispositif de production"@fr ,
-                                   "Production device"@en ,
-                                   "Produktionsgerät"@de .
+                        dcterms:description "A device used in a ProductionJob to create or process a MediaResource."@en ;
+                        rdfs:label "Production device"@en ;
+                        skos:definition "an owl:ObjectProperty relating an ec:ProductionJob to an ec:ProductionDevice"@en .
 
 
 ###  http://www.w3.org/2000/01/rdf-schema#related
@@ -4261,87 +3150,63 @@ rdfs:related rdf:type owl:ObjectProperty .
 
 ###  http://www.w3.org/2006/time#hasTRS
 time:hasTRS rdf:type owl:ObjectProperty ;
-            dcterms:description "Das zeitliche Referenzsystem, das von einer zeitlichen Positions- oder Ausdehnungsbeschreibung verwendet wird."@de ,
-                                "Le système de référence temporel utilisé par une description de position ou d'étendue temporelle."@fr ,
-                                "The temporal reference system used by a temporal position or extent description."@en ;
-            rdfs:label "A un TRS"@fr ,
-                       "Has TRS"@en ,
-                       "Hat TRS"@de .
+            dcterms:description "The temporal reference system used by a temporal position or extent description."@en ;
+            rdfs:label "Has TRS"@en .
 
 
 ###  http://www.w3.org/ns/ma-ont#hasPermissions
 <http://www.w3.org/ns/ma-ont#hasPermissions> rdf:type owl:ObjectProperty ;
-                                             dcterms:description "Pour définir les autorisations telles que définies dans l'ontologie des médias du W3C (ma-ont)"@fr ,
-                                                                 "To set permissions as defined in the W3C Media Ontology (ma-ont)."@en ,
-                                                                 "Zur Definition von Berechtigungen, wie sie in der W3C-Medien-Ontologie (ma-ont) definiert sind"@de ;
-                                             rdfs:label "Berechtigungen"@de ,
-                                                        "Permissions"@en ,
-                                                        "Permissions"@fr ;
+                                             dcterms:description "To set permissions as defined in the W3C Media Ontology (ma-ont)."@en ;
+                                             rdfs:label "Permissions"@en ;
                                              skos:prefLabel "Permissions"^^xsd:string .
 
 
 ###  https://rdf-vocabulary.ddialliance.org/xkos/after
 xkos:after rdf:type owl:ObjectProperty ;
            rdfs:subPropertyOf xkos:temporal ;
-           rdfs:label "after"@en ,
-                      "après"@fr ,
-                      "nach"@de .
+           rdfs:label "after"@en .
 
 
 ###  https://rdf-vocabulary.ddialliance.org/xkos/before
 xkos:before rdf:type owl:ObjectProperty ;
             rdfs:subPropertyOf xkos:temporal ;
-            rdfs:label "avant"@fr ,
-                       "before"@en ,
-                       "vor"@de .
+            rdfs:label "before"@en .
 
 
 ###  https://rdf-vocabulary.ddialliance.org/xkos/next
 xkos:next rdf:type owl:ObjectProperty ;
           rdfs:subPropertyOf xkos:succeeds ;
-          rdfs:label "next"@en ,
-                     "nächste"@de ,
-                     "suivant"@fr .
+          rdfs:label "next"@en .
 
 
 ###  https://rdf-vocabulary.ddialliance.org/xkos/precedes
 xkos:precedes rdf:type owl:ObjectProperty ;
               rdfs:subPropertyOf xkos:sequential ;
-              rdfs:label "precedes"@en ,
-                         "précède"@fr ,
-                         "steht vor"@de .
+              rdfs:label "precedes"@en .
 
 
 ###  https://rdf-vocabulary.ddialliance.org/xkos/previous
 xkos:previous rdf:type owl:ObjectProperty ;
               rdfs:subPropertyOf xkos:precedes ;
-              rdfs:label "previous"@en ,
-                         "précédent"@fr ,
-                         "vorherige"@de .
+              rdfs:label "previous"@en .
 
 
 ###  https://rdf-vocabulary.ddialliance.org/xkos/sequential
 xkos:sequential rdf:type owl:ObjectProperty ;
                 rdfs:subPropertyOf skos:related ;
-                rdfs:label "sequential"@en ,
-                           "sequenziell"@de ,
-                           "séquentiel"@fr .
+                rdfs:label "sequential"@en .
 
 
 ###  https://rdf-vocabulary.ddialliance.org/xkos/succeeds
 xkos:succeeds rdf:type owl:ObjectProperty ;
               rdfs:subPropertyOf xkos:sequential ;
-              rdfs:label "folgt auf"@de ,
-                         "réussit"@fr ,
-                         "succeeds"@en .
+              rdfs:label "succeeds"@en .
 
 
 ###  https://rdf-vocabulary.ddialliance.org/xkos/temporal
 xkos:temporal rdf:type owl:ObjectProperty ;
               rdfs:subPropertyOf xkos:sequential ;
-              rdfs:label "Zeitliche"@de ,
-                         "temporal"@en ,
-                         "temporel"@fr .
+              rdfs:label "temporal"@en .
 
 
 #################################################################
@@ -4351,1128 +3216,739 @@ xkos:temporal rdf:type owl:ObjectProperty ;
 ###  http://purl.org/dc/elements/1.1/source
 dc:source rdf:type owl:DatatypeProperty ;
           rdfs:range rdfs:Literal ;
-          dcterms:description "Pour identifier une ressource comme étant la source d'une autre Resource."@fr ,
-                              "To identify a Resource as the source of another Resource."@en ,
-                              "Um eine Resource als Quelle einer anderen Resource zu identifizieren."@de ;
-          rdfs:label "Quelle"@de ,
-                     "Source"@en ,
-                     "Source :"@fr .
+          dcterms:description "To identify a Resource as the source of another Resource."@en ;
+          rdfs:label "Source"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#DID
 ec:DID rdf:type owl:DatatypeProperty ;
        rdfs:range xsd:integer ;
-       dcterms:description "Das Data Identifier Wort (zusammen mit der SDID, falls verwendet), gibt die Art der Zusatzdaten an, denen das Paket entspricht entspricht."@de ,
-                           "Le mot Data Identifier (ainsi que le SDID, s'il est utilisé), indique le type de données auxiliaires auquel correspond le paquet au paquet."@fr ,
-                           "The Data Identifier word (along with the SDID, if used), indicates the type of ancillary data that the packet corresponds to."@en ;
-       rdfs:label "DID"@de ,
-                  "DID"@en ,
-                  "DID"@fr .
+       dcterms:description "The Data Identifier word (along with the SDID, if used), indicates the type of ancillary data that the packet corresponds to."@en ;
+       rdfs:label "Data identifier word"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#SDID
 ec:SDID rdf:type owl:DatatypeProperty ;
         rdfs:range xsd:integer ;
-        dcterms:description "Mot d'identification de données secondaires pour les données auxiliaires. Identificateur de mode d'envoi. Un identificateur qui indique le moment de la transmission pour les données de sous-titres codés."@fr ,
-                            "Secondary data identification word for ancillary data. Send mode identifier. An identifier which indicates the transmission timing for closed caption data."@en ,
-                            "Sekundärdaten-Kennwort für Zusatzdaten. Kennung für den Sendemodus. Eine Kennung, die den Übertragungszeitpunkt für Untertiteldaten angibt."@de ;
-        rdfs:label "SDID"@de ,
-                   "SDID"@en ,
-                   "SDID"@fr .
+        dcterms:description "Secondary data identification word for ancillary data. Send mode identifier. An identifier which indicates the transmission timing for closed caption data."@en ;
+        rdfs:label "Send mode identifier"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#abstract
 ec:abstract rdf:type owl:DatatypeProperty ;
             rdfs:subPropertyOf ec:contentDescription ;
             rdfs:range rdfs:Literal ;
-            dcterms:description "Pour fournir un résumé."@fr ,
-                                "To provide an abstract."@en ,
-                                "Um eine Zusammenfassung zu erstellen."@de ;
-            rdfs:label "Abstract"@en ,
-                       "Abstrakt"@de ,
-                       "Résumé"@fr .
+            dcterms:description "An abstract summarizing the content."@en ;
+            rdfs:label "Abstract"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#age
 ec:age rdf:type owl:DatatypeProperty ;
        rdfs:range xsd:integer ;
-       dcterms:description "Das Alter eines Kontakts/einer Person in Jahren."@de ,
-                           "L'âge en années d'un contact/personne."@fr ,
-                           "The age in years of a Contact/Person."@en ;
-       rdfs:label "Age"@en ,
-                  "Alter"@de ,
-                  "Âge"@fr .
+       dcterms:description "The age in years of a Contact/Person."@en ;
+       rdfs:label "Age"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#agentDbpedia
 ec:agentDbpedia rdf:type owl:DatatypeProperty ;
                 rdfs:subPropertyOf ec:agentLinkedData ;
                 rdfs:range xsd:anyURI ;
-                dcterms:description "A link to a DBPedia page."@en ,
-                                    "Ein Link zu einer DBPedia-Seite."@de ,
-                                    "Un lien vers une page DBPedia."@fr ;
-                rdfs:label "DBPedia"@de ,
-                           "DBPedia"@en ,
-                           "DBPedia"@fr .
+                dcterms:description "A link to a DBPedia page."@en ;
+                rdfs:label "Dbpedia"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#agentEmailAddress
 ec:agentEmailAddress rdf:type owl:DatatypeProperty ;
                      rdfs:range xsd:string ;
-                     dcterms:description "Pour fournir une adresse e-mail."@fr ,
-                                         "To provide an email address."@en ,
-                                         "Um eine E-Mail-Adresse anzugeben."@de ;
-                     rdfs:label "E-Mail"@de ,
-                                "e-mail"@fr ,
-                                "email"@en .
+                     dcterms:description "The email address of an Agent."@en ;
+                     rdfs:label "Email"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#agentFacebook
 ec:agentFacebook rdf:type owl:DatatypeProperty ;
                  rdfs:subPropertyOf ec:agentSocialMedia ;
                  rdfs:range xsd:anyURI ;
-                 rdfs:label "Facebook"@de ,
-                            "Facebook"@en ,
-                            "Facebook"@fr .
+                 dcterms:description "Links to an Agent's Facebook page or profile as a URI."@en ;
+                 rdfs:label "Facebook"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#agentFee
 ec:agentFee rdf:type owl:DatatypeProperty ;
             rdfs:range rdfs:Literal ;
-            dcterms:description "Das Honorar eines Agenten."@de ,
-                                "Les honoraires d'un agent."@fr ,
-                                "The fee of an Agent."@en ;
-            rdfs:label "Agent fee"@en ,
-                       "Agenturgebühr"@de ,
-                       "Frais d'agent"@fr .
+            dcterms:description "The fee of an Agent."@en ;
+            rdfs:label "Agent fee"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#agentFlickr
 ec:agentFlickr rdf:type owl:DatatypeProperty ;
                rdfs:subPropertyOf ec:agentSocialMedia ;
                rdfs:range xsd:anyURI ;
-               rdfs:label "Flickr"@de ,
-                          "Flickr"@en ,
-                          "Flickr"@fr .
+               dcterms:description "Links to an Agent's Flickr account."@en ;
+               rdfs:label "Flickr"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#agentImdb
 ec:agentImdb rdf:type owl:DatatypeProperty ;
              rdfs:subPropertyOf ec:agentLinkedData ;
              rdfs:range xsd:anyURI ;
-             dcterms:description "A link to an imdb page."@en ,
-                                 "Ein Link zu einer imdb-Seite."@de ,
-                                 "Un lien vers une page imdb."@fr ;
-             rdfs:label "IMDB"@de ,
-                        "IMDB"@en ,
-                        "IMDB"@fr .
+             dcterms:description "A link to an imdb page."@en ;
+             rdfs:label "IMDB"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#agentInstagram
 ec:agentInstagram rdf:type owl:DatatypeProperty ;
                   rdfs:subPropertyOf ec:agentSocialMedia ;
                   rdfs:range xsd:anyURI ;
-                  rdfs:label "Instagram"@de ,
-                             "Instagram"@en ,
-                             "Instagram"@fr .
+                  dcterms:description "Links to an Agent’s Instagram account URI."@en ;
+                  rdfs:label "Instagram"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#agentLinkedData
 ec:agentLinkedData rdf:type owl:DatatypeProperty ;
                    rdfs:range xsd:anyURI ;
-                   dcterms:description "Einen Haken für verknüpfte Daten bereitstellen. Bereich: eine URL oder URI."@de ,
-                                       "Pour fournir un lien avec les données liées. Range: une URL ou une URI."@fr ,
-                                       "To provide a hook to linked data. Range: a URL or URI."@en ;
-                   rdfs:label "Agent linked data"@en ,
-                              "Données liées à l'agent"@fr ,
-                              "Verknüpfte Daten des Agenten"@de .
+                   dcterms:description "A link to linked data for the agent, expressed as a URL or URI."@en ;
+                   rdfs:label "Agent linked data"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#agentLinkedIn
 ec:agentLinkedIn rdf:type owl:DatatypeProperty ;
                  rdfs:subPropertyOf ec:agentSocialMedia ;
                  rdfs:range xsd:anyURI ;
-                 rdfs:label "LinkedIn"@de ,
-                            "LinkedIn"@en ,
-                            "LinkedIn"@fr .
+                 dcterms:description "Links to an Agent's LinkedIn profile."@en ;
+                 rdfs:label "LinkedIn profile"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#agentMobileTelephoneNumber
 ec:agentMobileTelephoneNumber rdf:type owl:DatatypeProperty ;
                               rdfs:subPropertyOf ec:agentTelephoneNumber ;
                               rdfs:range xsd:string ;
-                              dcterms:description "Pour fournir le numéro de téléphone mobile d'un Agent (Contact/Personne ou organisation)"@fr ,
-                                                  "To provide the mobile telephone number of an Agent (Contact/Person or organisation)"@en ,
-                                                  "Zur Angabe der Mobiltelefonnummer eines Agenten (Kontaktperson/Person oder Organisation)"@de ;
-                              rdfs:label "Mobil"@de ,
-                                         "Mobile"@en ,
-                                         "Mobile"@fr .
+                              dcterms:description "The mobile telephone number of an Agent (Contact/Person or Organisation)."@en ;
+                              rdfs:label "Mobile"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#agentPreviousName
 ec:agentPreviousName rdf:type owl:DatatypeProperty ;
                      rdfs:range rdfs:Literal ;
-                     dcterms:description "Pour fournir le nom précédent d'un contact/personne."@fr ,
-                                         "To provide the previous name of a Contact/Person."@en ,
-                                         "Um den früheren Namen eines Kontakts/einer Person anzugeben."@de ;
-                     rdfs:label "Nom précédent"@fr ,
-                                "Previous name"@en ,
-                                "Vorheriger Name"@de .
+                     dcterms:description "The previous name of an Agent."@en ;
+                     rdfs:label "Previous name"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#agentRelatedInformationLink
 ec:agentRelatedInformationLink rdf:type owl:DatatypeProperty ;
                                rdfs:subPropertyOf ec:agentRelatedLink ;
                                rdfs:range xsd:anyURI ;
-                               dcterms:description "Bereitstellung eines Links zu einer WebResource mit Informationen zu einem Agenten (Kontakt/Person oder Organisation) enthält."@de ,
-                                                   "Pour fournir un lien vers une ressource web contenant des informations relatives à un agent (contact/personne ou organisation)."@fr ,
-                                                   "To provide a link to a web resource containing information related to an Agent (Contact/Person or Organisation)."@en ;
-                               rdfs:label "Lien d'information connexe"@fr ,
-                                          "Related information link"@en ,
-                                          "Verwandte Informationen Link"@de .
+                               dcterms:description "A link to a web resource containing information related to an Agent (Contact/Person or Organisation)."@en ;
+                               rdfs:label "Related information link"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#agentRelatedLink
 ec:agentRelatedLink rdf:type owl:DatatypeProperty ;
                     rdfs:range xsd:anyURI ;
-                    dcterms:description "Fournir un lien vers, par exemple, une ressource Web liée à un agent."@fr ,
-                                        "To provide a link to e.g. a web resource related to an Agent."@en ,
-                                        "Um einen Link z.B. zu einer Web-Resource im Zusammenhang mit einem Agent bereitzustellen."@de ;
-                    rdfs:label "Lien connexe"@fr ,
-                               "Related link"@en ,
-                               "Verwandter Link"@de .
+                    dcterms:description "A link to a web resource related to an Agent."@en ;
+                    rdfs:label "Related link"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#agentRelatedPressLink
 ec:agentRelatedPressLink rdf:type owl:DatatypeProperty ;
                          rdfs:subPropertyOf ec:agentRelatedLink ;
                          rdfs:range xsd:anyURI ;
-                         dcterms:description "Bereitstellung eines Links zu einer WebResource mit Informationen zu einem Agenten (Kontakt/Person oder Organisation) enthält."@de ,
-                                             "Pour fournir un lien vers une ressource web contenant des informations relatives à un agent (contact/personne ou organisation)."@fr ,
-                                             "To provide a link to a web resource containing information related to an Agent (Contact/Person or Organisation)."@en ;
-                         rdfs:label "Lien presse connexe"@fr ,
-                                    "Link zur Presse"@de ,
-                                    "Related press link"@en .
+                         dcterms:description "A link to a web resource containing information related to an Agent (Contact/Person or Organisation)."@en ;
+                         rdfs:label "Related press link"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#agentSocialMedia
 ec:agentSocialMedia rdf:type owl:DatatypeProperty ;
                     rdfs:range xsd:anyURI ;
-                    dcterms:description "Liens vers les médias sociaux d'un agent."@fr ,
-                                        "Links to an Agent's social media."@en ,
-                                        "Links zu den sozialen Medien eines Agenten."@de ;
-                    rdfs:label "Médias sociaux"@fr ,
-                               "Social media"@en ,
-                               "Soziale Medien"@de .
+                    dcterms:description "Links to an Agent's social media."@en ;
+                    rdfs:label "Social media"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#agentTelephoneNumber
 ec:agentTelephoneNumber rdf:type owl:DatatypeProperty ;
                         rdfs:range xsd:string ;
-                        dcterms:description "Pour fournir le numéro de téléphone d'un agent (Contact/Personne ou Organisation)."@fr ,
-                                            "To provide the telephone number of an Agent (Contact/Person or Organisation)."@en ,
-                                            "Zur Angabe der Telefonnummer eines Agenten (Kontaktperson/Person oder Organisation)."@de ;
-                        rdfs:label "Telefon"@de ,
-                                   "Telephone"@en ,
-                                   "Téléphone"@fr .
+                        dcterms:description "The telephone number of an Agent (Contact/Person or Organisation)."@en ;
+                        rdfs:label "Telephone"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#agentTwitter
 ec:agentTwitter rdf:type owl:DatatypeProperty ;
                 rdfs:subPropertyOf ec:agentSocialMedia ;
                 rdfs:range xsd:anyURI ;
-                rdfs:label "Twitter"@de ,
-                           "Twitter"@en ,
-                           "Twitter"@fr .
+                dcterms:description "Links to an Agent’s Twitter account URL."@en ;
+                rdfs:label "Twitter"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#agentWebHomepage
 ec:agentWebHomepage rdf:type owl:DatatypeProperty ;
                     rdfs:range xsd:anyURI ;
-                    dcterms:description "Pour fournir l'adresse de la page web d'un agent (contact/personne ou organisation)."@fr ,
-                                        "To provide the address of the webpage of an Agent (Contact/Person or Organisation)."@en ,
-                                        "Zur Angabe der Adresse der Webseite eines Agenten (Kontaktperson/Person oder Organisation)."@de ;
-                    rdfs:label "Homepage"@de ,
-                               "Homepage"@en ,
-                               "Page d'accueil"@fr .
+                    dcterms:description "The webpage address of an Agent (Contact/Person or Organisation)."@en ;
+                    rdfs:label "Homepage"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#agentWikidata
 ec:agentWikidata rdf:type owl:DatatypeProperty ;
                  rdfs:subPropertyOf ec:agentLinkedData ;
                  rdfs:range xsd:anyURI ;
-                 dcterms:description "A link to a wikidata page."@en ,
-                                     "Ein Link zu einer wikidata-Seite."@de ,
-                                     "Un lien vers une page de wikidata."@fr ;
-                 rdfs:label "Wikidata"@de ,
-                            "Wikidata"@en ,
-                            "Wikidata"@fr .
+                 dcterms:description "A link to a wikidata page."@en ;
+                 rdfs:label "Wikidata"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#agentWikipedia
 ec:agentWikipedia rdf:type owl:DatatypeProperty ;
                   rdfs:subPropertyOf ec:agentSocialMedia ;
                   rdfs:range xsd:anyURI ;
-                  rdfs:label "Wikipedia"@de ,
-                             "Wikipedia"@en ,
-                             "Wikipedia"@fr .
+                  dcterms:description "Links to an Agent's Wikipedia page."@en ;
+                  rdfs:label "Wikipedia"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#animalCharacterName
 ec:animalCharacterName rdf:type owl:DatatypeProperty ;
                        rdfs:range rdfs:Literal ;
-                       dcterms:description "Pour associer le nom d'un personnage fictif à un animal."@fr ,
-                                           "To associate a fictitious character name with an animal."@en ,
-                                           "Um einen fiktiven Charakternamen mit einem Tier zu verbinden."@de ;
-                       rdfs:label "Animal character name"@en ,
-                                  "Name der Tierfigur"@de ,
-                                  "Nom du personnage animal"@fr .
+                       dcterms:description "The fictitious character name associated with an animal."@en ;
+                       rdfs:label "Animal character name"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#animalCode
 ec:animalCode rdf:type owl:DatatypeProperty ;
               rdfs:range rdfs:Literal ;
-              dcterms:description "Pour associer un code à un animal."@fr ,
-                                  "To associate a code with an animal."@en ,
-                                  "Um einen Code mit einem Tier zu verbinden."@de ;
-              rdfs:label "Animal code"@en ,
-                         "Code animal"@fr ,
-                         "Tiercode"@de .
+              dcterms:description "The code associated with an animal."@en ;
+              rdfs:label "Animal code"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#animalPassport
 ec:animalPassport rdf:type owl:DatatypeProperty ;
                   rdfs:range rdfs:Literal ;
-                  dcterms:description "Passeport d'un animal."@fr ,
-                                      "To replicate the passport of an animal."@en ,
-                                      "Um den Pass eines Tieres zu replizieren."@de ;
-                  rdfs:label "Animal passport"@en ,
-                             "Passeport pour animaux"@fr ,
-                             "Tierpass"@de .
+                  dcterms:description "To replicate the passport of an animal."@en ;
+                  rdfs:label "Animal passport"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#annotationConfidence
 ec:annotationConfidence rdf:type owl:DatatypeProperty ;
                         rdfs:range rdfs:Literal ;
-                        dcterms:description "Pour estimer la confiance dans une Annotation."@fr ,
-                                            "So schätzen Sie das Vertrauen in eine Anmerkung ein."@de ,
-                                            "To estimate the confidence in an Annotation."@en ;
-                        rdfs:label "Annotation confidence"@en ,
-                                   "Niveau de confiance dans l'annotation"@fr ,
-                                   "Vertrauen in die Kommentierung"@de .
+                        dcterms:description "To estimate the confidence in an Annotation."@en ;
+                        rdfs:label "Annotation confidence"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#annotationPurpose
 ec:annotationPurpose rdf:type owl:DatatypeProperty ;
                      rdfs:range rdfs:Literal ;
-                     dcterms:description "Définir l'objectif d'une annotation."@fr ,
-                                         "To define the purpose of an Annotation."@en ,
-                                         "Um den Zweck einer Anmerkung zu definieren."@de ;
-                     rdfs:label "Annotation purpose"@en ,
-                                "Objectif de l'annotation"@fr ,
-                                "Vertrauen in die Kommentierung"@de .
+                     dcterms:description "The purpose associated with an annotation."@en ;
+                     rdfs:label "Annotation purpose"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#annotationSaliency
 ec:annotationSaliency rdf:type owl:DatatypeProperty ;
                       rdfs:range rdfs:Literal ;
-                      dcterms:description "Pour estimer la saillance d'une Annotation."@fr ,
-                                          "So schätzen Sie die Bedeutung einer Anmerkung ein."@de ,
-                                          "To estimate the saliency of an Annotation."@en ;
-                      rdfs:label "Annotation saliency"@en ,
-                                 "Bedeutung von Kommentaren"@de ,
-                                 "Saillance des annotations"@fr .
+                      dcterms:description "To estimate the saliency of an Annotation."@en ;
+                      rdfs:label "Annotation saliency"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#artefactAvailability
 ec:artefactAvailability rdf:type owl:DatatypeProperty ;
                         rdfs:range xsd:boolean ;
-                        dcterms:description "Pour signaler la disponibilité d'un artefact."@fr ,
-                                            "To flag the availability of an Artefact."@en ,
-                                            "Zur Kennzeichnung der Verfügbarkeit eines Artefakts."@de ;
-                        rdfs:label "Artefact availability flag"@en ,
-                                   "Flagge für die Verfügbarkeit von Artefakten"@de ,
-                                   "Indicateur de disponibilité de l'artefact"@fr .
+                        dcterms:description "To flag the availability of an Artefact."@en ;
+                        rdfs:label "Artefact availability flag"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#artefactBoxHeight
 ec:artefactBoxHeight rdf:type owl:DatatypeProperty ;
                      rdfs:range xsd:nonNegativeInteger ;
-                     dcterms:description "Die Höhe der Box, die das Artefakt enthält."@de ,
-                                         "La hauteur de la boîte contenant l'artefact."@fr ,
-                                         "The height of the box containing the Artefact."@en ;
-                     rdfs:label "Artefact box height."@en ,
-                                "Hauteur de la boîte à artefacts."@fr ,
-                                "Höhe der Artefaktbox."@de .
+                     dcterms:description "The height of the box containing the Artefact."@en ;
+                     rdfs:label "Artefact box height"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#artefactBoxTopLeftCornerLineNumber
 ec:artefactBoxTopLeftCornerLineNumber rdf:type owl:DatatypeProperty ;
                                       rdfs:range xsd:nonNegativeInteger ;
-                                      dcterms:description "Die Koordinaten auf einer vertikalen Achse für die Position der linken oberen Ecke der Box, die das Artefakt enthält."@de ,
-                                                          "Les coordonnées sur un axe vertical de la position du coin supérieur gauche de la boîte contenant l'Artefact."@fr ,
-                                                          "The coordinates on a vertical axis of the position of the top left corner of the box containing the Artefact."@en ;
-                                      rdfs:label "Artefact box top left corner Y position."@en ,
-                                                 "Artefaktbox obere linke Ecke Y-Position."@de ,
-                                                 "Boîte d'artefact coin supérieur gauche position Y."@fr .
+                                      dcterms:description "The coordinates on a vertical axis of the position of the top left corner of the box containing the Artefact."@en ;
+                                      rdfs:label "Artefact box top left corner Y position"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#artefactBoxTopLeftCornerPixelNumber
 ec:artefactBoxTopLeftCornerPixelNumber rdf:type owl:DatatypeProperty ;
                                        rdfs:range xsd:nonNegativeInteger ;
-                                       dcterms:description "Die Koordinaten auf einer horizontalen Achse für die Position der linken oberen Ecke der Box, die das Artefakt enthält."@de ,
-                                                           "Les coordonnées sur un axe horizontal de la position du coin supérieur gauche de la boîte contenant l'Artefact."@fr ,
-                                                           "The coordinates on an horizontal axis of the position of the top left corner of the box containing the Artefact."@en ;
-                                       rdfs:label "Artefact box top left corner X position."@en ,
-                                                  "Artefaktbox obere linke Ecke X-Position."@de ,
-                                                  "Boîte d'artefact coin supérieur gauche position X."@fr .
+                                       dcterms:description "The coordinates on an horizontal axis of the position of the top left corner of the box containing the Artefact."@en ;
+                                       rdfs:label "Artefact box top left corner X position"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#artefactBoxWidth
 ec:artefactBoxWidth rdf:type owl:DatatypeProperty ;
                     rdfs:range xsd:nonNegativeInteger ;
-                    dcterms:description "Die Breite des Feldes, das das Artefakt enthält."@de ,
-                                        "La largeur de la boîte contenant l'artefact."@fr ,
-                                        "The width of the box containing the Artefact."@en ;
-                    rdfs:label "Artefact box width."@en ,
-                               "Breite des Artefaktkastens."@de ,
-                               "Largeur de la boîte à artefacts."@fr .
+                    dcterms:description "The width of the box containing the Artefact."@en ;
+                    rdfs:label "Artefact box width"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#artefactBrand
 ec:artefactBrand rdf:type owl:DatatypeProperty ;
                  rdfs:range rdfs:Literal ;
-                 dcterms:description "Pour spécifier la marque d'un artefact."@fr ,
-                                     "To specify the brand of an Artefact."@en ,
-                                     "Zur Angabe der Marke eines Artefakts."@de ;
-                 rdfs:label "Artefact brand"@en ,
-                            "Marke Artefact"@de ,
-                            "Marque d'un artefact"@fr .
+                 dcterms:description "The brand of an artefact."@en ;
+                 rdfs:label "Artefact brand"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#artefactColour
 ec:artefactColour rdf:type owl:DatatypeProperty ;
                   rdfs:range rdfs:Literal ;
-                  dcterms:description "Pour ournir le(s) clouleur(s) d'un artefact."@fr ,
-                                      "To provide the colour(s) of an Artefact."@en ,
-                                      "Um den/die Geruch(e) eines Artefakts bereitzustellen."@de ;
-                  rdfs:label "Artefact colour(s)"@en ,
-                             "Couleur(s) de l'artefact"@fr ,
-                             "Farbe(n) des Artefakts"@de .
+                  dcterms:description "The colour or colours of an artefact."@en ;
+                  rdfs:label "Artefact colour(s)"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#artefactComment
 ec:artefactComment rdf:type owl:DatatypeProperty ;
                    rdfs:range rdfs:Literal ;
-                   dcterms:description "Pour fournir un commentaire contextuel sur un artefact."@fr ,
-                                       "To provide a contextual comment about an Artefact."@en ,
-                                       "Um einen kontextbezogenen Kommentar zu einem Artefakt abzugeben."@de ;
-                   rdfs:label "Artefact comment"@en ,
-                              "Artefakt-Kommentar"@de ,
-                              "Commentaire sur l'artefact"@fr .
+                   dcterms:description "A contextual comment about an Artefact."@en ;
+                   rdfs:label "Artefact comment"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#artefactModel
 ec:artefactModel rdf:type owl:DatatypeProperty ;
                  rdfs:range rdfs:Literal ;
-                 dcterms:description "Pour spécifier un modèle d'un artefact."@fr ,
-                                     "To specify a model of an Artefact."@en ,
-                                     "Um ein Modell eines Artefakts anzugeben."@de ;
-                 rdfs:label "Artefact model"@en ,
-                            "Artefakt-Modell"@de ,
-                            "Modèle d'artefact"@fr .
+                 dcterms:description "The model associated with an Artefact."@en ;
+                 rdfs:label "Artefact model"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#artefactPeriod
 ec:artefactPeriod rdf:type owl:DatatypeProperty ;
                   rdfs:range rdfs:Literal ;
-                  dcterms:description "Pour spécifier la période associée à un artefact."@fr ,
-                                      "To specify the period associated with an Artefact."@en ,
-                                      "Zur Angabe des Zeitraums, der mit einem Artefakt verbunden ist."@de ;
-                  rdfs:label "Artefact period"@en ,
-                             "Artefakt Zeitraum"@de ,
-                             "Période de l'artefact"@fr .
+                  dcterms:description "The period associated with an Artefact."@en ;
+                  rdfs:label "Artefact period"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#artefactPriceAmount
 ec:artefactPriceAmount rdf:type owl:DatatypeProperty ;
                        rdfs:range rdfs:Literal ;
-                       dcterms:description "Pour préciser le prix d'un artefact."@fr ,
-                                           "To specifythe price of an Artefact."@en ,
-                                           "Um den Preis eines Artefakts anzugeben."@de ;
-                       rdfs:label "Artefact price"@en ,
-                                  "Artefakt Preis"@de ,
-                                  "Prix de l'artefact"@fr .
+                       dcterms:description "The price amount associated with an Artefact."@en ;
+                       rdfs:label "Artefact price"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#artefactReference
 ec:artefactReference rdf:type owl:DatatypeProperty ;
                      rdfs:range xsd:anyURI ;
-                     dcterms:description "Pour spécifier une référence d'un Artefact."@fr ,
-                                         "To specify a reference of an Artefact."@en ,
-                                         "Um eine Referenz eines Artefakts anzugeben."@de ;
-                     rdfs:label "Artefact reference"@en ,
-                                "Artefakt-Referenz"@de ,
-                                "Référence de l'artefact"@fr .
+                     dcterms:description "A reference identifying the Artefact, expressed as a URI."@en ;
+                     rdfs:label "Artefact reference"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#artefactStyle
 ec:artefactStyle rdf:type owl:DatatypeProperty ;
                  rdfs:range rdfs:Literal ;
-                 dcterms:description "Pour spécifier le style associé à un artefact."@fr ,
-                                     "To specify the style associated with an Artefact."@en ,
-                                     "Um den mit einem Artefakt verbundenen Stil festzulegen."@de ;
-                 rdfs:label "Artefact style"@en ,
-                            "Artefakt-Stil"@de ,
-                            "Style de l'artefact"@fr .
+                 dcterms:description "The style associated with an Artefact."@en ;
+                 rdfs:label "Artefact style"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#artefactUsageHistory
 ec:artefactUsageHistory rdf:type owl:DatatypeProperty ;
                         rdfs:range rdfs:Literal ;
-                        dcterms:description "Pour fournir des informations sur l'historique d'utilisation d'un artefact."@fr ,
-                                            "To provide information on the usage history of an Artefact."@en ,
-                                            "Um Informationen über die Nutzungshistorie eines Artefakts bereitzustellen."@de ;
-                        rdfs:label "Artefact usage history"@en ,
-                                   "Geschichte der Artefaktnutzung"@de ,
-                                   "Historique de l'utilisation de l'artefact"@fr .
+                        dcterms:description "Information about the usage history of an artefact."@en ;
+                        rdfs:label "Artefact usage history"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#artefactWebsite
 ec:artefactWebsite rdf:type owl:DatatypeProperty ;
                    rdfs:range xsd:anyURI ;
-                   dcterms:description "Pour indiquer un site web où l'on peut trouver plus d'informations sur l'artefact."@fr ,
-                                       "To specify a website where more information can be found on the Artefact."@en ,
-                                       "Zur Angabe einer Website, auf der Sie weitere Informationen über das Artefakt finden können."@de ;
-                   rdfs:label "Artefact Website"@de ,
-                              "Artefact website"@en ,
-                              "Site web d'Artefact"@fr .
+                   dcterms:description "A website with more information about the artefact."@en ;
+                   rdfs:label "Artefact website"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#aspectRatio
 ec:aspectRatio rdf:type owl:DatatypeProperty ;
                rdfs:range xsd:string ;
-               dcterms:description "Pour spécifier le rapport d'aspect."@fr ,
-                                   "To specify the aspect ratio."@en ,
-                                   "Um das Seitenverhältnis festzulegen."@de ;
-               rdfs:label "Aspect ratio"@en ,
-                          "Bildseitenverhältnis"@de ,
-                          "Rapport d'aspect"@fr .
+               dcterms:description "The aspect ratio associated with the media resource or picture."@en ;
+               rdfs:label "Aspect ratio"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#assetValue
 ec:assetValue rdf:type owl:DatatypeProperty ;
-              dcterms:description "Donne la valeur estimée ou réelle d'un actif."@fr ,
-                                  "To provide an estimated or actual value of an Asset."@en ,
-                                  "Um einen geschätzten oder tatsächlichen Wert eines Assets anzugeben."@de ;
-              rdfs:label "Asset value"@en ,
-                         "Valeur de l'actif"@fr ,
-                         "Vermögenswert"@de .
+              dcterms:description "The estimated or actual value of an asset."@en ;
+              rdfs:label "Asset value"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#audienceAgeHigh
 ec:audienceAgeHigh rdf:type owl:DatatypeProperty ;
-                   dcterms:description "Das maximale Alter eines Publikums."@de ,
-                                       "L'âge maximum d'une audience."@fr ,
-                                       "The maximum age of an Audience."@en ;
-                   rdfs:label "Age maximum du public visé"@fr ,
-                              "Alter des Publikums hoch"@de ,
-                              "Audience age high"@en .
+                   dcterms:description "The maximum age of an Audience."@en ;
+                   rdfs:label "Audience age high"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#audienceAgeLow
 ec:audienceAgeLow rdf:type owl:DatatypeProperty ;
-                  dcterms:description "Das Mindestalter eines Zuschauers."@de ,
-                                      "L'âge minimum d'une audience."@fr ,
-                                      "The minimum age of an Audience."@en ;
-                  rdfs:label "Alter des Publikums niedrig"@de ,
-                             "Audience age low"@en ,
-                             "Âge minimum du public visé."@fr .
+                  dcterms:description "The minimum age of an Audience."@en ;
+                  rdfs:label "Audience age low"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#audienceCount
 ec:audienceCount rdf:type owl:DatatypeProperty ;
-                 dcterms:description "Die Reichweite des Publikums in Zahlen oder Prozent."@de ,
-                                     "La portée de l'audience en nombre ou en pourcentage."@fr ,
-                                     "The Audience reach in numbers or percent."@en ;
-                 rdfs:label "Anzahl der Zuhörer"@de ,
-                            "Audience number"@en ,
-                            "Valeur d'audience"@fr .
+                 dcterms:description "The Audience reach in numbers or percent."@en ;
+                 rdfs:label "Audience number"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#audienceInterest
 ec:audienceInterest rdf:type owl:DatatypeProperty ;
-                    dcterms:description "Die Punkte, die für ein Publikum von Interesse sind."@de ,
-                                        "Les points d'intérêt d'une audience."@fr ,
-                                        "The points of interest of an Audience."@en ;
-                    rdfs:label "Audience interest"@en ,
-                               "Interesse des Publikums"@de ,
-                               "Intérêt du public"@fr .
+                    dcterms:description "The points of interest of an Audience."@en ;
+                    rdfs:label "Audience interest"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#audioBitRate
 ec:audioBitRate rdf:type owl:DatatypeProperty ;
                 rdfs:range xsd:nonNegativeInteger ;
-                dcterms:description "Die Audio-Bitrate."@de ,
-                                    "Le débit binaire audio."@fr ,
-                                    "The audio bitrate."@en ;
-                rdfs:label "Audio bitrate"@en ,
-                           "Audio-Bitrate"@de ,
-                           "Débit binaire audio"@fr .
+                dcterms:description "The numerical bitrate of the audio component, expressed as a non-negative integer."@en ;
+                rdfs:label "Audio bitrate"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#audioBitRateMax
 ec:audioBitRateMax rdf:type owl:DatatypeProperty ;
                    rdfs:range xsd:nonNegativeInteger ;
-                   dcterms:description "Die maximale Audio-Bitrate."@de ,
-                                       "Le débit binaire audio maximal."@fr ,
-                                       "The max audio bitrate."@en ;
-                   rdfs:label "Audio bitrate max"@en ,
-                              "Audio-Bitrate max."@de ,
-                              "Débit binaire audio max."@fr .
+                   dcterms:description "The max audio bitrate."@en ;
+                   rdfs:label "Audio bitrate max"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#audioBitRateMode
 ec:audioBitRateMode rdf:type owl:DatatypeProperty ;
                     rdfs:range rdfs:Literal ;
-                    dcterms:description "Der Modus für die Audio-Bitrate."@de ,
-                                        "Le mode de débit binaire audio."@fr ,
-                                        "The audio bitrate mode."@en ;
-                    rdfs:label "Audio bitrate mode"@en ,
-                               "Audio-Bitrate-Modus"@de ,
-                               "Mode de débit binaire audio"@fr .
+                    dcterms:description "The audio bitrate mode."@en ;
+                    rdfs:label "Audio bitrate mode"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#audioEncodingLevel
 ec:audioEncodingLevel rdf:type owl:DatatypeProperty ;
                       rdfs:subPropertyOf ec:encodingLevel ;
                       rdfs:range rdfs:Literal ;
-                      dcterms:description "Die Kodierungsebene, wie sie in den Spezifikationen definiert ist."@de ,
-                                          "Le niveau de codage tel que défini dans les spécifications."@fr ,
-                                          "The encoding level as defined in specifications."@en ;
-                      rdfs:label "Audio encoding level"@en ,
-                                 "Niveau d'encodage audio"@fr ,
-                                 "Pegel der Audiokodierung"@de .
+                      dcterms:description "The encoding level as defined in specifications."@en ;
+                      rdfs:label "Audio encoding level"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#audioEncodingProfile
 ec:audioEncodingProfile rdf:type owl:DatatypeProperty ;
                         rdfs:subPropertyOf ec:encodingProfile ;
                         rdfs:range rdfs:Literal ;
-                        dcterms:description "Das Kodierungsprofil, wie in den Spezifikationen definiert."@de ,
-                                            "Le profil de codage tel que défini dans les spécifications."@fr ,
-                                            "The encoding profile as defined in specifications."@en ;
-                        rdfs:label "Audio encoding profile"@en ,
-                                   "Audio-Kodierungsprofil"@de ,
-                                   "Profil d'encodage audio"@fr .
+                        dcterms:description "The encoding profile as defined in specifications."@en ;
+                        rdfs:label "Audio encoding profile"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#audioTrackConfiguration
 ec:audioTrackConfiguration rdf:type owl:DatatypeProperty ;
                            rdfs:range rdfs:Literal ;
-                           dcterms:description "Die Konfiguration der Audiospuren, die in der der MediaResource."@de ,
-                                               "La configuration des pistes audio contenues dans la MediaResource."@fr ,
-                                               "The configuration of audio tracks contained in the MediaResource."@en ;
-                           rdfs:label "Audio track configuration"@en ,
-                                      "Configuration des pistes audio"@fr ,
-                                      "Konfiguration der Audiospur"@de .
+                           dcterms:description "The configuration of audio tracks contained in the MediaResource."@en ;
+                           rdfs:label "Audio track configuration"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#audioTrackNumber
 ec:audioTrackNumber rdf:type owl:DatatypeProperty ;
                     rdfs:range xsd:nonNegativeInteger ;
-                    dcterms:description "Permet d’identifier une piste audio parmi plusieurs dans une MediaResource."@fr ,
-                                        "To identify an audio track among multiple tracks in a MediaResource."@en ,
-                                        "Zur Identifizierung einer Audiospur innerhalb einer MediaResource."@de ;
-                    rdfs:label "Audio Track Number"@en ,
-                               "Audiospurnummer"@de ,
-                               "Numéro de piste audio"@fr .
+                    dcterms:description "The audio track number used to distinguish one track from another in a media resource."@en ;
+                    rdfs:label "Audio track number"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#auditReportResults
 ec:auditReportResults rdf:type owl:DatatypeProperty ;
-                      dcterms:description "Pour exprimer les résultats combinés d'un ou plusieurs AuditJobs."@fr ,
-                                          "To express the combined results of one or more AuditJobs."@en ,
-                                          "Um die kombinierten Ergebnisse von einem oder mehreren AuditJobs."@de ;
-                      rdfs:label "Audit report results"@en ,
-                                 "Ergebnisse des Auditberichts"@de ,
-                                 "Résultats du rapport d'audit"@fr .
+                      dcterms:description "The combined results of one or more audit jobs."@en ;
+                      rdfs:label "Audit report results"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#awardCeremony
 ec:awardCeremony rdf:type owl:DatatypeProperty ;
                  rdfs:range rdfs:Literal ;
-                 dcterms:description "Pour fournir un nom de cérémonie de remise de prix."@fr ,
-                                     "To provide an Award ceremony name."@en ,
-                                     "Um einen Namen für die Preisverleihung anzugeben."@de ;
-                 rdfs:label "Award ceremony"@en ,
-                            "Cérémonie de remise des prix"@fr ,
-                            "Preisverleihung"@de .
+                 dcterms:description "The award ceremony name."@en ;
+                 rdfs:label "Award ceremony"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#bitDepth
 ec:bitDepth rdf:type owl:DatatypeProperty ;
             rdfs:range xsd:nonNegativeInteger ;
-            dcterms:description "Pour fournir le nombre bit à laquelle lz MediaResource a été encodée."@fr ,
-                                "To provide the bitdepth at which the MediaResource has been encoded."@en ,
-                                "Zur Angabe der Bit-Tiefe, mit der die MediaResource kodiert wurde."@de ;
-            rdfs:label "Bit depth"@en ,
-                       "Bit-Tiefe"@de ,
-                       "Profondeur de bit"@fr .
+            dcterms:description "The bit depth at which the media resource has been encoded."@en ;
+            rdfs:label "Bit depth"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#bitRate
 ec:bitRate rdf:type owl:DatatypeProperty ;
            rdfs:range xsd:nonNegativeInteger ;
-           dcterms:description "Pour fournir le débit binaire auquel la MediaResource peut être lue en bits/seconde. Débit binaire réel si constant, et débit binaire moyen si variable."@fr ,
-                               "To provide the bitrate at which the MediaResource can be played in bits/second. Current bitrate if constant, and average bitrate if variable."@en ,
-                               "Zur Angabe der Bitrate, mit der die MediaResource abgespielt werden kann, in Bits/Sekunde. Aktuelle Bitrate, wenn konstant, und durchschnittliche Bitrate, wenn variabel."@de ;
-           rdfs:label "Bitrate"@de ,
-                      "Bitrate"@en ,
-                      "Bitrate"@fr .
+           dcterms:description "The bitrate at which the MediaResource can be played, in bits per second. Use the current bitrate if constant, or the average bitrate if variable."@en ;
+           rdfs:label "Bit rate"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#bitRateMax
 ec:bitRateMax rdf:type owl:DatatypeProperty ;
               rdfs:range xsd:nonNegativeInteger ;
-              dcterms:description "Die maximale Bitrate, wenn variabel, in Bits pro Sekunde."@de ,
-                                  "Le débit maximal lorsqu'il est variable, en bits par seconde."@fr ,
-                                  "The maximum bitrate when variable, in bits per second."@en ;
-              rdfs:label "Débit binaire maximal"@fr ,
-                         "Maximale Bitrate"@de ,
-                         "Maximum bitrate"@en .
+              dcterms:description "The maximum bitrate when variable, in bits per second."@en ;
+              rdfs:label "Maximum bitrate"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#bitRateMode
 ec:bitRateMode rdf:type owl:DatatypeProperty ;
                rdfs:range rdfs:Literal ;
-               dcterms:description "A flag to indicate if the bit rate is fixed or variable."@en ,
-                                   "Ein Flag, das anzeigt, ob die Bitrate fest oder variabel ist. variabel ist."@de ,
-                                   "Un drapeau pour indiquer si le débit binaire est fixe ou variable."@fr ;
-               rdfs:label "Bitrate mode"@en ,
-                          "Mode de débit binaire"@fr ,
-                          "Modus Bitrate"@de .
+               dcterms:description "A flag to indicate if the bit rate is fixed or variable."@en ;
+               rdfs:label "Bitrate mode"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#bitRateOverall
 ec:bitRateOverall rdf:type owl:DatatypeProperty ;
                   rdfs:range xsd:nonNegativeInteger ;
-                  dcterms:description "Pour fournir le débit binaire global auquel la MediaResource peut être lue en bits/seconde. Débit binaire réel si constant, et débit binaire moyen si variable."@fr ,
-                                      "To provide the overall bitrate at which the MediaResource can be played in bits/second. Current bitrate if constant, and average bitrate if variable."@en ,
-                                      "Zur Angabe der Gesamtbitrate, mit der die MediaResource abgespielt werden kann, in Bits/Sekunde. Aktuelle Bitrate, wenn konstant, und durchschnittliche Bitrate, wenn variabel."@de ;
-                  rdfs:label "Débit binaire global"@fr ,
-                             "Gesamt-Bitrate"@de ,
-                             "Overall bitrate"@en .
+                  dcterms:description "The overall bitrate at which the MediaResource can be played, in bits per second. Use the current bitrate if constant, and the average bitrate if variable."@en ;
+                  rdfs:label "Overall bitrate"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#bookmark
 ec:bookmark rdf:type owl:DatatypeProperty ;
             rdfs:subPropertyOf ec:contentDescription ;
             rdfs:range rdfs:Literal ;
-            dcterms:description "Pour fournir un signet."@fr ,
-                                "To provide a bookmark."@en ,
-                                "Um ein Lesezeichen zu setzen."@de ;
-            rdfs:label "Bookmark"@en ,
-                       "Bookmark"@fr ,
-                       "Lesezeichen"@de .
+            dcterms:description "A bookmark value associated with an editorial object."@en ;
+            rdfs:label "Bookmark"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#characterEndIndex
 ec:characterEndIndex rdf:type owl:DatatypeProperty ;
                      rdfs:range xsd:integer ;
-                     dcterms:description "Pour identifier l'indice de caractère de fin de la portion de texte à laquelle s'applique l'annotation."@fr ,
-                                         "To identify the end character index of the portion of text to which the Annotation applies."@en ,
-                                         "Zur Ermittlung des Endzeichenindexes des Textabschnitts, auf den sich die Anmerkung bezieht."@de ;
-                     rdfs:label "Annotation character start index"@en ,
-                                "Index de début de caractère d'annotation"@fr ,
-                                "Index für den Beginn der Annotationszeichen"@de .
+                     dcterms:description "The end character index of the portion of text to which the annotation applies."@en ;
+                     rdfs:label "Annotation character start index"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#characterStartIndex
 ec:characterStartIndex rdf:type owl:DatatypeProperty ;
                        rdfs:range xsd:integer ;
-                       dcterms:description "Pour identifier l'indice de caractère de début de la portion de texte à laquelle l'annotation s'applique."@fr ,
-                                           "To identify the start character index of the portion of text to which the Annotation applies."@en ,
-                                           "Um den Index des Anfangszeichens des Textabschnitts zu ermitteln, auf den sich die Anmerkung bezieht."@de ;
-                       rdfs:label "Annotation text character start index"@en ,
-                                  "Indice du début du caractère du texte annoté"@fr ,
-                                  "Zeichenindex für den Beginn des Kommentartextes"@de .
+                       dcterms:description "The start character index of the portion of text to which the annotation applies."@en ;
+                       rdfs:label "Annotation text character start index"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#codecFamily
 ec:codecFamily rdf:type owl:DatatypeProperty ;
                rdfs:range rdfs:Literal ;
-               dcterms:description "Pour fournir des informations sur la famille de produits du Codec."@fr ,
-                                   "To provide information on the product family of the Codec."@en ,
-                                   "Zur Bereitstellung von Informationen über die Produktfamilie des Codec."@de ;
-               rdfs:label "Codec family"@en ,
-                          "Codec-Familie"@de ,
-                          "Famille de codecs"@fr .
+               dcterms:description "The product family of the codec."@en ;
+               rdfs:label "Codec family"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#codecVersion
 ec:codecVersion rdf:type owl:DatatypeProperty ;
                 rdfs:range rdfs:Literal ;
-                dcterms:description "Pour fournir des informations sur la version du Codec."@fr ,
-                                    "To provide information on the version of the Codec."@en ,
-                                    "Um Informationen über die Version des Codec bereitzustellen."@de ;
-                rdfs:label "Codec Version"@de ,
-                           "Codec version"@en ,
-                           "Version du codec"@fr .
+                dcterms:description "The version of the codec."@en ;
+                rdfs:label "Codec version"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#comments
 ec:comments rdf:type owl:DatatypeProperty ;
             rdfs:subPropertyOf ec:contentDescription ;
             rdfs:range rdfs:Literal ;
-            dcterms:description "Pour fournir un commentaire."@fr ,
-                                "To provide a comment."@en ,
-                                "Um einen Kommentar abzugeben."@de ;
-            rdfs:label "Commentaires"@fr ,
-                       "Comments"@en ,
-                       "Kommentare"@de .
+            dcterms:description "A comment associated with the editorial object."@en ;
+            rdfs:label "Comments"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#consumptionDeviceBrand
 ec:consumptionDeviceBrand rdf:type owl:DatatypeProperty ;
-                          dcterms:description "Die Marke eines ConsumptionDevice."@de ,
-                                              "La marque d'un ConsumptionDevice."@fr ,
-                                              "The brand of a ConsumptionDevice."@en ;
-                          rdfs:label "Consumption device brand"@en ,
-                                     "Marke des Verbrauchsgeräts"@de ,
-                                     "Marque du dispositif de consommation"@fr .
+                          dcterms:description "The brand of a ConsumptionDevice."@en ;
+                          rdfs:label "Consumption device brand"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#consumptionDeviceBrowser
 ec:consumptionDeviceBrowser rdf:type owl:DatatypeProperty ;
-                            dcterms:description "Der Browser, der mit einem ConsumptionDevice kompatibel ist."@de ,
-                                                "Le navigateur compatible avec un ConsumptionDevice."@fr ,
-                                                "The browser compatible with a ConsumptionDevice."@en ;
-                            rdfs:label "Browser für Verbrauchsgeräte"@de ,
-                                       "Consumption device browser"@en ,
-                                       "Navigateur du dispositif de consommation"@fr .
+                            dcterms:description "The browser compatible with a ConsumptionDevice."@en ;
+                            rdfs:label "Consumption device browser"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#consumptionDeviceModel
 ec:consumptionDeviceModel rdf:type owl:DatatypeProperty ;
-                          dcterms:description "Das Modell eines ConsumptionDevice."@de ,
-                                              "Le modèle d'un ConsumptionDevice."@fr ,
-                                              "The model of a ConsumptionDevice."@en ;
-                          rdfs:label "Consumption device model"@en ,
-                                     "Modèle de dispositif de consommation"@fr ,
-                                     "Verbrauchsgerät Modell"@de .
+                          dcterms:description "The model of a ConsumptionDevice."@en ;
+                          rdfs:label "Consumption device model"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#consumptionDeviceOS
 ec:consumptionDeviceOS rdf:type owl:DatatypeProperty ;
-                       dcterms:description "Das Betriebssystem eines ConsumptionDevice."@de ,
-                                           "Le système d'exploitation d'un ConsumptionDevice."@fr ,
-                                           "The operating system of a ConsumptionDevice."@en ;
-                       rdfs:label "Consumption device OS"@en ,
-                                  "Os du dispositif de consommation"@fr ,
-                                  "Verbrauchsgerät OS"@de .
+                       dcterms:description "The operating system of a ConsumptionDevice."@en ;
+                       rdfs:label "Consumption device OS"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#consumptionLicenceText
 ec:consumptionLicenceText rdf:type owl:DatatypeProperty ;
-                          dcterms:description "Die Bedingungen für eine Verbrauchslizenz."@de ,
-                                              "Les conditions d'une licence de consommation."@fr ,
-                                              "The terms of a ConsumptionLicence."@en ;
-                          rdfs:label "Consumption licence"@en ,
-                                     "Licence de consommation"@fr ,
-                                     "Verbrauchslizenz"@de .
+                          dcterms:description "The terms of a ConsumptionLicence."@en ;
+                          rdfs:label "Consumption licence"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#contentDescription
 ec:contentDescription rdf:type owl:DatatypeProperty ;
                       rdfs:range rdfs:Literal ;
-                      dcterms:description "Ceci peut être spécialisé en utilisant des sous-propriétés comme celles définies dans https://github.com/ebu/ebu_cs/blob/main/metadata/cs/ebu_DescriptionTypeCodeCS.xml mises en œuvre à titre d'exemple, comme par exemple \"summary\" ou \"script\"."@fr ,
-                                          "Dies kann durch die Verwendung von Untereigenschaften spezialisiert werden wie in https://github.com/ebu/ebu_cs/blob/main/metadata/cs/ebu_DescriptionTypeCodeCS.xml definiert als Beispiele implementiert sind, wie z.B. 'summary' oder 'Skript'."@de ,
-                                          "This can be specialised by using sub-properties like defined in https://github.com/ebu/ebu_cs/blob/main/metadata/cs/ebu_DescriptionTypeCodeCS.xml implemented as examples as e.g. 'summary' or 'script'."@en ;
+                      dcterms:description "This can be specialized by using sub-properties like defined in https://github.com/ebu/ebu_cs/blob/main/metadata/cs/ebu_DescriptionTypeCodeCS.xml implemented as examples such as 'summary' or 'script'."@en ;
                       rdfs:isDefinedBy <dc:description> ;
-                      rdfs:label "Beschreibung des Inhalts"@de ,
-                                 "Content description"@en ,
-                                 "Description du contenu"@fr .
+                      rdfs:label "Content description"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#contractCostAmount
 ec:contractCostAmount rdf:type owl:DatatypeProperty ;
-                      dcterms:description "Der Betrag der ContractCost."@de ,
-                                          "Le montant du ContractCost."@fr ,
-                                          "The amount of the ContractCost."@en ;
-                      rdfs:label "Cost amount"@en ,
-                                 "Kostenbetrag"@de ,
-                                 "Montant du coût"@fr .
+                      dcterms:description "The amount of the ContractCost."@en ;
+                      rdfs:label "Cost amount"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#costumeSizeInformation
 ec:costumeSizeInformation rdf:type owl:DatatypeProperty ;
                           rdfs:range rdfs:Literal ;
-                          dcterms:description "Recueillir toutes les informations disponibles utiles pour déterminer la taille d'un Costume."@fr ,
-                                              "To collect all information available useful to determine the size of a Costume."@en ,
-                                              "Um alle verfügbaren Informationen zu sammeln, die nützlich sind, um die Größe eines Kostüms zu bestimmen."@de ;
-                          rdfs:label "Costume size information"@en ,
-                                     "Informationen zur Kostümgröße"@de ,
-                                     "Informations sur la taille des costumes"@fr .
+                          dcterms:description "To collect all information available useful to determine the size of a Costume."@en ;
+                          rdfs:label "Costume size information"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#costumeTexture
 ec:costumeTexture rdf:type owl:DatatypeProperty ;
                   rdfs:range rdfs:Literal ;
-                  dcterms:description "Bereich: eine Zeichenkette oder ein Konzeptcode aus einem Vokabular, z.B. Getty"@de ,
-                                      "Gamme : une chaîne de caractères ou un code de concept d'un vocabulaire, par exemple Getty"@fr ,
-                                      "Range: a string or a Concept code from a vocabulary, e.g. Getty To define the texture of a Costume."@en ;
-                  rdfs:label "Costume texture"@en ,
-                             "Textur des Kostüms"@de ,
-                             "Texture du costume"@fr .
+                  dcterms:description "Range: a string or a Concept code from a vocabulary, e.g. Getty To define the texture of a Costume."@en ;
+                  rdfs:label "Costume texture"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#day
 ec:day rdf:type owl:DatatypeProperty ;
        rdfs:range xsd:integer ;
-       rdfs:label "Day"@en ,
-                  "Jour"@fr ,
-                  "Tag"@de .
+       dcterms:description "The day component of a date or date-time value, expressed as an integer."@en ;
+       rdfs:label "Day"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#description
 ec:description rdf:type owl:DatatypeProperty ;
                rdfs:range rdfs:Literal ;
-               dcterms:description "A summary of the resource."@en ,
-                                   "Eine Zusammenfassung der Resource."@de ,
-                                   "Un résumé de la ressource."@fr ;
-               rdfs:label "Beschreibung"@de ,
-                          "Description"@en ,
-                          "Description"@fr .
+               dcterms:description "A summary of the resource."@en ;
+               rdfs:label "Description"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dimensions
 ec:dimensions rdf:type owl:DatatypeProperty ;
               rdfs:range rdfs:Literal ;
-              dcterms:description "Beschreibt die physischen Abmessungen einer MediaResource, wobei die Maßeinheiten als Teil des Wertes verkettet werden."@de ,
-                                  "Describes the physical dimensions of a MediaResource, with units of measure concatenated to become part of the value."@en ,
-                                  "Décrit les dimensions physiques d'une MediaResource, les unités de mesure étant concaténées pour faire partie de la valeur."@fr ;
-              rdfs:label "Abmessungen"@de ,
-                         "Dimensions"@en ,
-                         "Dimensions"@fr .
+              dcterms:description "Describes the physical dimensions of a MediaResource, with units of measure concatenated to become part of the value."@en ;
+              rdfs:label "Dimensions"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#displayOrder
 ec:displayOrder rdf:type owl:DatatypeProperty ;
                 rdfs:range rdfs:Literal ;
-                dcterms:description "Die Reihenfolge, in der ein Agent in einer Szene erscheint."@de ,
-                                    "L'ordre dans lequel un agent apparaît dans une scène."@fr ,
-                                    "The order in which an Agent appears in a scene."@en ;
-                rdfs:label "Bestellung anzeigen"@de ,
-                           "Display order"@en ,
-                           "Ordre d'affichage"@fr .
+                dcterms:description "The order in which an Agent appears in a scene."@en ;
+                rdfs:label "Display order"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#editUnit
 ec:editUnit rdf:type owl:DatatypeProperty ;
             rdfs:range xsd:long ;
-            dcterms:description "Die Bearbeitungseinheit ist z.B. der Kehrwert der Audio Sample-Rate oder Video-Frame-Rate."@de ,
-                                "L'unité de montage est par exemple l'inverse du taux d'échantillonnage audio ou de la fréquence d'images vidéo."@fr ,
-                                "The edit unit is e.g. the inverse of the audio sample rate or video frame rate."@en ;
-            rdfs:label "Edit unit"@en ,
-                       "Einheit bearbeiten"@de ,
-                       "Unité d'édition"@fr .
+            dcterms:description "The edit unit is e.g. the inverse of the audio sample rate or video frame rate."@en ;
+            rdfs:label "Edit unit"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#editUnitNumbering
 ec:editUnitNumbering rdf:type owl:DatatypeProperty ;
                      rdfs:range xsd:long ;
-                     dcterms:description "Temps exprimé en nombre d'unités de montage ou d'échantillons."@fr ,
-                                         "Time expressed as the number of editunits or samples."@en ,
-                                         "Zeit, ausgedrückt in der Anzahl der Bearbeitungseinheiten oder Stichproben."@de ;
-                     rdfs:label "Edit unit numbering"@en ,
-                                "Edite la numérotation des unités"@fr ,
-                                "Nummerierung der Einheiten bearbeiten"@de .
+                     dcterms:description "Time expressed as the number of edit units or samples."@en ;
+                     rdfs:label "Edit unit numbering"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#education
 ec:education rdf:type owl:DatatypeProperty ;
              rdfs:range rdfs:Literal ;
-             dcterms:description "Informationen über die Ausbildung zu liefern."@de ,
-                                 "Pour fournir des informations sur l'éducation."@fr ,
-                                 "To provide information on the education."@en ;
-             rdfs:label "Bildung"@de ,
-                        "Education"@en ,
-                        "Éducation"@fr .
+             dcterms:description "Information about a person's education."@en ;
+             rdfs:label "Education"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#encodingLevel
 ec:encodingLevel rdf:type owl:DatatypeProperty ;
                  rdfs:range rdfs:Literal ;
-                 dcterms:description "Pour définir un niveau d'encodage."@fr ,
-                                     "To define an encoding level."@en ,
-                                     "Um eine Kodierungsebene zu definieren."@de ;
-                 rdfs:label "Encoding level"@en ,
-                            "Kodierungsebene"@de ,
-                            "Niveau de codage"@fr .
+                 dcterms:description "The encoding level associated with a media resource."@en ;
+                 rdfs:label "Encoding level"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#encodingProfile
 ec:encodingProfile rdf:type owl:DatatypeProperty ;
                    rdfs:range rdfs:Literal ;
-                   dcterms:description "Das Kodierungsprofil, wie in den Spezifikationen definiert."@de ,
-                                       "Le profil de codage tel que défini dans les spécifications."@fr ,
-                                       "The encoding profile as defined in specifications."@en ;
-                   rdfs:label "Encoding profile"@en ,
-                              "Kodierungsprofil"@de ,
-                              "Profil d'encodage"@fr .
+                   dcterms:description "The encoding profile as defined in specifications."@en ;
+                   rdfs:label "Encoding profile"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#episodeNumber
 ec:episodeNumber rdf:type owl:DatatypeProperty ;
                  rdfs:range xsd:integer ;
-                 dcterms:description "Die Episodennummer"@de ,
-                                     "Le numéro de l'épisode"@fr ,
-                                     "The Episode Number"@en ;
-                 rdfs:label "Episode number"@en ,
-                            "Folge Nummer"@de ,
-                            "Numéro d'épisode"@fr .
+                 dcterms:description "The integer episode number assigned to a Programme."@en ;
+                 rdfs:label "Episode number"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#episodeNumberInSeason
 ec:episodeNumberInSeason rdf:type owl:DatatypeProperty ;
                          rdfs:range xsd:integer ;
-                         dcterms:description "Die Episodennummer in einer Staffel"@de ,
-                                             "Le numéro d'épisode dans une saison"@fr ,
-                                             "The Episode Number in a season"@en ;
-                         rdfs:label "Episode number in season"@en ,
-                                    "Nummer der Episode in der Staffel"@de ,
-                                    "Numéro d'épisode dans la saison"@fr .
+                         dcterms:description "The Episode Number in a season."@en ;
+                         rdfs:label "Episode number in season"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#episodeNumberInSerial
 ec:episodeNumberInSerial rdf:type owl:DatatypeProperty ;
                          rdfs:range xsd:integer ;
-                         rdfs:label "Episodennummer der Serie"@de ,
-                                    "episode number of serial"@en ,
-                                    "numéro d'épisode de la série"@fr .
+                         dcterms:description "An integer giving the episode number of a programme within a serial."@en ;
+                         rdfs:label "Episode number of serial"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#episodeNumberInSeries
 ec:episodeNumberInSeries rdf:type owl:DatatypeProperty ;
                          rdfs:range xsd:integer ;
-                         dcterms:description "Die Episodennummer in einer Serie"@de ,
-                                             "Le numéro de l'épisode dans une série"@fr ,
-                                             "The Episode Number in a series"@en ;
-                         rdfs:label "Episode number in series"@en ,
-                                    "Nummer der Episode in der Serie"@de ,
-                                    "Numéro d'épisode dans la série"@fr .
+                         dcterms:description "The Episode Number in a series."@en ;
+                         rdfs:label "Episode number in series"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#equivalentTime
 ec:equivalentTime rdf:type owl:DatatypeProperty ;
                   rdfs:range xsd:float ;
                   dc:description "Notation of time in seconds compares different ways to denote time, like timecode or sample count."@en ;
-                  rdfs:label "entsprechende Zeit"@de ,
-                             "equivalent time"@en ,
-                             "temps équivalent"@fr .
+                  dcterms:description "A numeric value indicating the equivalent time for a timeline point."@en ;
+                  rdfs:label "Equivalent time"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#familyInformation
 ec:familyInformation rdf:type owl:DatatypeProperty ;
                      rdfs:range rdfs:Literal ;
-                     dcterms:description "Pour fournir des informations sur la famille d'une personne."@fr ,
-                                         "To provide information on the family of a Person."@en ,
-                                         "Um Informationen über die Familie einer Person bereitzustellen."@de ;
-                     rdfs:label "Family information"@en ,
-                                "Informationen zur Familie"@de ,
-                                "Informations sur la famille"@fr .
+                     dcterms:description "Information about a person's family."@en ;
+                     rdfs:label "Family information"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#familyName
 ec:familyName rdf:type owl:DatatypeProperty ;
               rdfs:range rdfs:Literal ;
-              dcterms:description "Der Familienname einer Person."@de ,
-                                  "Le nom de famille d'une personne."@fr ,
-                                  "The family name of a Person."@en ;
-              rdfs:label "Familienname"@de ,
-                         "Family name"@en ,
-                         "Nom de famille"@fr .
+              dcterms:description "The family name of a Person."@en ;
+              rdfs:label "Family name"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#fileName
 ec:fileName rdf:type owl:DatatypeProperty ,
                      owl:FunctionalProperty ;
             rdfs:range xsd:string ;
-            dcterms:description "Der Name der Datei, die die Resource enthält."@de ,
-                                "Le nom du fichier contenant la ressource."@fr ,
-                                "The name of the file containing the Resource."@en ;
-            rdfs:label "Dateiname"@de ,
-                       "File name"@en ,
-                       "Nom du fichier"@fr .
+            dcterms:description "The name of the file containing the Resource."@en ;
+            rdfs:label "File name"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#fileSize
 ec:fileSize rdf:type owl:DatatypeProperty ;
             rdfs:range xsd:nonNegativeInteger ;
-            dcterms:description "Fournit la taille d'une ressource en octets."@fr ,
-                                "Gibt die Größe einer Resource in Bytes an."@de ,
-                                "Provides the size of a Resource in bytes."@en ;
-            rdfs:label "Dateigröße"@de ,
-                       "File size"@en ,
-                       "Taille du fichier"@fr .
+            dcterms:description "Provides the size of a Resource in bytes."@en ;
+            rdfs:label "File size"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#firstShowing
 ec:firstShowing rdf:type owl:DatatypeProperty ,
                          owl:FunctionalProperty ;
                 rdfs:range xsd:boolean ;
-                dcterms:description "Pour signaler qu'il s'agit d'une première présentation PublicationEvent."@fr ,
-                                    "To flag this is a first showing PublicationEvent."@en ,
-                                    "Um dies zu kennzeichnen, muss zuerst ein PublicationEvent angezeigt werden."@de ;
-                rdfs:label "Erste Flagge zeigen"@de ,
-                           "First showing flag"@en ,
-                           "Premier drapeau d'exposition"@fr .
+                dcterms:description "To flag this is a first showing PublicationEvent."@en ;
+                rdfs:label "First showing flag"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#firstShowingThisService
 ec:firstShowingThisService rdf:type owl:DatatypeProperty ,
                                     owl:FunctionalProperty ;
                            rdfs:range xsd:boolean ;
-                           dcterms:description "Pour notifier, il s'agit d'un premier événement de publication sur ce service."@fr ,
-                                               "To flag this is a first showing PublicationEvent on this service."@en ,
-                                               "Um zu kennzeichnen das dies das erste PublicationEvent ist, das in diesem Dienst angezeigt wird."@de ;
-                           rdfs:label "Drapeau pour la première apparition en service"@fr ,
-                                      "Erste Anzeige auf der Serviceflagge"@de ,
-                                      "First showing on service flag"@en .
+                           dcterms:description "To flag this is a first showing PublicationEvent on this service."@en ;
+                           rdfs:label "First showing on service flag"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#folksonomy
 ec:folksonomy rdf:type owl:DatatypeProperty ;
               rdfs:range rdfs:Literal ;
-              dcterms:description "Bietet eine vom Benutzer/Zuschauer generierte Beschreibung, Markierung oder Bezeichnung für Resourceninhalte."@de ,
-                                  "Fournit une description, une balise ou une étiquette générée par l'utilisateur/audience pour le contenu de la ressource."@fr ,
-                                  "Provides a user/audience-generated description, tag, or label for resource content."@en ;
-              rdfs:label "Folksonomie"@fr ,
-                         "Folksonomy"@de ,
-                         "Folksonomy"@en .
+              dcterms:description "Provides a user/audience-generated description, tag, or label for resource content."@en ;
+              rdfs:label "Folksonomy"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#foodCategory
 ec:foodCategory rdf:type owl:DatatypeProperty ;
                 rdfs:range rdfs:Literal ;
-                dcterms:description "Pour définir une catégorie d'aliments."@fr ,
-                                    "To define a category of Food."@en ,
-                                    "Um eine Kategorie von Lebensmitteln zu definieren."@de ;
-                rdfs:label "Catégorie d'aliments"@fr ,
-                           "Food category"@en ,
-                           "Kategorie Lebensmittel"@de .
+                dcterms:description "A category of food."@en ;
+                rdfs:label "Food category"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#foodIngredient
 ec:foodIngredient rdf:type owl:DatatypeProperty ;
                   rdfs:range rdfs:Literal ;
-                  dcterms:description "Die Lebensmittelzutaten oder Lebensmittelartikel."@de ,
-                                      "Les ingrédients alimentaires ou les produits alimentaires."@fr ,
-                                      "The Food ingredients or Food items."@en ;
-                  rdfs:label "Food ingredient"@en ,
-                             "Ingrédient alimentaire"@fr ,
-                             "Lebensmittelzutat"@de .
+                  dcterms:description "The Food ingredients or Food items."@en ;
+                  rdfs:label "Food ingredient"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#formatId
@@ -5482,1610 +3958,1043 @@ ec:formatId rdf:type owl:DatatypeProperty ;
                                        xsd:string
                                      )
                        ] ;
-            dcterms:description "An Id attributed to a Format."@en ,
-                                "Eine Id, die einem Format zugeordnet ist."@de ,
-                                "Un Id attribué à un Format."@fr ;
-            rdfs:label "Format Id"@de ,
-                       "Format Id"@en ,
-                       "Id du format"@fr .
+            dcterms:description "An Id attributed to a Format."@en ;
+            rdfs:label "Format id"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#frameHeight
 ec:frameHeight rdf:type owl:DatatypeProperty ;
                rdfs:subPropertyOf ec:height ;
                rdfs:range xsd:integer ;
-               dcterms:description "Die Höhe eines Videobildes."@de ,
-                                   "La hauteur d'une image vidéo."@fr ,
-                                   "The height of a video frame."@en ;
-               rdfs:label "Frame height"@en ,
-                          "Hauteur du cadre"@fr ,
-                          "Rahmenhöhe"@de .
+               dcterms:description "The height of a video frame."@en ;
+               rdfs:label "Frame height"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#frameHeightUnit
 ec:frameHeightUnit rdf:type owl:DatatypeProperty ;
                    rdfs:subPropertyOf ec:heightUnit ;
                    rdfs:range rdfs:Literal ;
-                   dcterms:description "Die Einheit, die zur Messung der Höhe eines Rahmens verwendet wird."@de ,
-                                       "L'unité utilisée pour mesurer la hauteur d'un cadre."@fr ,
-                                       "The unit used to measure the height of a frame."@en ;
-                   rdfs:label "Einheit Rahmenhöhe"@de ,
-                              "Frame height unit"@en ,
-                              "Unité de hauteur du cadre"@fr .
+                   dcterms:description "The unit used to measure the height of a frame."@en ;
+                   rdfs:label "Frame height unit"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#frameRate
 ec:frameRate rdf:type owl:DatatypeProperty ;
              rdfs:range rdfs:Literal ;
-             dcterms:description "Die Einheit, mit der die Bildrate einer MediaResource in Bildern/Sekunde ausgedrückt wird."@de ,
-                                 "L'unité utilisée pour exprimer la fréquence d'images d'une MediaResource en images/seconde."@fr ,
-                                 "The unit used to express the frame rate of a MediaResource in frames/second."@en ;
-             rdfs:label "Bildrate"@de ,
-                        "Frame rate"@en ,
-                        "Fréquence d'images"@fr .
+             dcterms:description "The unit used to express the frame rate of a MediaResource in frames/second."@en ;
+             rdfs:label "Frame rate"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#frameSizeUnit
 ec:frameSizeUnit rdf:type owl:DatatypeProperty ;
                  rdfs:range rdfs:Literal ;
-                 dcterms:description "Die Einheit, die verwendet wird, um die Breite oder Höhe des Rahmens auszudrücken. Höhe. Die Einheit ist standardmäßig 'Pixel'."@de ,
-                                     "L'unité utilisée pour exprimer la largeur ou la hauteur. L'unité par défaut est le \"pixel\"."@fr ,
-                                     "The unit used to express the frame width or height. The unit by default is 'pixel'."@en ;
-                 rdfs:label "Frame size unit"@en ,
-                            "Rahmengröße Einheit"@de ,
-                            "Unité de taille de cadre"@fr .
+                 dcterms:description "The unit used to express the frame width or height. The unit by default is 'pixel'."@en ;
+                 rdfs:label "Frame size unit"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#frameWidth
 ec:frameWidth rdf:type owl:DatatypeProperty ;
               rdfs:subPropertyOf ec:width ;
               rdfs:range xsd:integer ;
-              dcterms:description "Die Breite eines Videobildes."@de ,
-                                  "La largeur d'une image vidéo."@fr ,
-                                  "The width of a video frame."@en ;
-              rdfs:label "Frame width"@en ,
-                         "Largeur du cadre"@fr ,
-                         "Rahmenbreite"@de .
+              dcterms:description "The width of a video frame."@en ;
+              rdfs:label "Frame width"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#frameWidthUnit
 ec:frameWidthUnit rdf:type owl:DatatypeProperty ;
                   rdfs:subPropertyOf ec:widthUnit ;
                   rdfs:range rdfs:Literal ;
-                  dcterms:description "Die Einheit, die zur Messung der Breite eines Rahmens verwendet wird."@de ,
-                                      "L'unité utilisée pour mesurer la largeur d'un cadre."@fr ,
-                                      "The unit used to measure the width of a frame."@en ;
-                  rdfs:label "Einheit Rahmenbreite"@de ,
-                             "Frame width unit"@en ,
-                             "Unité de largeur du cadre"@fr .
+                  dcterms:description "The unit used to measure the width of a frame."@en ;
+                  rdfs:label "Frame width unit"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#free
 ec:free rdf:type owl:DatatypeProperty ,
                  owl:FunctionalProperty ;
         rdfs:range xsd:boolean ;
-        dcterms:description "A flag to indicate that the access to the PublicationEvent is 'free'."@en ,
-                            "Ein Flag, das anzeigt, dass der Zugriff auf das PublicationEvent 'frei' ist."@de ,
-                            "Un drapeau pour indiquer que l'accès au PublicationEvent est \"libre\"."@fr ;
-        rdfs:label "Accès gratuit"@fr ,
-                   "Free access"@en ,
-                   "Freier Zugang"@de .
+        dcterms:description "A flag to indicate that the access to the PublicationEvent is 'free'."@en ;
+        rdfs:label "Free access"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#gender
 ec:gender rdf:type owl:DatatypeProperty ;
           rdfs:range rdfs:Literal ;
-          dcterms:description "Das Geschlecht einer Person, z.B. männlich oder weiblich."@de ,
-                              "Le genre d'une personne, par exemple, homme ou femme."@fr ,
-                              "The gender of a Person e.g. male or female."@en ;
-          rdfs:label "Gender"@en ,
-                     "Genre"@fr ,
-                     "Geschlecht"@de .
+          dcterms:description "The gender of a Person e.g. male or female."@en ;
+          rdfs:label "Gender"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#givenName
 ec:givenName rdf:type owl:DatatypeProperty ;
              rdfs:range rdfs:Literal ;
-             dcterms:description "Der Vorname einer Person."@de ,
-                                 "Le prénom d'une personne."@fr ,
-                                 "The given name of a Person."@en ;
-             rdfs:label "Given name"@en ,
-                        "Nom de famille"@fr ,
-                        "Vorname"@de .
+             dcterms:description "The given name of a Person."@en ;
+             rdfs:label "Given name"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hashValue
 ec:hashValue rdf:type owl:DatatypeProperty ;
              rdfs:range xsd:string ;
-             dcterms:description "Der Hash-Wert, der einer Resource zugeordnet ist. Es gibt es verschiedene Methoden / Algorithmen zur Berechnung von Hash-Werten, die als Untereigenschaften definiert werden können. Unter-Eigenschaften."@de ,
-                                 "La valeur de hachage associée à une ressource. Il existe différentes méthodes / algorithmes pour calculer les valeurs de hachage, qui peuvent être définies en tant que sous-propriétés."@fr ,
-                                 "The hash value associated with a Resource. There are different methods / algorithms to calculate hash values, which can be defined as subproperties."@en ;
-             rdfs:label "Code de hachage"@fr ,
-                        "Hash code"@en ,
-                        "Hash-Code"@de .
+             dcterms:description "The hash value associated with a Resource. There are different methods / algorithms to calculate hash values, which can be defined as sub-properties."@en ;
+             rdfs:label "Hash code"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#height
 ec:height rdf:type owl:DatatypeProperty ;
           rdfs:range xsd:integer ;
-          dcterms:description "Die Höhe z.B. eines Videobildes wird normalerweise ausgedrückt als Anzahl von Zeilen oder die Höhe eines Bildes/Bildes, ausgedrückt in Millimetern oder anders."@de ,
-                              "La hauteur d'une image vidéo, par exemple, généralement exprimée en nombre de lignes ou la hauteur d'une photo/image exprimée en millimètres ou autre unité."@fr ,
-                              "The height of e.g. a video frame typically expressed as a number of lines or the height of a picture/image expressed in millimeters or else."@en ;
-          rdfs:label "Hauteur"@fr ,
-                     "Height"@en ,
-                     "Höhe"@de .
+          dcterms:description "The height of e.g. a video frame typically expressed as a number of lines or the height of a picture/image expressed in millimeters or else."@en ;
+          rdfs:label "Height"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#heightUnit
 ec:heightUnit rdf:type owl:DatatypeProperty ;
               rdfs:range rdfs:Literal ;
-              dcterms:description "Pour spécifier une unité pour exprimer la hauteur."@fr ,
-                                  "To specify a unit to express height."@en ,
-                                  "Um eine Einheit für die Höhe anzugeben."@de ;
-              rdfs:label "Height unit"@en ,
-                         "Höheneinheit"@de ,
-                         "Unité de hauteur"@fr .
+              dcterms:description "The unit used to express height."@en ;
+              rdfs:label "Height unit"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#highlights
 ec:highlights rdf:type owl:DatatypeProperty ;
               rdfs:subPropertyOf ec:contentDescription ;
               rdfs:range rdfs:Literal ;
-              dcterms:description "Pour fournir des points forts."@fr ,
-                                  "To provide highlights."@en ,
-                                  "Um Highlights zu bieten."@de ;
-              rdfs:label "Highlights"@en ,
-                         "Höhepunkte"@de ,
-                         "Points forts"@fr .
+              dcterms:description "Provides highlights for an editorial object as a concise content description."@en ;
+              rdfs:label "Highlights"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hobbies
 ec:hobbies rdf:type owl:DatatypeProperty ;
            rdfs:range rdfs:Literal ;
-           dcterms:description "Die Hobbys einer Person."@de ,
-                               "Les loisirs d'une personne."@fr ,
-                               "The hobbies of a Person."@en ;
-           rdfs:label "Hobbies"@en ,
-                      "Hobbys"@de ,
-                      "Passe-temps"@fr .
+           dcterms:description "The hobbies of a Person."@en ;
+           rdfs:label "Hobbies"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#iFrameSize
 ec:iFrameSize rdf:type owl:DatatypeProperty ;
               rdfs:range xsd:int ;
-              dcterms:description "Der Abstand zwischen 2 I-Frames wird auch als Gop-Größe bezeichnet."@de ,
-                                  "La distance entre 2 I-frames également connue comme la taille du gap."@fr ,
-                                  "The distance between 2 I-frames also known as the gop size."@en ;
-              rdfs:label "I-Frame/Gop-Größe"@de ,
-                         "I-frame/Gop size"@en ,
-                         "Taille I-frame/Gap"@fr .
+              dcterms:description "The distance between 2 I-frames also known as the gop size."@en ;
+              rdfs:label "I-frame/GOP size"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#identifierValue
 ec:identifierValue rdf:type owl:DatatypeProperty ;
                    rdfs:range rdfs:Literal ;
-                   dcterms:description "Bereich: String oder anyURI."@de ,
-                                       "Plage : chaîne de caractères ou anyURI."@fr ,
-                                       "To provide the value attributed to an Identifier. Range: string or anyURI."@en ;
-                   rdfs:label "Identifier value"@en ,
-                              "Valeur d'identification"@fr ,
-                              "Wert der Kennung"@de .
+                   dcterms:description "The value associated with an identifier. It may be a string or anyURI."@en ;
+                   rdfs:label "Identifier value"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#inchesPerSecond
 ec:inchesPerSecond rdf:type owl:DatatypeProperty ;
                    rdfs:subPropertyOf ec:playbackSpeed ;
                    rdfs:range xsd:double ;
-                   dcterms:description "Gibt die Zoll pro Sekunde an, mit der ein analoges Audioband für den menschlichen Verzehr wiedergegeben werden sollte."@de ,
-                                       "Identifie les pouces par seconde auxquels une bande audio analogique doit être lue pour la consommation humaine."@fr ,
-                                       "Identifies the inches per second at which an analog audio tape should be played back for human consumption."@en ;
-                   rdfs:label "Inches per second"@en ,
-                              "Pouces par seconde"@fr ,
-                              "Zentimeter pro Sekunde"@de .
+                   dcterms:description "Identifies the inches per second at which an analog audio tape should be played back for human consumption."@en ;
+                   rdfs:label "Inches per second"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#internetConnectivity
 ec:internetConnectivity rdf:type owl:DatatypeProperty ,
                                  owl:FunctionalProperty ;
-                        dcterms:description "Pour indiquer si le service nécessite une connection Internet."@fr ,
-                                            "To indicate if the Service requires Internet connectivity."@en ,
-                                            "Zur Angabe, ob der Dienst eine Internetverbindung erfordert Konnektivität erfordert."@de ;
-                        rdfs:label "Connectivité Internet"@fr ,
-                                   "Internet connectivity"@en ,
-                                   "Internet-Verbindung"@de .
+                        dcterms:description "Indicates whether the service requires Internet connectivity."@en ;
+                        rdfs:label "Internet connectivity"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isoDuration
 ec:isoDuration rdf:type owl:DatatypeProperty ;
                rdfs:range xsd:string ;
-               dcterms:description "a duration expressed as a string formatted as ISO8601 ie PT3M23S"@en ,
-                                   "eine Dauer, ausgedrückt als Zeichenkette im Format ISO8601, also PT3M23S"@de ,
-                                   "une durée exprimée sous la forme d'une chaîne de caractères au format ISO8601 : PT3M23S"@fr ;
-               rdfs:label "Durée ISO"@fr ,
-                          "ISO duration"@en ,
-                          "ISO-Dauer"@de .
+               dcterms:description "A duration expressed as a string formatted as ISO8601 ie PT3M23S."@en ;
+               rdfs:label "ISO duration"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#lineNumber
 ec:lineNumber rdf:type owl:DatatypeProperty ;
               rdfs:range xsd:integer ;
-              dcterms:description "Ppur fournir le numéro de la ligne sur laquelle les données auxiliaires sont transportées et l'équivalent dans le domaine numérique."@fr ,
-                                  "To provide the number of the line on which ancillary data is being carried and the equivalent in the digital domain."@en ,
-                                  "Zur Angabe der Nummer der Leitung, auf der Zusatzdaten übertragen werden, und die Entsprechung im digitalen Bereich."@de ;
-              rdfs:label "Line number"@en ,
-                         "Numéro de ligne"@fr ,
-                         "Zeilennummer"@de .
+              dcterms:description "The number of the line on which ancillary data is carried in the digital domain."@en ;
+              rdfs:label "Line number"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#live
 ec:live rdf:type owl:DatatypeProperty ,
                  owl:FunctionalProperty ;
         rdfs:range xsd:boolean ;
-        dcterms:description "A flag to signal that content is live"@en ,
-                            "Ein Flag, das signalisiert, dass der Inhalt live ist"@de ,
-                            "Un drapeau pour signaler que le contenu est en direct"@fr ;
-        rdfs:label "En direct"@fr ,
-                   "Live"@de ,
-                   "Live"@en .
+        dcterms:description "A flag to signal that content is live."@en ;
+        rdfs:label "Live"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#locationAddressApartmentNumber
 ec:locationAddressApartmentNumber rdf:type owl:DatatypeProperty ;
                                   rdfs:range xsd:string ;
-                                  dcterms:description "Die Nummer, die eine Wohnung in einem Haus identifiziert."@de ,
-                                                      "Le numéro identifiant un appartement dans une maison."@fr ,
-                                                      "The number identifying an apartment in a house."@en ;
-                                  rdfs:label "Appartmentnummer"@de ,
-                                             "apartment number"@en ,
-                                             "numéro de l'appartement"@fr .
+                                  dcterms:description "The number identifying an apartment in a house."@en ;
+                                  rdfs:label "Apartment number"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#locationAddressArea
 ec:locationAddressArea rdf:type owl:DatatypeProperty ;
                        rdfs:range rdfs:Literal ;
-                       dcterms:description "Pour fournir la partie Zone d'une adresse."@fr ,
-                                           "To provide the Area part of an Address."@en ,
-                                           "Um den Bereich Teil einer Adresse."@de ;
-                       rdfs:label "Area"@en ,
-                                  "Bereich"@de ,
-                                  "Zone"@fr .
+                       dcterms:description "The area part of an address associated with a location."@en ;
+                       rdfs:label "Area"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#locationAddressCountry
 ec:locationAddressCountry rdf:type owl:DatatypeProperty ;
                           rdfs:range rdfs:Literal ;
-                          dcterms:description "Pour fournir le nom du pays et ou le code du pays."@fr ,
-                                              "To provide the country name and or country code."@en ,
-                                              "Zur Angabe des Ländernamens und/oder des Ländercodes Code."@de ;
-                          rdfs:label "Country"@en ,
-                                     "Land"@de ,
-                                     "Pays"@fr .
+                          dcterms:description "The country name or country code for the location."@en ;
+                          rdfs:label "Country"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#locationAddressHouseNumber
 ec:locationAddressHouseNumber rdf:type owl:DatatypeProperty ;
                               rdfs:range xsd:string ;
-                              dcterms:description "Die Nummer, die einem Haus oder einem Eingang in einer Straße gegeben wird"@de ,
-                                                  "Le numéro donné à la maison ou à une entrée dans une rue"@fr ,
-                                                  "The number given to the house or an entrance in a street"@en ;
-                              rdfs:label "Hausnummer"@de ,
-                                         "house number"@en ,
-                                         "numéro de maison"@fr .
+                              dcterms:description "The number given to the house or an entrance in a street."@en ;
+                              rdfs:label "House number"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#locationAddressMunicipality
 ec:locationAddressMunicipality rdf:type owl:DatatypeProperty ;
                                rdfs:range rdfs:Literal ;
-                               dcterms:description "Pour fournir le nom d'une ville, d'un village, etc."@fr ,
-                                                   "To provide the name of a city, village, etc."@en ,
-                                                   "Zur Angabe des Namens einer Stadt, eines Dorfes, usw."@de ;
-                               rdfs:label "Gemeinde"@de ,
-                                          "municipality"@en ,
-                                          "municipalité"@fr .
+                               dcterms:description "Provides the name of a city, village, etc."@en ;
+                               rdfs:label "Municipality"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#locationAddressPostalCode
 ec:locationAddressPostalCode rdf:type owl:DatatypeProperty ;
                              rdfs:range rdfs:Literal ;
-                             dcterms:description "Pour fournir le code de l' adresse postale ."@fr ,
-                                                 "To provide an address postal code."@en ,
-                                                 "Zur Angabe einer Postleitzahl für die Adresse code."@de ;
-                             rdfs:label "Code postal"@fr ,
-                                        "Postal code"@en ,
-                                        "Postleitzahl"@de .
+                             dcterms:description "The postal code associated with a location."@en ;
+                             rdfs:label "Postal code"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#locationAddressStreetName
 ec:locationAddressStreetName rdf:type owl:DatatypeProperty ;
                              rdfs:range rdfs:Literal ;
-                             dcterms:description "Der Name der Straße, des Platzes oder des Blocks in einer Adresse"@de ,
-                                                 "Le nom de la rue, de la place ou du bloc dans une adresse"@fr ,
-                                                 "The name of the street, square or block in a adress"@en ;
-                             rdfs:label "Straßenname"@de ,
-                                        "nom de la rue"@fr ,
-                                        "street name"@en .
+                             dcterms:description "The name of the street, square or block in an address."@en ;
+                             rdfs:label "Street name"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#locationAltitude
 ec:locationAltitude rdf:type owl:DatatypeProperty ;
                     rdfs:range xsd:float ;
-                    dcterms:description "Pour définir l'altitude d'un emplacement en mètres."@fr ,
-                                        "So definieren Sie die Höhe eines Ortes in Metern."@de ,
-                                        "To define the altitude of a Location in meters."@en ;
-                    rdfs:label "Altitude"@en ,
-                               "Altitude"@fr ,
-                               "Höhenlage"@de .
+                    dcterms:description "The altitude of a Location in meters."@en ;
+                    rdfs:label "Altitude"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#locationCoordinateSystemName
 ec:locationCoordinateSystemName rdf:type owl:DatatypeProperty ;
                                 rdfs:range rdfs:Literal ;
-                                dcterms:description "Pour spécifier le nom du système de coordonnées gps utilisé pour l'emplacement."@fr ,
-                                                    "To specify the name of the gps coordinate system used for the Location."@en ,
-                                                    "Zur Angabe des Namens des GPS-Koordinatensystems Systems, das für den Standort verwendet wird."@de ;
-                                rdfs:label "Coordinate system"@en ,
-                                           "Koordinatensystem"@de ,
-                                           "Système de coordonnées"@fr .
+                                dcterms:description "The name of the GPS coordinate system used for a location."@en ;
+                                rdfs:label "Coordinate system"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#locationLatitude
 ec:locationLatitude rdf:type owl:DatatypeProperty ;
                     rdfs:range xsd:float ;
-                    dcterms:description "Der Breitengrad des Ortes."@de ,
-                                        "La latitude de l'emplacement."@fr ,
-                                        "The latitude of the Location."@en ;
-                    rdfs:label "Breitengrad"@de ,
-                               "Latitude"@en ,
-                               "Latitude"@fr .
+                    dcterms:description "The latitude of the Location."@en ;
+                    rdfs:label "Latitude"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#locationLongitude
 ec:locationLongitude rdf:type owl:DatatypeProperty ;
                      rdfs:range xsd:float ;
-                     dcterms:description "Pour définir la longitude de la emplacement."@fr ,
-                                         "So definieren Sie den Längengrad des Standortes."@de ,
-                                         "To define the longitude of the Location."@en ;
-                     rdfs:label "Longitude"@en ,
-                                "Longitude"@fr ,
-                                "Längengrad"@de .
+                     dcterms:description "The longitude of the Location."@en ;
+                     rdfs:label "Longitude"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#locatorTargetInformation
 ec:locatorTargetInformation rdf:type owl:DatatypeProperty ;
                             rdfs:range rdfs:Literal ;
-                            dcterms:description "Information on the locator target."@en ,
-                                                "Informationen über das Ortungsziel."@de ,
-                                                "Informations sur la cible du localisateur."@fr ;
-                            rdfs:label "Informationen zum Ziel des Locators"@de ,
-                                       "Informations sur la cible du localisateur"@fr ,
-                                       "Locator target information"@en .
+                            dcterms:description "Information on the locator target."@en ;
+                            rdfs:label "Locator target information"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#log
 ec:log rdf:type owl:DatatypeProperty ;
        rdfs:subPropertyOf ec:contentDescription ;
        rdfs:range rdfs:Literal ;
-       dcterms:description "Pour enregistrer tout le contenu selon des règles et des critères prédéfinis, sous la forme d'une séquence neutre de descriptions textuelles (éventuellement minutées)."@fr ,
-                           "To log everything in the content following predefined rules and criterias, as a neutral sequence of (possibly timed) textual descriptions."@en ,
-                           "Um alles im Inhalt nach vordefinierten Regeln und Kriterien als neutrale Abfolge von (möglicherweise zeitlich begrenzten) Textbeschreibungen zu protokollieren."@de ;
-       rdfs:label "Journal de bord"@fr ,
-                  "Log"@en ,
-                  "Protokoll"@de .
+       dcterms:description "To log everything in the content following predefined rules and criteria, as a neutral sequence of (possibly timed) textual descriptions."@en ;
+       rdfs:label "Log"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#loudnessIntegratedLoudness
 ec:loudnessIntegratedLoudness rdf:type owl:DatatypeProperty ;
                               rdfs:range xsd:float ;
-                              dcterms:description "Der Wert für die integrierte Lautheit, gemessen auf AudioProgramme- oder AudioContent-Ebene."@de ,
-                                                  "La valeur de l'intensité sonore intégrée mesurée au niveau de l'AudioProgramme ou de l'AudioContent."@fr ,
-                                                  "The value for integrated loudness measured at AudioProgramme or AudioContent level."@en ;
-                              rdfs:label "Integrated loudness"@en ,
-                                         "Integrierte Lautstärke"@de ,
-                                         "loudness intégré"@fr .
+                              dcterms:description "The value for integrated loudness measured at AudioProgramme or AudioContent level."@en ;
+                              rdfs:label "Integrated loudness"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#loudnessMaxMomentary
 ec:loudnessMaxMomentary rdf:type owl:DatatypeProperty ;
                         rdfs:range xsd:float ;
-                        dcterms:description "Der Wert für die maximale momentane Lautstärke, gemessen auf AudioProgramme- oder AudioContent-Ebene."@de ,
-                                            "La valeur de l'intensité sonore maximale momentanée mesurée au niveau de l'AudioProgramme ou de l'AudioContent."@fr ,
-                                            "The value for maximum momentary loudness measured at AudioProgramme or AudioContent level."@en ;
-                        rdfs:label "Intensité sonore maximale momentanée"@fr ,
-                                   "Max momentary loudness"@en ,
-                                   "Maximale momentane Lautstärke"@de .
+                        dcterms:description "The value for maximum momentary loudness measured at AudioProgramme or AudioContent level."@en ;
+                        rdfs:label "Max momentary loudness"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#loudnessMaxShortTerm
 ec:loudnessMaxShortTerm rdf:type owl:DatatypeProperty ;
                         rdfs:range xsd:float ;
-                        dcterms:description "Der Wert für die maximale kurzfristige Lautstärke, gemessen auf der Ebene des AudioProgramms oder AudioContents."@de ,
-                                            "La valeur de l'intensité sonore maximale à court terme mesurée au niveau de l'AudioProgramme ou de l'AudioContent."@fr ,
-                                            "The value for maximum max short term loudness measured at AudioProgramme or AudioContent level."@en ;
-                        rdfs:label "Max short term loudness"@en ,
-                                   "Maximale Kurzzeit-Lautstärke"@de ,
-                                   "Sonie maximale à court terme"@fr .
+                        dcterms:description "The value for maximum max short term loudness measured at AudioProgramme or AudioContent level."@en ;
+                        rdfs:label "Max short term loudness"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#loudnessMaxTruepeak
 ec:loudnessMaxTruepeak rdf:type owl:DatatypeProperty ;
                        rdfs:range xsd:float ;
-                       dcterms:description "Der Wert für die maximale wahre Spitzenlautheit, gemessen auf AudioProgramme- oder AudioContent-Ebene."@de ,
-                                           "La valeur de l'intensité sonore maximale de crête vraie mesurée au niveau de l'AudioProgramme ou de l'AudioContent."@fr ,
-                                           "The value for maximum true peak loudness measured at AudioProgramme or AudioContent level."@en ;
-                       rdfs:label "Max true peak loudness"@en ,
-                                  "Max true peak loudness"@fr ,
-                                  "Max. wahre Spitzenlautstärke"@de .
+                       dcterms:description "The value for maximum true peak loudness measured at AudioProgramme or AudioContent level."@en ;
+                       rdfs:label "Max true peak loudness"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#loudnessMethod
 ec:loudnessMethod rdf:type owl:DatatypeProperty ;
                   rdfs:range rdfs:Literal ;
-                  dcterms:description "Die Methode zur Messung der Lautheit auf der Ebene des AudioProgramms oder AudioContents."@de ,
-                                      "La méthode de mesure de l'intensité sonore au niveau de l'AudioProgramme ou de l'AudioContent."@fr ,
-                                      "The method for loudness measurement at AudioProgramme or AudioContent level."@en ;
-                  rdfs:label "Loudness method"@en ,
-                             "Loudness-Methode"@de ,
-                             "Méthode de sonorité"@fr .
+                  dcterms:description "The method for loudness measurement at AudioProgramme or AudioContent level."@en ;
+                  rdfs:label "Loudness method"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#loudnessRange
 ec:loudnessRange rdf:type owl:DatatypeProperty ;
                  rdfs:range xsd:float ;
-                 dcterms:description "Der Lautstärkebereich, gemessen auf der Ebene des AudioProgramms oder des AudioContents."@de ,
-                                     "La plage d'intensité sonore mesurée au niveau de l'AudioProgramme ou de l'AudioContent."@fr ,
-                                     "The loudness range measured at AudioProgramme or AudioContent level."@en ;
-                 rdfs:label "Loudness range"@en ,
-                            "Loudness-Bereich"@de ,
-                            "Plage de sonorité"@fr .
+                 dcterms:description "The loudness range measured at AudioProgramme or AudioContent level."@en ;
+                 rdfs:label "Loudness range"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#maritalStatus
 ec:maritalStatus rdf:type owl:DatatypeProperty ;
                  rdfs:range rdfs:Literal ;
-                 dcterms:description "Pour identifier l'état civil d'une personne."@fr ,
-                                     "To identify the marital status of a Person."@en ,
-                                     "Zur Identifizierung des Familienstandes einer Person."@de ;
-                 rdfs:label "Familienstand"@de ,
-                            "Marital Status"@en ,
-                            "État civil"@fr .
+                 dcterms:description "The marital status associated with a person."@en ;
+                 rdfs:label "Marital status"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#measureValue
 ec:measureValue rdf:type owl:DatatypeProperty ;
-                dcterms:description "Pour fournir la valeur d'une mesure."@fr ,
-                                    "To provide the value of a Measure."@en ,
-                                    "Um den Wert einer Maßnahme anzugeben."@de ;
-                rdfs:label "Measure value"@en ,
-                           "Valeur de mesure"@fr ,
-                           "Wert messen"@de .
+                dcterms:description "The value of the Measure as a literal."@en ;
+                rdfs:label "Measure value"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#measureValueMax
 ec:measureValueMax rdf:type owl:DatatypeProperty ;
-                   dcterms:description "Pour définir la valeur maximale d'une mesure lorsque applicable."@fr ,
-                                       "To define the maximum value of a Measure when applicable."@en ,
-                                       "Um den maximalen Wert einer Kennzahl zu definieren, wenn gilt."@de ;
-                   rdfs:label "Maximalwert messen"@de ,
-                              "Measure maximum value"@en ,
-                              "Mesure de la valeur maximale"@fr .
+                   dcterms:description "The maximum value of a Measure when applicable."@en ;
+                   rdfs:label "Measure maximum value"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#measureValueMin
 ec:measureValueMin rdf:type owl:DatatypeProperty ;
-                   dcterms:description "Pour définir la valeur minimale d'une mesure lorsque applicable."@fr ,
-                                       "To define the minimum value of a Measure when applicable."@en ,
-                                       "Um den Mindestwert einer Maßnahme zu definieren, wenn gilt."@de ;
-                   rdfs:label "Measure minimum value"@en ,
-                              "Mesure de la valeur minimale"@fr ,
-                              "Minimalwert messen"@de .
+                   dcterms:description "The minimum value of a Measure, when applicable."@en ;
+                   rdfs:label "Measure minimum value"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#microphone
 ec:microphone rdf:type owl:DatatypeProperty ,
                        owl:FunctionalProperty ;
-              dcterms:description "Pour indiquer si le service nécessite un microphone."@fr ,
-                                  "To indicate if the Service requires a microphone."@en ,
-                                  "Um anzugeben, ob der Service ein Mikrofon benötigt."@de ;
-              rdfs:label "Microphone"@en ,
-                         "Microphone"@fr ,
-                         "Mikrofon"@de .
+              dcterms:description "Indicates whether the consumption device profile requires a microphone."@en ;
+              rdfs:label "Microphone"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#midRollAdAllowed
 ec:midRollAdAllowed rdf:type owl:DatatypeProperty ,
                              owl:FunctionalProperty ;
                     rdfs:range xsd:boolean ;
-                    dcterms:description "A flag to indicate whether it is allowed to insert ad breaks in mid-roll."@en ,
-                                        "Ein Flag, das anzeigt, ob es erlaubt ist, Werbeunterbrechungen in der Mitte der Rolle einzufügen."@de ,
-                                        "Un drapeau pour indiquer s'il est autorisé d'insérer des coupures publicitaires en mid-roll."@fr ;
-                    rdfs:label "Midroll ad allowed"@en ,
-                               "Midroll-Anzeige erlaubt"@de ,
-                               "Publicité midroll autorisée"@fr .
+                    dcterms:description "A flag to indicate whether it is allowed to insert ad breaks in mid-roll."@en ;
+                    rdfs:label "Midroll ad allowed"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#middleName
 ec:middleName rdf:type owl:DatatypeProperty ;
               rdfs:range rdfs:Literal ;
-              dcterms:description "Pour fournir un ou plusieurs seconds prénoms à une personne."@fr ,
-                                  "To provide one or more middle names for a Person."@en ,
-                                  "Um einen oder mehrere zweite Namen für eine Person anzugeben."@de ;
-              rdfs:label "Middle name"@en ,
-                         "Mittlerer Name"@de ,
-                         "Second prénom"@fr .
+              dcterms:description "One or more middle names associated with a Person."@en ;
+              rdfs:label "Middle name"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#month
 ec:month rdf:type owl:DatatypeProperty ;
          rdfs:range xsd:integer ;
-         rdfs:label "Mois"@fr ,
-                    "Monat"@de ,
-                    "Month"@en .
+         dcterms:description "An integer representing the month of the year."@en ;
+         rdfs:label "Month"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#name
 ec:name rdf:type owl:DatatypeProperty ;
         rdfs:range rdfs:Literal ;
-        dcterms:description "Die Bezeichnung der Resource."@de ,
-                            "La désignation de la ressource."@fr ,
-                            "The designation of the resource."@en ;
-        rdfs:label "Name"@de ,
-                   "Name"@en ,
-                   "Nom"@fr .
+        dcterms:description "The designation of the resource."@en ;
+        rdfs:label "Name"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#nickName
 ec:nickName rdf:type owl:DatatypeProperty ;
             rdfs:range rdfs:Literal ;
-            dcterms:description "Der Spitzname einer Person."@de ,
-                                "Le surnom d'une personne."@fr ,
-                                "The nickname of a Person."@en ;
-            rdfs:label "Nickname"@en ,
-                       "Spitzname"@de ,
-                       "Surnom"@fr .
+            dcterms:description "The nickname of a Person."@en ;
+            rdfs:label "Nickname"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#noiseFilter
 ec:noiseFilter rdf:type owl:DatatypeProperty ,
                         owl:FunctionalProperty ;
                rdfs:range xsd:boolean ;
-               dcterms:description "A flag to signal that a noise filter has been used."@en ,
-                                   "Ein Flag, das anzeigt, dass ein Rauschfilter verwendet wurde. verwendet wurde."@de ,
-                                   "Un drapeau pour signaler qu'un filtre de bruit a été utilisé."@fr ;
-               rdfs:label "Filtre anti-bruit"@fr ,
-                          "Noise filter"@en ,
-                          "Rauschfilter"@de .
+               dcterms:description "A flag to signal that a noise filter has been used."@en ;
+               rdfs:label "Noise filter"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#notRated
 ec:notRated rdf:type owl:DatatypeProperty ;
             rdfs:range xsd:boolean ;
-            dcterms:description "A flag to indicate that the EditorialObject has not been rated."@en ,
-                                "Eine Markierung, die anzeigt, dass das EditorialObject noch nicht bewertet wurde."@de ,
-                                "Un drapeau pour indiquer que l'EditorialObject n'a pas été évalué."@fr ;
-            rdfs:label "Nicht bewertet"@de ,
-                       "Non évalué"@fr ,
-                       "Not rated"@en .
+            dcterms:description "A flag to indicate that the EditorialObject has not been rated."@en ;
+            rdfs:label "Not rated"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#occupation
 ec:occupation rdf:type owl:DatatypeProperty ;
               rdfs:range rdfs:Literal ;
-              dcterms:description "Der Name der Tätigkeit / des Berufs einer Person."@de ,
-                                  "Le nom de l'emploi / de la profession d'une personne."@fr ,
-                                  "The job / occupation name of a Person."@en ;
-              rdfs:label "Beruf"@de ,
-                         "Occupation"@en ,
-                         "Profession"@fr .
+              dcterms:description "The job / occupation name of a Person."@en ;
+              rdfs:label "Occupation"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#officeEmailAddress
 ec:officeEmailAddress rdf:type owl:DatatypeProperty ;
                       rdfs:subPropertyOf ec:agentEmailAddress ;
                       rdfs:range xsd:string ;
-                      dcterms:description "Pour fournir l'adresse électronique professionnelle/bureautique d'un agent (contact/personne ou organisation)."@fr ,
-                                          "So geben Sie die berufliche/offizielle E-Mail-Adresse Adresse eines Agenten (Kontaktperson/Person oder Organisation)."@de ,
-                                          "To provide the professional/office email address of an Agent (Contact/Person or Organisation)."@en ;
-                      rdfs:label "Büro E-Mail"@de ,
-                                 "Courriel du bureau"@fr ,
-                                 "Office email"@en .
+                      dcterms:description "The professional or office email address of a Person."@en ;
+                      rdfs:label "Office email"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#officeMobileTelephoneNumber
 ec:officeMobileTelephoneNumber rdf:type owl:DatatypeProperty ;
                                rdfs:subPropertyOf ec:agentTelephoneNumber ;
                                rdfs:range xsd:string ;
-                               dcterms:description "Pour fournir le numéro de téléphone mobile du bureau d'un agent (contact/personne)."@fr ,
-                                                   "To provide the office mobile telephone number of an Agent (Contact/Person)."@en ,
-                                                   "Um die Mobiltelefonnummer des Büros eines Agenten (Kontaktperson/Person)."@de ;
-                               rdfs:label "Telefon (privat)"@de ,
-                                          "Telephone (office)"@en ,
-                                          "Téléphone (bureau)"@fr .
+                               dcterms:description "The office mobile telephone number of a Person."@en ;
+                               rdfs:label "Telephone (office)"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#officeTelephoneNumber
 ec:officeTelephoneNumber rdf:type owl:DatatypeProperty ;
                          rdfs:subPropertyOf ec:agentTelephoneNumber ;
                          rdfs:range xsd:string ;
-                         dcterms:description "Pour fournir le numéro de téléphone du bureau d'un agent (contact/personne)."@fr ,
-                                             "To provide the office telephone number of an Agent (Contact/Person)."@en ,
-                                             "Zur Angabe der Bürotelefonnummer eines Agenten (Kontaktperson/Person)."@de ;
-                         rdfs:label "Telefon ()"@de ,
-                                    "Telephone (office)"@en ,
-                                    "Téléphone (bureau)"@fr .
+                         dcterms:description "The office telephone number of a Person."@en ;
+                         rdfs:label "Telephone (office)"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#onStagePositionCoordinateX
 ec:onStagePositionCoordinateX rdf:type owl:DatatypeProperty ;
-                              dcterms:description "Die x-Koordinaten innerhalb eines 3-Achsen-Raumkoordinaten Raum."@de ,
-                                                  "Les coordonnées x dans un espace à 3 axes"@fr ,
-                                                  "The x coordinates within a 3 axis spatial coordinates space."@en ;
-                              rdfs:label "Coordonnée X"@fr ,
-                                         "X coordinate"@en ,
-                                         "X-Koordinate"@de .
+                              dcterms:description "The x coordinates within a 3 axis spatial coordinates space."@en ;
+                              rdfs:label "X coordinate"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#onStagePositionCoordinateY
 ec:onStagePositionCoordinateY rdf:type owl:DatatypeProperty ;
-                              dcterms:description "Die y-Koordinaten innerhalb eines 3-Achsen-Raumkoordinaten Raum."@de ,
-                                                  "Les coordonnées y dans un espace à 3 axes."@fr ,
-                                                  "The y coordinates within a 3 axis spatial coordinates space."@en ;
-                              rdfs:label "Coordonnée Y"@fr ,
-                                         "Y coordinate"@en ,
-                                         "Y-Koordinate"@de .
+                              dcterms:description "The y coordinates within a 3 axis spatial coordinates space."@en ;
+                              rdfs:label "Y coordinate"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#onStagePositionCoordinateZ
 ec:onStagePositionCoordinateZ rdf:type owl:DatatypeProperty ;
-                              dcterms:description "Die z-Koordinaten innerhalb eines 3-Achsen-Raumkoordinaten Raum."@de ,
-                                                  "Les coordonnées z dans un espace à 3 axes."@fr ,
-                                                  "The z coordinates within a 3 axis spatial coordinates space."@en ;
-                              rdfs:label "Coordonnée Z"@fr ,
-                                         "Z coordinate"@en ,
-                                         "Z-Koordinate"@de .
+                              dcterms:description "The z coordinates within a 3 axis spatial coordinates space."@en ;
+                              rdfs:label "Z coordinate"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#onStagePositionCoordinatesReferencePoint
 ec:onStagePositionCoordinatesReferencePoint rdf:type owl:DatatypeProperty ;
-                                            dcterms:description "Pour définir un point de référence pour un ensemble de coordonnées définissant une position sur la scène."@fr ,
-                                                                "To define a reference point for a set of coordinates defining a position on stage."@en ,
-                                                                "Um einen Referenzpunkt für einen Satz von Koordinaten zu definieren, der eine Position auf der Bühne definiert."@de ;
-                                            rdfs:label "On stage position coordinates reference point"@en ,
-                                                       "Point de référence des coordonnées de la position sur scène"@fr ,
-                                                       "Position auf der Bühne Koordinaten Referenzpunkt"@de .
+                                            dcterms:description "The reference point used to define a set of coordinates for a position on stage."@en ;
+                                            rdfs:label "On stage position coordinates reference point"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#orderedFlag
 ec:orderedFlag rdf:type owl:DatatypeProperty ,
                         owl:FunctionalProperty ;
                rdfs:range xsd:boolean ;
-               dcterms:description "A flag to indicate that a EditorialObject is member of an ordered group or is an ordered group (e.g. Series)"@en ,
-                                   "Ein Flag, das anzeigt, dass ein EditorialObject Mitglied einer geordneten Gruppe ist oder eine geordnete Gruppe ist (z.B. Serie)"@de ,
-                                   "Un indicateur pour indiquer qu'un ÉditorialObject est membre d'un groupe ordonné ou est un groupe ordonné (par ex. Série)"@fr ;
-               rdfs:label "Geordnet"@de ,
-                          "Ordered"@en ,
-                          "Ordonné"@fr .
+               dcterms:description "A flag to indicate that a EditorialObject is member of an ordered group or is an ordered group (e.g. Series)."@en ;
+               rdfs:label "Ordered"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#orientation
 ec:orientation rdf:type owl:DatatypeProperty ;
                rdfs:range rdfs:Literal ;
-               dcterms:description "Die Ausrichtung eines Dokuments oder eines Bildes, d.h. Querformat oder Hochformat Hochformat."@de ,
-                                   "L'orientation d'un document ou d'une image, c'est-à-dire paysage ou portrait."@fr ,
-                                   "The orientation of a Document or an Image i.e. landscape or portrait."@en ;
-               rdfs:label "Orientation"@en ,
-                          "Orientation"@fr ,
-                          "Orientierung"@de .
+               dcterms:description "The orientation of a Document or an Image i.e. landscape or portrait."@en ;
+               rdfs:label "Orientation"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#packageByteSize
 ec:packageByteSize rdf:type owl:DatatypeProperty ;
                    rdfs:range xsd:long ;
-                   dcterms:description "Die Größe eines Medienpakets in Bytes."@de ,
-                                       "La taille d'un paquet média en octets."@fr ,
-                                       "The size of a media package in Bytes."@en ;
-                   rdfs:label "Package size (in bytes)"@en ,
-                              "Paketgröße (in Bytes)"@de ,
-                              "Taille du paquet (en octets)"@fr .
+                   dcterms:description "The size of a media package in Bytes."@en ;
+                   rdfs:label "Package size (in bytes)"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#packageName
 ec:packageName rdf:type owl:DatatypeProperty ;
                rdfs:range rdfs:Literal ;
-               dcterms:description "Der Name eines Medienpakets in Bytes."@de ,
-                                   "Le nom d'un paquet média en octets."@fr ,
-                                   "The name of a media package in Bytes."@en ;
-               rdfs:label "Name des Pakets"@de ,
-                          "Nom du paquet"@fr ,
-                          "Package name"@en .
+               dcterms:description "The name of a media package in Bytes."@en ;
+               rdfs:label "Package name"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#partTotalNumber
 ec:partTotalNumber rdf:type owl:DatatypeProperty ;
                    rdfs:range xsd:integer ;
-                   dcterms:description "Die Gesamtzahl der Teile, die mit einem EditorialObject verbunden sind."@de ,
-                                       "Le nombre total de Parts associées à un EditorialObject."@fr ,
-                                       "The total number of Parts associated with an EditorialObject."@en ;
-                   rdfs:label "Numéro total de la pièce"@fr ,
-                              "Part total number"@en ,
-                              "Teil Gesamtnummer"@de .
+                   dcterms:description "The total number of Parts associated with an EditorialObject."@en ;
+                   rdfs:label "Part total number"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#period
 ec:period rdf:type owl:DatatypeProperty ;
           rdfs:range rdfs:Literal ;
-          dcterms:description "Die Zeitspanne, in der ein Ereignis eingetreten ist."@de ,
-                              "La période de temps pendant laquelle un événement s'est produit."@fr ,
-                              "The period of time during which an Event has occurred."@en ;
-          rdfs:label "Period"@en ,
-                     "Période"@fr ,
-                     "Zeitraum"@de .
+          dcterms:description "The period of time during which an Event has occurred."@en ;
+          rdfs:label "Period"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#personHeight
 ec:personHeight rdf:type owl:DatatypeProperty ;
                 rdfs:range rdfs:Literal ;
-                dcterms:description "Pour indiquer la taille d'une personne."@fr ,
-                                    "To indicate the height of a person."@en ,
-                                    "Zur Angabe der Größe einer Person."@de ;
-                rdfs:label "Hauteur de la personne"@fr ,
-                           "Höhe der Person"@de ,
-                           "Person height"@en .
+                dcterms:description "The height of a person."@en ;
+                rdfs:label "Person height"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#personWeight
 ec:personWeight rdf:type owl:DatatypeProperty ;
                 rdfs:range rdfs:Literal ;
-                dcterms:description "Pour indiquer le poids d'une personne."@fr ,
-                                    "To indicate the weight of a person."@en ,
-                                    "Zur Angabe des Gewichts einer Person."@de ;
-                rdfs:label "Gewicht der Person"@de ,
-                           "Person weight"@en ,
-                           "Poids de la personne"@fr .
+                dcterms:description "The weight of a person."@en ;
+                rdfs:label "Person weight"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#playbackSpeed
 ec:playbackSpeed rdf:type owl:DatatypeProperty ;
                  rdfs:range xsd:double ;
-                 dcterms:description "Gibt die Rate der Zeiteinheiten an, in der die Resource für den menschlichen Verzehr wiedergegeben werden soll. Wenn die Maßeinheit bekannt ist, verwenden Sie die Untereigenschaften framesPerSecond oder inchesPerSecond."@de ,
-                                     "Identifie le taux d'unités par rapport au temps auquel la ressource doit être lue pour la consommation humaine. Si l'unité de mesure est connue, utilisez les sous-propriétés framesPerSecond ou inchesPerSecond."@fr ,
-                                     "Identifies the rate of units against time at which the resource should be played back for human consumption. If the unit of measure is known, use sub-properties framesPerSecond or inchesPerSecond."@en ;
-                 rdfs:label "Playback speed"@en ,
-                            "Vitesse de lecture"@fr ,
-                            "Wiedergabegeschwindigkeit"@de .
+                 dcterms:description "Identifies the rate of units against time at which the resource should be played back for human consumption. If the unit of measure is known, use sub-properties framesPerSecond or inchesPerSecond."@en ;
+                 rdfs:label "Playback speed"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#playlist
 ec:playlist rdf:type owl:DatatypeProperty ;
             rdfs:subPropertyOf ec:contentDescription ;
             rdfs:range rdfs:Literal ;
-            dcterms:description "Pour fournir une liste de lecture."@fr ,
-                                "To provide a playlist."@en ,
-                                "Um eine Wiedergabeliste bereitzustellen."@de ;
-            rdfs:label "Liste de lecture"@fr ,
-                       "Playlist"@en ,
-                       "Wiedergabeliste"@de .
+            dcterms:description "A playlist associated with the editorial object."@en ;
+            rdfs:label "Playlist"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#position
 ec:position rdf:type owl:DatatypeProperty ;
             rdfs:range rdfs:Literal ;
-            dcterms:description "Pour indiquer la position d'un objet éditorial dans un groupe ordonné. groupe ordonné."@fr ,
-                                "To indicate the position of an EditorialObject in an ordered group."@en ,
-                                "Zur Angabe der Position eines EditorialObjects in einer geordneten Gruppe."@de ;
-            rdfs:label "Position"@de ,
-                       "Position"@en ,
-                       "Position"@fr .
+            dcterms:description "The position of an EditorialObject within an ordered group."@en ;
+            rdfs:label "Position"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#privateEmailAddress
 ec:privateEmailAddress rdf:type owl:DatatypeProperty ;
                        rdfs:subPropertyOf ec:agentEmailAddress ;
                        rdfs:range xsd:string ;
-                       dcterms:description "Pour fournir l'adresse électronique privée d'un agent (contact/personne)"@fr ,
-                                           "So geben Sie die private E-Mail-Adresse eines Agenten (Kontakt/Person)"@de ,
-                                           "To provide the private email address of an Agent (Contact/Person)"@en ;
-                       rdfs:label "Courriel privé"@fr ,
-                                  "Private E-Mail"@de ,
-                                  "Private email"@en .
+                       dcterms:description "The private email address of a Person."@en ;
+                       rdfs:label "Private email"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#privateHomepage
 ec:privateHomepage rdf:type owl:DatatypeProperty ;
                    rdfs:subPropertyOf ec:agentWebHomepage ;
                    rdfs:range xsd:anyURI ;
-                   dcterms:description "Pour fournir une page d'accueil web privée d'un agent (Contact/Personne)."@fr ,
-                                       "To provide an private web homepage of an Agent (Contact/Person)."@en ,
-                                       "Um eine private Web-Homepage eines Agenten bereitzustellen (Kontakt/Person)."@de ;
-                   rdfs:label "Homepage (privat)"@de ,
-                              "Homepage (private)"@en ,
-                              "Page d'accueil (privée)"@fr .
+                   dcterms:description "The private web homepage of a Person."@en ;
+                   rdfs:label "Homepage (private)"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#privateMobileTelephoneNumber
 ec:privateMobileTelephoneNumber rdf:type owl:DatatypeProperty ;
                                 rdfs:subPropertyOf ec:agentTelephoneNumber ;
                                 rdfs:range xsd:string ;
-                                dcterms:description "Pour fournir le numéro de téléphone mobile privé d'un agent (contact/personne)."@fr ,
-                                                    "To provide the private mobile telephone number of an Agent (Contact/Person)."@en ,
-                                                    "Zur Angabe der privaten Mobiltelefonnummer eines Agenten (Kontaktperson/Person)."@de ;
-                                rdfs:label "Telefon (privat)"@de ,
-                                           "Telephone (private)"@en ,
-                                           "Téléphone (privé)"@fr .
+                                dcterms:description "The private mobile telephone number of a Person."@en ;
+                                rdfs:label "Telephone (private)"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#privateTelephoneNumber
 ec:privateTelephoneNumber rdf:type owl:DatatypeProperty ;
                           rdfs:subPropertyOf ec:agentTelephoneNumber ;
                           rdfs:range xsd:string ;
-                          dcterms:description "Pour fournir le numéro de téléphone privé d'un agent (contact/personne)."@fr ,
-                                              "To provide the private telephone number of an Agent (Contact/Person)."@en ,
-                                              "Zur Angabe der privaten Telefonnummer eines Agenten (Kontakt/Person)."@de ;
-                          rdfs:label "Telefon (privat)"@de ,
-                                     "Telephone (private)"@en ,
-                                     "Téléphone (privé)"@fr .
+                          dcterms:description "The private telephone number associated with a Person."@en ;
+                          rdfs:label "Telephone (private)"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#productionSynopsis
 ec:productionSynopsis rdf:type owl:DatatypeProperty ;
                       rdfs:subPropertyOf ec:contentDescription ;
                       rdfs:range rdfs:Literal ;
-                      dcterms:description "A synopsis or summary provided by the producer at the time of production."@en ,
-                                          "Eine Zusammenfassung, die der Produzent zum Zeitpunkt der Produktion zur Verfügung stellt."@de ,
-                                          "Un synopsis ou un résumé fourni par le producteur au moment de la production."@fr ;
-                      rdfs:label "Production synopsis"@en ,
-                                 "Synopse der Produktion"@de ,
-                                 "Synopsis de la production"@fr .
+                      dcterms:description "A synopsis or summary provided by the producer at the time of production."@en ;
+                      rdfs:label "Production synopsis"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#promotionalInformation
 ec:promotionalInformation rdf:type owl:DatatypeProperty ;
                           rdfs:subPropertyOf ec:contentDescription ;
                           rdfs:range rdfs:Literal ;
-                          dcterms:description "Pour fournir des informations promotionnelles textuelles."@fr ,
-                                              "To provide textual promotional information."@en ,
-                                              "Zur Bereitstellung von Werbeinformationen in Textform."@de ;
-                          rdfs:label "Informationen zur Werbung"@de ,
-                                     "Informations promotionnelles"@fr ,
-                                     "Promotional information"@en .
+                          dcterms:description "Textual promotional information associated with the content."@en ;
+                          rdfs:label "Promotional information"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#pubStatus
 ec:pubStatus rdf:type owl:DatatypeProperty ;
              rdfs:subPropertyOf ec:contentDescription ;
              rdfs:range rdfs:Literal ;
-             dcterms:description "Pour indiquer un statut de publication."@fr ,
-                                 "To indicate a publication status."@en ,
-                                 "Zur Angabe eines Veröffentlichungsstatus."@de ;
-             rdfs:label "Publication status"@en ,
-                        "Status der Veröffentlichung"@de ,
-                        "État de la publication"@fr .
+             dcterms:description "The publication status associated with the editorial object."@en ;
+             rdfs:label "Publication status"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#publicationPlanTitle
-ec:publicationPlanTitle rdf:type owl:DatatypeProperty .
+ec:publicationPlanTitle rdf:type owl:DatatypeProperty ;
+                        dcterms:description "A title associated with a publication plan. It is a literal value used to name or identify the publication plan."@en ;
+                        rdfs:label "Publication plan title"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#publishingEventsLeft
-ec:publishingEventsLeft rdf:type owl:DatatypeProperty .
+ec:publishingEventsLeft rdf:type owl:DatatypeProperty ;
+                        dcterms:description "The number of publishing events remaining."@en ;
+                        rdfs:label "Publishing events left"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#radioTuner
 ec:radioTuner rdf:type owl:DatatypeProperty ,
                        owl:FunctionalProperty ;
-              dcterms:description "Pour indiquer si le service nécessite un tuner radio."@fr ,
-                                  "To indicate if the Service requires a radio tuner."@en ,
-                                  "Zur Angabe, ob der Service einen Radiotuner benötigt."@de ;
-              rdfs:label "Radio tuner"@en ,
-                         "Radio-Tuner"@de ,
-                         "Tuner radio"@fr .
+              dcterms:description "Whether the service requires a radio tuner."@en ;
+              rdfs:label "Radio tuner"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ratingScaleMax
 ec:ratingScaleMax rdf:type owl:DatatypeProperty ;
                   rdfs:range rdfs:Literal ;
-                  dcterms:description "Der maximale Wert der für die Bewertung verwendeten Skala."@de ,
-                                      "La valeur maximale de l'échelle utilisée pour le classement."@fr ,
-                                      "The maximum value of the scale used for the Rating."@en ;
-                  rdfs:label "Bewertungsskala (höchster Wert)"@de ,
-                             "Rating scale (top value)"@en ,
-                             "Échelle d'évaluation (valeur supérieure)"@fr .
+                  dcterms:description "The maximum value of the scale used for the Rating."@en ;
+                  rdfs:label "Rating scale (top value)"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ratingScaleMin
 ec:ratingScaleMin rdf:type owl:DatatypeProperty ;
                   rdfs:range rdfs:Literal ;
-                  dcterms:description "Der Mindestwert der Skala, die für die Bewertung einer MediaResource."@de ,
-                                      "La valeur minimale de l'échelle utilisée pour la notation une MediaResource."@fr ,
-                                      "The minimum value of the scale used for rating a MediaResource."@en ;
-                  rdfs:label "Bewertungsskala (Mindestwert)"@de ,
-                             "Rating scale (min. value)"@en ,
-                             "Échelle d'évaluation (valeur minimale)"@fr .
+                  dcterms:description "The minimum value of the scale used for rating a MediaResource."@en ;
+                  rdfs:label "Rating scale (min. value)"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ratingSystemEnvironment
 ec:ratingSystemEnvironment rdf:type owl:DatatypeProperty ;
                            rdfs:range rdfs:Literal ;
-                           dcterms:description "Identifier l'environnement dans lequel la notation s'applique."@fr ,
-                                               "To identify the environment in which rating applies."@en ,
-                                               "Um die Umgebung zu identifizieren, in der die Bewertung gilt."@de ;
-                           rdfs:label "Bewertung der Umgebung"@de ,
-                                      "Environnement d'évaluation"@fr ,
-                                      "Rating environment"@en .
+                           dcterms:description "The environment in which the rating applies."@en ;
+                           rdfs:label "Rating environment"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ratingSystemName
 ec:ratingSystemName rdf:type owl:DatatypeProperty ;
                     rdfs:range rdfs:Literal ;
-                    dcterms:description "Pour identifier un système de notation par son nom."@fr ,
-                                        "So identifizieren Sie ein Rating-System anhand seines Namens."@de ,
-                                        "To identify a Rating system by its name."@en ;
-                    rdfs:label "Bewertungssystem"@de ,
-                               "Rating system"@en ,
-                               "Système d'évaluation"@fr .
+                    dcterms:description "The name of the rating system."@en ;
+                    rdfs:label "Rating system"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ratingValue
 ec:ratingValue rdf:type owl:DatatypeProperty ;
                rdfs:range rdfs:Literal ;
-               dcterms:description "Pour exprimer une valeur de notation en texte libre définie dans un système de classification des notes."@fr ,
-                                   "To express a free text Rating value defined in a rating classification scheme."@en ,
-                                   "Um einen Freitext-Bewertungswert auszudrücken, der in einem einem Rating-Klassifizierungsschema."@de ;
-               rdfs:label "Bewertung"@de ,
-                          "Classement"@fr ,
-                          "Rating"@en .
+               dcterms:description "The free-text value of a rating defined in a rating classification scheme."@en ;
+               rdfs:label "Rating"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#readyForPublication
 ec:readyForPublication rdf:type owl:DatatypeProperty ;
                        rdfs:range xsd:boolean ;
-                       dcterms:description "A flag to indicate that the resource/essence is ready for publication."@en ,
-                                           "Ein Kennzeichen, das anzeigt, dass die Resource/Essenz zur Veröffentlichung bereit ist. Veröffentlichung."@de ,
-                                           "Un drapeau pour indiquer que la ressource/essence est prête à être publiée."@fr ;
-                       rdfs:label "Bereit zur Veröffentlichung"@de ,
-                                  "Prêt pour la publication"@fr ,
-                                  "Ready for publication"@en .
+                       dcterms:description "A flag to indicate that the resource/essence is ready for publication."@en ;
+                       rdfs:label "Ready for publication"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#reason
 ec:reason rdf:type owl:DatatypeProperty ;
           rdfs:range rdfs:Literal ;
-          dcterms:description "A reason given for a rating."@en ,
-                              "Ein Grund, der für eine Bewertung angegeben wird."@de ,
-                              "Une raison donnée pour une évaluation."@fr ;
-          rdfs:label "Grund"@de ,
-                     "Motif"@fr ,
-                     "Reason"@en .
+          dcterms:description "A reason given for a rating."@en ;
+          rdfs:label "Reason"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#regionDelimX
 ec:regionDelimX rdf:type owl:DatatypeProperty ;
                 rdfs:range xsd:integer ;
-                dcterms:description "Pour définir le coin supérieur gauche d'une zone sur l'axe des x. Si elle est présente avec regionDelimy, la définition de la zone est complétée par les valeurs associées de la hauteur et de la largeur."@fr ,
-                                    "So definieren Sie die linke obere Ecke einer Zone auf der der x-Achse. Wenn mit regionDelimy vorhanden, wird die Zonendefinition ergänzt durch die zugehörigen Werte für Höhe und Breite ergänzt."@de ,
-                                    "To define the top left corner of a zone on the x-axis. If present with regionDelimy, the zone definition is complemented by the associated values of the height and width."@en ;
-                rdfs:label "Begrenzer der Region (x-Achse)"@de ,
-                           "Délimiteur de région (axe des x)"@fr ,
-                           "Region delimiter (x-axis)"@en .
+                dcterms:description "The x-axis coordinate of the top-left corner of a zone. If present with regionDelimy, the zone definition is complemented by the associated values of the height and width."@en ;
+                rdfs:label "Region delimiter (x-axis)"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#regionDelimY
 ec:regionDelimY rdf:type owl:DatatypeProperty ;
                 rdfs:range xsd:integer ;
-                dcterms:description "Pour définir le coin inférieur droit d'une zone sur l'axe des y. Si elle est présente avec regionDelimX, la définition de la zone est complétée par les valeurs associées de la hauteur et de la largeur."@fr ,
-                                    "So definieren Sie die untere rechte Ecke einer Zone auf der der y-Achse. Wenn mit regionDelimX vorhanden, wird die Zonendefinition ergänzt durch die zugehörigen Werte für Höhe und Breite ergänzt."@de ,
-                                    "To define the bottom right corner of a zone on the y-axis. If present with regionDelimX, the zone definition is complemented by the associated values of the height and width."@en ;
-                rdfs:label "Begrenzer der Region (y-Achse)"@de ,
-                           "Délimiteur de région (axe des ordonnées)"@fr ,
-                           "Region delimiter (y-axis)"@en .
+                dcterms:description "The y-axis coordinate of the bottom right corner of a zone. If present with regionDelimX, the zone definition is complemented by the associated values of the height and width."@en ;
+                rdfs:label "Region delimiter (y-axis)"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#relationOrderedGroupFlag
 ec:relationOrderedGroupFlag rdf:type owl:DatatypeProperty ;
                             rdfs:range xsd:boolean ;
-                            dcterms:description "A boolean to define if a Relation is defined within and ordered group."@en ,
-                                                "Ein boolescher Wert, der angibt, ob eine Relation innerhalb einer geordneten Gruppe definiert ist."@de ,
-                                                "Un booléen pour définir si une Relation est définie dans un groupe ordonné."@fr ;
-                            rdfs:label "Relation Drapeau de groupe ordonné"@fr ,
-                                       "Relation Geordnete Gruppe Flagge"@de ,
-                                       "Relation Ordered group flag"@en .
+                            dcterms:description "A boolean to define if a Relation is defined within and ordered group."@en ;
+                            rdfs:label "Relation ordered group flag"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#relationRunningOrderNumber
 ec:relationRunningOrderNumber rdf:type owl:DatatypeProperty ;
                               rdfs:range xsd:integer ;
-                              dcterms:description "Die Bestellnummer in einer Liste."@de ,
-                                                  "Le numéro d'ordre dans une liste."@fr ,
-                                                  "The order number in a list."@en ;
-                              rdfs:label "Relation Laufende Bestellnummer"@de ,
-                                         "Relation Numéro d'ordre courant"@fr ,
-                                         "Relation Running Order Number"@en .
+                              dcterms:description "The order number in a list."@en ;
+                              rdfs:label "Relation running order number"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#relationTotalNumberOfGroupMembers
 ec:relationTotalNumberOfGroupMembers rdf:type owl:DatatypeProperty ;
                                      rdfs:range xsd:integer ;
-                                     dcterms:description "Gesamtzahl der Gruppenmitglieder in einer Relation."@de ,
-                                                         "Nombre total de membres du groupe dans une Relation."@fr ,
-                                                         "Total number of group members in a Relation."@en ;
-                                     rdfs:label "Gesamtzahl der Gruppenmitglieder."@de ,
-                                                "Nombre total de membres du groupe."@fr ,
-                                                "Total number of group members."@en .
+                                     dcterms:description "Total number of group members in a Relation."@en ;
+                                     rdfs:label "Total number of group members"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#resolution
 ec:resolution rdf:type owl:DatatypeProperty ;
               rdfs:range rdfs:Literal ;
-              dcterms:description "Pour définir la résolution d'un actif, par exemple une vidéo, une image..."@fr ,
-                                  "To define the resolution of an Asset e.g. video, image..."@en ,
-                                  "Zum Festlegen der Auflösung eines Assets, z.B. eines Videos, Bildes..."@de ;
-              rdfs:label "Auflösung"@de ,
-                         "Resolution"@en ,
-                         "Résolution"@fr .
+              dcterms:description "The resolution of an editorial object, such as a video or image."@en ;
+              rdfs:label "Resolution"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#rightsClearanceFlag
 ec:rightsClearanceFlag rdf:type owl:DatatypeProperty ,
                                 owl:FunctionalProperty ;
                        rdfs:range xsd:boolean ;
-                       dcterms:description "A flag to indicate that righst have been cleared"@en ,
-                                           "Ein Flag, das anzeigt, dass die Rechte gelöscht wurden"@de ,
-                                           "Un drapeau pour indiquer que les droits ont été effacés."@fr ;
-                       rdfs:label "Drapeau d'autorisation de droits"@fr ,
-                                  "Flagge zur Rechteklärung"@de ,
-                                  "Rights clearance flag"@en .
+                       dcterms:description "A flag to indicate that rights have been cleared."@en ;
+                       rdfs:label "Rights clearance flag"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#rightsExpression
 ec:rightsExpression rdf:type owl:DatatypeProperty ;
                     rdfs:range rdfs:Literal ;
-                    dcterms:description "Einen Ausdruck von Rechten zum Ausdruck bringen."@de ,
-                                        "Pour exprimer une expression de Droits."@fr ,
-                                        "To express an expression of Rights."@en ;
-                    rdfs:label "Droits"@fr ,
-                               "Rechte"@de ,
-                               "Rights"@en .
+                    dcterms:description "The expression of rights associated with the resource."@en ;
+                    rdfs:label "Rights"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#rightsLink
 ec:rightsLink rdf:type owl:DatatypeProperty ;
               rdfs:range xsd:anyURI ;
-              dcterms:description "A link to e.g. a webpage where an expression of the rights can be found and consulted."@en ,
-                                  "Ein Link zu z.B. einer Webseite, auf der ein Ausdruck der der Rechte gefunden und konsultiert werden kann."@de ,
-                                  "Un lien vers, par exemple, une page web où une expression des les droits peut être trouvée et consultée."@fr ;
-              rdfs:label "Rechte Web-Resource"@de ,
-                         "Resource web sur les droits"@fr ,
-                         "Rights web resource"@en .
+              dcterms:description "A link to e.g. a webpage where an expression of the rights can be found and consulted."@en ;
+              rdfs:label "Rights web resource"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#rightsUsageRestrictions
 ec:rightsUsageRestrictions rdf:type owl:DatatypeProperty ;
-                           dcterms:description "Pour spécifier un ensemble de UsageRestrictions."@fr ,
-                                               "To specify a set of UsageRestrictions."@en ,
-                                               "Um eine Reihe von Nutzungseinschränkungen anzugeben."@de ;
-                           rdfs:label "Einschränkungen bei der Verwendung"@de ,
-                                      "Restrictions d'utilisation"@fr ,
-                                      "Usage restrictions"@en .
+                           dcterms:description "Specifies a set of usage restrictions."@en ;
+                           rdfs:label "Usage restrictions"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ruleStatement
 ec:ruleStatement rdf:type owl:DatatypeProperty ;
-                 dcterms:description "Pour exprimer une déclaration relative à une règle."@fr ,
-                                     "To express a statement related to a Rule."@en ,
-                                     "Um eine Aussage in Bezug auf eine Regel zu machen."@de ;
-                 rdfs:label "Erklärung zur Regel"@de ,
-                            "Rule statement"@en ,
-                            "Énoncé de la règle"@fr .
+                 dcterms:description "A statement associated with a Rule."@en ;
+                 rdfs:label "Rule statement"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#salutationTitle
 ec:salutationTitle rdf:type owl:DatatypeProperty ;
                    rdfs:range rdfs:Literal ;
-                   dcterms:description "Pour fournir un titre de salutation, par exemple M. Ms, Dr, Pr."@fr ,
-                                       "To provide a salutation title e.g M. Ms, Dr, Pr."@en ,
-                                       "Um einen Anrede-Titel anzugeben, z. B. M. Ms, Dr, Pr."@de ;
-                   rdfs:label "Anrede Titel"@de ,
-                              "Salutation title"@en ,
-                              "Titre de la salutation"@fr .
+                   dcterms:description "A salutation title such as Mr, Ms, Dr, or Prof."@en ;
+                   rdfs:label "Salutation title"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#sampleRate
 ec:sampleRate rdf:type owl:DatatypeProperty ;
               rdfs:range xsd:integer ;
-              dcterms:description "Die Frequenz, mit der Audio pro Sekunde abgetastet wird. Auch Sampling-Rate genannt."@de ,
-                                  "La fréquence à laquelle l'audio est échantillonné par seconde. Également appelée fréquence d'échantillonnage."@fr ,
-                                  "The frequency at which audio is sampled per second. Also called sampling rate."@en ;
-              rdfs:label "Sample Rate"@de ,
-                         "Sample Rate"@en ,
-                         "Taux d'échantillonnage"@fr .
+              dcterms:description "The frequency at which audio is sampled per second. Also called sampling rate."@en ;
+              rdfs:label "Sample rate"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#sampleSize
 ec:sampleSize rdf:type owl:DatatypeProperty ;
               rdfs:range xsd:integer ;
-              dcterms:description "Die Größe eines Audio-Samples in Bits. Auch Bittiefe genannt."@de ,
-                                  "La taille d'un échantillon audio en bits. Également appelée profondeur de bits."@fr ,
-                                  "The size of an audio sample in bits. Also called bit depth."@en ;
-              rdfs:label "Sample size"@en ,
-                         "Stichprobengröße"@de ,
-                         "Taille de l'échantillon"@fr .
+              dcterms:description "The size of an audio sample in bits. Also called bit depth."@en ;
+              rdfs:label "Sample size"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#sampleType
 ec:sampleType rdf:type owl:DatatypeProperty ;
               rdfs:range rdfs:Literal ;
-              dcterms:description "Die Art der Hörprobe."@de ,
-                                  "Le type d'échantillon audio."@fr ,
-                                  "The type of audio sample."@en ;
-              rdfs:label "Sample type"@en ,
-                         "Typ der Probe"@de ,
-                         "Type d'échantillon"@fr .
+              dcterms:description "The type of audio sample."@en ;
+              rdfs:label "Sample type"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#scanningFormat
 ec:scanningFormat rdf:type owl:DatatypeProperty ;
                   rdfs:range rdfs:Literal ;
-                  dcterms:description "Pour définir le format de numérisation d'une MediaResource. Pour la vidéo, les deux principales valeurs sont \"entrelacé\" ou \"progressif\"."@fr ,
-                                      "So definieren Sie das Scanformat für eine MediaResource. Für Video sind die beiden wichtigsten Werte \"interlaced\" oder \"progressiv\"."@de ,
-                                      "To define the scanning format for a MediaResource. For video, the two main values are \"interlaced\" or \"progressive\"."@en ;
-                  rdfs:label "Format de numérisation"@fr ,
-                             "Format scannen"@de ,
-                             "Scanning format"@en .
+                  dcterms:description "The scanning format of a media resource. For video, the two main values are \"interlaced\" or \"progressive\"."@en ;
+                  rdfs:label "Scanning format"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#script
 ec:script rdf:type owl:DatatypeProperty ;
           rdfs:subPropertyOf ec:contentDescription ;
           rdfs:range rdfs:Literal ;
-          dcterms:description "Pour fournir un script."@fr ,
-                              "To provide a script."@en ,
-                              "Um ein Skript bereitzustellen."@de ;
-          rdfs:label "Script"@en ,
-                     "Script"@fr ,
-                     "Skript"@de .
+          dcterms:description "The script content associated with an editorial object."@en ;
+          rdfs:label "Script"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#seasonNumber
 ec:seasonNumber rdf:type owl:DatatypeProperty ;
                 rdfs:range xsd:integer ;
-                dcterms:description "Pour fournir un numéro de saison."@fr ,
-                                    "To provide a Season number."@en ,
-                                    "Um eine Saisonnummer anzugeben."@de ;
-                rdfs:label "Numéro de la saison"@fr ,
-                           "Saison Nummer"@de ,
-                           "Season number"@en .
+                dcterms:description "The season number associated with the work."@en ;
+                rdfs:label "Season number"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#segmentNumber
 ec:segmentNumber rdf:type owl:DatatypeProperty ;
                  rdfs:range xsd:integer ;
-                 dcterms:description "Die Nummer, die einem Segment als eines unter vielen zugeordnet ist. vielen."@de ,
-                                     "Le nombre associé à un segment comme un parmi plusieurs."@fr ,
-                                     "The number associated with a segment as one among many."@en ;
-                 rdfs:label "Numéro de segment"@fr ,
-                            "Segment Nummer"@de ,
-                            "Segment number"@en .
+                 dcterms:description "The number associated with a segment as one among many."@en ;
+                 rdfs:label "Segment number"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#shotLog
 ec:shotLog rdf:type owl:DatatypeProperty ;
            rdfs:subPropertyOf ec:contentDescription ;
            rdfs:range rdfs:Literal ;
-           dcterms:description "Fournit une description plan par plan d'une MediaResource."@fr ,
-                               "Liefert eine Shot-by-Shot-Beschreibung einer MediaResource."@de ,
-                               "Provides a shot-by-shot description of a MediaResource."@en ;
-           rdfs:label "Journal de bord"@fr ,
-                      "Schießprotokoll"@de ,
-                      "Shot log"@en .
+           dcterms:description "Provides a shot-by-shot description of a MediaResource."@en ;
+           rdfs:label "Shot log"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#soundOutput
 ec:soundOutput rdf:type owl:DatatypeProperty ,
                         owl:FunctionalProperty ;
-               dcterms:description "A flag to indicate if the Service requires a sound output."@en ,
-                                   "Drapeau pour indiquer si le service exige une sortie son."@fr ,
-                                   "Ein Flag, das anzeigt, ob der Dienst eine Tonausgabe benötigt Ausgabe."@de ;
-               rdfs:label "Sortie sonore"@fr ,
-                          "Sound output"@en ,
-                          "Tonausgabe"@de .
+               dcterms:description "A flag to indicate if the Service requires a sound output."@en ;
+               rdfs:label "Sound output"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#suffix
 ec:suffix rdf:type owl:DatatypeProperty ;
           rdfs:range rdfs:Literal ;
-          dcterms:description "Pour fournir un suffixe associé à un nom de personne, par exemple Jr."@fr ,
-                              "To provide a suffix associated with a Person name e.g. Jr."@en ,
-                              "Zur Bereitstellung eines Suffixes in Verbindung mit einem Personennamen, z. B. Jr."@de ;
-          rdfs:label "Nachsilbe"@de ,
-                     "Suffix"@en ,
-                     "Suffixe"@fr .
+          dcterms:description "The suffix associated with a person's name, such as Jr."@en ;
+          rdfs:label "Suffix"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#summary
 ec:summary rdf:type owl:DatatypeProperty ;
            rdfs:subPropertyOf ec:contentDescription ;
            rdfs:range rdfs:Literal ;
-           dcterms:description "Pour fournir un résumé."@fr ,
-                               "To provide a summary."@en ,
-                               "Um eine Zusammenfassung zu geben."@de ;
-           rdfs:label "Résumé"@fr ,
-                      "Summary"@en ,
-                      "Zusammenfassung"@de .
+           dcterms:description "A summary of the content."@en ;
+           rdfs:label "Summary"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#synopsis
 ec:synopsis rdf:type owl:DatatypeProperty ;
             rdfs:subPropertyOf ec:contentDescription ;
             rdfs:range rdfs:Literal ;
-            dcterms:description "Pour fournir un résumé."@fr ,
-                                "To provide a summary."@en ,
-                                "Um eine Zusammenfassung zu geben."@de ;
-            rdfs:label "Synopsis"@de ,
-                       "Synopsis"@en ,
-                       "Synopsis"@fr .
+            dcterms:description "A summary of the content."@en ;
+            rdfs:label "Synopsis"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#tableOfContent
 ec:tableOfContent rdf:type owl:DatatypeProperty ;
                   rdfs:subPropertyOf ec:contentDescription ;
                   rdfs:range rdfs:Literal ;
-                  dcterms:description "pour fournir une table des matières."@fr ,
-                                      "to provide a table of content."@en ,
-                                      "um ein Inhaltsverzeichnis zu erstellen."@de ;
-                  rdfs:label "Inhaltsverzeichnis"@de ,
-                             "Table des matières"@fr ,
-                             "Table of content"@en .
+                  dcterms:description "The table of content for the editorial object."@en ;
+                  rdfs:label "Table of content"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#tag
 ec:tag rdf:type owl:DatatypeProperty ;
        rdfs:subPropertyOf ec:contentDescription ;
        rdfs:range rdfs:Literal ;
-       dcterms:description "Pour fournir une liste de balises."@fr ,
-                           "To provide a list of tags."@en ,
-                           "Zur Bereitstellung einer Liste von Tags."@de ;
-       rdfs:label "Tag"@de ,
-                  "Tag"@en ,
-                  "Étiquette"@fr .
+       dcterms:description "A tag value associated with an editorial object."@en ;
+       rdfs:label "Tag"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#targetAudienceSystem
 ec:targetAudienceSystem rdf:type owl:DatatypeProperty ;
                         rdfs:range rdfs:Literal ;
-                        dcterms:description "Pour définir le système utilisé pour fournir un TargetAudience."@fr ,
-                                            "To define the system used to provide a TargetAudience."@en ,
-                                            "Um das System zu definieren, mit dem ein TargetAudience."@de ;
-                        rdfs:label "Système de public cible"@fr ,
-                                   "Target audience system"@en ,
-                                   "Zielgruppen-System"@de .
+                        dcterms:description "The system used to provide a target audience."@en ;
+                        rdfs:label "Target audience system"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#textInput
 ec:textInput rdf:type owl:DatatypeProperty ,
                       owl:FunctionalProperty ;
-             dcterms:description "Pour indiquer si le service nécessite une functionnalité de saisie de texte."@fr ,
-                                 "To indicate if the Service requires text input capability."@en ,
-                                 "Zur Angabe, ob der Service eine Texteingabe erfordert Fähigkeit."@de ;
-             rdfs:label "Capacité de saisie de texte"@fr ,
-                        "Text input capability"@en ,
-                        "Texteingabefähigkeit"@de .
+             dcterms:description "Indicates whether a consumption device profile requires text input capability."@en ;
+             rdfs:label "Text input capability"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#textLineBoxHeight
 ec:textLineBoxHeight rdf:type owl:DatatypeProperty ;
                      rdfs:range xsd:nonNegativeInteger ;
-                     dcterms:description "Die Höhe des Textfeldes, das die TextLine enthält."@de ,
-                                         "La hauteur de la zone de texte contenant la TextLine."@fr ,
-                                         "The height of the text box containing the TextLine."@en ;
-                     rdfs:label "Hauteur de la boîte de la ligne de texte."@fr ,
-                                "Höhe des Textfeldes."@de ,
-                                "Text line box height."@en .
+                     dcterms:description "The height of the text box containing the TextLine."@en ;
+                     rdfs:label "Text line box height"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#textLineBoxTopLeftCornerLineNumber
 ec:textLineBoxTopLeftCornerLineNumber rdf:type owl:DatatypeProperty ;
                                       rdfs:range xsd:nonNegativeInteger ;
-                                      dcterms:description "Die Koordinaten auf einer vertikalen Achse für die Position der linken oberen Ecke des Textfeldes, das die TextLine enthält."@de ,
-                                                          "Les coordonnées sur un axe vertical de la position du coin supérieur gauche de la zone de texte contenant la TextLine."@fr ,
-                                                          "The coordinates on a vertical axis of the position of the top left corner of the text box containing the TextLine."@en ;
-                                      rdfs:label "Position Y du coin supérieur gauche de la ligne de texte."@fr ,
-                                                 "Text line box top left corner Y position."@en ,
-                                                 "Textzeilenfeld obere linke Ecke Y-Position."@de .
+                                      dcterms:description "The coordinates on a vertical axis of the position of the top left corner of the text box containing the TextLine."@en ;
+                                      rdfs:label "Text line box top left corner Y position"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#textLineBoxTopLeftCornerPixelNumber
 ec:textLineBoxTopLeftCornerPixelNumber rdf:type owl:DatatypeProperty ;
                                        rdfs:range xsd:nonNegativeInteger ;
-                                       dcterms:description "Die Koordinaten auf einer horizontalen Achse für die Position der linken oberen Ecke des Textfeldes, das die Textzeile enthält."@de ,
-                                                           "Les coordonnées sur un axe horizontal de la position du coin supérieur gauche de la zone de texte contenant la TextLine."@fr ,
-                                                           "The coordinates on an horizontal axis of the position of the top left corner of the text box containing the TextLine."@en ;
-                                       rdfs:label "Boîte de ligne de texte en haut à gauche Position Corner X."@fr ,
-                                                  "Text line box top left Corner X position."@en ,
-                                                  "Textzeilenfeld oben links Corner X Position."@de .
+                                       dcterms:description "The coordinates on an horizontal axis of the position of the top left corner of the text box containing the TextLine."@en ;
+                                       rdfs:label "Text line box top left corner X position"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#textLineBoxWidth
 ec:textLineBoxWidth rdf:type owl:DatatypeProperty ;
                     rdfs:range xsd:nonNegativeInteger ;
-                    dcterms:description "Die Breite des Textfeldes, das die TextLine enthält."@de ,
-                                        "La largeur de la zone de texte contenant la TextLine."@fr ,
-                                        "The width of the text box containing the TextLine."@en ;
-                    rdfs:label "Breite des Textfeldes."@de ,
-                               "Largeur de la boîte de la ligne de texte."@fr ,
-                               "Text line box width."@en .
+                    dcterms:description "The width of the text box containing the TextLine."@en ;
+                    rdfs:label "Text line box width"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#textLineContent
 ec:textLineContent rdf:type owl:DatatypeProperty ;
                    rdfs:range rdfs:Literal ;
-                   dcterms:description "Pour fournir le contenu d'une ligne de texte."@fr ,
-                                       "To provide the content of a text line."@en ,
-                                       "Um den Inhalt einer Textzeile anzugeben."@de ;
-                   rdfs:label "Ligne de texte"@fr ,
-                              "Text line"@en ,
-                              "Textzeile"@de .
+                   dcterms:description "The content of a text line."@en ;
+                   rdfs:label "Text line"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#textLineOrder
 ec:textLineOrder rdf:type owl:DatatypeProperty ;
                  rdfs:range rdfs:Literal ;
-                 dcterms:description "Die Reihenfolge, in der eine Textzeile z.B. in einer Szene zu finden ist."@de ,
-                                     "L'ordre dans lequel une ligne de texte peut être trouvée, par exemple dans une scène."@fr ,
-                                     "The order in which a text line can be found e.g. in a scene."@en ;
-                 rdfs:label "Ordre des lignes de texte"@fr ,
-                            "Reihenfolge der Textzeilen"@de ,
-                            "Text line order"@en .
+                 dcterms:description "The order in which a text line can be found e.g. in a scene."@en ;
+                 rdfs:label "Text line order"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#timeOfDay
 ec:timeOfDay rdf:type owl:DatatypeProperty ;
              rdfs:range xsd:time ;
-             dcterms:description "A time expressed as a normal time of day"@en ,
-                                 "Eine Zeit, ausgedrückt als normale Tageszeit"@de ,
-                                 "Une heure exprimée comme une heure normale de la journée"@fr ;
-             rdfs:label "Tageszeit"@de ,
-                        "heure de la journée"@fr ,
-                        "time of day"@en .
+             dcterms:description "A time expressed as a normal time of day."@en ;
+             rdfs:label "Time of day"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#timecodeExpression
 ec:timecodeExpression rdf:type owl:DatatypeProperty ;
                       rdfs:range xsd:string ;
-                      dcterms:description "A time expressed as timecode."@en ,
-                                          "Eine Zeit ausgedrückt als Timecode."@de ,
-                                          "Un temps exprimé sous forme de timecode."@fr ;
-                      rdfs:label "Timecode-Ausdruck"@de ,
-                                 "expression du timecode"@fr ,
-                                 "timecode expression"@en .
+                      dcterms:description "A time expressed as timecode."@en ;
+                      rdfs:label "Timecode expression"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#timeshift
 ec:timeshift rdf:type owl:DatatypeProperty ,
                       owl:FunctionalProperty ;
-             dcterms:description "A flag to indicate if the Service requires timeshift support."@en ,
-                                 "Ein Kennzeichen, das angibt, ob der Dienst die Unterstützung von Zeitverschiebungen benötigt. Unterstützung benötigt."@de ,
-                                 "Un drapeau pour indiquer si le service a besoin d'une équipe de travail en horaires décalés. soutien."@fr ;
-             rdfs:label "Soutien aux horaires décalés"@fr ,
-                        "Timeshift support"@en ,
-                        "Unterstützung für Timeshift"@de .
+             dcterms:description "A flag to indicate if the Service requires timeshift support."@en ;
+             rdfs:label "Timeshift support"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#title
 ec:title rdf:type owl:DatatypeProperty ;
          rdfs:range rdfs:Literal ;
-         dcterms:description "Alle Werte des EBU-Titelstatus-Klassifizierungsschemas (https://github.com/ebu/ebu_cs/blob/main/metadata/cs/ebu_TitleStatusCodeCS.xml) sind Kandidaten Untereigenschaften der Eigenschaft title, wie sie zum Beispiel mit alternativeTitel."@de ,
-                             "Specifies the title or name given to the resource. A root for the definition of subproperties defining ebucore titles of different types. The ebucore title type can be used to define sub-properties to optionally refine the category of the title. All value of the EBU title status classification scheme (https://github.com/ebu/ebu_cs/blob/main/metadata/cs/ebu_TitleStatusCodeCS.xml) are candidates subproperties of the title property as implemented for an example with alternativeTitle."@en ,
-                             "Toutes les valeurs du système de classification du statut du titre de l'UER (https://github.com/ebu/ebu_cs/blob/main/metadata/cs/ebu_TitleStatusCodeCS.xml) sont des candidats sous-propriétés de la propriété title comme implémenté par exemple avec alternativeTitle."@fr ;
-         rdfs:label "Titel"@de ,
-                    "Title"@en ,
-                    "Titre"@fr .
+         dcterms:description "Specifies the title or name given to the resource. A root for the definition of sub-properties defining ebucore titles of different types. The ebucore title type can be used to define sub-properties to optionally refine the category of the title. All values of the EBU title status classification scheme (https://github.com/ebu/ebu_cs/blob/main/metadata/cs/ebu_TitleStatusCodeCS.xml) are candidate sub-properties of the title property as implemented for an example with alternativeTitle."@en ;
+         rdfs:label "Title"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#totalNumberOfAudioChannels
 ec:totalNumberOfAudioChannels rdf:type owl:DatatypeProperty ;
                               rdfs:range xsd:nonNegativeInteger ;
-                              dcterms:description "Die Gesamtzahl der Audiokanäle, die in der der MediaResource."@de ,
-                                                  "Le nombre total de canaux audio contenus dans la MediaResource."@fr ,
-                                                  "The total number of audio channels contained in the MediaResource."@en ;
-                              rdfs:label "Nombre de canal audio"@fr ,
-                                         "Number of audio channel"@en ,
-                                         "Nummer des Audiokanals"@de .
+                              dcterms:description "The total number of audio channels contained in the MediaResource."@en ;
+                              rdfs:label "Number of audio channel"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#totalNumberOfAudioTracks
 ec:totalNumberOfAudioTracks rdf:type owl:DatatypeProperty ;
                             rdfs:range xsd:integer ;
-                            dcterms:description "Die Gesamtzahl der Audiospuren angeben.."@de ,
-                                                "Pour fournir le nombre total de pistes audio."@fr ,
-                                                "To provide the total number of audio tracks."@en ;
-                            rdfs:label "Anzahl der Audiospuren"@de ,
-                                       "Nombre de pistes audio"@fr ,
-                                       "Number of audio tracks"@en .
+                            dcterms:description "The total number of audio tracks in a media resource."@en ;
+                            rdfs:label "Number of audio tracks"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#totalNumberOfEpisodes
 ec:totalNumberOfEpisodes rdf:type owl:DatatypeProperty ;
                          rdfs:range xsd:integer ;
-                         dcterms:description "Pour fournir le nombre total d'épisodes d'une série ou d'une saison."@fr ,
-                                             "To provide the total number of episodes in a Series or a Season."@en ,
-                                             "Zur Angabe der Gesamtzahl der Episoden einer Serie oder einer Staffel."@de ;
-                         rdfs:label "Gesamtzahl der Episoden"@de ,
-                                    "Nombre total d'épisodes"@fr ,
-                                    "Total number of episodes"@en .
+                         dcterms:description "The total number of episodes associated with a series or season."@en ;
+                         rdfs:label "Total number of episodes"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#totalNumberOfGroupMembers
 ec:totalNumberOfGroupMembers rdf:type owl:DatatypeProperty ;
                              rdfs:range xsd:integer ;
-                             dcterms:description "Pour fournir le nombre total de membres dans un groupe."@fr ,
-                                                 "To provide the total number of members in a Group."@en ,
-                                                 "Zur Angabe der Gesamtzahl der Mitglieder einer Gruppe."@de ;
-                             rdfs:label "Gesamtzahl der Gruppenmitglieder"@de ,
-                                        "Nombre total de membres du groupe"@fr ,
-                                        "Total number of Group members"@en .
+                             dcterms:description "The total number of members in a group."@en ;
+                             rdfs:label "Total number of group members"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#totalNumberOfVideoTracks
 ec:totalNumberOfVideoTracks rdf:type owl:DatatypeProperty ;
                             rdfs:range xsd:integer ;
-                            dcterms:description "Die Gesamtzahl der Videospuren angeben."@de ,
-                                                "Pour fournir le nombre total de pistes vidéo."@fr ,
-                                                "To provide the total number of video tracks."@en ;
-                            rdfs:label "Anzahl der Videospuren"@de ,
-                                       "Nombre de pistes vidéo"@fr ,
-                                       "Number of video tracks"@en .
+                            dcterms:description "The total number of video tracks in the media resource."@en ;
+                            rdfs:label "Number of video tracks"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#username
 ec:username rdf:type owl:DatatypeProperty ;
             rdfs:range rdfs:Literal ;
-            dcterms:description "Der Benutzername, unter dem eine Person bekannt ist bekannt ist, z.B. wenn Sie einen Bewertungswert zuweisen."@de ,
-                                "Le nom d'utilisateur par lequel une personne est connue, par exemple lors de l'attribution d'une valeur d'évaluation."@fr ,
-                                "The username by which a Person is known e.g. when attributing a rating value."@en ;
-            rdfs:label "Benutzername"@de ,
-                       "Nom d'utilisateur :"@fr ,
-                       "Username"@en .
+            dcterms:description "The username by which a Person is known e.g. when attributing a rating value."@en ;
+            rdfs:label "Username"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#version
 ec:version rdf:type owl:DatatypeProperty ;
            rdfs:range rdfs:Literal ;
-           dcterms:description "Pour fournir des informations sur la version actuelle d'un EditorialObject."@fr ,
-                               "To provide information on the current version of an EditorialObject."@en ,
-                               "Um Informationen über die aktuelle Version eines EditorialObjects bereitzustellen."@de ;
-           rdfs:label "Version"@de ,
-                      "Version"@en ,
-                      "Version"@fr .
+           dcterms:description "The current version of an EditorialObject."@en ;
+           rdfs:label "Version"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#videoBitRate
 ec:videoBitRate rdf:type owl:DatatypeProperty ;
                 rdfs:range xsd:nonNegativeInteger ;
-                dcterms:description "Die Video-Bitrate. Zur Angabe der Bitrate, mit der die MediaResource abgespielt werden kann in Bits/Sekunde. Aktuelle Bitrate, wenn konstant, und durchschnittliche Bitrate, wenn variabel."@de ,
-                                    "Le débit binaire de la vidéo. Pour fournir le débit binaire auquel la MediaResource peut être lue en bits/seconde. Débit binaire actuel si constant, et débit binaire moyen si variable."@fr ,
-                                    "The video bitrate. To provide the bitrate at which the MediaResource can be played in bits/second. Current bitrate if constant, and average bitrate if variable."@en ;
-                rdfs:label "Débit binaire vidéo"@fr ,
-                           "Video bitrate"@en ,
-                           "Video-Bitrate"@de .
+                dcterms:description "The video bitrate. To provide the bitrate at which the MediaResource can be played in bits/second. Current bitrate if constant, and average bitrate if variable."@en ;
+                rdfs:label "Video bitrate"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#videoBitRateMax
 ec:videoBitRateMax rdf:type owl:DatatypeProperty ;
                    rdfs:range xsd:nonNegativeInteger ;
-                   dcterms:description "Die maximale Video-Bitrate."@de ,
-                                       "Le débit binaire vidéo maximum."@fr ,
-                                       "The maximum video bitrate."@en ;
-                   rdfs:label "Débit binaire vidéo max"@fr ,
-                              "Video bitrate max"@en ,
-                              "Video-Bitrate max."@de .
+                   dcterms:description "The maximum video bitrate."@en ;
+                   rdfs:label "Video bitrate max"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#videoBitRateMode
 ec:videoBitRateMode rdf:type owl:DatatypeProperty ;
                     rdfs:range rdfs:Literal ;
-                    dcterms:description "Der Modus für die Video-Bitrate."@de ,
-                                        "Le mode de débit binaire vidéo."@fr ,
-                                        "The video bitrate mode."@en ;
-                    rdfs:label "Mode de débit binaire vidéo"@fr ,
-                               "Video bitrate mode"@en ,
-                               "Video-Bitrate-Modus"@de .
+                    dcterms:description "The video bitrate mode."@en ;
+                    rdfs:label "Video bitrate mode"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#videoDisplay
 ec:videoDisplay rdf:type owl:DatatypeProperty ,
                          owl:FunctionalProperty ;
-                dcterms:description "A flag to indicate if the Service requires a video display."@en ,
-                                    "Eine Markierung, die anzeigt, ob der Dienst eine Videoanzeige benötigt. Anzeige benötigt."@de ,
-                                    "Un drapeau pour indiquer si le service exige un affichage vidéo."@fr ;
-                rdfs:label "Affichage vidéo"@fr ,
-                           "Video display"@en ,
-                           "Videoanzeige"@de .
+                dcterms:description "A flag to indicate if the Service requires a video display."@en ;
+                rdfs:label "Video display"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#videoEncodingLevel
 ec:videoEncodingLevel rdf:type owl:DatatypeProperty ;
                       rdfs:subPropertyOf ec:encodingLevel ;
                       rdfs:range rdfs:Literal ;
-                      dcterms:description "Die Kodierungsebene, wie sie in den Spezifikationen definiert ist."@de ,
-                                          "Le niveau de codage tel que défini dans les spécifications."@fr ,
-                                          "The encoding level as defined in specifications."@en ;
-                      rdfs:label "Ebene der Videokodierung"@de ,
-                                 "Niveau d'encodage vidéo"@fr ,
-                                 "Video encoding level"@en .
+                      dcterms:description "The encoding level as defined in specifications."@en ;
+                      rdfs:label "Video encoding level"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#videoEncodingProfile
 ec:videoEncodingProfile rdf:type owl:DatatypeProperty ;
                         rdfs:subPropertyOf ec:encodingProfile ;
                         rdfs:range rdfs:Literal ;
-                        dcterms:description "Die Kodierungsebene, wie sie in den Spezifikationen definiert ist."@de ,
-                                            "Le niveau de codage tel que défini dans les spécifications."@fr ,
-                                            "The encoding level as defined in specifications."@en ;
-                        rdfs:label "Profil d'encodage vidéo"@fr ,
-                                   "Video encoding profile"@en ,
-                                   "Video-Kodierungsprofil"@de .
+                        dcterms:description "The encoding level as defined in specifications."@en ;
+                        rdfs:label "Video encoding profile"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#videoTrackNumber
 ec:videoTrackNumber rdf:type owl:DatatypeProperty ;
                     rdfs:range xsd:nonNegativeInteger ;
-                    dcterms:description "Permet d’identifier une piste vidéo parmi plusieurs dans une MediaResource."@fr ,
-                                        "To identify a video track among multiple tracks in a MediaResource."@en ,
-                                        "Zur Identifizierung einer Videospur innerhalb einer MediaResource."@de ;
-                    rdfs:label "Numéro de piste vidéo"@fr ,
-                               "Video Track Number"@en ,
-                               "Videospurnummer"@de .
+                    dcterms:description "The number used to identify a video track among multiple tracks in a media resource."@en ;
+                    rdfs:label "Video track number"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#webcam
 ec:webcam rdf:type owl:DatatypeProperty ,
                    owl:FunctionalProperty ;
-          dcterms:description "A flag to indicate if the Service requires a webcam."@en ,
-                              "Eine Markierung, die anzeigt, ob der Dienst eine Webcam benötigt."@de ,
-                              "Un drapeau pour indiquer si le service nécessite une webcam."@fr ;
-          rdfs:label "Webcam"@de ,
-                     "Webcam"@en ,
-                     "Webcam"@fr .
+          dcterms:description "A flag to indicate if the Service requires a webcam."@en ;
+          rdfs:label "Webcam"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#width
 ec:width rdf:type owl:DatatypeProperty ;
          rdfs:range xsd:integer ;
-         dcterms:description "Die Breite z.B. eines Videobildes wird normalerweise ausgedrückt als Anzahl von Pixeln oder als Bild in Millimetern."@de ,
-                             "La largeur d'une image vidéo, par exemple, généralement exprimée en nombre de pixels, ou image/photo en millimètres."@fr ,
-                             "The width of e.g. a video frame typically expressed as a number of pixels, or picture/image in millimeters."@en ;
-         rdfs:label "Breite"@de ,
-                    "Largeur"@fr ,
-                    "Width"@en .
+         dcterms:description "The width of e.g. a video frame typically expressed as a number of pixels, or picture/image in millimeters."@en ;
+         rdfs:label "Width"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#widthUnit
 ec:widthUnit rdf:type owl:DatatypeProperty ;
              rdfs:range rdfs:Literal ;
-             dcterms:description "Die Einheit, mit der eine Breite gemessen wird, z.B. in Pixeln oder Anzahl der Zeilen oder Millimeter oder anderes."@de ,
-                                 "L'unité utilisée pour mesurer une largeur, par exemple en pixels ou en nombre de lignes ou en millimètres ou autre."@fr ,
-                                 "The unit used to measure a width e.g. in pixels or number of lines or millimeters or else."@en ;
-             rdfs:label "Einheit Breite"@de ,
-                        "Unité de largeur"@fr ,
-                        "Width unit"@en .
+             dcterms:description "The unit used to measure a width e.g. in pixels or number of lines or millimeters or else."@en ;
+             rdfs:label "Width unit"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#wordCount
 ec:wordCount rdf:type owl:DatatypeProperty ;
              rdfs:range xsd:integer ;
-             dcterms:description "Die Anzahl der in einem Dokument enthaltenen Wörter."@de ,
-                                 "Le nombre de mots contenus dans un document."@fr ,
-                                 "The number of words contained in a document."@en ;
-             rdfs:label "Nombre de mots"@fr ,
-                        "Word count"@en ,
-                        "Wortzahl"@de .
+             dcterms:description "The number of words contained in a document."@en ;
+             rdfs:label "Word count"@en .
 
 
 ###  http://www.w3.org/2006/time#day
 time:day rdf:type owl:DatatypeProperty ;
          rdfs:range xsd:gDay ;
-         rdfs:label "Tag"@de ,
-                    "day"@en ,
-                    "jour"@fr .
+         rdfs:label "day"@en .
 
 
 ###  http://www.w3.org/2006/time#inXSDDateTimeStamp
@@ -7096,17 +5005,13 @@ time:inXSDDateTimeStamp rdf:type owl:DatatypeProperty ;
 ###  http://www.w3.org/2006/time#month
 time:month rdf:type owl:DatatypeProperty ;
            rdfs:range xsd:gMonth ;
-           rdfs:label "Monat"@de ,
-                      "mois"@fr ,
-                      "month"@en .
+           rdfs:label "month"@en .
 
 
 ###  http://www.w3.org/2006/time#year
 time:year rdf:type owl:DatatypeProperty ;
           rdfs:range xsd:gYear ;
-          rdfs:label "Jahr"@de ,
-                     "année"@fr ,
-                     "year"@en .
+          rdfs:label "year"@en .
 
 
 #################################################################
@@ -7115,12 +5020,8 @@ time:year rdf:type owl:DatatypeProperty ;
 
 ###  http://purl.org/dc/elements/1.1/Agent
 dc:Agent rdf:type owl:Class ;
-         dcterms:description "A resource that acts or has the power to act."@en ,
-                             "Eine Resource, die handelt oder die die Macht hat zu handeln."@de ,
-                             "une ressource qui agit ou a le pouvoir d'agir."@fr ;
-         rdfs:label "Agent"@de ,
-                    "Agent"@en ,
-                    "Agent"@fr .
+         dcterms:description "A resource that acts or has the power to act."@en ;
+         rdfs:label "Agent"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AccessConditions
@@ -7134,12 +5035,9 @@ ec:AccessConditions rdf:type owl:Class ;
                                       owl:onProperty ec:hasGeoBlockingWhitelist ;
                                       owl:allValuesFrom skos:Concept
                                     ] ;
-                    dcterms:description "Die Bedingungen, unter denen auf Inhalte zugegriffen werden kann."@de ,
-                                        "Les conditions dans lesquelles le contenu est accessible."@fr ,
-                                        "The conditions under which content can be accessed."@en ;
-                    rdfs:label "Access conditions"@en ,
-                               "Conditions d'accès"@fr ,
-                               "Zugangsbedingungen"@de .
+                    dcterms:description "The requirements under which access to content or its publication is granted."@en ;
+                    rdfs:label "Access conditions"@en ;
+                    skos:definition "a ec:Rights that define the requirements under which access to an ec:Asset or a ec:PublicationEvent is granted"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Account
@@ -7172,21 +5070,11 @@ ec:Account rdf:type owl:Class ;
                              owl:onProperty ec:name ;
                              owl:allValuesFrom rdfs:Literal
                            ] ;
-           dcterms:description "A registration Account to a Service. Account information can vary from one Service to another. Such information covers e.g. a (nick)name, a login, an age, sex, domains of interest or more."@en ,
-                               "Das Konto, unter dem einen Nutzer bei einem Dienst registriert ist. Die registrierten Informationen zum Konto können je nach Service unterschiedlich sein. Beispiele: (Spitz-)name, Login-Name, Alter, Geschlecht, Interessensgebiete, etc."@de ,
-                               "Un compte d'inscription à un service. Les informations relatives au compte peuvent varier d'un service à l'autre. Ces informations couvrent par exemple un nom, un surnom, un loggin, un âge, le sexe, des domaines d'intérêt."@fr ;
-           rdfs:label "Account"@en ,
-                      "Compte"@fr ,
-                      "Nutzerkonto"@de ;
-           skos:definition "a registration identity for a media service"@en ,
-                           "eine Registrierungsidentität für einen Mediendienst"@de ,
-                           "une identité d'enregistrement pour un service de médias"@fr ;
+           dcterms:description "A registration Account to a Service. Account information can vary from one Service to another. Such information covers e.g. a (nick)name, a login, an age, sex, domains of interest or more."@en ;
+           rdfs:label "Account"@en ;
+           skos:definition "a registration identity for a media service"@en ;
            skos:example """- a registered user to access netflix
-- a registered family with nicknames and devices to access a VOD service"""@en ,
-                        """- ein registrierter Benutzer für den Zugang zu Netflix
-- eine registrierte Familie mit Nicknames und Geräten für den Zugang zu einem VOD-Dienst"""@de ,
-                        """- un utilisateur enregistré pour accéder à Netflix
-- une famille enregistrée avec des surnoms et des appareils pour accéder à un service de VOD"""@fr .
+- a registered family with nicknames and devices to access a VOD service"""@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Action
@@ -7225,34 +5113,25 @@ ec:Action rdf:type owl:Class ;
                             owl:onProperty ec:name ;
                             owl:allValuesFrom rdfs:Literal
                           ] ;
-          dcterms:description "A class to log Actions."@en ,
-                              "Eine Klasse zum Protokollieren von Aktionen."@de ,
-                              "Une classe pour enregistrer les actions."@fr ;
-          rdfs:label "Action"@en ,
-                     "Action"@fr ,
-                     "Aktion"@de .
+          dcterms:description "An entry from a list of actions, often used to create log entries about something happening along the timeline of content, eg. a goal scored in a football game."@en ;
+          rdfs:label "Action"@en ;
+          skos:definition "a skos:Concept classifying an action that happens in the course of an event or some content"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ActionType
 ec:ActionType rdf:type owl:Class ;
               rdfs:subClassOf skos:Concept ;
-              dcterms:description "Pour définir un type d'action."@fr ,
-                                  "To define a type of Action."@en ,
-                                  "Um eine Art von Aktion zu definieren."@de ;
-              rdfs:label "Action type"@en ,
-                         "Aktionstyp"@de ,
-                         "Type d'action"@fr .
+              dcterms:description "An entry from a list of actions, often used to create log entries about something happening along the timeline of content, eg. a goal scored in a football game."@en ;
+              rdfs:label "Action type"@en ;
+              skos:definition "a skos:Concept classifying an action that happens in the course of an event or some content"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ActiveFormatDescriptorCode
 ec:ActiveFormatDescriptorCode rdf:type owl:Class ;
                               rdfs:subClassOf ec:Format ;
-                              dcterms:description "Pour définir un code de format actif."@fr ,
-                                                  "So definieren Sie einen aktiven Formatcode."@de ,
-                                                  "To define an active format code."@en ;
-                              rdfs:label "Active format descriptor code"@en ,
-                                         "Aktiver Format-Deskriptor-Code"@de ,
-                                         "Code du descripteur de format actif"@fr .
+                              dcterms:description "An entry from the classification of aspect ratios of a media resource on display."@en ;
+                              rdfs:label "Active format descriptor code"@en ;
+                              skos:definition "a ec:Format classifying the aspect ratio of a ec:MediaResource when displayed"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Affiliation
@@ -7288,21 +5167,11 @@ ec:Affiliation rdf:type owl:Class ;
                                  owl:onProperty ec:name ;
                                  owl:allValuesFrom rdfs:Literal
                                ] ;
-               dcterms:description "An Organisation to which a Contact is affiliated (with period of validity)."@en ,
-                                   "Eine Organisation, der ein Kontakt angehört (mit Gültigkeitsdauer)."@de ,
-                                   "Une organisation à laquelle un contact est affilié (avec une période de validité)."@fr ;
-               rdfs:label "Affiliation"@en ,
-                          "Affiliation"@fr ,
-                          "Zugehörigkeit"@de ;
-               skos:definition "an association of a Person to an Organisation for a period of time"@en ,
-                               "eine Verbindung einer Person mit einer Organisation für einen bestimmten Zeitraum"@de ,
-                               "l'association d'une personne à une organisation pour une période donnée"@fr ;
+               dcterms:description "An Organisation to which a Contact is affiliated (with period of validity)."@en ;
+               rdfs:label "Affiliation"@en ;
+               skos:definition "an association of a Person to an Organisation for a period of time"@en ;
                skos:example """- a person's employment with the BBC from hiring to retirement
-- the hosting of a BBC weekly radio show on a radio channel over 8 years"""@en ,
-                            """- die Beschäftigung einer Person bei der BBC von der Einstellung bis zum Eintritt in den Ruhestand
-- die Moderation einer wöchentlichen BBC-Radiosendung auf einem Radiokanal über 8 Jahre"""@de ,
-                            """- l'emploi d'une personne à la BBC, de son embauche à sa retraite
-- l'animation d'une émission hebdomadaire de la BBC sur une chaîne de radio pendant 8 ans"""@fr .
+- the hosting of a BBC weekly radio show on a radio channel over 8 years"""@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Agent
@@ -7464,15 +5333,9 @@ ec:Agent rdf:type owl:Class ;
                            owl:onProperty ec:displayOrder ;
                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ;
-         dcterms:description "An «Agent» is either a Contact/Person or Organisation to which is associated a Role corresponding to the contribution the «Agent» brings to the realisation of a MediaResource or EditorialObject."@en ,
-                             "Ein Akteur ist entweder eine Kontaktperson oder eine Organisation, deren Beitrag zur Realisierung eines Inhaltsobjektes oder eines Medienobjektes durch eine Rolle beschrieben wird."@de ,
-                             "Un acteur est un terme général, soit un contact ou une personne ou une organisation à laquelle est associé un rôle correspondant à la contribution que l'acteur apporte à la réalisation d'une MediaResource ou d'un EditorialObject."@fr ;
-         rdfs:label "Agent"@en ,
-                    "Akteur"@de ,
-                    "Un acteur"@fr ;
-         skos:definition "an entity performing an activity in the media business"@en ,
-                         "eine Entität, die eine Tätigkeit in der Medienbranche ausübt"@de ,
-                         "une entité exerçant une activité dans le secteur des médias"@fr ;
+         dcterms:description "An «Agent» is either a Contact/Person or Organisation to which is associated a Role corresponding to the contribution the «Agent» brings to the realisation of a MediaResource or EditorialObject."@en ;
+         rdfs:label "Agent"@en ;
+         skos:definition "an entity performing an activity in the media business"@en ;
          skos:example """- a film director
 - a camera woman
 - a sound engineer
@@ -7481,25 +5344,7 @@ ec:Agent rdf:type owl:Class ;
 - a publishing media enterprise
 - a content providing enterprise
 - a distribution network enterprise
-- a consumption device manufacturing enterprise"""@en ,
-                      """- ein Filmregisseur
-- eine Kamerafrau
-- ein Tontechniker
-- eine Schauspielerin
-- eine Autorin
-- ein veröffentlichendes Medienunternehmen
-- ein Unternehmen, das Inhalte bereitstellt
-- ein Unternehmen, das ein Vertriebsnetz bereitstellt
-- ein Unternehmen, das Endgeräte herstellt"""@de ,
-                      """- un réalisateur de films
-- une caméraman
-- un ingénieur du son
-- une actrice
-- un auteur
-- une entreprise de médias d'édition
-- une entreprise de fourniture de contenu
-- une entreprise de réseau de distribution
-- une entreprise de fabrication de dispositifs de consommation"""@fr .
+- a consumption device manufacturing enterprise"""@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AlternativeTitle
@@ -7534,9 +5379,9 @@ ec:AlternativeTitle rdf:type owl:Class ;
                                       owl:onProperty ec:name ;
                                       owl:allValuesFrom rdfs:Literal
                                     ] ;
-                    rdfs:label "Alternative title"@en ,
-                               "Alternativer Titel"@de ,
-                               "Titre alternatif"@fr .
+                    dcterms:description "A title is a name for a piece or a group of content."@en ;
+                    rdfs:label "Alternative title"@en ;
+                    skos:definition "a name of a certain type given to an ec:EditorialObject"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AncillaryData
@@ -7562,23 +5407,17 @@ ec:AncillaryData rdf:type owl:Class ;
                                    owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                    owl:onDataRange xsd:integer
                                  ] ;
-                 dcterms:description "Alle mit dem Inhalt gelieferten Zusatzdaten mit Ausnahme von Untertiteln und Untertitelung."@de ,
-                                     "Any ancillary data provided with the content other than captioning and subtitling."@en ,
-                                     "Toute donnée auxiliaire fournie avec le contenu autres que le sous-titrage et le sous-titrage."@fr ;
-                 rdfs:label "Ancillary data"@en ,
-                            "Données auxiliaires"@fr ,
-                            "Ergänzende Daten"@de .
+                 dcterms:description "A track containing supplemental data that accompanies video or audio content."@en ;
+                 rdfs:label "Ancillary data"@en ;
+                 skos:definition "a ec:DataTrack of data of a supplemental nature"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AncillaryDataFormat
 ec:AncillaryDataFormat rdf:type owl:Class ;
                        rdfs:subClassOf ec:DataFormat ;
-                       dcterms:description "Pour définir le format des données auxiliaires telles que les les données patrimoniales qui étaient auparavant transportées dans des intervalles de suppression verticale. Ces données sont fournies sous forme de libre dans une étiquette d'annotation ou comme un identifiant pointant vers un terme dans un schéma de classification. de classification."@fr ,
-                                           "To define the format of AncillaryData such as legacy data used to be carried in vertical blanking intervals. This is provided as free text in an annotation label or as an identifier pointing to a term in a classification scheme."@en ,
-                                           "Zur Definition des Formats von Zusatzdaten wie z.B. Legacy-Daten, die in vertikalen Austastlücken übertragen werden. Diese werden als freier Text in einer Beschriftung oder als Bezeichner, der auf einen Begriff in einem Klassifikationsschema verweist Schema."@de ;
-                       rdfs:label "Ancillary data format"@en ,
-                                  "Format der Zusatzdaten"@de ,
-                                  "Format des données auxiliaires"@fr .
+                       dcterms:description "An entry from the classification of structure schemes for data that supplement audio, video, or images, e.g., legacy data that used to be carried in vertical blanking intervals of video broadcast signals."@en ;
+                       rdfs:label "Ancillary data format"@en ;
+                       skos:definition "a ec:DataFormat classifying the structure of supplemental data"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Animal
@@ -7649,34 +5488,25 @@ ec:Animal rdf:type owl:Class ;
                             owl:onProperty ec:gender ;
                             owl:maxCardinality "1"^^xsd:nonNegativeInteger
                           ] ;
-          dcterms:description "Pour identifier un animal."@fr ,
-                              "To identify an animal."@en ,
-                              "Um ein Tier zu identifizieren."@de ;
-          rdfs:label "Animal"@en ,
-                     "Animal"@fr ,
-                     "Tier"@de .
+          dcterms:description "An animal that is related to or depicted in a piece of work."@en ;
+          rdfs:label "Animal"@en ;
+          skos:definition "an animal with a role in ec:Involvement"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AnimalBreedCode
 ec:AnimalBreedCode rdf:type owl:Class ;
                    rdfs:subClassOf skos:Concept ;
-                   dcterms:description "Pour fournir un code de race pour un animal."@fr ,
-                                       "To provide a breed code for an animal."@en ,
-                                       "Zur Bereitstellung eines Rassencodes für ein Tier."@de ;
-                   rdfs:label "Animal breed code"@en ,
-                              "Code de la race animale"@fr ,
-                              "Code der Tierrasse"@de .
+                   dcterms:description "An entry from the breed classification of animals."@en ;
+                   rdfs:label "Animal breed code"@en ;
+                   skos:definition "a skos:Concept classifying an ec:Animal by their breed"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AnimalColourCode
 ec:AnimalColourCode rdf:type owl:Class ;
                     rdfs:subClassOf skos:Concept ;
-                    dcterms:description "Pour fournir un code de couleur pour un animal.."@fr ,
-                                        "To provide a colour code for an animal."@en ,
-                                        "Zur Bereitstellung eines Farbcodes für ein Tier."@de ;
-                    rdfs:label "Animal colour code"@en ,
-                               "Code couleur des animaux"@fr ,
-                               "Farbcode für Tiere"@de .
+                    dcterms:description "An entry from the colour classification of animals."@en ;
+                    rdfs:label "Animal colour code"@en ;
+                    skos:definition "a skos:Concept classifying an ec:Animal by their colour"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Annotation
@@ -7749,23 +5579,17 @@ ec:Annotation rdf:type owl:Class ;
                                 owl:onProperty ec:annotationSaliency ;
                                 owl:maxCardinality "1"^^xsd:nonNegativeInteger
                               ] ;
-              dcterms:description "A class used to annotate Assets."@en ,
-                                  "Eine Klasse, mit der Sie Assets mit Anmerkungen versehen können."@de ,
-                                  "Une classe utilisée pour annoter les actifs."@fr ;
-              rdfs:label "Anmerkung"@de ,
-                         "Annotation"@en ,
-                         "Annotation"@fr .
+              dcterms:description "Annotations are meaningful terms that are associated with things. Things that are annotated with the same terms are implicitly associated."@en ;
+              rdfs:label "Annotation"@en ;
+              skos:definition "a string that is assigned to owl:Thing for implicit association amongst them"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AnnotationType
 ec:AnnotationType rdf:type owl:Class ;
                   rdfs:subClassOf skos:Concept ;
-                  dcterms:description "Pour définir un type d'Annotation."@fr ,
-                                      "To define a type of Annotation."@en ,
-                                      "Um eine Art von Anmerkung zu definieren."@de ;
-                  rdfs:label "Annotation type"@en ,
-                             "Art der Annotation"@de ,
-                             "Type d'annotation"@fr .
+                  dcterms:description "An entry from the classification of annotations."@en ;
+                  rdfs:label "Annotation type"@en ;
+                  skos:definition "a skos:Concept classifying an ec:Annotation"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Artefact
@@ -7890,46 +5714,28 @@ ec:Artefact rdf:type owl:Class ;
                               owl:onProperty ec:name ;
                               owl:allValuesFrom rdfs:Literal
                             ] ;
-            dcterms:description "Permet d'identifier tous les artefacts utilisés dans une production tels que les costumes, les objets, accessoires."@fr ,
-                                "Sämtliche Artefakte, die im Rahmen einer Produktion unterschieden werden können, z.B. Produkte, Kostüme, Requisiten"@de ,
-                                "To identify all Artefacts used in a production such as costumes, objects, products."@en ;
-            rdfs:label "Artefact"@en ,
-                       "Artefact"@fr ,
-                       "Artefakt"@de ;
-            skos:definition "a Thing used in a ProductionJob, often visible and deliberately chosen for its value to the meaning of the content"@en ,
-                            "ein Ding, das in einer Produktion verwendet wird, oft sichtbar und absichtlich wegen seines Wertes für die Bedeutung des Inhalts ausgewählt"@de ,
-                            "une chose utilisée dans un travail de production, souvent visible et délibérément choisie pour sa valeur pour le sens du contenu."@fr ;
-            skos:example """- die Kostüme und Requisiten in einem Film
-- die nicht-dynamische Kulisse, Stühle, Tische in einer Talkshow"""@de ,
-                         """- les costumes et les accessoires dans un film
-- la toile de fond non dynamique, les chaises, la table dans un talk-show"""@fr ,
-                         """- the costumes and props in a movie
+            dcterms:description "Something used during a production, often visible or audible and deliberately chosen for its value to the resulting content, such as costumes, objects, or products."@en ;
+            rdfs:label "Artefact"@en ;
+            skos:definition "an object made or modified by a human being, typically one of cultural or historical interest; used in a ec:ProductionJob, often visible or audible, and deliberately chosen for its value to the resulting ec:EditorialObject"@en ;
+            skos:example """- the costumes and props in a movie
 - the non-dynamic backdrop, chairs, table in a talk show"""@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ArtefactType
 ec:ArtefactType rdf:type owl:Class ;
                 rdfs:subClassOf skos:Concept ;
-                dcterms:description "Pour définir un type d'artefact."@fr ,
-                                    "To define a type of artefact."@en ,
-                                    "Um eine Art von Artefakt zu definieren."@de ;
-                rdfs:label "Artefact type"@en ,
-                           "Artefakt-Typ"@de ,
-                           "Type d'artefact"@fr .
+                dcterms:description "An entry from the classification of media production artefacts."@en ;
+                rdfs:label "Artefact type"@en ;
+                skos:definition "a skos:Concept classifying an ec:Artefact"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Article
 ec:Article rdf:type owl:Class ;
            rdfs:subClassOf ec:EditorialWork ;
-           rdfs:label "Article"@en ,
-                      "Article"@fr ,
-                      "Artikel"@de ;
-           skos:definition "an EditorialWork consisting of text, graphic, sometimes video or audio, created for publication on web-sites, blogs and other channels similar to the more traditional paper-based publications"@en ,
-                           "ein redaktionelles Werk, das aus Text, Grafik, manchmal auch Video oder Audio besteht und für die Veröffentlichung auf Websites, Blogs und anderen Kanälen erstellt wird, die den traditionelleren papierbasierten Publikationen ähneln"@de ,
-                           "une œuvre éditoriale composée de texte, de graphiques, parfois de vidéo ou d'audio, créée pour être publiée sur des sites web, des blogs et d'autres canaux similaires aux publications papier plus traditionnelles."@fr ;
-           skos:example "- a news article on BBC's website"@en ,
-                        "- ein Nachrichtenartikel auf der Website der BBC"@de ,
-                        "- un article de presse sur le site de la BBC"@fr .
+           dcterms:description "A work consisting of text, graphics, sometimes video or audio, and created for publication on websites, blogs, etc., or other platforms similar to the more traditional paper-based publications."@en ;
+           rdfs:label "Article"@en ;
+           skos:definition "an ec:EditorialWork consisting of text, graphics, sometimes video or audio, created for publication on websites, blogs, et al., or other platforms similar to the more traditional paper-based publications"@en ;
+           skos:example "- a news article on BBC's website"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Asset
@@ -8115,38 +5921,21 @@ ec:Asset rdf:type owl:Class ;
                            owl:onDataRange xsd:boolean
                          ] ;
          owl:disjointWith ec:Rating ;
-         dcterms:description "Assets are EditorialObjects or Resources with associated Rights. An «Asset» is an object to which an identifier will be associated at commissioning time. It serves as a central reference point to manage rights associated with EditorialObjects, MediaResources or Essences, and - by inference - PublicationEvents (distribution and exploitation conditions). Remember that the MediaResources or Essences will in this model always be represented by an EditorialObject. Example: The CCDM model allows the association of Rights to a related EditorialObject that is represented by one or more Essences."@en ,
-                             "Assets sind Inhaltsobjekte oder Medienobjekte und ihre zugeordneten (Verwertungs-)Rechte. Ein Asset erhält durch die Beauftragung einen Identifikator. Es dient als zentrale Referenz, um die Rechte zu verwalten, die mit Inhaltsobjekten, Medienobjekten, Essenzen sowie Veröffentlichungsereignissen (per Deduktion) verknüpft sind. Achtung: Medienobjekte oder Essenzen werden in diesem Modell immer durch Inhaltsobjekte repräsentiert. Beispiel: CCDM gestattet die Verknüpfung von Verwertungsrechten mit einem Inhaltsobjekt, das von einem oder auch mehreren Essenzen repräsentiert wird."@de ,
-                             "Les actifs sont des EditorialObjects ou des ressources avec des droits associés. Un \"Asset\" est un objet auquel un identifiant sera associé lors de la mise en service. Il sert de point de référence central pour gérer les droits associés aux EditorialObjects, MediaResources ou Essences, et par déduction - les PublicationEvents (conditions de distribution et d'exploitation). Il est a noté que les MediaResources ou Essences seront dans ce modèle toujours représentées par un EditorialObject. Exemple : Le modèle CCDM permet l'association de droits à un EditorialObject connexe représenté par une ou plusieurs essences, Essences."@fr ;
-         rdfs:label "Actif"@fr ,
-                    "Asset"@de ,
-                    "Asset"@en ;
-         skos:definition "a media object that is intended for publication and consumption, attributed with author's rights and copyrights, and representing value."@en ,
-                         "ein Medienobjekt, das für die Veröffentlichung und den Konsum bestimmt ist, mit Urheberrechten und Copyrights versehen ist und einen Wert darstellt."@de ,
-                         "un objet médiatique destiné à être publié et consommé, auquel sont attribués des droits d'auteur et des droits de reproduction, et qui représente une valeur."@fr ;
+         dcterms:description "Assets are abstractions of audio, audiovisual, or bibliographical media objects. They serve to describe the value and the associated rights of the media object."@en ;
+         rdfs:label "Asset"@en ;
+         skos:definition "a piece of content that represents an ec:AssetValue in the context of the owner's business and may carry ec:Rights"@en ;
          skos:example """- a film on tape in the archive
 - a digital audio recording with associated author's right and copyright
 - a book
-- a collection of books"""@en ,
-                      """- ein Film auf Band im Archiv
-- eine digitale Tonaufnahme mit Urheberrecht und Copyright
-- ein Buch
-- eine Sammlung von Büchern"""@de ,
-                      """- un film sur bande dans les archives
-- un enregistrement audio numérique avec droits d'auteur et copyright associés
-- un livre
-- une collection de livres"""@fr .
+- a collection of books"""@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AssetType
 ec:AssetType rdf:type owl:Class ;
              rdfs:subClassOf skos:Concept ;
-             dcterms:description "Pour définir un type d'actif."@fr ,
-                                 "To define a type of asset."@en ,
-                                 "Um eine Art von Asset zu definieren."@de ;
-             rdfs:label "Asset type"@en ,
-                        "Asset-Typ"@de ,
-                        "Type d'actif"@fr .
+             dcterms:description "An entry from the classification of media assets."@en ;
+             rdfs:label "Asset type"@en ;
+             skos:definition "a skos:Concept classifying an ec:Asset"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AssetValue
@@ -8175,23 +5964,17 @@ ec:AssetValue rdf:type owl:Class ;
                                 owl:onProperty ec:name ;
                                 owl:allValuesFrom rdfs:Literal
                               ] ;
-              dcterms:description "Beschreibt den Wert eines Assets."@de ,
-                                  "Permet de décrire la valeur d'un actif"@fr ,
-                                  "To describe the value associated with an Asset."@en ;
-              rdfs:label "Asset value"@en ,
-                         "Assetwert"@de ,
-                         "Valeur d'un actif"@fr .
+              dcterms:description "The value of an asset expressed as an amount of money, a description of the value or a non-financial expression or type."@en ;
+              rdfs:label "Asset value"@en ;
+              skos:definition "a financial or intrinsic value of an ec:Asset"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Atmosphere
 ec:Atmosphere rdf:type owl:Class ;
               rdfs:subClassOf ec:Type ;
-              dcterms:description "Pour décrire un sentiment résumant l'atmosphère."@fr ,
-                                  "To describe a feeling summarising the atmosphere."@en ,
-                                  "Um ein Gefühl zu beschreiben, das die Atmosphäre zusammenfasst."@de ;
-              rdfs:label "Atmosphere"@en ,
-                         "Atmosphäre"@de ,
-                         "Atmosphère"@fr .
+              dcterms:description "A list of entries to classify the atmosphere represented in some content."@en ;
+              rdfs:label "Atmosphere"@en ;
+              skos:definition "a ec:Type that lists classifications of the atmosphere of the content"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Audience
@@ -8236,39 +6019,17 @@ ec:Audience rdf:type owl:Class ;
                               owl:onProperty ec:name ;
                               owl:allValuesFrom rdfs:Literal
                             ] ;
-            dcterms:description "A group of Consumers or an aggregation of groups of Consumers clustered e.g. by class of age , social categories or else."@en ,
-                                "Eine Gruppe von Nutzern oder eine Aggregation von Nutzergruppen gebildet durch z.B. Altersklasse, soziale Kategorien o.ä."@de ,
-                                "Un groupe de consommateurs ou une aggrégation de groupes de consommateurs. Par exemple, un groupe peut correspondre à un ensemble de consommateurs d'une même tranche d'âges ou d'une même catégorie socioprofessionnelle."@fr ;
-            rdfs:label "Audience"@en ,
-                       "Audience"@fr ,
-                       "Publikum"@de ;
-            skos:definition "a segment of the potential consumers of media services distinguished by criteria that shape their consumption behaviour, like age, education, sex, social status, residence, attitudes, etc"@en ,
-                            "ein Segment der potenziellen Konsumenten von Mediendiensten, das sich durch Kriterien wie Alter, Bildung, Geschlecht, sozialer Status, Wohnort, Einstellungen usw. auszeichnet, die ihr Konsumverhalten beeinflussen"@de ,
-                            "un segment de consommateurs potentiels de services de médias qui se distingue par des critères qui déterminent son comportement de consommation, comme l'âge, l'éducation, le sexe, le statut social, le lieu de résidence, les attitudes, etc."@fr ;
-            skos:example """- 14 bis 29 Jahre
-- Landjugend
-- Männer über 70
-- kulturinteressierte Menschen
-- Spaßorientierte Menschen
-- Eltern von Schulkindern
-- Gering gebildete Männer unter 25
-- junge progressive Menschen"""@de ,
-                         """- age 14 to 29
+            dcterms:description "A group of potential media consumers clustered by age, interest, social categories, or similar. Audience descriptions are used to characterize the intended or observed population for editorial or service analysis."@en ;
+            rdfs:label "Audience"@en ;
+            skos:definition "a group of potential media consumers clustered by age, interest, social categories, or similar"@en ;
+            skos:example """- age 14 to 29
 - rural youth
 - males over 70
 - culture oriented people
 - fun oriented people
 - school kid's parents
 - low educated males under 25
-- young progressive people"""@en ,
-                         """- de 14 à 29 ans
-- les jeunes ruraux
-- les hommes de plus de 70 ans
-- personnes orientées vers la culture
-- personnes orientées vers le divertissement
-- parents d'écoliers
-- hommes peu instruits de moins de 25 ans
-- jeunes progressistes"""@fr .
+- young progressive people"""@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AudienceLevel
@@ -8278,12 +6039,9 @@ ec:AudienceLevel rdf:type owl:Class ;
                                    owl:onProperty ec:targetAudienceSystem ;
                                    owl:allValuesFrom rdfs:Literal
                                  ] ;
-                 dcterms:description "Das Zielpublikum (Zielregion, Zielgruppen Kategorie der Zielgruppe, aber auch Empfehlung der Eltern), für die die MedienResource bestimmt ist."@de ,
-                                     "Le public cible (région cible, catégorie de catégorie de public cible mais aussi recommandation d'orientation parentale) à laquelle la ressource médiatique est destinée."@fr ,
-                                     "The target audience (target region, target audience category but also parental guidance recommendation) for which the media resource is intended. This is provided as free text in an annotation label or as an identifier pointing to a term in a classification scheme."@en ;
-                 rdfs:label "Public cible"@fr ,
-                            "Target audience"@en ,
-                            "Zielpublikum"@de .
+                 dcterms:description "The rating of the conformity of some content to an intended audience defined by a target audience system."@en ;
+                 rdfs:label "Target audience"@en ;
+                 skos:definition "a ec:Rating for the conformity of the ec:EditorialObject to an intended ec:Audience"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AudienceRating
@@ -8293,56 +6051,41 @@ ec:AudienceRating rdf:type owl:Class ;
                                     owl:onProperty ec:hasAudienceScoreRecordingTechnique ;
                                     owl:allValuesFrom skos:Concept
                                   ] ;
-                  dcterms:description "Die Zielgruppe, für die die Resource geeignet ist gemäß Einstufungen wie MPAA (http://en.wikipedia.org/wiki/Motion_picture_rating_system) oder anderen organisatorischen / nationalen / lokalen Standards."@de ,
-                                      "Le public par lequel la ressource peut être vu selon des classements tels que MPAA (http://en.wikipedia.org/wiki/Motion_picture_rating_system) ou d'autres normes organisationnelles / nationales / locales."@fr ,
-                                      "The audience by which the Resource can be seen according to ratings like MPAA (http://en.wikipedia.org/wiki/Motion_picture_rating_system) or other organisational / national / local standards."@en ;
-                  rdfs:label "Audience rating"@en ,
-                             "Classification du public"@fr ,
-                             "Eignung für Publikum"@de .
+                  dcterms:description "The level of appropriateness for a defined audience according to a standard, e.g. like http://en.wikipedia.org/wiki/Motion_picture_rating_system."@en ;
+                  rdfs:label "Audience rating"@en ;
+                  skos:definition "a ec:Rating expressing the appropriateness for a defined ec:Audience"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AudienceScoreRecordingTechnique
 ec:AudienceScoreRecordingTechnique rdf:type owl:Class ;
                                    rdfs:subClassOf skos:Concept ;
-                                   dcterms:description "Définir la technique utilisée pour mesurer un score d'audience."@fr ,
-                                                       "To define the technique use to measure an audience score."@en ,
-                                                       "Um die Technik zu definieren, mit der ein Publikumsscore gemessen wird."@de ;
-                                   rdfs:label "Audience score recording technique"@en ,
-                                              "Aufnahmetechnik für Publikumspartituren"@de ,
-                                              "Technique d'enregistrement des partitions d'audience"@fr .
+                                   dcterms:description "An entry from the classification of techniques used to measure audience score."@en ;
+                                   rdfs:label "Audience score recording technique"@en ;
+                                   skos:definition "a skos:Concept classifying the technique used to measure an audience score"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AudioChannelFunction
 ec:AudioChannelFunction rdf:type owl:Class ;
                         rdfs:subClassOf skos:Concept ;
-                        dcterms:description "Pour définir la fonction d'un AudioChannel."@fr ,
-                                            "So definieren Sie die Funktion eines AudioChannels."@de ,
-                                            "To define the function of an AudioChannel."@en ;
-                        rdfs:label "Audio channel function"@en ,
-                                   "Fonction de canal audio"@fr ,
-                                   "Funktion Audiokanal"@de .
+                        dcterms:description "An entry from the classification of functions of an audio channel."@en ;
+                        rdfs:label "Audio channel function"@en ;
+                        skos:definition "a skos:Concept classifying the function of audio channel"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AudioChannelPurpose
 ec:AudioChannelPurpose rdf:type owl:Class ;
                        rdfs:subClassOf skos:Concept ;
-                       dcterms:description "Pour définir l'objectif d'un AudioChannel."@fr ,
-                                           "To define the purpose of an AudioChannel."@en ,
-                                           "Um den Zweck eines AudioChannels zu definieren."@de ;
-                       rdfs:label "Audio channel purpose"@en ,
-                                  "Objectif du canal audio"@fr ,
-                                  "Zweck des Audiokanals"@de .
+                       dcterms:description "An entry from the classification of purposes of an audio channel."@en ;
+                       rdfs:label "Audio channel purpose"@en ;
+                       skos:definition "a skos:Concept classifying the purpose of an audio channel"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AudioCodec
 ec:AudioCodec rdf:type owl:Class ;
               rdfs:subClassOf ec:Codec ;
-              dcterms:description "Pour fournir des informations sur un codec audio."@fr ,
-                                  "To provide information about an audio codec."@en ,
-                                  "Zur Bereitstellung von Informationen über einen Audiocodec."@de ;
-              rdfs:label "Audio codec"@en ,
-                         "Audio-Codec"@de ,
-                         "Codec audio"@fr .
+              dcterms:description "The codec used in the production of audio content."@en ;
+              rdfs:label "Audio codec"@en ;
+              skos:definition "a ec:Codec used in the production of an audio stream, file or track"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AudioContent
@@ -8377,70 +6120,49 @@ ec:AudioContent rdf:type owl:Class ;
                                   owl:onProperty ec:loudnessMethod ;
                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                 ] ;
-                dcterms:description "An audioContent defines one component of a programme (e.g. background music), its association with an audioGroup (e.g. a 2.0 audioPackFormat of audioChannelFormats for stereo reproduction), its association with an audioStreamFormat, and its set of loudness parameters."@en ,
-                                    "Ein audioContent definiert eine Komponente eines Programms (z.B. Hintergrundmusik Musik), seine Zuordnung zu einer audioGroup (z.B. ein 2.0 audioPackFormat von audioChannelFormats für die Stereowiedergabe), seine Zuordnung zu einem audioStreamFormat und seine Lautheitsparameter."@de ,
-                                    "Un AudioContent définit un composant d'un programme (par exemple, une musique de fond musique), son association avec un audioGroup (par exemple, un 2.0 audioPackFormat de audioChannelFormats pour la reproduction stéréo), son association avec un audioStreamFormat, et son ensemble de paramètres d'intensité sonore."@fr ;
-                rdfs:label "Audio content"@en ,
-                           "Audio-inhalt"@de ,
-                           "Contenu audio"@fr .
+                dcterms:description "A segment of a programme with its descriptive metadata according to the EBU R128 loudness standard and its set of loudness parameters. This notion of a segment will often, but not always, encompass the entire timeline."@en ;
+                rdfs:label "Audio content"@en ;
+                skos:definition "a ec:EditorialSegment of audio signals that are described according to the EBU R128 loudness standard"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AudioContentType
 ec:AudioContentType rdf:type owl:Class ;
                     rdfs:subClassOf skos:Concept ;
-                    dcterms:description "pour définir un type de AudioContent."@fr ,
-                                        "to define a type of AudioContent."@en ,
-                                        "um einen Typ von AudioContent zu definieren."@de ;
-                    rdfs:label "Audio content type"@en ,
-                               "Typ der Audio-Inhalte"@de ,
-                               "Type de contenu audio"@fr .
+                    dcterms:description "An entry from the classification of types of audio content according to the loudness standard."@en ;
+                    rdfs:label "Audio content type"@en ;
+                    skos:definition "a skos:Concept classifying the type of ec:AudioContent"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AudioDescription
 ec:AudioDescription rdf:type owl:Class ;
                     rdfs:subClassOf ec:AudioTrack ;
-                    dcterms:description "A Track containing audio description."@en ,
-                                        "Ein Track mit Audiobeschreibung."@de ,
-                                        "Une piste contenant une description audio."@fr ;
-                    rdfs:label "Audio description"@en ,
-                               "Audio-Beschreibung"@de ,
-                               "Description audio"@fr .
+                    dcterms:description "An audio track describing the visible scenes for visually impaired viewers."@en ;
+                    rdfs:label "Audio description"@en ;
+                    skos:definition "a ec:AudioTrack describing the visible scenes on the screen for the visually impaired"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AudioEncodingFormat
 ec:AudioEncodingFormat rdf:type owl:Class ;
                        rdfs:subClassOf ec:EncodingFormat ;
-                       dcterms:description "Das Kodierungsformat für das Audio."@de ,
-                                           "Le format d'encodage pour l'audio."@fr ,
-                                           "The encoding format for the audio."@en ;
-                       rdfs:label "Audio encoding format"@en ,
-                                  "Format d'encodage audio"@fr ,
-                                  "Format der Audiokodierung"@de .
+                       dcterms:description "An entry from the classification of transformations that produce digital audio resources from audio signals."@en ;
+                       rdfs:label "Audio encoding format"@en ;
+                       skos:definition "a ec:EncodingFormat classifying the transformation from an audio signal to audio data in a ec;MediaResource"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AudioFormat
 ec:AudioFormat rdf:type owl:Class ;
                rdfs:subClassOf ec:Format ;
-               dcterms:description "Spezifiziert das Audioformat der MedienResource."@de ,
-                                   "Spécifie le format audio."@fr ,
-                                   "To specify the format used for audio."@en ;
-               rdfs:label "Audio format"@en ,
-                          "Audioformat"@de ,
-                          "Format audio"@fr .
+               dcterms:description "An entry from the classification of audio formats."@en ;
+               rdfs:label "Audio format"@en ;
+               skos:definition "a ec:Format classifying the encoding format used for audio information"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AudioObject
 ec:AudioObject rdf:type owl:Class ;
                rdfs:subClassOf ec:MediaResource ;
-               dcterms:description "Pour définir un objet audio en référence au Modèle de définition audio (ADM)"@fr ,
-                                   "So definieren Sie ein Audioobjekt mit Bezug auf das Audio Definition Model (ADM)"@de ,
-                                   "To define an audio object in reference to the Audio Definition Model (ADM)"@en ;
-               rdfs:label "Audio object"@en ,
-                          "Audio-Objekt"@de ,
-                          "Objet audio"@fr ;
-               skos:definition "a MediaResource in the form of an object in reference to the Audio Definition Model (ADM)"@en ,
-                               "eine MedienResource in Form eines Objektes wie es im Audio Definition Model (ADM) beschrieben ist"@de ,
-                               "une ressource média sous la forme d'un objet tel que décrit dans le modèle de définition audio (ADM)"@fr .
+               dcterms:description "A media resource in the form of an object in reference to the Audio Definition Model (ADM)."@en ;
+               rdfs:label "Audio object"@en ;
+               skos:definition "a ec:MediaResource in the form of an object in reference to the Audio Definition Model (ADM)"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AudioProgramme
@@ -8475,59 +6197,42 @@ ec:AudioProgramme rdf:type owl:Class ;
                                     owl:onProperty ec:loudnessMethod ;
                                     owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                   ] ;
+                  dcterms:description "A whole programme with its descriptive metadata according to the EBU R128 loudness standard and its set of loudness parameters."@en ;
                   rdfs:isDefinedBy <https://tech.ebu.ch/docs/r/r128.pdf> ;
-                  rdfs:label "Audio Programm"@de ,
-                             "Audio programme"@en ,
-                             "Programme audio"@fr ;
-                  skos:definition """An individual, self-contained audio-visual or audio-only item to be presented in Radio, Television or other electronic media. An advertisement (commercial), trailer, promotional item (‘promo’),
-interstitial or similar item (“Short-form Content”) shall also be
-considered to be an (Audio)programme in this context."""@en ,
-                                  "Ein einzelner, in sich geschlossener audiovisueller oder reiner Audiobeitrag, der im Radio, Fernsehen oder anderen elektronischen Medien präsentiert wird. Auch Werbung (Werbespot), Trailer, Werbebeiträge („Promo“), Interstitials oder ähnliche Beiträge („Kurzformat-Inhalte“) gelten in diesem Zusammenhang als \"AudioProgramme\"."@de ,
-                                  "Un élément audiovisuel individuel et autonome, ou uniquement audio, destiné à être diffusé à la radio, à la télévision ou sur d'autres supports électroniques. Une publicité (annonce), une bande-annonce, un élément promotionnel (promo), un interstitiel ou un élément similaire (le « contenu court ») est également considéré comme un \"AudioProgramme\" dans ce contexte."@fr .
+                  rdfs:label "Audio programme"@en ;
+                  skos:definition "an ec:EditorialWork of audio signals that are described according to the EBU R128 loudness standard"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AudioProgrammeType
 ec:AudioProgrammeType rdf:type owl:Class ;
                       rdfs:subClassOf skos:Concept ;
-                      dcterms:description "pour définir un type d'AudioProgramme."@fr ,
-                                          "to define a type of AudioProgramme."@en ,
-                                          "um einen Typ von AudioProgrammen zu definieren."@de ;
-                      rdfs:label "Audio programme type"@en ,
-                                 "Typ des Audioprogramms"@de ,
-                                 "Type de programme audio"@fr .
+                      dcterms:description "An entry from the classification of types of audio programmes as used for measuring loudness in a finished production."@en ;
+                      rdfs:label "Audio programme type"@en ;
+                      skos:definition "a skos:Concept classifying the type of ec:AudioProgrammet"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AudioStream
 ec:AudioStream rdf:type owl:Class ;
                rdfs:subClassOf ec:Stream ;
-               dcterms:description "An audioStreamFormat describes a decodable signal - PCM signal or a Dolby E stream for example. It is composed of one or more AudioTracks."@en ,
-                                   "Ein audioStreamFormat beschreibt ein dekodierbares Signal - zum Beispiel ein PCM-Signal oder einen Dolby E-Stream. Es besteht aus einem oder mehreren AudioTracks."@de ,
-                                   "Un AudioStreamFormat décrit un signal décodable - un signal PCM ou un flux Dolby E par exemple. Il est composé d'une ou plusieurs AudioTracks."@fr ;
-               rdfs:label "Audio stream"@en ,
-                          "Audio-Stream"@de ,
-                          "Flux audio"@fr .
+               dcterms:description "A data stream containing a decidable audio signal, e.g. PCM, Dolby E. It is composed of one or more AudioTracks."@en ;
+               rdfs:label "Audio stream"@en ;
+               skos:definition "a ec:Stream with encoded audio"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AudioTrack
 ec:AudioTrack rdf:type owl:Class ;
               rdfs:subClassOf ec:Track ;
-              dcterms:description "An audioTrack is the basic audio data container of a medium. Attribute is an unambiguous reference to this container in a given medium. An audioTrack object defines a component of an audioStream. A single set of samples or data in the storage medium. Represents a physical container or carrier to hold an audio stream. This should be usually defined by many attributes such as ID, format (e.g. 48 kHz/24 bits), linkage information (e.g. odd/even)â€¦"@en ,
-                                  "Ein audioTrack ist der grundlegende Audiodaten-Container eines Mediums. Ein Attribut ist ein eindeutiger Verweis auf diesen Container in einem bestimmten Medium."@de ,
-                                  "Une audioTrack est le conteneur de données audio de base d'un support. L'attribut est une référence non ambiguë à ce conteneur dans un support donné."@fr ;
-              rdfs:label "Audio track"@en ,
-                         "Audiospur"@de ,
-                         "Piste audio"@fr .
+              dcterms:description "A track that contains encoded audio signals and defines a component of an audio stream."@en ;
+              rdfs:label "Audio track"@en ;
+              skos:definition "a ec:Track containing encoded audio signal and forming part of an ech:AudioStream"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AudioTrackPurpose
 ec:AudioTrackPurpose rdf:type owl:Class ;
                      rdfs:subClassOf skos:Concept ;
-                     dcterms:description "Pour décrire l'objectif d'une piste audio, par exemple le doublage."@fr ,
-                                         "To describe the purpose of an AudioTrack e.g. dubbing."@en ,
-                                         "Um den Zweck eines AudioTracks zu beschreiben, z.B. die Nachvertonung."@de ;
-                     rdfs:label "Audio track purpose"@en ,
-                                "Objectif de la piste audio"@fr ,
-                                "Zweck der Audiospur"@de .
+                     dcterms:description "An entry from the classification of purposes of an audio track."@en ;
+                     rdfs:label "Audio track purpose"@en ;
+                     skos:definition "a skos:Concept classifying the purpose of an ec:AudioTrack"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AuditJob
@@ -8541,24 +6246,12 @@ ec:AuditJob rdf:type owl:Class ;
                               owl:onProperty ec:usesMeasure ;
                               owl:allValuesFrom ec:Measure
                             ] ;
-            dcterms:description "Eine Prüfaufgabe untersucht die Einhaltung einer Regel durch eine Messung."@de ,
-                                "L'évaluation de la conformité est effectuée par rapport à une mesure, Measure, associée à une règle, Rule, via un AuditJob."@fr ,
-                                "The assessment of compliance is made against a Measure associated with a Rule via an AuditJob."@en ;
-            rdfs:label "Audit Job"@en ,
-                       "Prüfaufgabe"@de ,
-                       "Une tâche d'audit"@fr ;
-            skos:definition "Bewertung der Einhaltung einer Maßnahme"@de ,
-                            "assessment of compliance against a Measure"@en ,
-                            "évaluation de la conformité par rapport à une mesure"@fr ;
-            skos:example """- Messung des maximalen Lautstärkepegels in der Tonspur einer Videodatei
-- Messung des Anteils der Redezeit in einer Debatte der Kandidaten vor einer Wahl
-- Messung des Anteils der männlichen/weiblichen Experten in allen Programmen eines Publikationsdienstes"""@de ,
-                         """- measuring the maximum volume level in the audio track of a video file
+            dcterms:description "The assessment of compliance is made against a Measure associated with a Rule via an AuditJob."@en ;
+            rdfs:label "Audit job"@en ;
+            skos:definition "an assessment of compliance against a Measure"@en ;
+            skos:example """- measuring the maximum volume level in the audio track of a video file
 - measuring the share of speaker time in a debate of the candidates before an election
-- measuring the share of male/females experts across all programmes of a publication service"""@en ,
-                         """- mesurer le niveau de volume maximal de la piste audio d'un fichier vidéo
-- mesurer la part du temps de parole dans un débat des candidats avant une élection
-- mesurer la part des experts hommes/femmes dans l'ensemble des programmes d'un service de publication"""@fr .
+- measuring the share of male/females experts across all programmes of a publication service"""@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AuditReport
@@ -8603,12 +6296,8 @@ ec:AuditReport rdf:type owl:Class ;
                                  owl:onProperty ec:name ;
                                  owl:allValuesFrom rdfs:Literal
                                ] ;
-               dcterms:description "An AuditReport aggregates results from related AuditJob."@en ,
-                                   "Ein Prüfbericht führt die Ergebnisse von Prüfaufgaben zusammen."@de ,
-                                   "Un rapport d'audit regroupe les résultats des tâche de contrôle auxquelles il est lié."@fr ;
-               rdfs:label "Audit Report"@en ,
-                          "Prüfbericht"@de ,
-                          "Rapport d'audit"@fr ;
+               dcterms:description "An AuditReport aggregates results from related AuditJob."@en ;
+               rdfs:label "Audit report"@en ;
                skos:definition "a report on aggregated results from auditing"@en .
 
 
@@ -8655,23 +6344,17 @@ ec:Award rdf:type owl:Class ;
                            owl:onProperty ec:awardCeremony ;
                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
                          ] ;
-         dcterms:description "Pour décrire un prix et les informations associées."@fr ,
-                             "To describe an Award and associated information."@en ,
-                             "Zur Beschreibung eines Awards und der damit verbundenen Informationen."@de ;
-         rdfs:label "Auszeichnung"@de ,
-                    "Award"@en ,
-                    "Prix"@fr .
+         dcterms:description "A prize, such as money, or something else, for something that somebody has done."@en ;
+         rdfs:label "Award"@en ;
+         skos:definition "a financial or symbolic prize given to an ec:Agent to honor an outstanding performance, achievement or contribution"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AwardType
 ec:AwardType rdf:type owl:Class ;
              rdfs:subClassOf skos:Concept ;
-             dcterms:description "Pour définir un type d'attribution."@fr ,
-                                 "To define a type of Award."@en ,
-                                 "Um eine Art von Award zu definieren."@de ;
-             rdfs:label "Art der Auszeichnung"@de ,
-                        "Award type"@en ,
-                        "Type de prix"@fr .
+             dcterms:description "An entry from the classification of award types."@en ;
+             rdfs:label "Award type"@en ;
+             skos:definition "a skos:Concept classifying the type of ec:Award"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#BibliographicalObject
@@ -8685,23 +6368,17 @@ ec:BibliographicalObject rdf:type owl:Class ;
                                            owl:onProperty ec:references ;
                                            owl:allValuesFrom ec:EditorialObject
                                          ] ;
-                         dcterms:description "Documents de nature diverse."@fr ,
-                                             "Documents of various nature."@en ,
-                                             "Dokumente verschiedener Art."@de ;
-                         rdfs:label "Bibliographical object"@en ,
-                                    "Bibliographisches Objekt"@de ,
-                                    "Objet bibliographique"@fr .
+                         dcterms:description "A written piece of work."@en ;
+                         rdfs:label "Bibliographical object"@en ;
+                         skos:definition "a ec:Asset consisting of text"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Biography
 ec:Biography rdf:type owl:Class ;
              rdfs:subClassOf ec:BibliographicalObject ;
-             dcterms:description "Pour enregistrer une biographie."@fr ,
-                                 "To record a biography."@en ,
-                                 "Um eine Biographie aufzunehmen."@de ;
-             rdfs:label "Biographie"@de ,
-                        "Biographie"@fr ,
-                        "Biography"@en .
+             dcterms:description "A book about the life of a person."@en ;
+             rdfs:label "Biography"@en ;
+             skos:definition "a ec:BibliographicalObject about the life of a ec:Person"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Campaign
@@ -8738,71 +6415,45 @@ ec:Campaign rdf:type owl:Class ;
                               owl:onProperty ec:title ;
                               owl:allValuesFrom rdfs:Literal
                             ] ;
-            dcterms:description "A Campaign defines a strategy for publishing content (EditorialObjects and related Resources/MediaResources/Essences) to a targeted Audience according to a PublicationPlan. Campaign strategies can be adapted taking into account the analysis of the Resonance of related ConsumptionEvents (e.g. likes, downloads, etc). Campaigns can apply to a variety of broadcasting strategies e.g. advertising campaigns, promotional campaigns or else."@en ,
-                                "Eine Kampagne legt die Strategie zur Publikation eines Produktes (Medieninhalt und damit verbundene Resourcen/Medienobjekte/Essenzen) für ein Zielpublikum gemäß eines Publikationsplans fest. Kampagnenstrategien können angepasst werden, indem die Resonanz auf Nutzungsereignisse (z.B. likes, downloads, etc.) analysiert wird. Kampagnen können für unterschiedlichste Produkte angewendet werden, z.B. Werbekampagnen, Promotionskampagnen, o.ä."@de ,
-                                "Une campagne définit une stratégie de publication de contenu (objets éditoriaux et ressources/médias/essence) auprès d'un public cible conformément à un plan de publication. Les stratégies de campagne peuvent être adaptées en fonction l'analyse de la Résonance de la Consommation des Evenements associée ( par exemple le nombre de like ou de téléchargements, etc ...). Les campagnes s'appliquent à différentes stratégies de diffusion, on peut citer par exemple les campagnes publicitaires ou les campagnes promotionnelles."@fr ;
-            rdfs:label "Campagne"@fr ,
-                       "Campaign"@en ,
-                       "Kampagne"@de ;
-            skos:definition "a strategy for coordinated publishing effort towards a target audience"@en ,
-                            "eine Strategie zur koordinierten Veröffentlichung von Medieninhalten für ein Zielpublikum"@de ,
-                            "une stratégie de coordination des efforts de publication en direction d'un public cible"@fr ;
+            dcterms:description "A Campaign defines a strategy for publishing content (EditorialObjects and related Resources/MediaResources/Essences) to a targeted Audience according to a PublicationPlan. Campaign strategies can be adapted taking into account the analysis of the Resonance of related ConsumptionEvents (e.g. likes, downloads, etc.). Campaigns can apply to a variety of broadcasting strategies e.g. advertising campaigns, promotional campaigns or else."@en ;
+            rdfs:label "Campaign"@en ;
+            skos:definition "a strategy for coordinated publishing effort towards a target audience"@en ;
             skos:example """- an advertisement effort for a product, by publishing a set of videos at a time and on a channel, when and where the target audience can be effectively reached
-- an announcement of the journalistic coverage of an upcoming government election from many different perspectives and for a variety of target audiences published on several channels of linear TV, linear radio, social media, podcast portals, etc."""@en ,
-                         """- eine Werbemaßnahme für ein Produkt, bei der eine Reihe von Videos zu einem Zeitpunkt und auf einem Kanal veröffentlicht wird, zu dem und an dem das Zielpublikum effektiv erreicht werden kann
-- eine Ankündigung der journalistischen Berichterstattung über eine bevorstehende Regierungswahl aus vielen verschiedenen Perspektiven und für eine Vielzahl von Zielgruppen, die auf mehreren Kanälen des linearen Fernsehens, des linearen Radios, der sozialen Medien, der Podcast-Portale usw. veröffentlicht wird"""@de ,
-                         """- un effort publicitaire pour un produit, en publiant un ensemble de vidéos à un moment et sur un canal, quand et où le public cible peut être atteint efficacement
-- une annonce de la couverture journalistique d'une élection gouvernementale à venir sous de nombreux angles différents et pour une variété de publics cibles, publiée sur plusieurs canaux de télévision linéaire, de radio linéaire, de médias sociaux, de portails de podcasts, etc."""@fr .
+- an announcement of the journalistic coverage of an upcoming government election from many different perspectives and for a variety of target audiences published on several channels of linear TV, linear radio, social media, podcast portals, etc."""@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#CampaignPackage
 ec:CampaignPackage rdf:type owl:Class ;
                    rdfs:subClassOf ec:EditorialGroup ;
-                   rdfs:label "Campaign package"@en ,
-                              "Kampagnen-Paket"@de ,
-                              "Paquet de campagne"@fr ;
-                   skos:definition "a group of EditorialObjects to advertise a product, a service, an event ..."@en ,
-                                   "eine Gruppe von EditorialObjects, um ein Produkt, eine Dienstleistung, ein Ereignis zu bewerben ..."@de ,
-                                   "un groupe d'EditorialObjects pour faire la publicité d'un produit, d'un service, d'un événement ..."@fr ;
+                   dcterms:description "A package of promotional content to advertise a product, a service, an event or similar in various ways but in a coordinated effort."@en ;
+                   rdfs:label "Campaign package"@en ;
+                   skos:definition "an ec:EditorialGroup whose members are brought together to advertise a product, a service, an event, or similar in various ways but in a coordinated effort"@en ;
                    skos:example """- a set of different ads for one product
-- a set of different trailers for a film"""@en ,
-                                """- eine Reihe von verschiedenen Anzeigen für ein Produkt
-- eine Reihe von verschiedenen Trailern für einen Film"""@de ,
-                                """- un ensemble de publicités différentes pour un produit
-- un ensemble de bandes-annonces différentes pour un film"""@fr .
+- a set of different trailers for a film"""@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Captioning
 ec:Captioning rdf:type owl:Class ;
               rdfs:subClassOf ec:Track ;
-              dcterms:description "Pour signaler la présence de malentendants sous-titrage."@fr ,
-                                  "To signal the presence of hard of hearing captioning."@en ,
-                                  "Um das Vorhandensein von Schwerhörigkeit zu signalisieren Untertitelung."@de ;
-              rdfs:label "Captioning"@en ,
-                         "Sous-titrage"@fr ,
-                         "Untertitel"@de .
+              dcterms:description "A track containing text from transcribed dialogues or a description of the audio for the hard of hearing."@en ;
+              rdfs:label "Captioning"@en ;
+              skos:definition "a ec:Track containing text from transcribed dialogues or description of the audio for the hard of hearing"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#CaptioningFormat
 ec:CaptioningFormat rdf:type owl:Class ;
                     rdfs:subClassOf ec:DataFormat ;
-                    dcterms:description "Définir le format du sous-titrage. L'utilisation principale du sous-titrage est la transcription pour les malentendants. Celle-ci est fournie sous forme de texte libre dans une étiquette d'annotation ou comme un identifiant pointant vers un terme dans un schéma de classification."@fr ,
-                                        "To define the format of captioning. Captioning's main use is for hard of hearing transcription. This is provided as free text in an annotation label or as an identifier pointing to a term in a classification scheme."@en ,
-                                        "Zur Definition des Formats der Untertitelung. Untertitel werden hauptsächlich für die Übertragung für Hörgeschädigte verwendet. Diese wird als freier Text in einer Beschriftung oder als Kennung, die auf einen Begriff in einem Klassifikationsschema."@de ;
-                    rdfs:label "Captioning format"@en ,
-                               "Format de sous-titrage"@fr ,
-                               "Format der Untertitel"@de .
+                    dcterms:description "An entry from the classification of structure schemes for captioning data, mainly used for transcription."@en ;
+                    rdfs:label "Captioning format"@en ;
+                    skos:definition "a ec:DataFormat classifying the structure of captioning data from transcriptions"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#CastMember
 ec:CastMember rdf:type owl:Class ;
               rdfs:subClassOf ec:Person ;
-              dcterms:description "A member of the cast list (a list of performers/actors and associated fictitious characters)."@en ,
-                                  "Ein Mitglied der Besetzungsliste (eine Liste von Darstellern/Schauspielern und zugehörigen fiktiven Charaktere)."@de ,
-                                  "Un membre de la liste des acteurs (une liste d'interprètes/acteurs et de personnages fictifs associés)."@fr ;
-              rdfs:label "Cast member"@en ,
-                         "Membre de la distribution"@fr ,
-                         "Mitglied der Besetzung"@de .
+              dcterms:description "A cast member performs a role or acts as a character in a screenplay."@en ;
+              rdfs:label "Cast member"@en ;
+              skos:definition "a ec:Person that is a member of the cast of a fictional piece of work"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Character
@@ -8829,56 +6480,41 @@ ec:Character rdf:type owl:Class ;
                                owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                owl:onClass ec:Person
                              ] ;
-             dcterms:description "E.g. a fictitious contact / person."@en ,
-                                 "Par exemple, un contact / une personne fictive."@fr ,
-                                 "Z.B. ein fiktiver Kontakt / eine fiktive Person."@de ;
-             rdfs:label "Caractère"@fr ,
-                        "Character"@en ,
-                        "Rolle"@de .
+             dcterms:description "A character is played by an actor in a screenplay or drama."@en ;
+             rdfs:label "Character"@en ;
+             skos:definition "a fictitious ec:Person in a screenplay or drama"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#CityCode
 ec:CityCode rdf:type owl:Class ;
             rdfs:subClassOf skos:Concept ;
-            dcterms:description "Pour attribuer un code de ville."@fr ,
-                                "So weisen Sie einen Stadtcode zu."@de ,
-                                "To allocate a city code."@en ;
-            rdfs:label "City code"@en ,
-                       "Code de la ville"@fr ,
-                       "Stadtcode"@de .
+            dcterms:description "An entry from the postal codes of cities."@en ;
+            rdfs:label "City code"@en ;
+            skos:definition "a skos:Concept classifying cities by their postal codes"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ClosedCaptions
 ec:ClosedCaptions rdf:type owl:Class ;
                   rdfs:subClassOf ec:Captioning ;
-                  dcterms:description "Closed captioning is provided as separate content."@en ,
-                                      "Le sous-titrage codé est fourni en tant que contenu."@fr ,
-                                      "Untertitel werden als separater Inhalt bereitgestellt. Inhalt."@de ;
-                  rdfs:label "Closed caption"@en ,
-                             "Geschlossene Unterschrift"@de ,
-                             "Légende fermée"@fr .
+                  dcterms:description "A captioning that exists in a media resource of its own, outside of video, i.e. it can be turned on or off at any time."@en ;
+                  rdfs:label "Closed caption"@en ;
+                  skos:definition "a ec:Captioning that exists in a ec:MediaResource of its own, outside of video"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ClosedSigning
 ec:ClosedSigning rdf:type owl:Class ;
                  rdfs:subClassOf ec:Signing ;
-                 dcterms:description "Closed signing is provided as separate content."@en ,
-                                     "Geschlossene Gebärdensprache wird als separater Inhalt bereitgestellt."@de ,
-                                     "La signalisation fermée est fournie en tant que contenu séparé."@fr ;
-                 rdfs:label "Closed signing"@en ,
-                            "Geschlossene Gebärdensprache"@de ,
-                            "Signalisation fermée"@fr .
+                 dcterms:description "A signing that is provided as a separate media resource, separate from the video or audio content, i.e., it can be turned on or off at any time."@en ;
+                 rdfs:label "Closed signing"@en ;
+                 skos:definition "a ec:Signing that exists in a ec:MediaResource of its own, outside of video"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ClosedSubtitling
 ec:ClosedSubtitling rdf:type owl:Class ;
                     rdfs:subClassOf ec:Subtitling ;
-                    dcterms:description "Closed subtitles are provided as separate content."@en ,
-                                        "Geschlossene Untertitel werden als separater Inhalt bereitgestellt. Inhalt."@de ,
-                                        "Les sous-titres fermés sont fournis en tant que contenu."@fr ;
-                    rdfs:label "Closed subtitling"@en ,
-                               "Geschlossene Untertitelung"@de ,
-                               "Sous-titrage fermé"@fr .
+                    dcterms:description "A subtitling that is carried in its own media resource, besides media resources for audio and/or video. Subtitling can be turned on or off."@en ;
+                    rdfs:label "Closed subtitling"@en ;
+                    skos:definition "a ec:Subtitling that exists in a ec:MediaResource of its own, outside of video"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Codec
@@ -8911,57 +6547,41 @@ ec:Codec rdf:type owl:Class ;
                            owl:onProperty ec:name ;
                            owl:allValuesFrom rdfs:Literal
                          ] ;
-         dcterms:description "Pour fournir des informations sur un codec."@fr ,
-                             "To provide information on a codec."@en ,
-                             "Um Informationen über einen Codec bereitzustellen."@de ;
-         rdfs:label "Codec"@de ,
-                    "Codec"@en ,
-                    "Codec"@fr .
+         dcterms:description "The technique used to encode and decode photo, video, or audio information into files or streams."@en ;
+         rdfs:label "Codec"@en ;
+         skos:definition "a coding/decoding technique used in the production of a ec:MediaResource"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Collection
 ec:Collection rdf:type owl:Class ;
               rdfs:subClassOf ec:EditorialGroup ;
-              dcterms:description "A group of EditorialObjects. There can be many types of collections for which specific sub-classes should be defined. In the worl of archives, A collection corresponds to all items belonging to an individual / collector."@en ,
-                                  "Eine Gruppe von EditorialObjects. Es kann viele Arten von Sammlungen geben, für die spezifische Unterklassen definiert werden sollten. In der Welt der Archiven entspricht eine Sammlung allen Objekten, die zu einem einzelnen / Sammler."@de ,
-                                  "Un groupe d'EditorialObjects. Il peut y avoir de nombreux types de collections pour lesquelles des sous-classes spécifiques doivent être définies. Dans le monde des archives, une collection correspond à tous les éléments appartenant à un individu / collectionneur."@fr ;
-              rdfs:label "Collection"@en ,
-                         "Collection"@fr ,
-                         "Kollektion"@de .
+              dcterms:description "A group of content of many types. Grouping is done according to a concept or intention. In the world of archives, a collection corresponds to all items belonging to an individual/collector."@en ;
+              rdfs:label "Collection"@en ;
+              skos:definition "an ec:EditorialGroup that can group content of any type"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ColourSpace
 ec:ColourSpace rdf:type owl:Class ;
                rdfs:subClassOf ec:Format ;
-               dcterms:description "Der Farbraum einer VideoResource. A ColourSpace wird als freier Text in einer Beschriftung oder als Bezeichner definiert, der auf einen Begriff in einem auf einen Begriff in einem Klassifizierungsschema wie http://www.ebu.ch/metadata/ontologies/skos/ebu_ColourCodeCS.rdf."@de ,
-                                   "L'espace-couleur d'une VideoResource. A espace couleur est défini comme du texte libre dans une étiquette d'annotation ou comme un identifiant pointant vers un terme dans un schéma de classification tel que http://www.ebu.ch/metadata/ontologies/skos/ebu_ColourCodeCS.rdf."@fr ,
-                                   "The CoulourSpace of a VideoResource. A ColourSpace is defined as free text in an annotation label or as an identifier pointing to a term in a classification scheme such as http://www.ebu.ch/metadata/ontologies/skos/ebu_ColourCodeCS.rdf."@en ;
-               rdfs:label "Colour space"@en ,
-                          "Espace couleur"@fr ,
-                          "Farbraum"@de .
+               dcterms:description "An entry from the classification of colour spaces for videos."@en ;
+               rdfs:label "Colour space"@en ;
+               skos:definition "a ec:Format classifying the colour space of a video"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#CommercialCode
 ec:CommercialCode rdf:type owl:Class ;
                   rdfs:subClassOf ec:Type ;
-                  dcterms:description "Pour identifier un type de contenu commercial."@fr ,
-                                      "To identify a type of commercial content."@en ,
-                                      "Um eine Art von kommerziellen Inhalten zu identifizieren."@de ;
-                  rdfs:label "Code commercial"@fr ,
-                             "Commercial code"@en ,
-                             "Handelsgesetzbuch"@de .
+                  dcterms:description "A list of entries to classify commercial content, e.g. EBU's classification scheme on Commerciality Type."@en ;
+                  rdfs:label "Commercial code"@en ;
+                  skos:definition "a ec:Type that lists types of commercial content"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Component
 ec:Component rdf:type owl:Class ;
              rdfs:subClassOf ec:MediaResource ;
-             dcterms:description "A component e.g. audio, video, data or else or a MediaResource or Essence."@en ,
-                                 "Eine Komponente, z.B. Audio, Video, Daten oder sonstiges oder eine MediaResource oder Essence."@de ,
-                                 "Un composant, par exemple audio, vidéo, données ou autre, ou une MediaResource ou une Essence."@fr ;
-             rdfs:label "Component"@en ,
-                        "Composant"@fr ,
-                        "Komponente"@de ;
-             skos:definition "a MediaResource that is a component of another MediaResource"@en .
+             dcterms:description "A media resource that is an ingredient of another media resource e.g. audio track, data track or similar."@en ;
+             rdfs:label "Component"@en ;
+             skos:definition "a ec:MediaResource that is an ingredient of another ec:MediaResource"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Consumer
@@ -8983,21 +6603,11 @@ ec:Consumer rdf:type owl:Class ;
                               owl:onProperty ec:usesConsumptionDevice ;
                               owl:allValuesFrom ec:ConsumptionDevice
                             ] ;
-            dcterms:description "An individual who consumes the Service using a ConsumptionDevice. The Consumer can be associated with an Audience. His actions lead to data around the ConsumptionEvents and associated ResonanceEvents. A consumer can be registered to a Service via an Account containing information about that Concumer to a varying degree of detaill (e.g. age, sex, matrimonial status, address). This is further defined in Consumption Licence when applicable."@en ,
-                                "Eine Person, die einen Service konsumiert mit Hilfe eines Endgerätes. Der Nutzer kann zu einem Publikum gehören. Seine Aktivitäten führen zu Nutzungsereignissen und zu Resonanzereignissen. Ein Nutzer kann für einen Service registriert sein über ein Nutzerkonto, das den Nutzer in unterschiedlichem Detaillierungsgrad repräsentiert (z.B. Alter, Geschlecht, Adresse). Eine Nutzungslizenz definiert die genaueren Nutzungsbedingungen und -möglichkeiten."@de ,
-                                "Un individu qui consomme le service en utilisant un ConsumptionDevice. Le Consommateur peut être associé à une Audience. Ses actions conduisent à des données autour des ConsumptionEvents et des ResonanceEvents associés. Un consommateur peut être enregistré auprès d'un service par le biais d'un compte contenant des informations plus ou moins détaillées sur ce consommateur (par exemple, âge, sexe, situation matrimoniale, adresse). Ces informations sont définies plus précisément dans la licence de consommation, le cas échéant."@fr ;
-            rdfs:label "Consommateur"@fr ,
-                       "Consumer"@en ,
-                       "Nutzer"@de ;
-            skos:definition "a Person consuming a media service"@en ,
-                            "eine Person, die einen Mediendienst konsumiert"@de ,
-                            "une personne consommant un service de médias"@fr ;
+            dcterms:description "A person consuming a media service."@en ;
+            rdfs:label "Consumer"@en ;
+            skos:definition "a ec:Person consuming a media service"@en ;
             skos:example """- a radio listener
-- a video stream viewer"""@en ,
-                         """- ein Radiohörer
-- ein Videostream-Zuschauer"""@de ,
-                         """- un auditeur de radio
-- un spectateur de flux vidéo"""@fr .
+- a video stream viewer"""@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ConsumptionCount
@@ -9050,30 +6660,14 @@ ec:ConsumptionCount rdf:type owl:Class ;
                                       owl:onProperty ec:name ;
                                       owl:allValuesFrom rdfs:Literal
                                     ] ;
-                    dcterms:description "An aggregation of groups of counted Consumers"@en ,
-                                        "Eine Ansammlung von Gruppen von gezählten Verbrauchern"@de ,
-                                        "Une agrégation de groupes de Consommateurs comptés"@fr ;
-                    rdfs:label "Comptage des consommations"@fr ,
-                               "Consumption count"@en ,
-                               "Nutzungszahl/-anteil"@de ;
-                    skos:definition "die tatsächliche Anzahl und die Umstände von ConsumptionEvents für ein einzelnes PublicationEvent"@de ,
-                                    "le nombre réel et les circonstances des ConsumptionEvents pour un seul PublicationEvent"@fr ,
-                                    "the actual number and circumstances of ConsumptionEvents for a single PublicationEvent"@en ;
-                    skos:example """- 46% de part de marché des téléspectateurs français pour la finale de la coupe du monde de football 2022
-- 72% de part de marché des téléspectateurs français âgés de 14 à 29 ans pour la finale de la coupe du monde de football 2022
-- 18,7 millions de vues en direct des funérailles de l'ancien pape Benoît XVI en Europe
-- 36973 vues de la vidéo youtube \"Tom Hanks had an ICONIC chat with the Queen\" de l'émission \"The One Show\" de la BBC publiée 6 mois plus tôt
-- 2080 personnes présentes à la Liederhalle de Stuttgart pour un concert en direct de l'orchestre symphonique du SWR le 8 avril 2022"""@fr ,
-                                 """- a 46% market share of French viewers for the football world cup final 2022
+                    dcterms:description "A count of consumption events aggregated by one or more attributed properties, e.g. start time, end time, duration, publication event, service, platform, channel, device, account, consumer, resonance event, essence (stream or file), content, content genre, serial/series/season, and so on. Consumption counts are used to answer analytical questions and to compare answers over periods of time. Standardized counts (\"consumptions on our platform in July\") can be defined as subclasses and be stored and reused for comparison."@en ;
+                    rdfs:label "Consumption count"@en ;
+                    skos:definition "a count of ec:ConsumptionEvents aggregated by one or more attributed properties"@en ;
+                    skos:example """- a 46% market share of French viewers for the football world cup final 2022
 - a 72% market share of French viewers aged 14 to 29 for the football world cup final 2022
 - 18.7 million live stream views of the funeral of former pope Benedict in Europe
 - 36973 views of the youtube-video \"Tom Hanks had an ICONIC chat with the Queen\" from BBC's \"The One Show\" 6 months after publishing
-- 2080 attendees at Stuttgart Liederhalle for a live concert of SWR's symphonic orchestra on April 8, 2022"""@en ,
-                                 """- einen Marktanteil von 46 % bei den französischen Zuschauern für das Endspiel der Fußballweltmeisterschaft 2022
-- 72 % Marktanteil bei den französischen Zuschauern zwischen 14 und 29 Jahren für das Endspiel der Fußballweltmeisterschaft 2022
-- 18,7 Millionen Live-Stream-Zugriffe auf die Beerdigung des ehemaligen Papstes Benedikt in Europa
-- 36973 Aufrufe des youtube-Videos \"Tom Hanks had an ICONIC chat with the Queen\" von BBC's \"The One Show\" 6 Monate aber Veröffentlichung
-- 2080 Besucher in der Stuttgarter Liederhalle bei einem Live-Konzert des SWR-Sinfonieorchesters am 8. April 2022"""@de .
+- 2080 attendees at Stuttgart Liederhalle for a live concert of SWR's symphonic orchestra on April 8, 2022"""@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ConsumptionDevice
@@ -9122,27 +6716,13 @@ ec:ConsumptionDevice rdf:type owl:Class ;
                                        owl:onProperty ec:name ;
                                        owl:allValuesFrom rdfs:Literal
                                      ] ;
-                     dcterms:description "A device used to consume content."@en ,
-                                         "Ein Gerät zur Nutzung eines Medienproduktes."@de ,
-                                         "Un appareil utilisé pour consommer un contenu médiatique."@fr ;
-                     rdfs:label "Appareil de consommation"@fr ,
-                                "Consumption Device"@en ,
-                                "Endgerät"@de ;
-                     skos:definition "a device for using media services"@en ,
-                                     "ein Gerät zur Nutzung von Mediendiensten"@de ,
-                                     "un appareil permettant d'utiliser les services de médias"@fr ;
+                     dcterms:description "A device for consuming a media service, such as a television, set-top box, or other playback endpoint used to access media content."@en ;
+                     rdfs:label "Consumption device"@en ;
+                     skos:definition "a device for consuming a media service"@en ;
                      skos:example """- a smartphone
 - a smart TV
 - a fm radio set
-- a beamer fed with a media signal and projecting onto a screen"""@en ,
-                                  """- ein Smartphone
-- ein Smart-TV-Gerät
-- ein UKW-Radio
-- ein Beamer, der mit einem Mediensignal gespeist wird und auf eine Leinwand projiziert"""@de ,
-                                  """- un smartphone
-- un téléviseur intelligent
-- un poste de radio fm
-- un beamer alimenté par un signal média et projetant sur un écran"""@fr .
+- a beamer fed with a media signal and projecting onto a screen"""@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ConsumptionDeviceProfile
@@ -9215,24 +6795,12 @@ ec:ConsumptionDeviceProfile rdf:type owl:Class ;
                                               owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                               owl:onDataRange xsd:boolean
                                             ] ;
-                            dcterms:description "Das Profil eines Endgerätes.(z.B. Hersteller, Modell, Hardwareausstattung, Softwareausstattung, etc.)"@de ,
-                                                "Profile d'un appareil permettant de consommer du contenu médiatique. Cela peut-être un nom de modèle avec une version de hardware ou de software."@fr ,
-                                                "The profile of a ConsumptionDevice."@en ;
-                            rdfs:label "Consumption device profile"@en ,
-                                       "Endgeräteprofil"@de ,
-                                       "Profile d'un appareil de consommation"@fr ;
-                            skos:definition "a number of properties of an individual ConsumptionDevice that allows classification of the device"@en ,
-                                            "eine Reihe von Eigenschaften eines einzelnen Endgerätes, die eine Klassifizierung des Geräts ermöglichen"@de ,
-                                            "un certain nombre de propriétés d'un appareil de consommation individuel qui permettent la classification du dispositif"@fr ;
+                            dcterms:description "A set of characteristic properties to classify a consumption device, for example manufacturer, model, operating system, screen size, etc."@en ;
+                            rdfs:label "Consumption device profile"@en ;
+                            skos:definition "a set of properties that allow classification of a ec:ConsumptionDevice"@en ;
                             skos:example """- an Apple smartphone with iOS version > 16
 - a smart TV with screen 50' to 60' and HDR support
-- a VR headset"""@en ,
-                                         """- ein Apple-Smartphone mit iOS-Version > 16
-- einen Smart TV mit einem Bildschirm von 50' bis 60' und HDR-Unterstützung
-- ein VR-Headset"""@de ,
-                                         """- un smartphone Apple avec une version iOS > 16
-- une smart TV avec un écran de 50' à 60' et supportant le HDR
-- un casque VR"""@fr .
+- a VR headset"""@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ConsumptionEvent
@@ -9322,24 +6890,12 @@ ec:ConsumptionEvent rdf:type owl:Class ;
                                       owl:onProperty ec:name ;
                                       owl:allValuesFrom rdfs:Literal
                                     ] ;
-                    dcterms:description "A ConsumptionEvent reflecting the consumption of content during a PublicationEvent. For linear services the ConsumptionEvent and PublicationEvent happen at the same time. For non-linear services, the consumer decides about the time of the ConsumptionEvent. The ConsumptionEvent results into ResonanceEvent aggregated into Resonance data."@en ,
-                                        "Ein Nutzungsereignis repräsentiert die Nutzung eines Medienanproduktes im Rahmen eines Publikationsereignisses. Bei linearen Medienservices finden Nutzungsereignis und Publikationsereignis zur gleichen Zeit statt. Bei nicht-linearen Medienservices entscheidet der Nutzer selbst über den Zeitpunkt des Nutzungsereignisses (im Rahmen des Publikationszeitraums). Das Nutzunsereignis führt zu Resonanzereignissen, die zu Resonanzdaten aggregiert werden."@de ,
-                                        "Un événement de consommation, ConsumptionEvent, décrit la consommation de contenu médiatique durant un évènement de publication, PublicationEvent. Pour les services linéaires, le ConsumptionEvent et le PuclicationEvent, se produisent en même temps. Pour les services non linéaires, le consommateur décide du moment du ConsumptionEvent. Dans les deux cas, un ConsumptionEvent génère un évènement de raisonance, ResonanceEvent qui est agrégé aux données de raisonance, ResonanceData."@fr ;
-                    rdfs:label "Consumption event"@en ,
-                               "Nutzungsereignis"@de ,
-                               "Événement de consommation"@fr ;
-                    skos:definition "das Ereignis, dass ein Nutzer einen Mediendienst konsumiert"@de ,
-                                    "le cas où un consommateur consomme un service de médias"@fr ,
-                                    "the event of a Consumer consuming a media service"@en ;
+                    dcterms:description "A location and time span during which consumers of a media service use a device to read, watch or listen to some content that was published within that media service. E.g. a woman watching the latest video of BBC News on YouTube on her smartphone or a family watching a skiing competition during the winter Olympics live on their big screen at home."@en ;
+                    rdfs:label "Consumption event"@en ;
+                    skos:definition "an event of a ec:Consumer using a ec:Device to consume an ec:EditorialObject that was published in a ec:PublicationEvent within a ec:MediaService"@en ;
                     skos:example """- a person watching a news show on linear tv
 - a family listening to linear radio while having breakfast at home
-- a couple on their living room couch streaming a movie from a VoD service"""@en ,
-                                 """- eine Person, die eine Nachrichtensendung im linearen Fernsehen sieht
-- eine Familie, die beim Frühstück zu Hause lineares Radio hört
-- ein Paar auf der Couch im Wohnzimmer, das einen Film von einem VoD-Dienst streamt"""@de ,
-                                 """- une personne regardant une émission d'information sur la télévision linéaire
-- une famille qui écoute la radio linéaire en prenant son petit-déjeuner à la maison
-- un couple sur le canapé de leur salon en train de regarder un film en streaming depuis un service de VoD"""@fr .
+- a couple on their living room couch streaming a movie from a VoD service"""@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ConsumptionLicence
@@ -9373,112 +6929,76 @@ ec:ConsumptionLicence rdf:type owl:Class ;
                                         owl:onProperty ec:consumptionLicenceText ;
                                         owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                       ] ;
-                      dcterms:description "A licence attributed to a Consumer defining the terms for the consumption of content.  The ConsumptionLicence is verified by a mechanism that is usually located in the device and referred to as DRM (Digital Rights Management)."@en ,
-                                          "Eine Nutzungslizenz gehört zu einem Nutzer und legt die Nutzungsbedingungen für ein Produkt fest."@de ,
-                                          "Licence attribuée à un consommateur, Consumer, définissant les conditions de consommation d'un contenu. La licence de consommation, ConsumptionLicence, est vérifiée par un mécanisme généralement situé dans l'appareil, Device, et appelé DRM (Digital Rights Management)"@fr ;
-                      rdfs:label "Consumption licence"@en ,
-                                 "Licence de consommation"@fr ,
-                                 "Nutzungslizenz"@de ;
-                      skos:definition "a permit to consume a media service"@en ,
-                                      "eine Genehmigung zur Nutzung eines Mediendienstes"@de ,
-                                      "un permis de consommer un service de médias"@fr ;
+                      dcterms:description "A permit attributed to a consumer defines the terms of content consumption within a media service. E.g., the licence is verified by a mechanism often located in the device, referred to as DRM (Digital Rights Management). Age-restricted content can be consumed only after the consumer verifies their age."@en ;
+                      rdfs:label "Consumption licence"@en ;
+                      skos:definition "a permit attributed to a ec:Consumer that defines the terms of use for a ec:PublicationService or a ec:PublicationEvent of an ec:EditorialObject"@en ;
                       skos:example """- a subscription to unlimited streaming from spotify, encompassing 3 devices
 - a 3 month test subscription to a VoD service
-- the entitlement to consume free-to-air broadcast services as the resident of a country"""@en ,
-                                   """- ein Abonnement für unbegrenztes Streaming von Spotify, das 3 Geräte umfasst
-- ein 3-monatiges Testabonnement für einen VoD-Dienst
-- die Berechtigung, als Einwohner eines Landes frei empfangbare Rundfunkdienste zu konsumieren"""@de ,
-                                   """- un abonnement au streaming illimité de spotify, englobant 3 appareils
-- un abonnement d'essai de 3 mois à un service de VoD
-- le droit de consommer des services de radiodiffusion en clair en tant que résident d'un pays."""@fr .
+- the entitlement to consume free-to-air broadcast services as the resident of a country"""@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Contact
 ec:Contact rdf:type owl:Class ;
            rdfs:subClassOf ec:Person ;
-           dcterms:description "A Contact e.g. for a Person or Organisation."@en ,
-                               "Ein Kontakt z.B. für eine Person oder Organisation."@de ,
-                               "Un contact pour un personne ou une organisation"@fr ;
-           rdfs:label "Contact"@en ,
-                      "Contact"@fr ,
-                      "Kontakt"@de .
+           dcterms:description "A person's name and address details through which a connection can be established, often to an organisation or a business the person belongs to."@en ;
+           rdfs:label "Contact"@en ;
+           skos:definition "a ec:Person that is fully described by its address details"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ContainerCodec
 ec:ContainerCodec rdf:type owl:Class ;
                   rdfs:subClassOf ec:Codec ;
-                  dcterms:description "Pour identifier un codec de conteneur, par exemple MXF"@fr ,
-                                      "To identify an container codec, e.g. MXF"@en ,
-                                      "Zur Identifizierung eines Container-Codecs, z.B. MXF"@de ;
-                  rdfs:label "Codec de conteneur"@fr ,
-                             "Container codec"@en ,
-                             "Container-Codec"@de .
+                  dcterms:description "The codec used in the production of a content container."@en ;
+                  rdfs:label "Container codec"@en ;
+                  skos:definition "a ec:Codec used in the production of a container of ec:MediaResources"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ContainerEncodingFormat
 ec:ContainerEncodingFormat rdf:type owl:Class ;
                            rdfs:subClassOf ec:EncodingFormat ;
-                           dcterms:description "Pour définir le format d'encodage du Container."@fr ,
-                                               "To define the Container encoding format."@en ,
-                                               "Zur Definition des Container-Kodierungsformats."@de ;
-                           rdfs:label "Container encoding format"@en ,
-                                      "Container-Kodierungsformat"@de ,
-                                      "Format d'encodage du conteneur"@fr .
+                           dcterms:description "An entry from the classification of transformations that produce digital audio resources from audio signals."@en ;
+                           rdfs:label "Container encoding format"@en ;
+                           skos:definition "a ec:EncodingFormat classifying the transformation from source data into a container that is a ec;MediaResource"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ContainerFormat
 ec:ContainerFormat rdf:type owl:Class ;
                    rdfs:subClassOf ec:Format ;
-                   dcterms:description "Definiert das Format des Containers, z.B. imf oder MXF. Es hält Informationen über das Container- oder Verpackungsformat im Gegensatz zum Stream-Encoding Format des Kanals, z.B. mp3, Wave, Quicktime, ogg."@de ,
-                                       "Pour définir le format d'un conteneur, par exemple IMF ou MXF. Il fournit des informations sur le format du conteneur / wrapper en complément des informations sur l'encodage du flux fournies dans 'channel', (par exemple mp3, wave, Quicktime, ogg)."@fr ,
-                                       "To define the format of a container e.g. imf or MXF. It provides information on the container / wrapper format in complement to the stream encoding information provided in 'channel', (e.g. mp3, wave, Quicktime, ogg)."@en ;
-                   rdfs:label "Container format"@en ,
-                              "Containerformat"@de ,
-                              "Format du conteneur"@fr .
+                   dcterms:description "An entry from the classification of packing schemes for a collection of files or streams with encoded audio, video, image or data information packed in a single file that serves as a container."@en ;
+                   rdfs:label "Container format"@en ;
+                   skos:definition "a ec:Format classifying the packing scheme of a file containing a set of encoded audio, video, image and/or data streams"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ContainerMimeType
 ec:ContainerMimeType rdf:type owl:Class ;
                      rdfs:subClassOf ec:Format ;
-                     dcterms:description "Die Definition des Containers, falls er als ein MIME-Typ. Dies wird als freier Text in einer Beschriftung oder als Bezeichner angegeben der auf einen Begriff in einem Klassifizierungsschema verweist. Für weitere Informationen: http://www.iana.org/assignments/media-types/application/index.html."@de ,
-                                         "La définition du conteneur si elle est disponible en tant que un type MIME. Elle est fournie sous forme de texte libre dans une étiquette d'annotation ou comme identifiant pointant vers un terme dans un schéma de classification. Pour plus d'informations : http://www.iana.org/assignments/media-types/application/index.html."@fr ,
-                                         "The definition of the container if available as a MIME type. This is provided as free text in an annotation label or as an identifier pointing to a term in a classification scheme. For more information: http://www.iana.org/assignments/media-types/application/index.html."@en ;
-                     rdfs:label "Container Mime type"@en ,
-                                "Container Mime-Typ"@de ,
-                                "Type Mime du conteneur"@fr .
+                     dcterms:description "An entry from the classification of Internet media types. See also: http://www.iana.org/assignments/media-types/application/index.html."@en ;
+                     rdfs:label "Container mime type"@en ;
+                     skos:definition "a ec:Format classifying the structure of a file as its Internet media type"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ContentAlert
 ec:ContentAlert rdf:type owl:Class ;
                 rdfs:subClassOf ec:Type ;
-                dcterms:description "Pour fournir des informations sur un type particulier de contenu potentiellement sensible."@fr ,
-                                    "To provide information about a particular type of content potentially sensitive."@en ,
-                                    "Zur Bereitstellung von Informationen über eine bestimmte Art von potenziell sensiblen Inhalten."@de ;
-                rdfs:label "Alerte de contenu"@fr ,
-                           "Content alert"@en ,
-                           "Inhalt Alarm"@de .
+                dcterms:description "A list of entries to classify the type of alerting for some content."@en ;
+                rdfs:label "Content alert"@en ;
+                skos:definition "a ec:Type that list types of alerting for some content"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ContentEditorialCode
 ec:ContentEditorialCode rdf:type owl:Class ;
                         rdfs:subClassOf ec:Type ;
-                        dcterms:description "Pour définir un code de EditorialFormat"@fr ,
-                                            "To define a code of EditorialFormat"@en ,
-                                            "Um einen Code von EditorialFormat zu definieren"@de ;
-                        rdfs:label "Code éditorial"@fr ,
-                                   "Editorial code"@en ,
-                                   "Redaktioneller Code"@de .
+                        dcterms:description "A list of entries to classify some content by an editorial format code, e.g. EBU's classification scheme on Editorial Format Codes."@en ;
+                        rdfs:label "Editorial code"@en ;
+                        skos:definition "a ec:Type that lists editorial format codes for some content"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ContentEditorialFormat
 ec:ContentEditorialFormat rdf:type owl:Class ;
                           rdfs:subClassOf ec:Type ;
-                          dcterms:description "Pour définir un EditorialFormat"@fr ,
-                                              "To define an EditorialFormat"@en ,
-                                              "Um ein EditorialFormat zu definieren"@de ;
-                          rdfs:label "Editorial format"@en ,
-                                     "Format rédactionnel"@fr ,
-                                     "Redaktionelles Format"@de .
+                          dcterms:description "A list of entries to classify some content by an editorial format."@en ;
+                          rdfs:label "Editorial format"@en ;
+                          skos:definition "a ec:Type that lists editorial formats for some content"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Contract
@@ -9515,21 +7035,11 @@ ec:Contract rdf:type owl:Class ;
                               owl:onProperty ec:name ;
                               owl:allValuesFrom rdfs:Literal
                             ] ;
-            dcterms:description "A set of contractual terms involving different parties and Rights and used to commission/contract the creation of Resources. A Contract covers the ProductionOrder and sales order combined. The contract connects the Rights to any contractual parties. A contract defines one or more set of Rights."@en ,
-                                "Eine Sammlung rechtlicher Regelungen zwischen verschiedenen Parteien und Rechten, die genutzt wird, um die Herstellung von Medieninhalten und ihrer Resourcen/MedienResourcen/Essenzen zu beauftragen. Ein Vertrag deckt den Produktionsauftrag und den Einkaufsauftrag ab. Der Vertrag definiert die Aufteilung der Verwertungsrechte unter den Vertragspartnern."@de ,
-                                "Un ensemble de conditions contractuelles impliquant différentes parties et droits, RIghts. Un contrat est utilisé pour commander et contracter la création de ressources. Un Contrat couvre l'ordre de production, ProductionOrder et la commande de vente, combinés. Le contrat relie les droits, Rights, à toutes les parties contractantes. Un contrat définit un ou plusieurs ensembles de droits."@fr ;
-            rdfs:label "Contract"@en ,
-                       "Contrat"@fr ,
-                       "Vertrag"@de ;
-            skos:definition "an agreement between parties or a law concerning the rights and duties in the creation or publication of MediaResources"@en ,
-                            "eine Vereinbarung zwischen Parteien oder ein Gesetz über die Rechte und Pflichten bei der Erstellung oder Veröffentlichung von MedienResourcen"@de ,
-                            "un accord entre parties ou une loi concernant les droits et devoirs dans la création ou la publication de une ressource médiatique"@fr ;
+            dcterms:description "An agreement between parties or a law concerning the rights and duties in the creation or publication of content. More specific contracts for activities like licensing, buying, ordering, etc., can be defined as subclasses."@en ;
+            rdfs:label "Contract"@en ;
+            skos:definition "an agreement between ec:Agents or a law concerning the rights and duties in the creation or publication of ec:Assets"@en ;
             skos:example """- a contract between a PSM and a production company for the delivery of a series
-- a law about copyrights of news articles"""@en ,
-                         """- ein Vertrag zwischen einem PSM und einer Produktionsfirma über die Lieferung einer Serie
-- ein Gesetz über das Urheberrecht von Nachrichtenartikeln"""@de ,
-                         """- un contrat entre un PSM et une société de production pour la livraison d'une série
-- une loi sur les droits d'auteur des articles de presse"""@fr .
+- a law about copyrights of news articles"""@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ContractCost
@@ -9558,34 +7068,25 @@ ec:ContractCost rdf:type owl:Class ;
                                   owl:onProperty ec:name ;
                                   owl:allValuesFrom rdfs:Literal
                                 ] ;
-                dcterms:description "Beschreibt die Kosten eines Vertrages."@de ,
-                                    "Permet d'identifier les coûts associés à un contrat."@fr ,
-                                    "To identify the costs associated with a Contract."@en ;
-                rdfs:label "Contract cost"@en ,
-                           "Coût d'un contrat"@fr ,
-                           "Vertragskosten"@de .
+                dcterms:description "The financial costs associated to a contract."@en ;
+                rdfs:label "Contract cost"@en ;
+                skos:definition "costs associated to an ec:Contract"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ContractType
 ec:ContractType rdf:type owl:Class ;
                 rdfs:subClassOf skos:Concept ;
-                dcterms:description "Pour définir un type de contrat."@fr ,
-                                    "To define a type of contract."@en ,
-                                    "Um eine Art von Vertrag zu definieren."@de ;
-                rdfs:label "Contract type"@en ,
-                           "Type de contrat"@fr ,
-                           "Vertragstyp"@de .
+                dcterms:description "An entry from the classification of types of contracts."@en ;
+                rdfs:label "Contract type"@en ;
+                skos:definition "a skos:Concept classifying the type of a ec:Contract"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Copyright
 ec:Copyright rdf:type owl:Class ;
              rdfs:subClassOf ec:Rights ;
-             dcterms:description "Pour fournir un copyright d'auteur."@fr ,
-                                 "To provide a copyright statement."@en ,
-                                 "Um eine Urheberrechtserklärung abzugeben Erklärung."@de ;
-             rdfs:label "Copyright"@de ,
-                        "Copyright"@en ,
-                        "Copyright"@fr .
+             dcterms:description "The conditions under which content can be copied."@en ;
+             rdfs:label "Copyright"@en ;
+             skos:definition "a ec:Rights that define the conditions for copying a ec:MediaResource"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Costume
@@ -9611,106 +7112,74 @@ ec:Costume rdf:type owl:Class ;
                              owl:onProperty ec:gender ;
                              owl:maxCardinality "1"^^xsd:nonNegativeInteger
                            ] ;
-           dcterms:description "Die in den Produktionen verwendeten Kostüme zu identifizieren und zu beschreiben."@de ,
-                               "Identifier et décrire les costumes utilisés dans les productions."@fr ,
-                               "To identify and describe Costumes used in productions."@en ;
-           rdfs:label "Costume"@en ,
-                      "Costume"@fr ,
-                      "Kostüm"@de ;
-           skos:definition "a dress of an actress/actor used in a production"@en ,
-                           "die Kleidung einer Schauspielerin/eines Schauspielers in einer Produktion"@de ,
-                           "une robe d'une actrice/acteur utilisée dans une production"@fr ;
-           skos:example "- die Uniformen der Star Trek-Besatzung"@de ,
-                        "- les uniformes portés par l'équipage de Star Trek"@fr ,
-                        "- the uniforms worn by the Star Trek crew"@en .
+           dcterms:description "A piece of clothing that an actress or actor wears while acting."@en ;
+           rdfs:label "Costume"@en ;
+           skos:definition "an ec:Artefact in the form of a garment that an actress or actor wears while acting"@en ;
+           skos:example "- the uniforms worn by the Star Trek crew"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#CostumeType
 ec:CostumeType rdf:type owl:Class ;
                rdfs:subClassOf skos:Concept ;
-               dcterms:description "Pour définir un type de costume."@fr ,
-                                   "So definieren Sie einen Kostümtyp."@de ,
-                                   "To define a costume type."@en ;
-               rdfs:label "Costume type"@en ,
-                          "Typ Kostüm"@de ,
-                          "Type de costume"@fr .
+               dcterms:description "An entry from the classification of types of costumes."@en ;
+               rdfs:label "Costume type"@en ;
+               skos:definition "a skos:Concept classifying the type of a ec:Costume"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#CountryCode
 ec:CountryCode rdf:type owl:Class ;
                rdfs:subClassOf skos:Concept ;
-               dcterms:description "Pour identifier un pays par son code ISO."@fr ,
-                                   "So identifizieren Sie ein Land anhand seines ISO-Codes."@de ,
-                                   "To identify a country by its ISO code."@en ;
-               rdfs:label "Code pays"@fr ,
-                          "Country code"@en ,
-                          "Ländercode"@de .
+               dcterms:description "An entry from the ISO codes of countries."@en ;
+               rdfs:label "Country code"@en ;
+               skos:definition "a skos:Concept classifying countries by their ISO codes"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#CoverageRestrictions
 ec:CoverageRestrictions rdf:type owl:Class ;
                         rdfs:subClassOf ec:Rights ;
-                        dcterms:description "Bereitstellung von Informationen über mögliche Einschränkungen hinsichtlich der zeitlichen und räumlichen Abdeckung für die Veröffentlichung."@de ,
-                                            "Fournir des informations sur les éventuelles restrictions concernant la couverture temporelle et spatiale pour la publication."@fr ,
-                                            "To provide information on possible restrictions regarding the temporal and spatial coverage for publication."@en ;
-                        rdfs:label "Coverage restrictions"@en ,
-                                   "Einschränkungen der Deckung"@de ,
-                                   "Restrictions de couverture"@fr .
+                        dcterms:description "The limitations for publishing content, e.g. in terms of time or spatial coverage."@en ;
+                        rdfs:label "Coverage restrictions"@en ;
+                        skos:definition "a ec:Rights that define the limitations for publishing an ec:Asset"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#CreativeCommons
 ec:CreativeCommons rdf:type owl:Class ;
                    rdfs:subClassOf ec:Rights ;
-                   dcterms:description "A set of creative commons rights."@en ,
-                                       "Eine Reihe von Creative-Commons-Rechten."@de ,
-                                       "Un ensemble de droits de creative commons."@fr ;
-                   rdfs:label "Creative commons"@en ,
-                              "Creative commons"@fr ,
-                              "Kreative Gemeingüter"@de .
+                   dcterms:description "A standardized set of licensing conditions edited by a non-profit organisation that authors can choose from to limit the use of their works by others."@en ;
+                   rdfs:label "Creative commons"@en ;
+                   skos:definition "a ec:Rights that is a standardized set of licencing conditions selectable for authors (as ec:RightsHolder) to protect their work"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#CrewMember
 ec:CrewMember rdf:type owl:Class ;
               rdfs:subClassOf ec:Person ;
-              dcterms:description "Permet d'identifier un membre d'une équipe."@fr ,
-                                  "To identify a member of the crew."@en ,
-                                  "Zur Identifikation eines Stabsmitglieds"@de ;
-              rdfs:label "Crew"@en ,
-                         "Stab"@de ,
-                         "Équipe"@fr .
+              dcterms:description "Crew members work in the production of media resources."@en ;
+              rdfs:label "Crew"@en ;
+              skos:definition "a ec:Person who is a member of the workforce in the production of a media resource"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#CuisineStyle
 ec:CuisineStyle rdf:type owl:Class ;
                 rdfs:subClassOf skos:Concept ;
-                dcterms:description "Pour identifier un style de cuisine."@fr ,
-                                    "To identify a style of Cuisine."@en ,
-                                    "Um einen Küchenstil zu identifizieren."@de ;
-                rdfs:label "Cuisine style"@en ,
-                           "Stil der Küche"@de ,
-                           "Style de cuisine"@fr .
+                dcterms:description "An entry from the classification of cuisine styles to describe food."@en ;
+                rdfs:label "Cuisine style"@en ;
+                skos:definition "a skos:Concept classifying the style of a cuisine to describe ec:Food"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#CurrencyCode
 ec:CurrencyCode rdf:type owl:Class ;
                 rdfs:subClassOf skos:Concept ;
-                dcterms:description "Pour identifier une devise par son code ISO."@fr ,
-                                    "So identifizieren Sie eine Währung anhand ihres ISO-Codes."@de ,
-                                    "To identify a currency by its ISO code."@en ;
-                rdfs:label "Code devise"@fr ,
-                           "Currency code"@en ,
-                           "Währungscode"@de .
+                dcterms:description "An entry from the ISO codes of currencies."@en ;
+                rdfs:label "Currency code"@en ;
+                skos:definition "a skos:Concept classifying currencies by their ISO codes"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#DataFormat
 ec:DataFormat rdf:type owl:Class ;
               rdfs:subClassOf ec:Format ;
-              dcterms:description "Spezifiziert das verwendete Datenformat der MedienResource."@de ,
-                                  "Spécifie le format utilisé pour les data"@fr ,
-                                  "To specify the format used for data."@en ;
-              rdfs:label "Data format"@en ,
-                         "Datenformat"@de ,
-                         "Format des data"@fr .
+              dcterms:description "An entry from the classification of structure schemes for data."@en ;
+              rdfs:label "Data format"@en ;
+              skos:definition "a ec:Format classifying the structure of data"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#DataTrack
@@ -9720,45 +7189,33 @@ ec:DataTrack rdf:type owl:Class ;
                                owl:onProperty ec:hasDataFormat ;
                                owl:allValuesFrom ec:DataFormat
                              ] ;
-             dcterms:description "Ancillary data track e.g. \"captioning\" or \"subtitling\" in addition to video and audio tracks."@en ,
-                                 "Piste de données auxiliaires, par exemple le \"sous-titrage\" ou le \"captioning\". ou \"sous-titrage\" en plus des pistes vidéo et audio."@fr ,
-                                 "Zusatzdatenspur z.B. \"Captioning\" oder \"Untertitelung\" zusätzlich zu den Video- und Audiospuren."@de ;
-             rdfs:label "Data track"@en ,
-                        "Daten verfolgen"@de ,
-                        "Suivi des données"@fr .
+             dcterms:description "A track containing data that accompanies video or audio content."@en ;
+             rdfs:label "Data track"@en ;
+             skos:definition "a ec:Track containing data accompanying video or audio"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Department
 ec:Department rdf:type owl:Class ;
               rdfs:subClassOf ec:Organisation ;
-              dcterms:description "A department within an organisation."@en ,
-                                  "Eine Abteilung innerhalb einer Organisation."@de ,
-                                  "Un département au sein de l'organisation."@fr ;
-              rdfs:label "Abteilung"@de ,
-                         "Department"@en ,
-                         "Département"@fr .
+              dcterms:description "A section in a large organisation, typically built around a business task, like an archive department in a media enterprise."@en ;
+              rdfs:label "Department"@en ;
+              skos:definition "a ec:Organisation that is a substructure within an ec:Organisation"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#DepictedEvent
 ec:DepictedEvent rdf:type owl:Class ;
                  rdfs:subClassOf ec:Event ;
-                 dcterms:description "A DepictedEVent is fictitious or historical or other sort of Event that the content of the EditorialObject or resource relates to."@en ,
-                                     "Ein DepictedEVent ist ein fiktives oder historisches oder eine andere Art von Ereignis, auf das sich der Inhalt des EditorialObjects oder der Resource bezieht bezieht."@de ,
-                                     "Un DepictedEVent est un événement fictif, historique ou autre type d'événement auquel le contenu de l'objet éditorial ou de la ressource se rapporte à."@fr ;
-                 rdfs:label "Dargestelltes Ereignis"@de ,
-                            "Depicted Event"@en ,
-                            "Événement décrit"@fr .
+                 dcterms:description "A DepictedEVent is fictitious or historical or other sort of Event that the content of the EditorialObject or resource relates to."@en ;
+                 rdfs:label "Depicted event"@en ;
+                 skos:definition "a ec:Event"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Disclaimer
 ec:Disclaimer rdf:type owl:Class ;
               rdfs:subClassOf ec:Rights ;
-              dcterms:description "Einen Haftungsausschluss jeglicher Art bereitzustellen Form."@de ,
-                                  "Pour fournir une clause de non-responsabilité de toute forme."@fr ,
-                                  "To provide a disclaimer of any form."@en ;
-              rdfs:label "Avis de non-responsabilité"@fr ,
-                         "Disclaimer"@en ,
-                         "Haftungsausschluss"@de .
+              dcterms:description "A declaration of an intentional giving up of an entitlement, claim, or privilege."@en ;
+              rdfs:label "Disclaimer"@en ;
+              skos:definition "a ec:Rights that declares the intentional giving up of an entitlement, claim, or privilege"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Document
@@ -9777,47 +7234,28 @@ ec:Document rdf:type owl:Class ;
                               owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                               owl:onDataRange xsd:integer
                             ] ;
-            dcterms:description "Pour décrire une publication sous la forme d'un document, par exemple une page web html (actualité) ou un document pdf, par exemple un script."@fr ,
-                                "To describe a publication in the form of a document e.g. a html webpage (news item) or a pdf document e.g. a script."@en ,
-                                "Zur Beschreibung einer Veröffentlichung in Form eines Dokumentes, z.B. einer html-Webseite (Nachricht) oder eines pdf-Dokuments, z.B. eines Skripts."@de ;
-            rdfs:label "Document"@en ,
-                       "Document"@fr ,
-                       "Dokument"@de ;
-            skos:definition "a Resource in the form of encoded text and/or graphics"@en ,
-                            "eine Resource in Form von kodiertem Text und/oder Grafiken"@de ,
-                            "une ressource sous forme de texte et/ou de graphiques codés"@fr ;
+            dcterms:description "A resource in the form of encoded text and/or graphics, e.g. a HTML webpage with news items; a screenplay as a PDF document."@en ;
+            rdfs:label "Document"@en ;
+            skos:definition "a ec:Resource in the form of encoded text and/or graphics"@en ;
             skos:example """- a text file
 - a paper book
-- a web page or a reusable block thereof"""@en ,
-                         """- eine Textdatei
-- ein Papierbuch
-- eine Webseite oder ein wiederverwendbarer Block davon"""@de ,
-                         """- un fichier texte
-- un livre papier
-- une page web ou un bloc réutilisable de celle-ci"""@fr .
+- a web page or a reusable block thereof"""@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#DocumentFormat
 ec:DocumentFormat rdf:type owl:Class ;
                   rdfs:subClassOf ec:Format ;
-                  dcterms:description "Pour fournir des informations techniques sur le format d'un document tel que l'orientation. Ces informations sont fournies sous forme de texte libre dans une d'une étiquette d'annotation ou comme un identifiant pointant vers un terme dans un de classification."@fr ,
-                                      "To provide technical information about the format of a document such as the orientation. This is provided as free text in an annotation label or as an identifier pointing to a term in a classification scheme."@en ,
-                                      "Zur Bereitstellung technischer Informationen über das Format eines Dokuments, z. B. die Ausrichtung. Diese Informationen werden als freier Text in einer Beschriftung oder als Bezeichner, der auf einen Begriff in einem Klassifizierungsschema verweist Schema."@de ;
-                  rdfs:label "Document format"@en ,
-                             "Format des Dokuments"@de ,
-                             "Format du document"@fr .
+                  dcterms:description "An entry from the classification of structure schemes for digital documents."@en ;
+                  rdfs:label "Document format"@en ;
+                  skos:definition "a ec:Format classifying the structure of a ec:Document"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Dopesheet
 ec:Dopesheet rdf:type owl:Class ;
              rdfs:subClassOf ec:Document ;
-             dcterms:description "Bietet zusätzliche Informationen zu einem NewsItem, z.B. Datum und Ort, Thema."@de ,
-                                 "Fournit des informations supplémentaires sur un NewsItem, par exemple la date et le lieu, le sujet."@fr ,
-                                 "Provides additional information about a NewsItem, e.g. date and place, subject."@en ;
-             rdfs:label "Dopesheet"@de ,
-                        "Dopesheet"@en ,
-                        "Dopesheet"@fr ;
-             skos:definition "a Document containing additional information about a news item."@en .
+             dcterms:description "A document containing additional information about a news item."@en ;
+             rdfs:label "Dopesheet"@en ;
+             skos:definition "a ec:Document containing additional information about a news item"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#EditUnitCount
@@ -9833,12 +7271,9 @@ ec:EditUnitCount rdf:type owl:Class ;
                                    owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                    owl:onDataRange xsd:long
                                  ] ;
-                 dcterms:description "An edit unit can be a frame, a sample or a extent of time."@en ,
-                                     "Eine Bearbeitungseinheit kann ein Frame, ein Sample oder eine Zeitspanne sein."@de ,
-                                     "Une unité de montage peut être un cadre, un échantillon ou une durée."@fr ;
-                 rdfs:label "Anzahl der Einheiten bearbeiten"@de ,
-                            "Edit unit count"@en ,
-                            "Modifier le nombre d'unités"@fr .
+                 dcterms:description "A point in time within the timeline of a content that is expressed in units of frames, samples or time."@en ;
+                 rdfs:label "Edit unit count"@en ;
+                 skos:definition "a ec:TimelinePoint expressed in units of frames, samples or times"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#EditorialExtra
@@ -9848,35 +7283,10 @@ ec:EditorialExtra rdf:type owl:Class ;
                                     owl:onProperty ec:hasProgramme ;
                                     owl:allValuesFrom ec:Programme
                                   ] ;
-                  rdfs:label "Editorial Extra"@de ,
-                             "Editorial Extra"@en ,
-                             "Éditorial Extra"@fr ;
-                  skos:definition "Ein Werk, das ein optionale Ergänzung zu einem anderen Werk ist und dazu dient zu erklären, zu unterhalten, zu werben oder ähnliches."@de ,
-                                  "an EditorialWork that serves as an optional addition to a main EditorialWork and intends to explain, entertain, advertise or similar."@en ,
-                                  "une œuvre qui sert de complément facultatif à une œuvre principal et qui vise à expliquer, à divertir, à faire de la publicité ou autre."@fr ;
-                  skos:example """Contenu supplémentaire pour un film de cinéma: bande-annonce, making of, bonus, outtakes, ...
-
-\"BehindTheScenes\":
-- Un éditorial extra qui rapport une histoire sur scenes de l'œuvre.
-- petit film expliquant les scènes de cascades d'un film d'action
-
-\"Bonus\":
-- un Éditorial Extra destiné à enrichir le contenu d'une œuvre principal.
-- Contenu additionnel pour un film à consommer séparément en tant que complément.
-
-\"Making of\":
-- Un film documentaire relatant le tournage ou la production d'un film ou d'une œuvre audiovisuelle (téléfilm, série télévisée…), voire d'une autre production artistique (bande dessinée par exemple).
-
-\"Outtakes\":
-- un Éditorial Extra rassemblant des prises de vue ou des scènes qui ont été triées en post-production, mais qui intéressent toujours les consommateurs pour le plaisir, la curiosité, etc.
-- un clip avec une collection de chutes sur le DVD bonus d'un film
-
-Bande annonce:
-- une Éditorial Extra avec une durée de promotion typique de 2 minutes maximum, promouvant un programme, un feuilleton ou une série à publier dans le futur.
-- Séquence AV faisant la promotion d’un film, d'une série ou d’une émission de télévision.
-- un aperçu d'une minute de l'épisode de dimanche prochain de la série allemande \"Tatort\".
-- un clip promotionnel pour la finale de la coupe du sport qui aura lieu ce soir"""@fr ,
-                               """Extra content for a movie: trailer, making of, bonus material, outtakes ...
+                  dcterms:description "An optional addition to a main work, created to explain, entertain, advertise, or similar, e.g., a trailer or behind-the-scenes."@en ;
+                  rdfs:label "Editorial extra"@en ;
+                  skos:definition "an ec:EditorialWork serving as an optional addition to a main ec:EditorialWork created to explain, entertain, advertise or similar"@en ;
+                  skos:example """Extra content for a movie: trailer, making of, bonus material, outtakes ...
 
 Behind the scenes:
 - an editorial extra that provides a story about scenes of the EditorialWork
@@ -9891,59 +7301,26 @@ Making of:
 - A documentary film about the shooting or production of a film or audiovisual work (TV film, TV series, etc.), or even another artistic production (e.g. comic strip).
 
 Outtakes:
-- an Editorial Extra collecting Shots or Scenes that were sorted out during post-production, but still appeal to consumers for fun, curiosity, etc
+- an Editorial Extra collecting Shots or Scenes that were sorted out during post-production, but still appeal to consumers for fun, curiosity, etc.
 - a clip with a collection of outtakes on a bonus DVD of a film
 
 Trailer:
 -an Editorial Extra with typical promotion length of up to 2 minutes, promoting a Programme, a Serial or a Series to be published in the future
 - An AV sequence promoting a film, series or television programme.
 - a 1-minute-preview for next Sunday's episode of German Series \"Tatort\"
-- a promo-clip for a sports-cup-final later tonight"""@en ,
-                               """Extra-Inhalte für einen Kinofilm: Trailer, Making of, Bonus-Material, Outtakes, ...
-
-\"BehindTheScenes\"
-- Ein Editorial Extra, das eine Geschichte über Szenen des Werkes erzählt.
-- Kurzfilm mit Erklärungen zu den Stunts in einem Actionfilm
-
-\"Bonus\":
-- ein Editorial Extra, das als erweiternder Inhalt eines Haupt-Werkes gedacht ist.
-- Zusätzliche Inhalte für einen Film, die separat als Erweiterung konsumiert werden können
-
-\"MakingOf\":
-- Ein Dokumentarfilm über die Dreharbeiten oder die Produktion eines Films oder eines audiovisuellen Werks (Fernsehfilm, Fernsehserie usw.) oder einer anderen künstlerischen Produktion (z. B. Comic).
-
-\"Outtakes\":
--ein Editorial Extra, in dem aussortierte Aufnahmen oder Szenen einer Produktion gesammelt werden, die den Nutzer aus Spaß, Neugier o.ä. ansprechen sollen
-- ein Clip mit einer Sammlung von Outtakes auf einer Bonus-DVD zu einem Film
-
-\"Trailer\":
-- ein Editorial Extra mit einer typischen Werbelänge von bis zu 2 Minuten, die eine Sendung, eine Serie oder eine Reihe bewirbt, die in Zukunft veröffentlicht werden soll
-- AV-Sequenz, die einen Film, eine Serie oder eine Fernsehsendung bewirbt.
-- eine 1-Minuten-Vorschau auf die Folge der deutschen Serie \"Tatort\" vom kommenden Sonntag
-- ein Promo-Clip für ein Sport-Pokal-Finale heute Abend"""@de .
+- a promo-clip for a sports-cup-final later tonight"""@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#EditorialFormat
 ec:EditorialFormat rdf:type owl:Class ;
                    rdfs:subClassOf ec:EditorialGroup ;
-                   rdfs:label "Format"@de ,
-                              "Format"@en ,
-                              "Format"@fr ;
-                   skos:definition "An EditorialGroup, developed with a specific editorial style, content layout, anchor-host, etc. to address a target audience. Most often used in the assessment of current offerings or in the development of new offerings."@en ,
-                                   "Eine EditorialGroup, die mit einem spezifischen redaktionellen Stil, Inhaltslayout, Moderator usw. entwickelt wurde, um eine Zielgruppe anzusprechen. Wird meist bei der Klassifizierung bestehender Angebote oder der Entwicklung neuer Angebote verwendet."@de ,
-                                   "Un groupe éditorial développé avec un style éditorial, une mise en page de contenu, un modérateur, etc. spécifiques, pour cibler un public spécifique. Généralement utilisé pour classer les offres existantes ou en développer de nouvelles."@fr ;
+                   dcterms:description "A set of content with a specific editorial style, content layout, anchor host, etc., to address a target audience. Most often used in the assessment of current offerings or in the development of new offerings."@en ;
+                   rdfs:label "Format"@en ;
+                   skos:definition "an ec:EditorialGroup of members with a specific editorial style, content layout, anchor-host, e.g., to address a target audience"@en ;
                    skos:example """- A game show with a specific host: \"Rudis Raterunde\"
 - A journal show on Asian topics: \"Asia Report\"
 - An evening news program: \"Tagesschau Main Edition at 8:00 PM\"
-- An online-streamed discussion show for young people with live audience members and a commentary feature: \"MixTalk\""""@en ,
-                                """- Un jeu télévisé animé par un animateur spécifique: \"Rudis Raterunde\"
-- Un journal télévisé sur l'Asie: \"Asia Report\"
-- Un journal télévisé du soir: \"Tagesschau Main Edition à 20h\"
-- Une émission de débat en ligne pour les jeunes, avec des spectateurs en direct et un commentaire: \"MixTalk\""""@fr ,
-                                """- eine Spiel-Show mit einem bestimmten Gastgeber: \"Rudis Raterunde\"
-- eine Journalsendung zu Themen aus Asien: \"Asienreport\"
-- eine abendliche Hauptnachrichtensendung: \"Tagesschau Hauptausgabe um 20:00\"
-- eine im Internet gestreamte Diskussionsendung für Jugendliche mit live zugeschalteten Gästen aus dem Publikum und Kommentarfunktion: \"MixTalk\""""@de .
+- An online-streamed discussion show for young people with live audience members and a commentary feature: \"MixTalk\""""@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#EditorialGroup
@@ -9965,12 +7342,9 @@ ec:EditorialGroup rdf:type owl:Class ;
                                     owl:onProperty ec:totalNumberOfGroupMembers ;
                                     owl:allValuesFrom xsd:integer
                                   ] ;
-                  dcterms:description "Pour définir une collection / un groupe de médias ressources, par exemple une série composée d'épisodes."@fr ,
-                                      "To define a collection / group of media resources, for example a series made of episodes."@en ,
-                                      "Zur Definition einer Sammlung/Gruppe von Medien Resourcen zu definieren, zum Beispiel eine Serie, die aus Episoden besteht."@de ;
-                  rdfs:label "Editorial group"@en ,
-                             "Groupe de rédaction"@fr ,
-                             "Gruppe von Medieninhalten"@de .
+                  dcterms:description "A set of works aligned by either story continuity, format similarity, a common motto, or similar."@en ;
+                  rdfs:label "Editorial group"@en ;
+                  skos:definition "a ec:EditorialObject that is a group of ec:EditorialWorks and/or ec:EditorialSegments"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#EditorialObject
@@ -10381,64 +7755,20 @@ ec:EditorialObject rdf:type owl:Class ;
                                      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                      owl:onDataRange xsd:boolean
                                    ] ;
-                   dcterms:description """An EditorialObject collects all the descriptive information about an object to be realised as a single MediaResource or a collection thereof. An «EditorialObject» describes any idea, any story and will be used to transform a concept into an editorial definition of a MediaResource before fabrication (Production Domain) and Distribution (Distribution Domain). An «EditorialObject» is a set of descriptive metadata summarising e.g. editing decisions. An «EditorialObject» can be a group of EditorialObjects. An «EditorialObject» can also be a part of another «EditorialObject», which is defined by its start time and duration. EditorialObjects can be ordered either as groups or as items on a timeline. Examples of simple EditorialObjects: Programme, Item, Shot,Part, etc. Examples of Groups: Brand, Series, Serial, Collection, etc.
-
-A simplifieduse-case:
-A news broadcast consists of two news items. One news item contains the last ten seconds of a one minute long interview taken from another source (i.e. 50\">60\" ). This could be modelled as follows:
-• The NewsBroadcast is linked to a MediaResource using the instantiates-property
-• The NewsItems are linked to the NewsBroadcast using a TimelineTrack. Tech 3351 EBU CCDM 13
-• The InterviewPart is linked to the NewsItem using the hasMember-property. Start and Duration are properties within the InterviewPart indicating its appearance within the NewsItem2.
-• The InterviewPart is linked to its original source using the existsAs-property
-• The Interview instantiates a MediaResource, which in turn is linked from the MediaResource of the NewsBroadcast using the hasSource-property
-• Representation of segmentation: TimelineTracks are preferred over hasPart-properties, when a rundown is needed, e.g. for playout."""@en ,
-                                       """Ein Medieninhalt versammelt sämtliche deskriptiven informationen über ein Objekt, das als Resource (oder eine Menge davon) realisiert werden soll. Der Medieninhalt beschreibt eine Idee, eine Geschichte und wird benutzt, um ein Konzept in eine inhaltliche Festlegung einer Resource zu erreichen, und zwar vor der Herstellung und der Verbreitung.
-
-Ein Medieninhalt besteht aus einer Menge beschreibender Metadaten, z.B. Schnittlisten. Ein Medieninhalt kann eine Gruppe von anderen Medieninhalten sein. Ein Medieninhalt kann auch Teil eines anderen Medieninhalts sein, was durch den Zeitpunkt des Beginns und die Dauer dafiniert wird. Medieninhalte können gruppiert werden or entlang einer Zeitachse angeordnet werden.
-
-Beispiele für einfache Medieninhalte: Sendung, Beitrag, Szene
-Beispiele für Gruppierungen: Marke, Serie, Reihe, Sammlung"""@de ,
-                                       """Un EditorialObject rassemble toutes les informations descriptives d'un objet à réaliser comme une MediaResource ou une collection de MediaResource. Un EditorialObject décrit une idée, une histoire. Il est utilisé pour transformer un concept en une définition éditoriale, une MediaResource avant sa fabrication (domaine de la production) et sa distribution (domaine de la distribution).
-Un EditorialObject est un ensemble de métadonnées descriptives résumant, par exemple, les décisions d'édition. Un EditorialObject peut être un groupe d'EditorialObjects. Un EditorialObject peut également faire partie d'un autre EditorialObject, qui est défini par son heure de début et sa durée.
-Les objets éditoriaux peuvent être ordonnés soit en tant que groupes, soit en tant qu'éléments sur une ligne de temps.
- Exemples d'EditorialObjects simples : Programme, Article, Une prise de vue, Une Partie, etc.
-Exemples de groupes d'EditorialObjects : Marque, Série, Collection, etc.
-
-Un cas d'utilisation simplifié :
-------------------------
-Un journal télévisé se compose de deux éléments d'information. L'un d'entre eux contient les dix dernières secondes d'une interview d'une minute provenant d'une autre source (c'est-à-dire entre la seconde 50 et la seconde 60).
-Cette situation pourrait être modélisée comme suit :
-o NewsBroadcast est lié à un MediaResource à l'aide de la propriété instantiates.
-o NewsItems sont liés au NewsBroadcast à l'aide d'un TimelineTrack. Tech 3351 EBU CCDM 13
-o L'InterviewPart est liée au NewsItem à l'aide de la propriété hasMember. Start et Duration sont des propriétés de l'InterviewPart qui indiquent son apparence dans le NewsItem.
-o L'InterviewPart est liée à sa source originale à l'aide de la propriété existsAs.
-o L'interview instancie une MediaResource, qui à son tour est liée à la MediaResource du NewsBroadcast à l'aide de la propriété hasSource.
-o Représentation de la segmentation : Les TimelineTracks sont préférés aux hasPart-properties, lorsqu'un récapitulatif est nécessaire, par exemple pour la diffusion."""@fr ;
-                   rdfs:label "Editorial object"@en ,
-                              "Medieninhalt"@de ,
-                              "Objet éditorial"@fr ;
-                   skos:definition "an Asset in the form of content related information about a MediaResource that may or may not exist."@en ,
-                                   "ein Asset in Form von inhaltsbezogenen Informationen über eine MediaResource, die existieren kann oder auch nicht."@de ,
-                                   "un actif sous forme d'informations liées au contenu d'une MediaResource qui peut ou non exister."@fr ;
+                   dcterms:description "An EditorialObject collects all the descriptive information about an object to be realised as a single MediaResource or a collection thereof. An «EditorialObject» describes any idea, any story and will be used to transform a concept into an editorial definition of a MediaResource before fabrication (Production Domain) and Distribution (Distribution Domain). An «EditorialObject» is a set of descriptive metadata summarising e.g. editing decisions. An «EditorialObject» can be a group of EditorialObjects. An «EditorialObject» can also be a part of another «EditorialObject», which is defined by its start time and duration. EditorialObjects can be ordered either as groups or as items on a timeline. Examples of simple EditorialObjects: Programme, Item, Shot, Part, etc. Examples of Groups: Brand, Series, Serial, Collection, etc. A simplified use-case: A news broadcast consists of two news items. One news item contains the last ten seconds of a one minute long interview taken from another source (i.e. 50\">60\" ). This could be modelled as follows: • The NewsBroadcast is linked to a MediaResource using the instantiates-property • The NewsItems are linked to the NewsBroadcast using a TimelineTrack. Tech 3351 EBU CCDM 13 • The InterviewPart is linked to the NewsItem using the hasMember-property. Start and Duration are properties within the InterviewPart indicating its appearance within the NewsItem2. • The InterviewPart is linked to its original source using the existsAs-property • The Interview instantiates a MediaResource, which in turn is linked from the MediaResource of the NewsBroadcast using the hasSource-property • Representation of segmentation: TimelineTracks are preferred over hasPart-properties, when a rundown is needed, e.g. for playout."@en ;
+                   rdfs:label "Editorial object"@en ;
+                   skos:definition "an Asset in the form of content related information about a MediaResource that may or may not exist"@en ;
                    skos:example """- a group of EditorialObjects
 - a single \"work of the mind\", a piece
-- a segment of a \"work of the mind\""""@en ,
-                                """- eine Gruppe von EditorialObjects
-- ein einzelnes \"Werk des Geistes\", ein Stück
-- ein Segment eines \"geistigen Werks\""""@de ,
-                                """- un groupe d'EditorialObjects
-- une \"œuvre de l'esprit\" unique, un morceau
-- un segment d'une \"œuvre de l'esprit\"."""@fr .
+- a segment of a \"work of the mind\""""@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#EditorialObjectType
 ec:EditorialObjectType rdf:type owl:Class ;
                        rdfs:subClassOf skos:Concept ;
-                       dcterms:description "Pour définir un type d'objet éditorial."@fr ,
-                                           "To define a type of editorial object."@en ,
-                                           "Um einen Typ eines redaktionellen Objekts zu definieren."@de ;
-                       rdfs:label "Editorial object type"@en ,
-                                  "Redaktioneller Objekttyp"@de ,
-                                  "Type d'objet rédactionnel"@fr .
+                       dcterms:description "An entry from the classification of types of editorial objects."@en ;
+                       rdfs:label "Editorial object type"@en ;
+                       skos:definition "a skos:Concept classifying the type of a ec:EditorialObject"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#EditorialSegment
@@ -10461,24 +7791,13 @@ ec:EditorialSegment rdf:type owl:Class ;
                                       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                       owl:onDataRange xsd:integer
                                     ] ;
-                    rdfs:label "Editorial Segment"@en ,
-                               "Redaktioneller Abschnitt"@de ,
-                               "Segment éditorial"@fr ;
-                    skos:definition "Ein Medieninhalt, der einen Ausschnitt eines anderen Medieninhaltes darstellt"@de ,
-                                    "an EditorialObject representing a fraction of an EditorialObject"@en ,
-                                    "un objet éditorial représentant une fraction d'un objet éditorial"@fr ;
+                    dcterms:description "A fraction of a work."@en ;
+                    rdfs:label "Editorial segment"@en ;
+                    skos:definition "an ec:EditorialObject representing a fraction of an ec:EditorialWork"@en ;
                     skos:example """- a scene in a movie
 - a section of an interview
 - an intro of a song
-- a paragraph of a text"""@en ,
-                                 """- eine Filmszene
-- eine Passage eines Interviews
-- das Intro eines Liedes
-- ein Textabschnitt"""@de ,
-                                 """- une scène de film
-- un extrait d'interview
-- l'introduction d'une chanson
-- un paragraphe d'un texte"""@fr .
+- a paragraph of a text"""@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#EditorialWork
@@ -10500,27 +7819,14 @@ ec:EditorialWork rdf:type owl:Class ;
                                    owl:onProperty ec:promotes ;
                                    owl:allValuesFrom ec:EditorialWork
                                  ] ;
-                 rdfs:label "Editorial work"@en ,
-                            "Werk"@de ,
-                            "Œuvre"@fr ;
-                 skos:definition "an EditorialObject describing a \"work of the mind\", a piece."@en ,
-                                 "ein Medieninhalt, der ein geistiges Werk, ein \"Stück\" ist"@de ,
-                                 "un objet éditorial décrivant une \"œuvre de l'esprit\", une pièce."@fr ;
+                 dcterms:description "Some content that is created for publication and consumption, e.g. a film, an episode of a series, an item in a news show, a web article, a social media post, etc."@en ;
+                 rdfs:label "Editorial work"@en ;
+                 skos:definition "an ec:EditorialObject representing a \"work of the mind\", a piece"@en ;
                  skos:example """- a film based on a playbook
 - a radio drama based on a playbook
 - a news programme with several items
 - an item in a news programme
-- an episode of a series"""@en ,
-                              """- ein Film nach einem Drehbuch
-- ein Hörspiel auf der Grundlage eines Spielbuchs
-- eine Nachrichtensendung mit mehreren Beiträgen
-- ein Beitrag in einer Nachrichtensendung
-- eine Folge einer Serie"""@de ,
-                              """- un film basé sur un livret de jeu
-- un feuilleton radiophonique basé sur un livret de jeu
-- un journal télévisé avec plusieurs sujets
-- un article dans un journal télévisé
-- un épisode d'une série"""@fr .
+- an episode of a series"""@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Emotion
@@ -10559,34 +7865,25 @@ ec:Emotion rdf:type owl:Class ;
                              owl:onProperty ec:name ;
                              owl:allValuesFrom rdfs:Literal
                            ] ;
-           dcterms:description "A class to log Emotions."@en ,
-                               "Eine Klasse zum Protokollieren von Emotionen."@de ,
-                               "Une classe pour enregistrer les émotions."@fr ;
-           rdfs:label "Emotion"@de ,
-                      "Emotion"@en ,
-                      "Émotion"@fr .
+           dcterms:description "A feeling related to an agent or a sequence in some content."@en ;
+           rdfs:label "Emotion"@en ;
+           skos:definition "a feeling related to a ec:Agent or a ec:Scene or a period of time in some content"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#EmotionType
 ec:EmotionType rdf:type owl:Class ;
                rdfs:subClassOf skos:Concept ;
-               dcterms:description "Pour définir un type d'émotion."@fr ,
-                                   "To define a type of emotion."@en ,
-                                   "Um eine Art von Emotion zu definieren."@de ;
-               rdfs:label "Emotion Typ"@de ,
-                          "Emotion type"@en ,
-                          "Type d'émotion"@fr .
+               dcterms:description "An entry from the classification of types of emotions."@en ;
+               rdfs:label "Emotion type"@en ;
+               skos:definition "a skos:Concept classifying the type of an emotion"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#EncodingFormat
 ec:EncodingFormat rdf:type owl:Class ;
                   rdfs:subClassOf ec:Format ;
-                  dcterms:description "Eine Definition des Kodierungsformats für Audio und Video. Dies wird als freier Text in einer Beschriftung oder als Bezeichner, der auf einen Begriff in einem Klassifikationsschema verweist, z.B. http://www.ebu.ch/metadata/ontologies/skos/ebu_AudioCompressionCodeCS.rdf oder http://www.ebu.ch/metadata/ontologies/skos/ebu_VideoCompressionCodeCS.rdf."@de ,
-                                      "Fournir une définition du format d'encodage pour l'audio et la vidéo. Cette définition est fournie sous forme de texte libre dans une étiquette d'annotation ou comme un identificateur pointant vers un terme dans un schéma de classification, par ex. http://www.ebu.ch/metadata/ontologies/skos/ebu_AudioCompressionCodeCS.rdf ou http://www.ebu.ch/metadata/ontologies/skos/ebu_VideoCompressionCodeCS.rdf."@fr ,
-                                      "To provide a definition of the encoding format for audio and video. This is provided as free text in an annotation label or as an identifier pointing to a term in a classification scheme e.g. http://www.ebu.ch/metadata/ontologies/skos/ebu_AudioCompressionCodeCS.rdf or http://www.ebu.ch/metadata/ontologies/skos/ebu_VideoCompressionCodeCS.rdf."@en ;
-                  rdfs:label "Encodage"@fr ,
-                             "Encoding"@en ,
-                             "Kodierung"@de .
+                  dcterms:description "An entry from the classification of transformations that produce digital resources such as video, audio, images or documents from source signals or data streams."@en ;
+                  rdfs:label "Encoding"@en ;
+                  skos:definition "a ec:Format classifying the transformation from a source signal or data to a ec:MediaResource, ec:Picture or ec:Document"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Essence
@@ -10605,21 +7902,11 @@ ec:Essence rdf:type owl:Class ;
                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                              owl:onDataRange xsd:boolean
                            ] ;
-           dcterms:description "C'est une ressource multimédia, MediaResource,qui peut être composée d'une ou plusieurs Pistes, Tracks. une ressource multimédia est définie par un objet éditorial d'un domaine éditorial, EditorialObject (Editorial Domain). Cet EditorialObject peut être matérialisé par des essences dans un ou plusieurs formats pour différents médias ou plateformes de diffusion."@fr ,
-                               "Die echte physische Repräsentation einer oder mehrerer MedienResourcen, die zur Nutzung bearbeitet wurde. Die Essenz ist eine physische Repräsentation einer MedienResource in einem spezillen Format für die Ausspielung oder Publikation. Essenz ist eine Sub-Klasse von MedienResource und erbt deren Eigenschaften. Essenzen treten auf in Form einfacher Dateien oder komplexer Pakete, z.B. wie es von verschiedenen Kameras verschiedener Hersteller geliefert wird."@de ,
-                               "The actual physical representation of one or more MediaResource edited for consumption. The Essence is a physical representation of a MediaResource in a particular Format destined for play-out or publishing. \"Essence is a subclass of a MediaResource and inherits the MediaResource properties. Essence can be available in a form of a simple file or complex packages (e.g. as delivered by cameras of different brands)."@en ;
-           rdfs:label "Essence"@en ,
-                      "Essence"@fr ,
-                      "Essenz"@de ;
-           skos:definition "a MediaResource in the form of a simple file or a complex file package for play-out or publishing"@en ,
-                           "eine MedienResource in Form einer einfachen Datei oder eines komplexen Dateipakets zur Ausspielung oder Veröffentlichung"@de ,
-                           "une ressource média sous la forme d'un fichier simple ou d'un paquet de fichiers complexes pour la diffusion ou la publication."@fr ;
+           dcterms:description "A media resource in the form of a single file or a file package for play-out or publishing, e.g. an audio file for playout on an audio on demand platform; a MXF container for playout; a video file together with additional language tracks and a subtitle file."@en ;
+           rdfs:label "Essence"@en ;
+           skos:definition "a ec:MediaResource in the form of a single file or a file package for play-out or publishing"@en ;
            skos:example """- a mxf file
-- a file package delivered by a camera of a specific brand"""@en ,
-                        """- eine mxf-Datei
-- ein Dateipaket, das von einer Kamera einer bestimmten Marke geliefert wird"""@de ,
-                        """- un fichier mxf
-- un paquet de fichiers fourni par un appareil photo d'une marque spécifique"""@fr .
+- a file package delivered by a camera of a specific brand"""@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Event
@@ -10671,89 +7958,65 @@ ec:Event rdf:type owl:Class ;
                            owl:onProperty ec:name ;
                            owl:allValuesFrom rdfs:Literal
                          ] ;
-         dcterms:description "An Event related to a Resource, e.g. as depicted in the Resource (real or fictional), etc."@en ,
-                             "Ein Ereignis, das mit einem Medieninhalt verknüpft ist, z.B. dargestellt in einer Resource (real oder fiktional), etc."@de ,
-                             "Un événement lié à une ressource, par exemple tel qu'il est décrit dans la ressource. Ainsi cet évènement peut être décrit comme réel ou fictif dans la ressource."@fr ;
-         rdfs:label "Ereignis"@de ,
-                    "Event"@en ,
-                    "Événement"@fr .
+         dcterms:description "A real or fictional happening that is covered in some content."@en ;
+         rdfs:label "Event"@en ;
+         skos:definition "a real or fictional happening covered in some content"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#EventType
 ec:EventType rdf:type owl:Class ;
              rdfs:subClassOf skos:Concept ;
-             dcterms:description "Pour définir un type d'événement."@fr ,
-                                 "To define a type of event."@en ,
-                                 "Um eine Art von Ereignis zu definieren."@de ;
-             rdfs:label "Ereignis-Typ"@de ,
-                        "Event type"@en ,
-                        "Type d'événement"@fr .
+             dcterms:description "An entry from the classification of types of events."@en ;
+             rdfs:label "Event type"@en ;
+             skos:definition "a skos:Concept classifying the type of a ec:Event"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ExclusivityType
 ec:ExclusivityType rdf:type owl:Class ;
                    rdfs:subClassOf skos:Concept ;
-                   dcterms:description "Définir un type de droits d'exclusivité."@fr ,
-                                       "To define a type of exclusity rights."@en ,
-                                       "Um eine Art von Ausschließlichkeitsrechten zu definieren."@de ;
-                   rdfs:label "Ausschließlichkeitstyp"@de ,
-                              "Exclusivity type"@en ,
-                              "Type d'exclusivité"@fr .
+                   dcterms:description "An entry from a list of types of particularity of rights."@en ;
+                   rdfs:label "Exclusivity type"@en ;
+                   skos:definition "a skos:Concept identifying the type of particularity of rights"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ExploitationIssues
 ec:ExploitationIssues rdf:type owl:Class ;
                       rdfs:subClassOf ec:Rights ;
-                      dcterms:description "Mettre en évidence les problèmes potentiels d'exploitation d'exploitation."@fr ,
-                                          "Potenzielle Ausbeutung hervorheben Probleme."@de ,
-                                          "To highlight potential exploitation issues."@en ;
-                      rdfs:label "Exploitation issues"@en ,
-                                 "Fragen der Ausbeutung"@de ,
-                                 "Problèmes d'exploitation"@fr .
+                      dcterms:description "A potential problem arising from the use of someone else's work."@en ;
+                      rdfs:label "Exploitation issues"@en ;
+                      skos:definition "a ec:Rights that highlight potential problems in the use of someone else's work"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#FictionalEvent
 ec:FictionalEvent rdf:type owl:Class ;
                   rdfs:subClassOf ec:Event ;
-                  dcterms:description "Pour décrire un événement fictif."@fr ,
-                                      "To describe a fictional Event."@en ,
-                                      "Um ein fiktives Ereignis zu beschreiben."@de ;
-                  rdfs:label "Fictional event"@en ,
-                             "Fiktives Ereignis"@de ,
-                             "Événement fictif"@fr .
+                  dcterms:description "An event that is not real."@en ;
+                  rdfs:label "Fictional event"@en ;
+                  skos:definition "a ec:Event that is not real"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#FictionalLocation
 ec:FictionalLocation rdf:type owl:Class ;
                      rdfs:subClassOf ec:Location ;
-                     dcterms:description "Pour décrire un lieu fictif."@fr ,
-                                         "To describe a fictional Location."@en ,
-                                         "Um einen fiktiven Ort zu beschreiben."@de ;
-                     rdfs:label "Fictional location"@en ,
-                                "Fiktiver Ort"@de ,
-                                "Lieu fictif"@fr .
+                     dcterms:description "A location that is not real."@en ;
+                     rdfs:label "Fictional location"@en ;
+                     skos:definition "a ec:Location that is not real"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#FictionalOrganisation
 ec:FictionalOrganisation rdf:type owl:Class ;
                          rdfs:subClassOf ec:Organisation ;
-                         dcterms:description "Pour définir une organisation fictive."@fr ,
-                                             "To define a fictional Organisation."@en ,
-                                             "Um eine fiktive Organisation zu definieren."@de ;
-                         rdfs:label "Fictional organisation"@en ,
-                                    "Fiktive Organisation"@de ,
-                                    "Organisation fictive"@fr .
+                         dcterms:description "A non-existent organisation mentioned in a fictional story."@en ;
+                         rdfs:label "Fictional organisation"@en ;
+                         skos:definition "an ec:Organisation that does not exist in reality, but as part of a fiction"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#FileFormat
 ec:FileFormat rdf:type owl:Class ;
               rdfs:subClassOf ec:Format ;
-              dcterms:description "A file format for Resources other than audiovisual resources. The format is defined as free text or pointing at a term in a classification scheme e.g. http://www.ebu.ch/metadata/ontologies/skos/ebu_FileFormatCS.rdf."@en ,
-                                  "Ein Dateiformat für andere Resourcen als audiovisuelle Resourcen. Das Format ist als freier Text oder als Verweis auf einen Begriff in einem Klassifikationsschema, z.B. http://www.ebu.ch/metadata/ontologies/skos/ebu_FileFormatCS.rdf."@de ,
-                                  "Un format de fichier pour les Resources autres que ressources audiovisuelles. Le format est défini comme texte libre ou pointant sur un terme dans un système de classification, par exemple http://www.ebu.ch/metadata/ontologies/skos/ebu_FileFormatCS.rdf."@fr ;
-              rdfs:label "Dateiformat"@de ,
-                         "File format"@en ,
-                         "Format de fichier"@fr .
+              dcterms:description "An entry from the classification of file formats for files with non-audiovisual content."@en ;
+              rdfs:label "File format"@en ;
+              skos:definition "a ec:Format for non-audiovisual resources"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Food
@@ -10779,23 +8042,17 @@ ec:Food rdf:type owl:Class ;
                           owl:onProperty ec:foodIngredient ;
                           owl:allValuesFrom rdfs:Literal
                         ] ;
-        dcterms:description "Pour décrire les aliments montrés ou consommés dans les productions."@fr ,
-                            "To describe Food shown or consumed in productions."@en ,
-                            "Zur Beschreibung von Lebensmitteln, die in Produktionen gezeigt oder konsumiert werden."@de ;
-        rdfs:label "Alimentation"@fr ,
-                   "Essen"@de ,
-                   "Food"@en .
+        dcterms:description "Provisions that are shown or consumed in a scene, such as an apple, a bottle of beer, etc."@en ;
+        rdfs:label "Food"@en ;
+        skos:definition "an edible item shown or consumed in a scene of the ec:EditorialObject"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#FoodStyle
 ec:FoodStyle rdf:type owl:Class ;
              rdfs:subClassOf skos:Concept ;
-             dcterms:description "Pour définir un style d'alimentation."@fr ,
-                                 "To define a style of food."@en ,
-                                 "Um einen Essensstil zu definieren."@de ;
-             rdfs:label "Essen Stil"@de ,
-                        "Food style"@en ,
-                        "Style alimentaire"@fr .
+             dcterms:description "An entry from the classification of food styles."@en ;
+             rdfs:label "Food style"@en ;
+             skos:definition "a skos:Concept classifying the style of ec:Food"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Format
@@ -10811,45 +8068,33 @@ ec:Format rdf:type owl:Class ;
                             owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                             owl:onClass ec:Identifier
                           ] ;
-          dcterms:description "A Format can be defined as a collection of audio / video / data and container Formats. A Format can be globally associated with a MediaResource but Specific audio / video / data and container Formats can also be distinctly associated with a MediaResource. The ContainerFormat defines the file / package structure of the MediaResource."@en ,
-                              "Ein Format wird definiert als eine Sammlung aus Audio-, Video-, Daten- und Containerformaten. Ein Format kann global mit einer MedienResource verknüpft sein, oder auch speziell nach unterschiedlichen Audio-, Video-, Daten- und Containerformaten. Das Containerformat definiert die Datei- bzw. Paketstruktur einer MedienResource."@de ,
-                              "Un format peut être défini comme une collection de formats audio/vidéo/données et de conteneurs. Un format peut être associé globalement à une ressource multimédia, mais des formats audio/vidéo/données et conteneurs spécifiques peuvent également être associés de manière distincte à une ressource multimédia. Le ContainerFormat définit la structure du fichier / paquet de la MediaResource."@fr ;
-          rdfs:label "Format"@de ,
-                     "Format"@en ,
-                     "Format"@fr .
+          dcterms:description "An entry from the classification of types of formats, that can also be more specific like audio / video / image / document / data and container formats. A format can be globally associated with a resource but more specific formats can also be distinctly associated with a more specific resource."@en ;
+          rdfs:label "Format"@en ;
+          skos:definition "a skos:Concept classifying the technical format of a ec:Resource"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Generation
 ec:Generation rdf:type owl:Class ;
               rdfs:subClassOf ec:Format ;
-              dcterms:description "Identifie la génération d'une version d'une ressource, c'est-à-dire master, edit master, copie de distribution, etc."@fr ,
-                                  "Identifies the generation of a version of a resource, i.e. master, edit master, distribution copy, etc."@en ,
-                                  "Identifiziert die Erzeugung einer Version einer Resource, d.h. Master, Edit Master, Verteilungskopie, etc."@de ;
-              rdfs:label "Generation"@de ,
-                         "Generation"@en ,
-                         "Génération"@fr .
+              dcterms:description "An entry from the classification of versions of media resources, e.g. \"master\", \"edit master\" or \"distribution copy\"."@en ;
+              rdfs:label "Generation"@en ;
+              skos:definition "a ec:Format classifying the version of a ec:MediaResource"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Genre
 ec:Genre rdf:type owl:Class ;
          rdfs:subClassOf ec:Type ;
-         dcterms:description "Cette classe est utilisée pour fournir des informations sur le genre de l'EditorialObject. Cette information est fournie sous forme de texte libre dans une étiquette d'annotation ou sous forme d'identificateur pointant vers un terme dans un schéma de classification, par exemple http://www.ebu.ch/metadata/ontologies/skos/ebu_ContentGenreCS.rdf ou http://www.ebu.ch/metadata/ontologies/skos/ebu_EditorialFormatCodeCS.rdf."@fr ,
-                             "Diese Klasse wird verwendet, um Informationen über das Genre des EditorialObjects bereitzustellen. Dies wird als freier Text in einer Beschriftung oder als Kennung, die auf einen Begriff in einem Klassifizierungsschema verweist, bereitgestellt, z.B. http://www.ebu.ch/metadata/ontologies/skos/ebu_ContentGenreCS.rdf oder http://www.ebu.ch/metadata/ontologies/skos/ebu_EditorialFormatCodeCS.rdf."@de ,
-                             "This class shall be used to provide information on the genre of the EditorialObject. This is provided as free text in an annotation label or as an identifier pointing to a term in a classification scheme e.g. http://www.ebu.ch/metadata/ontologies/skos/ebu_ContentGenreCS.rdf or http://www.ebu.ch/metadata/ontologies/skos/ebu_EditorialFormatCodeCS.rdf."@en ;
-         rdfs:label "Genre"@de ,
-                    "Genre"@en ,
-                    "Genre"@fr .
+         dcterms:description "A list of entries to classify some content by genre, e.g. EBU's classification scheme on ContentGenre."@en ;
+         rdfs:label "Genre"@en ;
+         skos:definition "a ec:Type that lists editorial genres for some content"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#IPRRestrictions
 ec:IPRRestrictions rdf:type owl:Class ;
                    rdfs:subClassOf ec:Rights ;
-                   dcterms:description "Bereitstellung von Informationen über geistiges Eigentum."@de ,
-                                       "Fournir des informations sur la propriété intellectuelle."@fr ,
-                                       "To provide information on intellectual property."@en ;
-                   rdfs:label "IPR restrictions"@en ,
-                              "IPR-Beschränkungen"@de ,
-                              "Restrictions DPI"@fr .
+                   dcterms:description "A limitation of the use of a work referring to intellectual property legislation or contracts."@en ;
+                   rdfs:label "IPR restrictions"@en ;
+                   skos:definition "a ec:Rights that limits the use of a work referring to intellectual property legislation or contracts"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Identifier
@@ -10880,65 +8125,43 @@ ec:Identifier rdf:type owl:Class ;
                                 owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                 owl:onDataRange xsd:string
                               ] ;
-              dcterms:description "Pour soutenir l'utilisation d'identifiants structurés."@fr ,
-                                  "To support the use of structured identifiers."@en ,
-                                  "Zur Unterstützung der Verwendung von strukturierten Identifikatoren."@de ;
-              rdfs:label "Identifiant"@fr ,
-                         "Identifier"@en ,
-                         "Identifikator"@de ;
-              skos:definition "a unique string associated with an entity"@en ,
-                              "eine eindeutige Zeichenkette, die einer Entität zugeordnet ist"@de ,
-                              "une chaîne de caractères unique associée à une entité"@fr ;
-              skos:example """- \"ISAN 0000-0001-8947-0000-8-0000-0000-D\" est une identifiant d'ISAN
-- \"10.5240/EA73-79D7-1B2B-B378-3A73-M\" est une identifiant de EIDR pour le film \"Blade Runner\""""@fr ,
-                           """- \"ISAN 0000-0001-8947-0000-8-0000-0000-D\" is an ISAN Identifier
-- \"10.5240/EA73-79D7-1B2B-B378-3A73-M\" is an EIDR Identifier for the movie \"Blade Runner\""""@en ,
-                           """- \"ISAN 0000-0001-8947-0000-8-0000-0000-D\" ist ein ISAN Identifikator
-- \"10.5240/EA73-79D7-1B2B-B378-3A73-M\" ist ein EIDR Identifikator des Films \"Blade Runner\""""@de .
+              dcterms:description "To support the use of structured identifiers."@en ;
+              rdfs:label "Identifier"@en ;
+              skos:definition "a unique string associated with an entity"@en ;
+              skos:example """- \"ISAN 0000-0001-8947-0000-8-0000-0000-D\" is an ISAN Identifier
+- \"10.5240/EA73-79D7-1B2B-B378-3A73-M\" is an EIDR Identifier for the movie \"Blade Runner\""""@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#IdentifierType
 ec:IdentifierType rdf:type owl:Class ;
                   rdfs:subClassOf skos:Concept ;
-                  dcterms:description "Pour définir un type d'identifiant."@fr ,
-                                      "So definieren Sie einen Typ von Identifikator."@de ,
-                                      "To define a type of identifier."@en ;
-                  rdfs:label "Identifier type"@en ,
-                             "Identifikator Typ"@de ,
-                             "Type d'identifiant"@fr .
+                  dcterms:description "An entry from the classification of types of identifiers."@en ;
+                  rdfs:label "Identifier type"@en ;
+                  skos:definition "a skos:Concept classifying the type of a ec:Identifier"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ImageCodec
 ec:ImageCodec rdf:type owl:Class ;
               rdfs:subClassOf ec:Codec ;
-              dcterms:description "pour identifier un codec pour les images"@fr ,
-                                  "to identify a codec for images"@en ,
-                                  "um einen Codec für Bilder zu identifizieren"@de ;
-              rdfs:label "Bild-Codec"@de ,
-                         "Codec d'image"@fr ,
-                         "Image codec"@en .
+              dcterms:description "The codec used in the production of digital images."@en ;
+              rdfs:label "Image codec"@en ;
+              skos:definition "a ec:Codec used in the production of a file for a photo"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ImageFormat
 ec:ImageFormat rdf:type owl:Class ;
                rdfs:subClassOf ec:Format ;
-               dcterms:description "Pour fournir des informations techniques sur le format d'une image, comme l'orientation. Ces informations sont fournies sous forme de texte libre dans une d'annotation ou comme identifiant pointant vers un terme dans un schéma de classification. de classification."@fr ,
-                                   "To provide technical information about the format of an image such as the orientation. This is provided as free text in an annotation label or as an identifier pointing to a term in a classification scheme."@en ,
-                                   "Zur Bereitstellung technischer Informationen über das Format eines Bildes, wie z.B. die Ausrichtung. Diese Informationen werden als freier Text in einer Beschriftung oder als Kennung, die auf einen Begriff in einem Klassifizierungsschema verweist Schema."@de ;
-               rdfs:label "Bildformat"@de ,
-                          "Format de l'image"@fr ,
-                          "Image format"@en .
+               dcterms:description "An entry from the classification of formats of pictures or media resources, e.g. \"3x4\", \"4x3\" or \"16x9\"."@en ;
+               rdfs:label "Image format"@en ;
+               skos:definition "a ec:Format classifying the relation of length vs. height of a ec:Picture or a ec:MediaResource"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#IntentionCode
 ec:IntentionCode rdf:type owl:Class ;
                  rdfs:subClassOf ec:Type ;
-                 dcterms:description "Pour indiquer le but dans lequel le contenu a été créé."@fr ,
-                                     "To indicate the purpose for which content was created."@en ,
-                                     "Zur Angabe des Zwecks, für den der Inhalt erstellt wurde."@de ;
-                 rdfs:label "Absichtscode"@de ,
-                            "Code d'intention"@fr ,
-                            "Intention code"@en .
+                 dcterms:description "A list of entries to classify the intention for the creation of some content, e.g. EBU's classification scheme of Intention Codes."@en ;
+                 rdfs:label "Intention code"@en ;
+                 skos:definition "a ec:Type that lists intentions for which some content was created"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Involvement
@@ -10987,27 +8210,13 @@ ec:Involvement rdf:type owl:Class ;
                                  owl:onProperty ec:name ;
                                  owl:allValuesFrom rdfs:Literal
                                ] ;
-               dcterms:description "Definiert eine Rolle, die ein Akteur übernimmt. Eine Rolle kann durch ein Concept aus SKOS repräsentiert werden."@de ,
-                                   "Permet de définir le rôle, Role, joué par un agent, Agent. Un rôle sera identifié, par exemple, par un Concept d'un schéma de classification SKOS."@fr ,
-                                   "To define Role played by an Agent. A «Role» will be identified e.g. by a Concept from a SKOS Classification Scheme."@en ;
-               rdfs:label "Beteiligung"@de ,
-                          "Implication"@fr ,
-                          "Involvement"@en ;
-               skos:definition "an Agent's participation in the creation or publication of a MediaResource"@en ,
-                               "die Beteiligung eines Akteurs an der Erstellung oder Veröffentlichung einer MedienResource"@de ,
-                               "la participation d'un Agent dans la création ou la publication d'une ressourceMédia"@fr ;
-               skos:example """- Verfassen eines Drehbuchs für eine Filmproduktion
-- Regie bei einem Film
-- Tontechnik für eine Talkshow
-- Erstellung von Spezialeffekten für einen Film"""@de ,
-                            """- authoring a screenplay for a film production
+               dcterms:description "An agent's participation in the content, e.g., an actress playing a character, a screenwriter, a production company, or a broadcaster holding the publishing rights."@en ;
+               rdfs:label "Involvement"@en ;
+               skos:definition "an ec:Agent's participation in an ec:EditorialObject or the creation or publication thereof"@en ;
+               skos:example """- authoring a screenplay for a film production
 - directing a movie
 - sound engineering of a talk show
-- creation special effects for a movie"""@en ,
-                            """- rédiger un scénario pour une production cinématographique
-- réalisation d'un film
-- ingénierie du son d'un talk-show
-- création d'effets spéciaux pour un film"""@fr .
+- creation special effects for a movie"""@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Item
@@ -11029,98 +8238,67 @@ ec:Item rdf:type owl:Class ;
                           owl:onProperty ec:hasProgramme ;
                           owl:allValuesFrom ec:Programme
                         ] ;
-        dcterms:description "An item e.g. newsItem or sportItem"@en ,
-                            "Ein Element, z.B. newsItem oder sportItem"@de ,
-                            "Un élément, par exemple newsItem ou sportItem"@fr ;
-        rdfs:label "Article"@fr ,
-                   "Beitrag"@de ,
-                   "Item"@en ;
-        skos:definition "an EditorialWork to be incorporated into a Programme, an Article or a Post"@en ,
-                        "ein Werk, das in ein Programm, einen Artikel oder einen Beitrag integriert werden soll"@de ,
-                        "un travail de rédaction à incorporer dans un programme, un article ou un message."@fr ;
+        dcterms:description "Content created to be incorporated into a programme, an article, or a post, e.g., a news item or a short video for social media."@en ;
+        rdfs:label "Item"@en ;
+        skos:definition "an ec:EditorialWork to be incorporated into a Programme, an Article or a Post"@en ;
         skos:example """- a news item to be incorporated in a news programme
-- a survey-clip to be incorporated in a debate"""@en ,
-                     """- eine Nachricht, die in eine Nachrichtensendung integriert werden soll
-- ein Umfrage-Clip, der in eine Debatte integriert werden soll"""@de ,
-                     """- un article d'actualité à intégrer dans un programme d'information
-- un clip d'enquête à intégrer dans un débat"""@fr .
+- a survey-clip to be incorporated in a debate"""@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#KeyCareerEvent
 ec:KeyCareerEvent rdf:type owl:Class ;
                   rdfs:subClassOf ec:KeyEvent ;
-                  dcterms:description "Décrire un événement clé de la carrière d'un contact."@fr ,
-                                      "Ein wichtiges Karriereereignis einer Kontaktperson beschreiben."@de ,
-                                      "To describe a key career Event of a Contact."@en ;
-                  rdfs:label "Key career event"@en ,
-                             "Wichtiges Karriere-Ereignis"@de ,
-                             "Événement de carrière clé"@fr .
+                  dcterms:description "A significant event for the career of a real or fictional person."@en ;
+                  rdfs:label "Key career event"@en ;
+                  skos:definition "a ec:KeyEvent for the career of a ec:Person"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#KeyEvent
 ec:KeyEvent rdf:type owl:Class ;
             rdfs:subClassOf ec:Event ;
-            dcterms:description "Pour décrire un événement important."@fr ,
-                                "To describe a significant event."@en ,
-                                "Um ein bedeutendes Ereignis zu beschreiben."@de ;
-            rdfs:label "Key event"@en ,
-                       "Wichtigstes Ereignis"@de ,
-                       "Événement clé"@fr .
+            dcterms:description "A significant event in a person’s career or personal life, or another notable happening covered in content."@en ;
+            rdfs:label "Key event"@en ;
+            skos:definition "a ec:Event that is significant"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#KeyPersonalEvent
 ec:KeyPersonalEvent rdf:type owl:Class ;
                     rdfs:subClassOf ec:KeyEvent ;
-                    dcterms:description "A key personal Event of a Contact."@en ,
-                                        "Ein wichtiges persönliches Ereignis eines Kontakts."@de ,
-                                        "Un événement personnel clé d'un contact."@fr ;
-                    rdfs:label "Key personal event"@en ,
-                               "Persönliches Schlüsselereignis"@de ,
-                               "Événement personnel clé"@fr .
+                    dcterms:description "A significant event in the personal life of a real or fictional person."@en ;
+                    rdfs:label "Key personal event"@en ;
+                    skos:definition "a ec:KeyEvent in the personal life a ec:Person"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Keyframe
 ec:Keyframe rdf:type owl:Class ;
             rdfs:subClassOf ec:Picture ;
-            dcterms:description "A key frame is a frame extracted from video, e.g. representative of a part of a MediaResource."@en ,
-                                "Ein Keyframe ist ein aus einem Video extrahiertes Bild, z.B. repräsentativ für einen Teil einer MedienResource."@de ,
-                                "Une image clé est une image extraite d'une vidéo, par exemple, représentative d'une partie d'une MediaResource."@fr ;
-            rdfs:label "Keyframe"@de ,
-                       "cadre de la clé"@fr ,
-                       "key frame"@en .
+            dcterms:description "A picture extracted at some point in time from a video, often called a \"frame\", used to represent the surrounding video sequence for easy navigation back and forth along the video timeline."@en ;
+            rdfs:label "Key frame"@en ;
+            skos:definition "a ec:Picture that is extracted at a point in time from a video and used to visually reference that same point in time"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Keyword
 ec:Keyword rdf:type owl:Class ;
            rdfs:subClassOf skos:Concept ;
-           dcterms:description "Pour fournir des mots-clés et définir des concepts clés illustrant le contenu de la ressource ou de l'objet éditorial. Ceci est fourni sous forme de texte libre libre dans une étiquette d'annotation ou comme identificateur pointant vers un terme dans un schéma de classification. de classification."@fr ,
-                               "To provide keywords and define key concepts illustrating the content of the Resource or EditorialObject. This is provided as free text in an annotation label or as an identifier pointing to a term in a classification scheme."@en ,
-                               "Um Schlüsselwörter und Schlüsselkonzepte zu definieren die den Inhalt der Resource oder des redaktionellen Objekts illustrieren. Dies wird als freier Text in einer Beschriftung oder als Bezeichner, der auf einen Begriff in einem Klassifikationsschema verweist Schema verweist."@de ;
-           rdfs:label "Keyword"@en ,
-                      "Mot-clé"@fr ,
-                      "Schlüsselwort"@de .
+           dcterms:description "An entry from the list of keywords to classify the content of a piece of work."@en ;
+           rdfs:label "Keyword"@en ;
+           skos:definition "a skos:Concept classifying the content of a ec:EditorialObject"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Language
 ec:Language rdf:type owl:Class ;
             rdfs:subClassOf skos:Concept ;
-            dcterms:description "Fournir des informations sur les langues présentes dans l'EditorialObject et son objectif. Ces informations sont fournies sous forme de texte libre dans une étiquette d'annotation ou comme un identifiant pointant vers un terme dans un système de classification. D'autres types spécifiques à la langue peuvent être ajoutés en tant que sous-classes de la langue."@fr ,
-                                "To provide information on languages present in the EditorialObject and its purpose. This is provided as free text in an annotation label or as an identifier pointing to a term in a classification scheme.Other language specific types may be added as subclasses of language."@en ,
-                                "Zur Bereitstellung von Informationen über die Sprachen in des EditorialObjects und dessen Zweck. Dies wird als freier Text in einer Beschriftung angegeben. oder als Bezeichner, der auf einen Begriff in einem Klassifikationsschema verweist. spezifische Typen können als Unterklassen von language hinzugefügt werden."@de ;
-            rdfs:label "Language"@en ,
-                       "Langue"@fr ,
-                       "Sprache"@de .
+            dcterms:description "An entry from the list of languages related to, e.g. a piece of work, a person or an organisation."@en ;
+            rdfs:label "Language"@en ;
+            skos:definition "a skos:Concept classifying the language of a ec:EditorialObject or ec:Agent"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Licensing
 ec:Licensing rdf:type owl:Class ;
              rdfs:subClassOf ec:Rights ;
-             dcterms:description "Pour définir les conditions de licence associées à un actif."@fr ,
-                                 "To define the licensing terms associated with an Asset."@en ,
-                                 "Zur Definition der mit einem Asset verbundenen Lizenzbedingungen."@de ;
-             rdfs:label "Licences"@fr ,
-                        "Licensing"@en ,
-                        "Lizenzierung"@de .
+             dcterms:description "A set of conditions under which the use of a work is granted."@en ;
+             rdfs:label "Licensing"@en ;
+             skos:definition "a ec:Rights that defines the conditions under which the use of a work is granted"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Location
@@ -11215,46 +8393,28 @@ ec:Location rdf:type owl:Class ;
                               owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                               owl:onDataRange xsd:float
                             ] ;
-            dcterms:description "A location related to the media resource, e.g. depicted in the resource (possibly fictional) or where the resource was created (shooting location), etc. A «Location» is used to define the spatial coverage of the story or recording locations like studios or in the field, associated with the EditorialObjects (or Part of EditorialObjects). Note: a type of location shall be defined as a sub-class of Location."@en ,
-                                "Ein Ort, der mit einer MedienResource verknüpft ist, z.B. darin dargestellt (auch fiktional) oder dort hergestellt (Drehort), etc. Ein Ort definiert den räumliche Bezug der Geschichte oder des Aufnahmeortes in einem Medieninhalt, wie z.b. im Studio, Außenaufnahme."@de ,
-                                "Une localisation est liée à la ressource média, elle peut être décrite dans la ressource et donc être éventuellement fictive. Elle peut aussi représenter le lieu où la ressource a été créée (lieu de tournage). Une localisation est utilisée pour définir la couverture spatiale du reportage ou des lieux d'enregistrement comme par exemple : studios ou sur le terrain, associés aux EditorialObjects (ou à une partie des EditorialObjects). Note: le type de localisation doit être décrit comme une sous-classe de localisation."@fr ;
-            rdfs:label "Localisation"@fr ,
-                       "Location"@en ,
-                       "Ort"@de ;
-            skos:definition "a spatial assignment to a media related locatable Thing"@en ,
-                            "eine räumliche Zuordnung zu einer medienbezogenen lokalisierbaren Sache"@de ,
-                            "une affectation spatiale à un élément localisable lié aux médias"@fr ;
-            skos:example """- London als Ort, an dem die BBC Nachrichtensendungen produziert
-- London als Schauplatz eines Drehbuchs
-- London als Ort der öffentlichen Ankündigung des Premierministers in einer BBC-Nachrichtensendung"""@de ,
-                         """- London as a place where BBC produces news shows
+            dcterms:description "A location related to the media resource, e.g. depicted in the resource (possibly fictional) or where the resource was created (shooting location), e.g. A «Location» is used to define the spatial coverage of the story or recording locations like studios or in the field, associated with the EditorialObjects (or Part of EditorialObjects). Note: a type of location shall be defined as a sub-class of Location."@en ;
+            rdfs:label "Location"@en ;
+            skos:definition "a spatial assignment to a media related locatable Thing"@en ;
+            skos:example """- London as a place where BBC produces news shows
 - London as a place for a screenplay
-- London as a place for the prime minister's public announcement covered in a BBC news show"""@en ,
-                         """- Londres, lieu de production des émissions d'information de la BBC
-- Londres comme lieu de tournage d'un scénario
-- Londres, lieu de l'annonce publique du Premier ministre couverte par un journal télévisé de la BBC"""@fr .
+- London as a place for the prime minister's public announcement covered in a BBC news show"""@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#LocationCode
 ec:LocationCode rdf:type owl:Class ;
                 rdfs:subClassOf skos:Concept ;
-                dcterms:description "A code given to a Location."@en ,
-                                    "Ein Code, der einem Ort zugeordnet ist."@de ,
-                                    "Un code donné à un emplacement."@fr ;
-                rdfs:label "Code de localisation."@fr ,
-                           "Location code."@en ,
-                           "Standort-Code."@de .
+                dcterms:description "An entry from a list of codes identifying a location."@en ;
+                rdfs:label "Location code"@en ;
+                skos:definition "a skos:Concept identifying a ec:Location"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#LocationType
 ec:LocationType rdf:type owl:Class ;
                 rdfs:subClassOf skos:Concept ;
-                dcterms:description "Pour définir un type d'emplacement."@fr ,
-                                    "So definieren Sie eine Art von Ort."@de ,
-                                    "To define a type of location."@en ;
-                rdfs:label "Location type"@en ,
-                           "Standorttyp"@de ,
-                           "Type d'emplacement"@fr .
+                dcterms:description "An entry from a list of types to classify locations."@en ;
+                rdfs:label "Location type"@en ;
+                skos:definition "a skos:Concept classifying the type of a ec:Location"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Locator
@@ -11279,23 +8439,17 @@ ec:Locator rdf:type owl:Class ;
                              owl:onProperty ec:name ;
                              owl:allValuesFrom rdfs:Literal
                            ] ;
-           dcterms:description "Benutzerdefinierte Attribute müssen von den Implementierern zugewiesen werden."@de ,
-                               "Custom attributes are to be associated by implementers. To provide information about complex locators."@en ,
-                               "Les attributs personnalisés doivent être associés par les implémenteurs."@fr ;
-           rdfs:label "Localisateur"@fr ,
-                      "Locator"@de ,
-                      "Locator"@en .
+           dcterms:description "A place within a location, e.g. a hall name and number in a large concert building."@en ;
+           rdfs:label "Locator"@en ;
+           skos:definition "an additional specification of a place subordinate to a ec:Locator"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Logo
 ec:Logo rdf:type owl:Class ;
         rdfs:subClassOf ec:Picture ;
-        dcterms:description "A Logo allows to visually identify an organisation, publicationService, publicationChannel, or ratings / parentalGuidance"@en ,
-                            "Ein Logo ermöglicht die visuelle Identifizierung einer Organisation, publicationService, publicationChannel oder Bewertungen / parentalGuidance"@de ,
-                            "Un Logo permet d'identifier visuellement une organisation, un service de publication, un canal de publication, ou un classement / parentalGuidance"@fr ;
-        rdfs:label "Logo"@de ,
-                   "Logo"@en ,
-                   "Logo"@fr .
+        dcterms:description "A picture representing an organisation, an award, a brand, a publication platform, a publication channel, a publication service or a rating. This list may be extended in the future."@en ;
+        rdfs:label "Logo"@en ;
+        skos:definition "a ec:Picture to represent an ec: Organization, a ec:Award, a ec:MarketingBrand, a ec:PublicationPlatform, a ec:PublicationChannel, a ec:PublicationService, or a ec:Rating"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#MarketingBrand
@@ -11320,21 +8474,10 @@ ec:MarketingBrand rdf:type owl:Class ;
                                     owl:onProperty ec:name ;
                                     owl:allValuesFrom rdfs:Literal
                                   ] ;
-                  rdfs:label "Brand"@en ,
-                             "Marke"@de ,
-                             "Marque"@fr ;
-                  skos:definition "a name, often accompanied by a logo, and given to an Asset or a Service or a group thereof to distinguish them from Assets or services provided by other manufacturer's or merchant's."@en ,
-                                  "ein Name, oft zusammen mit einem Logo, der einem Vermögenswert oder einer Dienstleistung oder einer Gruppe davon gegeben wird, um sie von Vermögenswerten oder Dienstleistungen anderer Hersteller oder Händler zu unterscheiden."@de ,
-                                  "un nom, souvent accompagné d'un logo, et donné à un bien ou à un service ou à un groupe de ceux-ci pour les distinguer des biens ou des services fournis par d'autres fabricants ou commerçants."@fr ;
-                  skos:example """- der Name einer PSM-Organisation: \"BBC\"
-- der Name eines Medienkanals: \"BBC4\"
-- der Name einer Serie: \"Downton Abbey\"
-- der Name einer Serie: \"BBC Nachrichten\""""@de ,
-                               """- le nom d'une organisation PSM : \"BBC\"
-- le nom d'une chaîne média : \"BBC4\"
-- le nom d'une série : \"Downton Abbey\"
-- le nom d'une série : \"BBC News\""""@fr ,
-                               """- the name of a PSM organization: \"BBC\"
+                  dcterms:description "A name, often accompanied by a logo, and given to an asset or a publication service or a group thereof to distinguish them from those provided by other manufacturers or merchants."@en ;
+                  rdfs:label "Brand"@en ;
+                  skos:definition "a name, often accompanied by a logo, and given to an ec:Asset or an ec:PublicationService or a group thereof to distinguish them from those provided by other manufacturers or merchants"@en ;
+                  skos:example """- the name of a PSM organization: \"BBC\"
 - the name of a media channel: \"BBC4\"
 - the name of a series: \"Downton Abbey\"
 - the name of a serial: \"BBC News\""""@en .
@@ -11378,24 +8521,12 @@ ec:Measure rdf:type owl:Class ;
                              owl:onProperty ec:name ;
                              owl:allValuesFrom rdfs:Literal
                            ] ;
-           dcterms:description "A Measure associated with a Rule to assess compliance through AuditJobs."@en ,
-                               "Eine Messung zu einer Regel untersucht deren Einhaltung durch Prüfaufgaben."@de ,
-                               "Une mesure associée à une règle, Rule, pour évaluer la conformité à travers des AuditJobs."@fr ;
-           rdfs:label "Measure"@en ,
-                      "Messung"@de ,
-                      "Mesure"@fr ;
-           skos:definition "Bestimmung einer Zahl und einer Einheit zur Beantwortung einer bestimmten Frage durch Zählen, Vergleichen, Aggregieren oder Berechnen"@de ,
-                           "act of determining a number and a unit to answer a given question, by counting, comparing, aggregating or calculating"@en ,
-                           "action de déterminer un nombre et une unité pour répondre à une question donnée, en comptant, comparant, agrégeant ou calculant."@fr ;
-           skos:example """- Bestimmung des Lautstärkepegels einer Tonspur
-- Zählen der Minuten, die ein Redner während einer Debatte hat
-- Zählen der Anzahl der weiblichen Experten in allen Sendungen von BBC One"""@de ,
-                        """- determining the volume level of audio track
+           dcterms:description "A Measure associated with a Rule to assess compliance through AuditJobs."@en ;
+           rdfs:label "Measure"@en ;
+           skos:definition "a act of determining a number and a unit to answer a given question, by counting, comparing, aggregating or calculating"@en ;
+           skos:example """- determining the volume level of audio track
 - counting the minutes that a speaker has during a debate
-- counting the number of female experts in all programmes of BBC One"""@en ,
-                        """- déterminer le niveau de volume d'une piste audio
-- compter les minutes dont dispose un orateur pendant un débat
-- compter le nombre de femmes expertes dans tous les programmes de BBC One"""@fr .
+- counting the number of female experts in all programmes of BBC One"""@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#MediaFragment
@@ -11405,15 +8536,9 @@ ec:MediaFragment rdf:type owl:Class ;
                                    owl:onProperty ec:isMediaFragmentOf ;
                                    owl:allValuesFrom ec:MediaResource
                                  ] ;
-                 dcterms:description "A MediaFragment is a temporal or spatial segment of a resource identified by a MediaGragment URI (http://www.w3.org/2008/WebVideo/Fragments/WD-media-fragments-spec/)."@en ,
-                                     "Ein MediaFragment ist ein zeitliches oder räumliches Segment einer Resource, das durch einen MediaGragment-URI identifiziert wird (http://www.w3.org/2008/WebVideo/Fragments/WD-media-fragments-spec/)."@de ,
-                                     "Un MediaFragment est un segment temporel ou spatial d'une ressource identifiée par un URI MediaGragment (http://www.w3.org/2008/WebVideo/Fragments/WD-media-fragments-spec/)."@fr ;
-                 rdfs:label "Fragment de média"@fr ,
-                            "Media Fragment"@en ,
-                            "Medienfragment"@de ;
-                 skos:definition "a MediaResource that is a temporal or spatial segment of a Resource as defined by the MediaFragment URI (http://www.w3.org/2008/WebVideo/Fragments/WD-media-fragments-spec/)"@en ,
-                                 "eine MedienResource, die ein zeitliches oder räumliches Segment einer Resource ist, das wie in MediaFragment-URI  (http://www.w3.org/2008/WebVideo/Fragments/WD-media-fragments-spec/) beschrieben ist"@de ,
-                                 "une ressource média qui est un segment temporel ou spatial d'une ressource telle que définie par un URI MediaFragment (http://www.w3.org/2008/WebVideo/Fragments/WD-media-fragments-spec/)."@fr .
+                 dcterms:description "A media resource that is a temporal or spatial segment of a resource as defined by the Media Fragment URI (http://www.w3.org/2008/WebVideo/Fragments/WD-media-fragments-spec/)."@en ;
+                 rdfs:label "Media fragment"@en ;
+                 skos:definition "a ec:MediaResource that is a temporal or spatial segment of a ec:Resource as defined by the Media Fragment URI (http://www.w3.org/2008/WebVideo/Fragments/WD-media-fragments-spec/)"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#MediaResource
@@ -11857,85 +8982,54 @@ ec:MediaResource rdf:type owl:Class ;
                                    owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                  ] ;
                  owl:disjointWith ec:Rating ;
-                 dcterms:description "An audiovisual MediaResource, which can be composed of one or more Tracks. A MediaResource is defined by an EditorialObject (Editorial Domain), which can be realised in Essences in one or more Formats for different delivery medias or platforms."@en ,
-                                     "Eine audiovisuelle MedienResource, die aus einer oder mehreren Spuren bestehen kann. Die MedienResource ist durch einen Medieninhalt definiert und kann durch Essenzen in einem oder mehreren Formaten für verschiedene Medien oder Plattformen realisiert werden."@de ,
-                                     "Une MediaResource audiovisuelle, qui peut être composée d'une ou plusieurs Pistes. une ressource multimédia, MediaResource est définie par un objet éditorial EditorialObject, (domaine éditorial), qui peut être réalisé dans des essences dans un ou plusieurs formats pour différents médias ou plateformes de diffusion."@fr ;
-                 rdfs:label "Media resource"@en ,
-                            "MedienResource"@de ,
-                            "Resource médiatique"@fr ;
-                 skos:definition "a Resource that comprises encoded audio, video, graphics, data or text"@en ,
-                                 "eine Resource, die aus kodierten Audio-, Video-, Grafik-, Daten- oder Textinhalten besteht"@de ,
-                                 "une ressource qui comprend du son, de la vidéo, des graphiques, des données ou du texte codés."@fr ;
+                 dcterms:description "A resource that comprises encoded audio, video, graphics, data or text."@en ;
+                 rdfs:label "Media resource"@en ;
+                 skos:definition "a ec:Resource that comprises encoded audio, video, graphics, data or text"@en ;
                  skos:example """- an audio CD
 - an audio track on a CD
 - an audio file
 - a video file
-- a video DVD"""@en ,
-                              """- eine Audio-CD
-- ein Audiotitel auf einer CD
-- eine Audiodatei
-- eine Videodatei
-- eine Video-DVD"""@de ,
-                              """- un CD audio
-- une piste audio sur un CD
-- un fichier audio
-- un fichier vidéo
-- un DVD vidéo"""@fr .
+- a video DVD"""@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#MediaResourceType
 ec:MediaResourceType rdf:type owl:Class ;
                      rdfs:subClassOf skos:Concept ;
-                     dcterms:description "Pour définir un type de MediaResource."@fr ,
-                                         "To define a type of MediaResource."@en ,
-                                         "Um einen Typ von MediaResource zu definieren."@de ;
-                     rdfs:label "Media resource type"@en ,
-                                "Typ der MedienResource"@de ,
-                                "Type de ressource média"@fr .
+                     dcterms:description "An entry from a list of types to classify media resources."@en ;
+                     rdfs:label "Media resource type"@en ;
+                     skos:definition "a skos:Concept classifying the type of a ec:MediaResource"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#MediaType
 ec:MediaType rdf:type owl:Class ;
              rdfs:subClassOf ec:Format ;
-             dcterms:description "Pour fournir des informations supplémentaires sur le type de support."@fr ,
-                                 "To provide additional information on the type of media."@en ,
-                                 "Um zusätzliche Informationen über die Art des Mediums zu erhalten."@de ;
-             rdfs:label "Media type"@en ,
-                        "Medientyp"@de ,
-                        "Type de média"@fr .
+             dcterms:description "An entry from the classification of types of media resources, often historic, like phonograph cylinder."@en ;
+             rdfs:label "Media type"@en ;
+             skos:definition "a ec:Format classifying additional type information about a ec:MediaResource"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Medium
 ec:Medium rdf:type owl:Class ;
           rdfs:subClassOf ec:Format ;
-          dcterms:description "Fournir des informations sur les formats de support dans lesquels la ressource est disponible. Cette information est fournie sous forme de texte libre dans une étiquette d'annotation ou comme un identifiant pointant vers un terme dans un schéma de classification."@fr ,
-                              "Informationen zu den Medienformaten bereitstellen, in denen die in denen die Resource verfügbar ist. Dies wird als freier Text in einer Beschriftung angegeben oder als Kennung, die auf einen Begriff in einem Klassifikationsschema verweist."@de ,
-                              "To provide information on the medium formats in which the resource is available. This is provided as free text in an annotation label or as an identifier pointing to a term in a classification scheme."@en ;
-          rdfs:label "Medium"@de ,
-                     "Medium"@en ,
-                     "Moyen"@fr .
+          dcterms:description "An entry from the classification of media that carry media resources, e.g. \"Betamax\", \"DVD\", \"LP\"."@en ;
+          rdfs:label "Medium"@en ;
+          skos:definition "a ec:Format classifying the medium carrying a ec:MediaResource"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#MetadataTrack
 ec:MetadataTrack rdf:type owl:Class ;
                  rdfs:subClassOf ec:Track ;
-                 dcterms:description "A Track on which metadata is embedded (e.g. MXF)."@en ,
-                                     "Eine Spur, in die Metadaten eingebettet sind (z. B. MXF)."@de ,
-                                     "Une piste sur laquelle sont intégrées des métadonnées (par exemple, MXF)."@fr ;
-                 rdfs:label "Metadata track"@en ,
-                            "Metadaten Spur"@de ,
-                            "Piste de métadonnées"@fr .
+                 dcterms:description "A track containing metadata about the content that it accompanies, e.g. in MXF containers."@en ;
+                 rdfs:label "Metadata track"@en ;
+                 skos:definition "a ec:Track containing metadata about the content that it accompanies"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#MimeType
 ec:MimeType rdf:type owl:Class ;
             rdfs:subClassOf ec:Format ;
-            dcterms:description "Die Definition des Containers, falls er als ein MIME-Typ. Dies wird als freier Text in einer Beschriftung oder als Bezeichner angegeben der auf einen Begriff in einem Klassifizierungsschema verweist. Für weitere Informationen: http://www.iana.org/assignments/media-types/index.html."@de ,
-                                "La définition du conteneur si elle est disponible en tant que un type MIME. Elle est fournie sous forme de texte libre dans une étiquette d'annotation ou comme identifiant pointant vers un terme dans un schéma de classification. Pour plus d'informations : http://www.iana.org/assignments/media-types/index.html."@fr ,
-                                "The definition of the container if available as a MIME type. This is provided as free text in an annotation label or as an identifier pointing to a term in a classification scheme. For more information: http://www.iana.org/assignments/media-types/index.html."@en ;
-            rdfs:label "Mime type"@en ,
-                       "Mime-Typ"@de ,
-                       "Type Mime"@fr .
+            dcterms:description "An entry from the classification of Internet media types. See also: http://www.iana.org/assignments/media-types/application/index.html."@en ;
+            rdfs:label "Mime type"@en ;
+            skos:definition "a ec:Format classifying the structure of a file as its Internet media type"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#NormalPlayTime
@@ -11951,9 +9045,9 @@ ec:NormalPlayTime rdf:type owl:Class ;
                                     owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                     owl:onDataRange xsd:time
                                   ] ;
-                  rdfs:label "Normal play time"@en ,
-                             "Normale Spielzeit"@de ,
-                             "Temps de jeu normal"@fr .
+                  dcterms:description "The duration of a content is expressed as a point in time in ISO format."@en ;
+                  rdfs:label "Normal play time"@en ;
+                  skos:definition "a ec:TimelinePoint representing the duration of a content expressed in ISO Format"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#OnStagePosition
@@ -11994,45 +9088,33 @@ ec:OnStagePosition rdf:type owl:Class ;
                                      owl:onProperty ec:onStagePositionCoordinatesReferencePoint ;
                                      owl:allValuesFrom rdfs:Literal
                                    ] ;
-                   dcterms:description "Gibt die Position eines Akteurs oder eines Produktionswerkzeuges auf einer Bühne an."@de ,
-                                       "Spécifie la position d'un agent, Agent, ou d'un appareil de production, ProductionDevice sur la scène, Stage."@fr ,
-                                       "To define the Position of a ProductionDevice or Agent on Stage."@en ;
-                   rdfs:label "Bühnenposition"@de ,
-                              "On Stage Position"@en ,
-                              "Position sur scène"@fr .
+                   dcterms:description "A position on a specific stage given in coordinates."@en ;
+                   rdfs:label "On stage position"@en ;
+                   skos:definition "a coordinate-based location on a ec:Stage"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#OpenCaptions
 ec:OpenCaptions rdf:type owl:Class ;
                 rdfs:subClassOf ec:Captioning ;
-                dcterms:description "Les légendes ouvertes sont gravées dans l l'image."@fr ,
-                                    "Offene Untertitel werden in das Bild eingebrannt Bild eingebrannt."@de ,
-                                    "Open Captions are burned in the image."@en ;
-                rdfs:label "Bildunterschriften öffnen"@de ,
-                           "Légendes ouvertes"@fr ,
-                           "Open captions"@en .
+                dcterms:description "A caption that is burnt into the images of a media resource. i.e. it cannot be turned off."@en ;
+                rdfs:label "Open captions"@en ;
+                skos:definition "a ec:Captioning that is burned in the images of a ec:MediaResource"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#OpenSigning
 ec:OpenSigning rdf:type owl:Class ;
                rdfs:subClassOf ec:Signing ;
-               dcterms:description "La signalisation ouverte est gravée dans l'image."@fr ,
-                                   "Offene Gebärdensprache ist in das Bild eingebrannt."@de ,
-                                   "Open singing is burnt in the image."@en ;
-               rdfs:label "Offene Gebärdensprache"@de ,
-                          "Open signing"@en ,
-                          "Signalisation ouverte"@fr .
+               dcterms:description "A signing that is burned in the images of a media resource."@en ;
+               rdfs:label "Open signing"@en ;
+               skos:definition "a ec:Signing that is burned in the images of a ec:MediaResource and cannot be turned off"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#OpenSubtitling
 ec:OpenSubtitling rdf:type owl:Class ;
                   rdfs:subClassOf ec:Subtitling ;
-                  dcterms:description "Les sous-titres ouverts sont gravés dans l l'image."@fr ,
-                                      "Offene Untertitel werden in das Bild gebrannt Bild eingebrannt."@de ,
-                                      "Open subtitles are burned in the image."@en ;
-                  rdfs:label "Open subtitling"@en ,
-                             "Ouvrir le sous-titrage"@fr ,
-                             "Untertitelung öffnen"@de .
+                  dcterms:description "A subtitling that is carried in the same media resource as audio and/or video. Subtitling cannot be turned on or off."@en ;
+                  rdfs:label "Open subtitling"@en ;
+                  skos:definition "a ec:Subtitling that is burned in the images of a ec:MediaResource"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Organisation
@@ -12064,55 +9146,23 @@ ec:Organisation rdf:type owl:Class ;
                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                   owl:onClass time:Instant
                                 ] ;
-                dcterms:description "An organisation (business, corporation, federation, etc.) or moral agent (government body)."@en ,
-                                    "Eine Organisation (Unternehmen, Körperschaft, Verband usw.) oder ein moralischer Akteur (Regierungsstelle)."@de ,
-                                    "Une organisation (entreprise, société, fédération, etc.) ou un agent moral (organisme gouvernemental)."@fr ;
-                rdfs:label "Organisation"@de ,
-                           "Organisation"@en ,
-                           "Organisation"@fr ;
-                skos:definition "an Agent in the form of an administrative and functional structure participating in media related activities"@en ,
-                                "ein Agent in Form einer Verwaltungs- und Funktionsstruktur, der an medienbezogenen Aktivitäten beteiligt ist"@de ,
-                                "un agent sous la forme d'une structure administrative et fonctionnelle participant à des activités liées aux médias"@fr ;
-                skos:example """- Organisations PSM
-- UER
-- société de gestion collective
-- studios de cinéma
-- cinémas
-- syndicat des auteurs"""@fr ,
-                             """- PSM organisations
+                dcterms:description "An organisation (business, corporation, federation, etc.) or moral agent (government body)."@en ;
+                rdfs:label "Organisation"@en ;
+                skos:definition "an Agent in the form of an administrative and functional structure participating in media related activities"@en ;
+                skos:example """- PSM organisations
 - EBU
 - collecting society
 - film studios
 - cinemas
-- authors' union"""@en ,
-                             """- PSM-Organisationen
-- EBU
-- Verwertungsgesellschaft
-- Filmstudios
-- Kinos
-- Autorenvereinigung"""@de .
-
-
-###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#OriginalLanguage
-ec:OriginalLanguage rdf:type owl:Class ;
-                    rdfs:subClassOf ec:Language ;
-                    dcterms:description "Die Originalsprache, in der das Redaktionsobjekt oder Resource erstellt und freigegeben wurde. Dies wird als freier Text angegeben in einer Beschriftung oder als Bezeichner, der auf einen Begriff in einem Klassifikationsschema verweist Schema verweist."@de ,
-                                        "La langue d'origine dans laquelle l objet éditorial ou Resource a été créé et diffusé. Elle est fournie sous forme de texte libre dans une étiquette d'annotation ou en tant qu'identifiant pointant vers un terme dans une classification de classification."@fr ,
-                                        "The original language in which the EditorialObject or Resource has been created and released. This is provided as free text in an annotation label or as an identifier pointing to a term in a classification scheme."@en ;
-                    rdfs:label "Language"@en ,
-                               "Langue"@fr ,
-                               "Sprache"@de .
+- authors' union"""@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#PartType
 ec:PartType rdf:type owl:Class ;
             rdfs:subClassOf skos:Concept ;
-            dcterms:description "Pour définir un type ou une pièce."@fr ,
-                                "To define a type or part."@en ,
-                                "Um einen Typ oder ein Teil zu definieren."@de ;
-            rdfs:label "Part type"@en ,
-                       "Teil Typ"@de ,
-                       "Type de pièce"@fr .
+            dcterms:description "An entry from a list of types to classify media resources."@en ;
+            rdfs:label "Part type"@en ;
+            skos:definition "a skos:Concept classifying the type of a ec:MediaResource"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Person
@@ -12258,49 +9308,29 @@ ec:Person rdf:type owl:Class ;
                             owl:onProperty ec:personHeight ;
                             owl:maxCardinality "1"^^xsd:nonNegativeInteger
                           ] ;
-          dcterms:description "A Person."@en ,
-                              "Eine Person."@de ,
-                              "Une personne.(physique)"@fr ;
-          rdfs:label "Person"@de ,
-                     "Person"@en ,
-                     "Personne"@fr ;
-          skos:definition "an individual Agent"@en ,
-                          "ein einzelner Agent"@de ,
-                          "un agent individuel"@fr ;
-          skos:example """- Alfred Hitchcock (Regisseur)
-- James Bond (Figur)
-- Sean Connery (Schauspieler)
-- John Ford (Pseudonym des Regisseurs John Martin Feeney)"""@de ,
-                       """- Alfred Hitchcock (director)
+          dcterms:description "A person who is an individual agent in the media domain."@en ;
+          rdfs:label "Person"@en ;
+          skos:definition "an individual Agent"@en ;
+          skos:example """- Alfred Hitchcock (director)
 - James Bond (character)
 - Sean Connery (actor)
-- John Ford (pseudonym used by the director John Martin Feeney)"""@en ,
-                       """- Alfred Hitchcock (réalisateur)
-- James Bond (personnage)
-- Sean Connery (acteur)
-- John Ford (pseudonyme utilisé par le réalisateur John Martin Feeney)"""@fr .
+- John Ford (pseudonym used by the director John Martin Feeney)"""@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#PhysicalResource
 ec:PhysicalResource rdf:type owl:Class ;
                     rdfs:subClassOf ec:Resource ;
-                    dcterms:description "Beschreibt eine physische Resource, z.B. ein Tonband."@de ,
-                                        "Pour décrire une ressource physique, par exemple une bande."@fr ,
-                                        "To describe a physical resource e.g. a tape."@en ;
-                    rdfs:label "Physical resource"@en ,
-                               "Physische Resource"@de ,
-                               "Resource physique"@fr .
+                    dcterms:description "A tangible resource for the storage and transportation of media content, e.g. a tape."@en ;
+                    rdfs:label "Physical resource"@en ;
+                    skos:definition "a tangible ec:Resource for the storage and transportation of media content"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Pictogram
 ec:Pictogram rdf:type owl:Class ;
              rdfs:subClassOf ec:Picture ;
-             dcterms:description "A visual / graphical representation of a concept."@en ,
-                                 "Eine visuelle / grafische Darstellung eines Konzepts."@de ,
-                                 "Une représentation visuelle / graphique d'un concept."@fr ;
-             rdfs:label "Pictogram"@en ,
-                        "Pictogramme"@fr ,
-                        "Piktogramm"@de .
+             dcterms:description "A picture, often abstracted, simplified or graphical, that represents a concept and aids non-verbal communication."@en ;
+             rdfs:label "Pictogram"@en ;
+             skos:definition "a ec:Picture, often abstracted, that represents or symbolizes a concept to aid non-verbal communication"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Picture
@@ -12343,55 +9373,31 @@ ec:Picture rdf:type owl:Class ;
                              owl:onProperty ec:frameWidthUnit ;
                              owl:maxCardinality "1"^^xsd:nonNegativeInteger
                            ] ;
-           dcterms:description "A photography, a logo, a pictogram, etc."@en ,
-                               "Eine Fotografie, ein Logo, ein Piktogramm, usw."@de ,
-                               "Une photographie, un logo, un pictogramme, etc."@fr ;
-           rdfs:label "Bild"@de ,
-                      "Photo"@fr ,
-                      "Picture"@en ;
-           skos:definition "a Resource in the form of an encoded picture"@en ,
-                           "eine Resource in Form eines kodierten Bildes"@de ,
-                           "une ressource sous la forme d'une image codée"@fr ;
+           dcterms:description "A photography, a logo, and a pictogram."@en ;
+           rdfs:label "Picture"@en ;
+           skos:definition "a Resource in the form of an encoded picture"@en ;
            skos:example """- a JPEG file of a photo, a logo, a graphic, ...
-- a PNG file of a photo, a logo, a graphic, ..."""@en ,
-                        """- eine JPEG-Datei eines Fotos, eines Logos, einer Grafik, ...
-- eine PNG-Datei eines Fotos, eines Logos, einer Grafik, ..."""@de ,
-                        """- un fichier JPEG d'une photo, d'un logo, d'un graphique, ...
-- un fichier PNG d'une photo, d'un logo, d'un graphique, ..."""@fr .
+- a PNG file of a photo, a logo, a graphic, ..."""@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#PictureDisplayFormat
 ec:PictureDisplayFormat rdf:type owl:Class ;
                         rdfs:subClassOf ec:Format ;
-                        dcterms:description "Pour définir un code de format d'affichage des images."@fr ,
-                                            "So definieren Sie einen Code für das Bildanzeigeformat."@de ,
-                                            "To define a picture display format code."@en ;
-                        rdfs:label "Code du format d'affichage des images"@fr ,
-                                   "Code für das Bildanzeigeformat"@de ,
-                                   "Picture display format code"@en .
+                        dcterms:description "An entry from the classification of formats that a display can have."@en ;
+                        rdfs:label "Picture display format code"@en ;
+                        skos:definition "a ec:Format classifying the format of a display"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Post
 ec:Post rdf:type owl:Class ;
         rdfs:subClassOf ec:EditorialWork ;
-        rdfs:label "Post"@de ,
-                   "Post"@en ,
-                   "Post"@fr ;
-        skos:definition "an EditorialWork consisting of text, graphic, sometimes video or audio, created for publication on social media platforms and alike"@en ,
-                        "ein redaktionelles Werk, das aus Text, Grafik, manchmal auch Video oder Audio besteht und für die Veröffentlichung auf Plattformen sozialer Medien und ähnlichem erstellt wird"@de ,
-                        "une œuvre éditoriale composée de texte, de graphiques, parfois de vidéo ou d'audio, créée pour être publiée sur des plateformes de médias sociaux ou autres."@fr ;
+        dcterms:description "A combination of text, graphics, sometimes video or audio, created to be published on a social media platform or similar."@en ;
+        rdfs:label "Post"@en ;
+        skos:definition "an ec:EditorialWork consisting of text, graphics, sometimes video or audio, created for publication on social media platforms or similar"@en ;
         skos:example """- a tweet on twitter
 - a post on Facebook
 - a post on Instagram
-- a video-post on Youtube"""@en ,
-                     """- ein Tweet auf Twitter
-- ein Beitrag auf Facebook
-- ein Beitrag auf Instagram
-- ein Video-Beitrag auf Youtube"""@de ,
-                     """- un tweet sur Twitter
-- une publication sur Facebook
-- un post sur Instagram
-- une vidéo postée sur Youtube"""@fr .
+- a video-post on Youtube"""@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ProductionDevice
@@ -12420,33 +9426,15 @@ ec:ProductionDevice rdf:type owl:Class ;
                                       owl:onProperty ec:name ;
                                       owl:allValuesFrom rdfs:Literal
                                     ] ;
-                    dcterms:description "A Device used for creating/processing a MediaResource."@en ,
-                                        "Ein Werkzeug zur Herstellung oder Bearbeitung einer MedienResource."@de ,
-                                        "Un appareil utilisé pour créer/traiter une ressource médiatique, MediaResource."@fr ;
-                    rdfs:label "Appareil de production"@fr ,
-                               "Production device"@en ,
-                               "Produktionswerkzeug"@de ;
-                    skos:definition "a tool to facilitate activities in a ProductionJob"@en ,
-                                    "ein Werkzeug zur Erleichterung der Aktivitäten im Rahmen einer Produktionsaufgabe"@de ,
-                                    "un outil pour faciliter les activités dans une tâche de production"@fr ;
+                    dcterms:description "A Device used for creating/processing a MediaResource."@en ;
+                    rdfs:label "Production device"@en ;
+                    skos:definition "a tool to facilitate activities in a ProductionJob"@en ;
                     skos:example """- a camera
 - a microphone
 - a video or sound mixer
 - a video or sound editor
 - spot lights
-- a LED wall"""@en ,
-                                 """- eine Kamera
-- ein Mikrofon
-- ein Video- oder Tonmischpult
-- einen Video- oder Ton-Editor
-- Scheinwerfer
-- eine LED-Wand"""@de ,
-                                 """- une caméra
-- un microphone
-- un mixeur vidéo ou son
-- un monteur vidéo ou son
-- des spots
-- un mur de LED"""@fr .
+- a LED wall"""@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ProductionJob
@@ -12533,24 +9521,12 @@ ec:ProductionJob rdf:type owl:Class ;
                                    owl:onProperty ec:name ;
                                    owl:allValuesFrom rdfs:Literal
                                  ] ;
-                 dcterms:description "A job / process to be performed to manipulate/create/modify/store/etc. MediaResources and Essences as defined in an associated EditorialObject. It is ordered by Contract."@en ,
-                                     "Eine Aufgabe oder ein Prozess, der ausgeführt wird, um eine MedienResource oder eine Essenz zu erstellen, zu modifizieren, zu speichern o.ä. MedienResource und Essenz werden gemäß einen Medieninhalt hergestellt. Die Produktionsaufgabe wird durch einen Vertrag beauftragt."@de ,
-                                     "Une tâche / un processus à exécuter pour manipuler/créer/modifier/stocker/etc. des MediaResources et Essences telles que définies dans un EditorialObject. Il est commandé par contrat, Contract."@fr ;
-                 rdfs:label "Production job"@en ,
-                            "Produktionsaufgabe"@de ,
-                            "Tâche de production"@fr ;
-                 skos:definition "a task or set of tasks to create, modify, manipulate, store, etc a MediaResource"@en ,
-                                 "eine Aufgabe oder eine Reihe von Aufgaben zum Erstellen, Ändern, Manipulieren, Speichern usw. einer MedienResource"@de ,
-                                 "une tâche ou un ensemble de tâches pour créer, modifier, manipuler, stocker, etc. une ressource médiatique"@fr ;
-                 skos:example """- Produktion einer Live-Show für die Ausstrahlung
-- das Filmen und Bearbeiten eines Nachrichtenclips
-- eine ausgelagerte Produktion eines kompletten Films"""@de ,
-                              """- a live show production for broadcasting
+                 dcterms:description "A job / process to be performed to manipulate/create/modify/store, etc., MediaResources and Essences as defined in an associated EditorialObject. It is ordered by Contract."@en ;
+                 rdfs:label "Production job"@en ;
+                 skos:definition "a task or set of tasks to create, modify, manipulate, store, or otherwise process a MediaResource"@en ;
+                 skos:example """- a live show production for broadcasting
 - filming and editing a news clip
-- an outsourced production of a complete movie"""@en ,
-                              """- la production d'une émission en direct pour la diffusion
-- le tournage et le montage d'un clip d'information
-- la production externalisée d'un film complet"""@fr .
+- an outsourced production of a complete movie"""@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ProductionOrder
@@ -12575,12 +9551,9 @@ ec:ProductionOrder rdf:type owl:Class ;
                                      owl:onProperty ec:name ;
                                      owl:allValuesFrom rdfs:Literal
                                    ] ;
-                   dcterms:description "Die Beauftragung zur Erstellung, zum Kauf oder zur Wiederverwendung einer MedienResource. Die Bedingungen eines Produktionsauftrages sind in einem Vertrag definiert."@de ,
-                                       "L'acte d'ordonner la création/production, l'achat ou la réutilisation des ressources mediatiques. Les termes d'un commande de production sont définis par Contrat."@fr ,
-                                       "The act of ordering the creation/production, purchase or reuse of MediaResources. The terms of a ProductionOrder are defined by Contract."@en ;
-                   rdfs:label "Commande de production"@fr ,
-                              "Production order"@en ,
-                              "Produktionsauftrag"@de .
+                   dcterms:description "A formal request for the creation, production, purchase or reuse of media resources, often resulting from a contract with a third party."@en ;
+                   rdfs:label "Production order"@en ;
+                   skos:definition "a formal request for the creation, production, purchase or reuse of ec:MediaResources often resulting from a ec:Contract"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Programme
@@ -12621,26 +9594,10 @@ ec:Programme rdf:type owl:Class ;
                                owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                owl:onDataRange xsd:integer
                              ] ;
-             dcterms:description "An EditorialObject corresponding to a MediaResource ready for publication."@en ,
-                                 "Ein EditorialObject, das einer MediaResource, die zur Veröffentlichung bereit ist."@de ,
-                                 "Un EditorialObject correspondant à une MediaResource prête à être publiée."@fr ;
-             rdfs:label "Programme"@en ,
-                        "Programme"@fr ,
-                        "Sendung"@de ;
-             skos:definition "an EditorialWork as a stand-alone piece or an episode of a Serial or Series, intended to be consumed as a whole"@en ,
-                             "ein Werk als eigenständiges Stück oder eine Episode einer Serie oder Reihe, die als Ganzes konsumiert werden soll"@de ,
-                             "une Œuvre de rédaction en tant que pièce autonome ou épisode d'un feuilleton ou d'une série, destinée à être consommée comme un tout."@fr ;
-             skos:example """- den Film \"Titanic\"
-- die Folge 2 \"Der blinde Bankier\" der Serie \"Sherlock\", einer Detektivserie
-- die heutige Folge von \"BBC News\", der täglichen Nachrichtensendung
-- die Folge 2 \"Frozen Worlds\" der Serie \"Our Planet\", einer Naturdokumentationsserie
-- am kommenden Montag die Folge der BBC-Serie \"Panorama\", eine politische Reportage"""@de ,
-                          """- le film \"Titanic\"
-- l'épisode 2 \"Le banquier aveugle\" de la série \"Sherlock\", une série policière
-- l'épisode du jour de \"BBC News\", la série d'émissions d'information quotidienne
-- l'épisode 2 \"Frozen Worlds\" de la série \"Our Planet\", une série documentaire sur la nature
-- l'épisode de lundi prochain de la série \"Panorama\" de la BBC, un reportage politique"""@fr ,
-                          """- the movie \"Titanic\"
+             dcterms:description "A stand-alone work or an episode of a serial or a series, created to be published and consumed as a whole."@en ;
+             rdfs:label "Programme"@en ;
+             skos:definition "an ec:EditorialWork as a stand-alone content or an episode of a ec:Serial or ec:Series and created to be published and consumed as a whole"@en ;
+             skos:example """- the movie \"Titanic\"
 - the episode 2 \"The Blind Banker\" of the series \"Sherlock\", a detective series
 - today's episode of \"BBC News\", the daily news show serial
 - the episode 2 \"Frozen Worlds\" of the series \"Our Planet\", a nature documentary series
@@ -12654,41 +9611,22 @@ ec:Promotion rdf:type owl:Class ;
                                owl:onProperty ec:isMemberOf ;
                                owl:allValuesFrom ec:CampaignPackage
                              ] ;
-             rdfs:label "Promotion"@en ,
-                        "Promotion"@fr ,
-                        "Werbung"@de ;
-             skos:definition "an EditorialWork for advertising purposes"@en ,
-                             "ein Werk für Werbezwecke"@de ,
-                             "un EditorialWork à des fins publicitaires"@fr ;
+             dcterms:description "An advertisement, e.g. for a car model, an event, a programme, a travel offer or similar."@en ;
+             rdfs:label "Promotion"@en ;
+             skos:definition "an ec:EditorialWork for advertising purposes"@en ;
              skos:example """- an ad for an insurance company
-- a promotion-clip for a PSM, one of its channels, its brands"""@en ,
-                          """- ein Werbespot für eine Versicherungsgesellschaft
-- ein Werbeclip für ein PSM, einen seiner Kanäle, seine Marken"""@de ,
-                          """- une publicité pour une compagnie d'assurance
-- un clip de promotion pour un GSP, une de ses chaînes, ses marques"""@fr .
+- a promotion-clip for a PSM, one of its channels, its brands"""@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Props
 ec:Props rdf:type owl:Class ;
          rdfs:subClassOf ec:Artefact ;
-         dcterms:description "Identifier et décrire les accessoires utilisés dans les productions (par exemple, les véhicules, les objets de formes et de marques diverses et leur fonction, etc.)"@fr ,
-                             "Requisiten, die in Produktionen verwendet werden, zu identifizieren und zu beschreiben (z.B. Fahrzeuge, Objekte verschiedener Formen und Marken und deren Zweck usw.)."@de ,
-                             "To identify and describe Props used in productions (e.g. vehicles, objects of various shapes and brand and purpose, etc.)."@en ;
-         rdfs:label "Accessoires"@fr ,
-                    "Props"@en ,
-                    "Requisiten"@de ;
-         skos:definition "an Artefact deliberately chosen to appear in a video"@en ,
-                         "ein Artefakt, das absichtlich ausgewählt wurde, um in einem Video zu erscheinen"@de ,
-                         "un artefact délibérément choisi pour apparaître dans une vidéo"@fr ;
+         dcterms:description "Some object that is visible or audible in a scene and deliberately chosen for its value to the resulting content, such as a stone, a weapon, a bag, etc."@en ;
+         rdfs:label "Props"@en ;
+         skos:definition "an object deliberately chosen to appear in a scene of the ec:EditorialObject"@en ;
          skos:example """- a car in a movie
 - furniture in a movie
-- a buzzer in a quiz show"""@en ,
-                      """- ein Auto in einem Film
-- Möbel in einem Film
-- ein Buzzer in einer Quizshow"""@de ,
-                      """- une voiture dans un film
-- un meuble dans un film
-- un buzzer dans un jeu télévisé"""@fr .
+- a buzzer in a quiz show"""@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Provenance
@@ -12727,29 +9665,19 @@ ec:Provenance rdf:type owl:Class ;
                                 owl:onProperty ec:name ;
                                 owl:allValuesFrom rdfs:Literal
                               ] ;
-              rdfs:label "Herkunft"@de ,
-                         "Origine"@fr ,
-                         "Provenance"@en ;
-              skos:definition "a set of properties describing the origin and lifecycle of a data object"@en ,
-                              "une Reihe von Eigenschaften, welche die Herkunft und den Lebenszyklus eines Datenobjektes beschreiben"@de ,
-                              "une chaîne de caractères unique associée à une entité"@fr ;
-              skos:example """- das Erzeugungsdatum eines Datenobjektes
-- das System, aus welchem das Datenobjekt ursprünglich stammt"""@de ,
-                           """- la date de création d'un objet de données
-- le système à partir duquel l'objet de données a été récupéré à l'origine"""@fr ,
-                           """- the creationDate of a data object
+              dcterms:description "Provenance records can identify the data object whose history is described, the agent to which it is attributed, and relevant creation or modification dates."@en ;
+              rdfs:label "Provenance"@en ;
+              skos:definition "a set of properties describing the origin and life cycle of a data object"@en ;
+              skos:example """- the creationDate of a data object
 - the system from which the data object was originally retrieved"""@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Pseudonym
 ec:Pseudonym rdf:type owl:Class ;
              rdfs:subClassOf ec:Person ;
-             dcterms:description "a fictitious name; especially : pen name or stage name"@en ,
-                                 "ein fiktiver Name; insbesondere: Pseudonym oder Künstlername"@de ,
-                                 "un nom fictif ; en particulier : nom de plume ou nom de scène"@fr ;
-             rdfs:label "Pseudonym"@de ,
-                        "Pseudonym"@en ,
-                        "Pseudonyme"@fr .
+             dcterms:description "A pseudonym is a fictitious name used by an author, an actor or others, invented to hide the real name, to sound better, to foster associations or similar."@en ;
+             rdfs:label "Pseudonym"@en ;
+             skos:definition "a fictitious ec:Person mainly described by its name that is used to hide the name of the real ec:Person"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#PublicationChannel
@@ -12812,26 +9740,10 @@ ec:PublicationChannel rdf:type owl:Class ;
                                         owl:onProperty ec:name ;
                                         owl:allValuesFrom rdfs:Literal
                                       ] ;
-                      dcterms:description "A channel through which content is published. It can take a variety of forms beyond broadcast and internet streaming, e.g. physical distribution of CDs /DVDs, etc."@en ,
-                                          "Ein Kanal, über den Inhalte veröffentlicht werden. Er kann eine Vielzahl von Formen annehmen, die über Rundfunk und Internet-Streaming hinausgehen, z. B. den physischen Vertrieb von CDs/DVDs usw."@de ,
-                                          "Un canal par lequel le contenu est publié. Il peut prendre diverses formes au-delà de la diffusion et du streaming sur Internet, par exemple la distribution physique de CD /DVD, etc."@fr ;
-                      rdfs:label "Canal de publication"@fr ,
-                                 "Publication channel"@en ,
-                                 "Publikationskanal"@de ;
-                      skos:definition "a connection to exchange content between provider and consumer operated on a PublicationPlatform"@en ,
-                                      "eine Verbindung zum Austausch von Inhalten zwischen Anbieter und Verbraucher, die über eine Publikationsplattform betrieben wird"@de ,
-                                      "une connexion pour échanger du contenu entre le fournisseur et le consommateur, opérée sur une plateforme de publication."@fr ;
-                      skos:example """- der DVB-S-Kanal auf 10714 MHz H auf dem Satelliten Astra 2E für den linearen Videodienst \"BBC One HD\".
-- der DVB-T-Kanal E23 in London/Chrystal Palace für den linearen Videodienst \"BBC One London\".
-- den Live-Videostream \"BBC One\" im Rahmen des BBC iPlayers
-- den Kanal @bbcradio1 auf youtube für den On-Demand-Videodienst \"BBC Radio 1 visual radio\".
-- den Kanal @elonmusk auf Twitter für einen sozialen Textdienst \"Elon Musk's Tweets\"."""@de ,
-                                   """- le canal DVB-S à 10714 MHz H sur le satellite Astra 2E pour le service vidéo linéaire \"BBC One HD\".
-- le canal DVB-T E23 à Londres/Chrystal Palace pour le service vidéo linéaire \"BBC One London\".
-- le flux vidéo en direct \"BBC One\" dans le cadre de BBC iPlayer
-- la chaîne @bbcradio1 sur youtube pour le service vidéo à la demande \"BBC Radio 1 visual radio\".
-- la chaîne @elonmusk sur twitter pour le service de texte social \"Elon Musk's Tweets\"."""@fr ,
-                                   """- the DVB-S channel at 10714 MHz H on the Astra 2E satellite for the linear video service \"BBC One HD\"
+                      dcterms:description "A connection through which a consumption device can consume a service, e.g. a cable receiver for linear services on a cable network, an FM receiver for linear audio services, the YouTube.com webpage or the YouTube application on Android for the VoD service YouTube, the BBC iPlayer App on LG Smart-TVs for BBC's VoD, event streaming and live streaming services."@en ;
+                      rdfs:label "Publication channel"@en ;
+                      skos:definition "a connection through which a ec:ConsumptionDevice can consume ec:PublicationServices"@en ;
+                      skos:example """- the DVB-S channel at 10714 MHz H on the Astra 2E satellite for the linear video service \"BBC One HD\"
 - the DVB-T channel E23 in London/Chrystal Palace for the linear video service \"BBC One London\"
 - the live video stream \"BBC One\" within the BBC iPlayer
 - the channel @bbcradio1 on youtube for the on demand video service \"BBC Radio 1 visual radio\"
@@ -12841,12 +9753,9 @@ ec:PublicationChannel rdf:type owl:Class ;
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#PublicationChannelType
 ec:PublicationChannelType rdf:type owl:Class ;
                           rdfs:subClassOf skos:Concept ;
-                          dcterms:description "Pour définir un type de canal de publication."@fr ,
-                                              "To define a type of publication channel."@en ,
-                                              "Um eine Art von Publikationskanal zu definieren."@de ;
-                          rdfs:label "Publication channel type"@en ,
-                                     "Publikationskanal-Typ"@de ,
-                                     "Type de canal de publication"@fr .
+                          dcterms:description "An entry from a list of types to classify publication channels."@en ;
+                          rdfs:label "Publication channel type"@en ;
+                          skos:definition "a skos:Concept classifying the type of a ec:PublicationChannel"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#PublicationEvent
@@ -12976,32 +9885,19 @@ ec:PublicationEvent rdf:type owl:Class ;
                                       owl:onDataRange xsd:boolean
                                     ] ;
                     owl:disjointWith ec:Rating ;
-                    dcterms:description "Beschreibt die Bereitstellung eines Medieninhaltes und seiner Essenz durch ein beliebiges Medium. Ein Publikationsereignis kann ein geplantes oder ein ungeplantes Ereignis im Rahmen eines linearen Angebot sein, oder eine Abrufmöglichkeit sowie live-streaming im nicht-linearen Angebot."@de ,
-                                        "Décrit toute apparition, manifestation, d'un objet éditorial, EditorialObjec et d'une essence associée, Essence, sur n'importe quel média (en direct, à la demande, à la télévision, etc.). Un PublicationEvent peut être par exemple, un événement programmé, un événement diffusé (à l'origine non programmé comme les \"dernières nouvelles\"), ou des événements non linéaires à la demande et des diffusions en direct."@fr ,
-                                        "To describe any manifestation of an EditorialObject and associated Essence on any media (live, on demand, catch-up TV, etc.). A PublicationEvent can be e.g. a scheduled event, a broadcast event (originally not scheduled like \"latest news\"), or non-linear on-demand events and live-streaming."@en ;
-                    rdfs:label "Publication Event"@en ,
-                               "Publikationsereignis"@de ,
-                               "Événement de publication"@fr ;
-                    skos:definition "das Ereignis der Veröffentlichung einer Essenz durch einen Dienst an einen Kanal unter Rechtebedingungen"@de ,
-                                    "l'événement de publication d'une Essence par un service à un canal sous conditions de droits"@fr ,
-                                    "the event of publishing an Essence by a service to a channel under rights conditions"@en ;
-                    skos:example """- die Übertragung des Endspiels der Fußballweltmeisterschaft 2022 in einem Live-Videodienst über Satellit durch die BBC in Großbritannien
-- die Veröffentlichung von Elon Musks Text \"Next I'm buying Coca Cola to put the cocaine back in\" auf Twitter, 27. April 2022, in seinem Kanal @elonmusk"""@de ,
-                                 """- la diffusion de la finale de la coupe du monde de football 2022 dans un service de vidéo en direct par satellite par la BBC en Grande-Bretagne
-- la publication du texte d'Elon Musk \"Next I'm buying Coca Cola to put the cocaine back in\" sur twitter, le 27 avril 2022, dans sa chaîne @elonmusk"""@fr ,
-                                 """- the broadcasting of the football world cup final 2022 in a live video service over satellite by the BBC in Great Britain
+                    dcterms:description "The time or time span and the media service within which the content is made technically accessible for devices of consumers, e.g. broadcasting a scheduled news show, uploading a documentary to a VoD platform, posting a meme on Instagram."@en ;
+                    rdfs:label "Publication event"@en ;
+                    skos:definition "a time or time span and the ec:PublicationService within which an ec:Essence is made technically accessible for ec:ConsumptionDevices of ec:Consumers"@en ;
+                    skos:example """- the broadcasting of the football world cup final 2022 in a live video service over satellite by the BBC in Great Britain
 - the posting of Elon Musk's text \"Next I'm buying Coca Cola to put the cocaine back in\" on twitter, April 27, 2022, in his channel @elonmusk"""@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#PublicationEventType
 ec:PublicationEventType rdf:type owl:Class ;
                         rdfs:subClassOf skos:Concept ;
-                        dcterms:description "Pour définir un type d'événement de publication."@fr ,
-                                            "To define a type of publication event."@en ,
-                                            "Um eine Art von Publikationsereignis zu definieren."@de ;
-                        rdfs:label "Art der Veröffentlichung"@de ,
-                                   "Publication event type"@en ,
-                                   "Type d'événement de publication"@fr .
+                        dcterms:description "An entry from a list of types to classify publication events."@en ;
+                        rdfs:label "Publication event type"@en ;
+                        skos:definition "a skos:Concept classifying the type of a ec:PublicationEvent"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#PublicationHistory
@@ -13010,12 +9906,9 @@ ec:PublicationHistory rdf:type owl:Class ;
                                         owl:onProperty ec:hasPublicationEvent ;
                                         owl:someValuesFrom ec:PublicationEvent
                                       ] ;
-                      dcterms:description "A collection of PublicationEvents through which a resource has been published."@en ,
-                                          "Eine Sammlung von Publikationsereignissen, durch die eine Resource veröffentlicht wurde."@de ,
-                                          "Une collection de PublicationEvents par lesquels une ressource a été publiée."@fr ;
-                      rdfs:label "Histoire de la publication"@fr ,
-                                 "Publication History"@en ,
-                                 "Veröffentlichungshistorie"@de .
+                      dcterms:description "A collection of publication events of the content."@en ;
+                      rdfs:label "Publication history"@en ;
+                      skos:definition "a collection of ec:PublicationEvents of an ec:EditorialObject"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#PublicationLog
@@ -13048,26 +9941,19 @@ ec:PublicationLog rdf:type owl:Class ;
                                     owl:onProperty ec:description ;
                                     owl:allValuesFrom rdfs:Literal
                                   ] ;
-                  rdfs:label "Journal de bord de la publication"@fr ,
-                             "Playout-Protokoll"@de ,
-                             "Publication log"@en ;
-                  skos:definition "a collection of consecutive PublicationEvents of a (typically linear) playout system"@en ,
-                                  "eine Sammlung aufeinanderfolgender PublicationEvents eines (in der Regel linearen) Ausspielsystems"@de ,
-                                  "une collection de PublicationEvents consécutifs d'un système de diffusion (typiquement linéaire)"@fr ;
-                  skos:example """- das \"as run log\" eines linearen TV-Wiedergabesystems für einen ganzen Tag
-- das \"As-Run-Log\" eines linearen Radio-Playout-Systems für den Vormittag"""@de ,
-                               """- le \"journal de bord\" d'un système de diffusion TV linéaire pour une journée entière
-- le \"journal de bord\" d'un système de diffusion radio linéaire pour la matinée"""@fr ,
-                               """- the \"as run log\" of a linear TV playout system for a full day
+                  dcterms:description "A collection of consecutive publication events of a service."@en ;
+                  rdfs:label "Publication log"@en ;
+                  skos:definition "a collection of consecutive ec:PublicationEvents of a ec:PublicationService"@en ;
+                  skos:example """- the \"as run log\" of a linear TV playout system for a full day
 - the \"as run log\" of a linear radio playout system for the morning"""@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#PublicationMedium
 ec:PublicationMedium rdf:type owl:Class ;
                      rdfs:subClassOf skos:Concept ;
-                     rdfs:label "Medium der Veröffentlichung"@de ,
-                                "Publication medium"@en ,
-                                "Support de publication"@fr .
+                     dcterms:description "An entry from a list of types to classify the publication medium, e.g. radio, tv, internet, online, streaming."@en ;
+                     rdfs:label "Publication medium"@en ;
+                     skos:definition "a skos:Concept classifying the type of a ec:PublicationMedium"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#PublicationPlan
@@ -13135,27 +10021,10 @@ ec:PublicationPlan rdf:type owl:Class ;
                                      owl:onProperty ec:publicationPlanTitle ;
                                      owl:allValuesFrom rdfs:Literal
                                    ] ;
-                   dcterms:description "A PublicationPlan describes a schedule of PublicationEvents (and their Audiences). The realisation of a PublicationPlan may require the specific acquisition or creation of content defined as a pair of EditorialObjects and Essence, which occurs through ProductionOrders. A PublicationPlan can be the result of associated Publication(sub)Plans. Examples: Example 1: A campaign of commercials for a product, consists of set of planned PublicationEvents. Example 2: A fiction film is promoted with several trailers published before the publication of the film."@en ,
-                                       "Ein Publikationsplan beschreibt eine Zeitplan von Publikationsereignissen und ihre Publika. Die Realisierung eines Publikationsplan erfordert möglicherweise den Einkauf oder die Herstellung von Medienprodukten (Medieninhalt mit Essenz), ausgelöst durch einen Produktionsauftrag. Ein Publikationsplan kann aus mehreren Publikationsplänen zusammengesetzt werden. Beispiele 1: Eine Werbekampagne für ein neues Produkt besteht aus einer Reihe geplanter Veröffentlichungsereignisse. Beispiel 2: Ein Film wird durch mehrere Trailer beworben, bevor er veröffentlicht wird."@de ,
-                                       """Un PublicationPlan décrit un calendrier de PublicationEvents ainsi que leurs audiences. La réalisation d'un plan de publication, PublicationPlan, peut nécessiter l'acquisition ou la création spécifique d'un contenu défini comme une paire d'objets éditoriaux, EditorialObjects, et d'essences, d'Essence. Ceci se produit par le biais d'ordres de production, ProductionOrders.
-Un plan de publication peut être le résultat de plans ou sous plans de publication associés.
-Exemple 1 : Une campagne publicitaire pour un produit consiste en un ensemble d'événements de publication, PublicationPlan, planifiée.
-Exemple 2 : Un film de fiction est promu avec plusieurs bandes annonces publiées avant la publication du film."""@fr ;
-                   rdfs:label "Plan de publication"@fr ,
-                              "Publication plan"@en ,
-                              "Publikationsplan"@de ;
-                   skos:definition "a schedule for one or many PublicationEvents to address a target audience, or a hierarchy of PublicationPlans"@en ,
-                                   "ein Zeitplan für eine oder mehrere Publikationsereignissen, um eine Zielgruppe anzusprechen, oder eine Hierarchie von Publikationsereignissen"@de ,
-                                   "un plan pour un ou plusieurs PublicationEvents pour s'adresser à un public cible, ou une hiérarchie de PublicationPlans"@fr ;
-                   skos:example """- das geplante Datum, die Uhrzeit und den Kanal für die Veröffentlichung eines Films
-- die geplanten Daten, Uhrzeiten und Kanäle für die Veröffentlichung der Episoden einer Serie
-- das geplante Programm eines Senders für einen Tag
-- die geplanten Daten, Uhrzeiten und Kanäle für eine Sammlung von Inhalten zu einem gemeinsamen Thema"""@de ,
-                                """- la date, l'heure et le canal prévus pour la publication d'un film
-- les dates, heures et chaînes prévues pour la publication des épisodes d'un feuilleton
-- l'horaire prévu pour une chaîne pendant une journée
-- les dates, heures et canaux prévus pour une collection de contenus sur un thème commun"""@fr ,
-                                """- the planned date, time and channel for the publication of a movie
+                   dcterms:description "A collection of scheduled publication events related to a targeted audience (e.g. a list of publications for sports lovers), promotion material for a content (e.g. a campaign of several commercials for a product), a time span in a media service (e.g. a full day's programme in a linear service), or other useful criteria."@en ;
+                   rdfs:label "Publication plan"@en ;
+                   skos:definition "a collection of scheduled ec:PublicationEvents related to a targeted ec:Audience, promotion material for an ec:EditorialObject, a time span in a ec:PublicationService or other useful criteria"@en ;
+                   skos:example """- the planned date, time and channel for the publication of a movie
 - the planned dates, times and channels for the publication of the episodes of a serial
 - the planned schedule for a channel during one day
 - the planned dates, times and channels for a collection of content about a common theme"""@en .
@@ -13164,12 +10033,9 @@ Exemple 2 : Un film de fiction est promu avec plusieurs bandes annonces publiée
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#PublicationPlanType
 ec:PublicationPlanType rdf:type owl:Class ;
                        rdfs:subClassOf skos:Concept ;
-                       dcterms:description "Pour définir un type de plan de publication."@fr ,
-                                           "To define a type of publication plan."@en ,
-                                           "Um eine Art von Veröffentlichungsplan zu definieren."@de ;
-                       rdfs:label "Publication plan type"@en ,
-                                  "Publikationsplan Typ"@de ,
-                                  "Type de plan de publication"@fr .
+                       dcterms:description "An entry from a list of types to classify the publication plan, like daily, monthly, yearly."@en ;
+                       rdfs:label "Publication plan type"@en ;
+                       skos:definition "a skos:Concept classifying the type of a ec:PublicationPlan"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#PublicationPlatform
@@ -13236,24 +10102,10 @@ ec:PublicationPlatform rdf:type owl:Class ;
                                          owl:onProperty ec:name ;
                                          owl:allValuesFrom rdfs:Literal
                                        ] ;
-                       dcterms:description "A platform like a network or operator platform."@en ,
-                                           "Eine Plattform wie ein Netzwerk oder eine Betreiberplattform."@de ,
-                                           "Une plateforme comme celle d'un réseau ou d'un opérateur."@fr ;
-                       rdfs:label "Plate-forme de publication"@fr ,
-                                  "Publication platform"@en ,
-                                  "Publikationsplattform"@de ;
-                       skos:definition "a facility that allows to connect sources and targets of content through uni- or bi-directional channels"@en ,
-                                       "eine technische Einrichtung, die es ermöglicht, Quellen und Ziele von MedienResourcen über uni- oder bidirektionale Kanäle zu verbinden"@de ,
-                                       "une installation qui permet de connecter des sources et des cibles de contenu par des canaux uni- ou bidirectionnels"@fr ;
-                       skos:example """- die Eutelsat-DVB-S-Übertragungsplattform
-- die youtube-Video-on-Demand-Plattform
-- alle Server, die über Internetprotokolle zugänglich sind und in HTML oder ähnlich kodierte Inhalte anbieten/aufnehmen
-- Fortnite, Decentraland oder Roblox als Metaversen"""@de ,
-                                    """- la plate-forme de diffusion DVB-S d'Eutelsat
-- la plateforme de vidéo à la demande youtube
-- tous les serveurs accessibles via les protocoles internet et offrant/prenant du contenu codé en HTML ou similaire
-- Fortnite, Decentraland ou Roblox comme métaverses"""@fr ,
-                                    """- the Eutelsat DVB-S broadcasting platform
+                       dcterms:description "A facility that distributes media services so that devices can access them through a channel, e.g. a satellite network distributes a video broadcast service so that a TV-set can access it through a satellite receiver; a VoD platform distributes a non-linear service so that a tablet can access it through an application. Platforms can be uni- or bidirectional. Platforms support a range of services and channels. The choices are limited by technology or by negotiation between the media service provider and the platform provider."@en ;
+                       rdfs:label "Publication platform"@en ;
+                       skos:definition "a facility that distributes ec:PublicationServices so that ec:ConsumptionDevices can access them through ec:PublicationChannels"@en ;
+                       skos:example """- the Eutelsat DVB-S broadcasting platform
 - the youtube video on demand platform
 - all servers accessible via internet protocols and offering / taking content encoded in HTML or similar
 - Fortnite, Decentraland or Roblox as metaverses"""@en .
@@ -13319,20 +10171,10 @@ ec:PublicationService rdf:type owl:Class ;
                                         owl:onProperty ec:name ;
                                         owl:allValuesFrom rdfs:Literal
                                       ] ;
-                      dcterms:description "A publication service is a channel or publishing platform that releases the content to a given Audience."@en ,
-                                          "Ein Service ist ein Kanal oder eine Publikationsplattform die einem Publikum den Zugriff auf Medienprodukte erlaubt."@de ,
-                                          "Un service de publication est un canal ou une plate-forme de publication qui diffuse le contenu à une audience donnée."@fr ;
-                      rdfs:label "Medienservice"@de ,
-                                 "Publication service"@en ,
-                                 "Service"@fr ;
-                      skos:definition "a service by which a publishing organisation or person publishes its content and offers access to consumers"@en ,
-                                      "ein Dienst, über den eine Verlagsorganisation oder eine Person ihre MedienResourcen veröffentlicht und den Nutzern Zugang dazu bietet"@de ,
-                                      "un service par lequel une organisation ou une personne publie son contenu et en offre l'accès aux consommateurs"@fr ;
-                      skos:example """- der lineare Videodienst mit dem Namen \"BBC One\"
-- der Video-on-Demand-Dienst von Netflix"""@de ,
-                                   """- le service vidéo linéaire dénommé \"BBC One
-- le service de vidéo à la demande de Netflix"""@fr ,
-                                   """- the linear video service named \"BBC One\"
+                      dcterms:description "A named media offering provided by a publisher, distributed by a platform and made accessible through a channel for devices to allow people to consume the service, e.g. a linear audio service distributed via FM; a non-linear video streaming service distributed via a PSM's own VoD platform; a YouTube channel distributed via the YouTube platform."@en ;
+                      rdfs:label "Publication service"@en ;
+                      skos:definition "a named media offering provided by a publishing ec:Agent, distributed by a ec:PublicationPlatform and made accessible through ec:PublicationChannels for ec:ConsumptionDevices to allow ec:Consumers to consume the service"@en ;
+                      skos:example """- the linear video service named \"BBC One\"
 - the video on demand service of Netflix"""@en .
 
 
@@ -13404,34 +10246,25 @@ ec:Rating rdf:type owl:Class ;
                             owl:onProperty ec:ratingSystemName ;
                             owl:maxCardinality "1"^^xsd:nonNegativeInteger
                           ] ;
-          dcterms:description "All the information about the rating/evaluation given to a media resource by an Agent i.e. a person/Contact or Organisation. This is provided as free text in an annotation label or as an identifier pointing to a term in a classification scheme."@en ,
-                              "Alle Informationen über die Bewertung/Beurteilung die einer MedienResource von einem Agenten, d.h. einer Person/Kontakt oder Organisation."@de ,
-                              "Toutes les informations concernant la note/évaluation donnée à une ressource média par un Agent c'est-à-dire une personne/Contact ou Organisation."@fr ;
-          rdfs:label "Bewertung"@de ,
-                     "Classement"@fr ,
-                     "Rating"@en .
+          dcterms:description "An evaluation of some content to judge the level of conformity with the applied criteria."@en ;
+          rdfs:label "Rating"@en ;
+          skos:definition "an evaluation of a ec:EditorialObject based on explainable criteria to judge the level of conformity"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Record
 ec:Record rdf:type owl:Class ;
           rdfs:subClassOf ec:BibliographicalObject ;
-          dcterms:description "Die Aufzeichnung der Beschreibung eines Assets."@de ,
-                              "L'enregistrement de la description d'un actif."@fr ,
-                              "The record the description of an Asset."@en ;
-          rdfs:label "Enregistrement"@fr ,
-                     "Record"@en ,
-                     "Rekord"@de .
+          dcterms:description "A written account of something that is kept for future reading or use."@en ;
+          rdfs:label "Record"@en ;
+          skos:definition "a ec:BibliographicalObject about something happening that is kept for later use"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#RegionCode
 ec:RegionCode rdf:type owl:Class ;
               rdfs:subClassOf skos:Concept ;
-              dcterms:description "Le code de région fait référence au code développé par l'Organisation internationale de normalisation (ISO). L'ISO a créé et maintient la norme ISO 3166 - Codes pour la représentation des noms de pays et de leurs subdivisions."@fr ,
-                                  "Region Code bezieht sich auf den von der Internationalen Organisation für Normung (ISO) entwickelten Code. Die ISO schuf und pflegt die Norm ISO 3166 - Codes für die Darstellung der Namen von Ländern und ihren Unterteilungen."@de ,
-                                  "Region Code refers to the code developed by the International Organization for Standardization (ISO). ISO created and maintains the ISO 3166 standard – Codes for the representation of names of countries and their subdivisions."@en ;
-              rdfs:label "Code de région"@fr ,
-                         "Region code"@en ,
-                         "Regionalcode"@de .
+              dcterms:description "An entry from a list of codes identifying regions of locations."@en ;
+              rdfs:label "Region code"@en ;
+              skos:definition "a skos:Concept identifying the region of a ec:Location"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Relation
@@ -13476,23 +10309,17 @@ ec:Relation rdf:type owl:Class ;
                               owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                               owl:onDataRange xsd:integer
                             ] ;
-            dcterms:description "Pour définir les liens et les relations."@fr ,
-                                "To define links and relations."@en ,
-                                "Zur Definition von Verbindungen und Beziehungen."@de ;
-            rdfs:label "Beziehung"@de ,
-                       "Relation"@en ,
-                       "Relation"@fr .
+            dcterms:description "A link between a person or organisation and a thing. The link can be classified, named, grouped and numbered."@en ;
+            rdfs:label "Relation"@en ;
+            skos:definition "a link between a ec:Agent and a owl:Thing"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#RelationType
 ec:RelationType rdf:type owl:Class ;
                 rdfs:subClassOf skos:Concept ;
-                dcterms:description "Pour spécifier un type de relation."@fr ,
-                                    "To specify a type of relation."@en ,
-                                    "Zur Angabe einer Art von Beziehung."@de ;
-                rdfs:label "Beziehungstyp"@de ,
-                           "Relation type"@en ,
-                           "Type de relation"@fr .
+                dcterms:description "An entry from a list of types to classify a relation."@en ;
+                rdfs:label "Relation type"@en ;
+                skos:definition "a skos:Concept identifying the type of a ec:Relation"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Reminder
@@ -13506,15 +10333,10 @@ ec:Reminder rdf:type owl:Class ;
                               owl:onProperty ec:isMemberOf ;
                               owl:allValuesFrom ec:CampaignPackage
                             ] ;
-            rdfs:label "Erinnerung"@de ,
-                       "Rappel"@fr ,
-                       "Reminder"@en ;
-            skos:definition "an EditorialWork referring to a previously published advertisement, promotion or alike, as a reminder to it"@en ,
-                            "ein Werk, das auf eine zuvor veröffentlichte Anzeige, Werbung oder ähnliches verweist, um daran zu erinnern"@de ,
-                            "un EditorialWork faisant référence à une annonce, une promotion ou autre publiée précédemment, pour la rappeler à l'ordre"@fr ;
-            skos:example "- a 4 second repetition of the logo and the jingle of an insurance company, minutes after a 15 second advertisement"@en ,
-                         "- eine 4-sekündige Wiederholung des Logos und des Jingles einer Versicherungsgesellschaft, Minuten nach einer 15-sekündigen Werbung"@de ,
-                         "- une répétition de 4 secondes du logo et du jingle d'une compagnie d'assurance, quelques minutes après une publicité de 15 secondes"@fr .
+            dcterms:description "A content that refers to previous promotion created to remind the consumer of the advertised object."@en ;
+            rdfs:label "Reminder"@en ;
+            skos:definition "an ec:EditorialWork that reminds a consumer of previous ec:Promotion"@en ;
+            skos:example "- a 4 second repetition of the logo and the jingle of an insurance company, minutes after a 15 second advertisement"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ResonanceCount
@@ -13547,30 +10369,14 @@ ec:ResonanceCount rdf:type owl:Class ;
                                     owl:onProperty ec:name ;
                                     owl:allValuesFrom rdfs:Literal
                                   ] ;
-                  dcterms:description "Die Aggregation von Daten über die Nutzung von Produkten durch eine Gruppe von Nutzern. Repräsentiert alle zählbaren oder erfassbaren Nutzungsaktivitäten durch Nutzer während des Nutzungsereignisses, aber zu nicht-individualisierbaren Ausdrücken zusammengefasst, z.B. click-Zahlen, Anzahl von Likes, Prozentsatz von Stimmen, Anzahl der Downloads, ... Die Analyse der Resonanzdaten erlaubt eine genauere Verfeinerung einer Kampagnenstrategie und des verknüpften Publikationsplans."@de ,
-                                      "La raisonance est une agrégation des données relatives à la consommation de contenu par un groupe de consommateurs. Représente toutes les actions de consommation dénombrables ou perceptibles par les consommateurs au cours d'un ConsumptionEvent agrégées pour former une expression non individuelle, par exemple taux de clics, nombre d'appréciations, pourcentage de votes, nombre de téléchargements, likes, pourcentage de votes, nombre de téléchargements. L'analyse des données de résonance permet plus particulièrement d'affiner une stratégie de Campagne et son plan de publication, PublicationPlan."@fr ,
-                                      "The aggregation of data about the consumption of content by a group of Consumers. Represents all countable or noticeable consumption actions by consumers during a ConsumptionEvent aggregated to form a non-individual expression, e.g. click rates, number of likes, percentage of votes, number of downloads... The analysis of the Resonance Data allows more particularly refining a Campaign strategy and its associated PublicationPlan."@en ;
-                  rdfs:label "Resonance"@en ,
-                             "Resonanz"@de ,
-                             "Résonance"@fr ;
-                  skos:definition "die Aggregation von Resonanzereignissen zur Anzeige der Leistung eines Inhalts oder eines Dienstes"@de ,
-                                  "l'agrégation des ResonanceEvents pour indiquer la performance d'un contenu ou d'un service"@fr ,
-                                  "the aggregation of ResonanceEvents to indicate performance of a content or a service"@en ;
-                  skos:example """- Marktanteil bei den Zuschauern einer Sport-Live-Übertragung
-- Wöchentliche Seitenaufrufe einer Nachrichten-Website
-- Anzahl der täglichen Unique User auf einer Nachrichten-Website
-- Anzahl der Likes für einen Instagram-Post
-- Anzahl der Aufrufe eines Films auf einem VOD-Portal"""@de ,
-                               """- market share of viewers on a sports live broadcast
+                  dcterms:description "The aggregation of resonance events, often within a time span, to indicate performance of a publication event, a service or content, e.g. market share for he live event \"UEFA Champions League Final 2025\" broadcast on DVB platforms compared to live stream on broadband distribution platform; the number of positive vs. negative comments on an instagram post within the first day of the publication."@en ;
+                  rdfs:label "Resonance"@en ;
+                  skos:definition "an aggregation of ec:ResonanceEvents, often within a time span, to indicate performance of a ec:PublicationEvent, a ec:PublicationService or an ec:EditorialObject"@en ;
+                  skos:example """- market share of viewers on a sports live broadcast
 - weekly page impressions of a news website
 - number of daily unique users on a news website
 - number of likes on an instagram post
-- number of views of a movie from a VOD portal"""@en ,
-                               """- part de marché des téléspectateurs sur une émission sportive en direct
-- nombre de pages vues par semaine sur un site d'information
-- nombre d'utilisateurs uniques quotidiens sur un site d'information
-- nombre de likes sur un message instagram
-- nombre de vues d'un film sur un portail VOD"""@fr .
+- number of views of a movie from a VOD portal"""@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ResonanceEvent
@@ -13619,46 +10425,17 @@ ec:ResonanceEvent rdf:type owl:Class ;
                                     owl:onProperty ec:name ;
                                     owl:allValuesFrom rdfs:Literal
                                   ] ;
-                  dcterms:description "Data about the consumption of content by a Consumer using a particular ConsumptionDevice. Represents all individual countable or noticeable actions by consumers during a consumptionEvent using a particular ConsumptionDevice, e.g. clicks, likes, comments, votes, tweets preferences, downloads... All ResonanceEvents are linked to a ConsumptionEvent and the associated Essence or EditorialObject. ResonanceEvents represent raw-data, that need to be aggregated (e.g. summed up). Such data can be seen as \"Big Data\" and require appropriate technology and techniques (e.g. processing algorithms).The aggregationof this data is a set of Resonance results."@en ,
-                                      """Daten zur Nutzung eines Medienproduktes durch einen Nutzer mit Hilfe eines speziellen Endgerätes.
-Repräsentiert alle individuell zählbaren oder erfassbaren Aktivitäten des Nutzers währen eines Nutzungsereignisses mit Hilfe eines Endgerätes, z.B. Klicks, Likes, Kommntare, Abstimmungen, Tweets, Downloads, etc.
-Alle Resonanzereignisse sind mit einem Nutzungsereignis verknüpft und dessen Essenz oder Medieninhalt.
-Resonanzereignisse  repräsentieren Rohdaten, die aggregiert werden müssen (z.B. durch Zusammenzählen). Solche Daten können als \"Big Data\" betrachtet werden und erfordern den Einsatz geeigneter Technologien and Verarbeitungsalgorithmen. Die Aggregation dieser Daten führt zu einem Resonanz-Objekt."""@de ,
-                                      """Un évènement de résonance est défini comme des données relatives à la consommation de contenu par un consommateur utilisant un dispositif de consommation particulier.
-Ces données représente toutes les actions individuelles comptabilisables ou perceptibles par les consommateurs au cours d'un ConsumptionEvent utilisant un ConsumptionDevice particulier, par exemple clics, likes, commentaires, votes, préférences tweets, téléchargements.
-Tous les ResonanceEvents sont liés à un ConsumptionEvent et à l'Essence associée ou à l'EditorialObject associé.
-Les ResonanceEvents représentent des données brutes, qui doivent être agrégées (par exemple, additionnées). Ces données peuvent être considérées comme des \"big data\" et nécessitent une technologie et des techniques appropriées (par exemple, des algorithmes de traitement).
-L'agrégation de ces données est un ensemble de résultats de résonance."""@fr ;
-                  rdfs:label "Resonance event"@en ,
-                             "Resonanzereignis"@de ,
-                             "Événement de résonance"@fr ;
-                  skos:definition "a countable or noticeable consumption-related action by a Consumer during or after a ConsumptionEvent"@en ,
-                                  "eine zählbare oder spürbare nuztungsbezogene Handlung eines Nutzers während oder nach einem Nutzungsereignis"@de ,
-                                  "une action liée à la consommation, dénombrable ou perceptible, effectuée par un consommateur pendant ou après un événement de consommation."@fr ;
-                  skos:example """- Ausschalten des Fernsehgeräts
-- Umschalten auf einen anderen Radiosender
-- Pausieren der Wiedergabe eines Videos von einem VOD-Portal
-- Suche nach Inhalten in einem VOD-Portal
-- einen Twitter-Beitrag liken, teilen oder kommentieren
-- ein Video auf youtube kommentieren
-- sich telefonisch bei der Programm-Hotline der PSM beschweren
-- Bewertung einer Radiosendung in der App des Radiosenders"""@de ,
-                               """- turning off the TV set
+                  dcterms:description "A countable or noticeable consumption-related action by a consumer during or after a consumption, e.g. a click on \"play\" or on \"pause\", likes, comments, votes, tweets, preferences, downloads. Resonance events are linked by content consumption. They represent raw data that need to be aggregated (e.g., summed)."@en ;
+                  rdfs:label "Resonance event"@en ;
+                  skos:definition "a countable or noticeable consumption-related action by a ec:Consumer during or after a ec:ConsumptionEvent"@en ;
+                  skos:example """- turning off the TV set
 - switching to another radio channel
 - pausing the playback of a video from a VOD portal
 - searching for content on a VOD portal
 - liking, sharing or commenting a twitter post
 - commenting a video on youtube
 - calling the PSM's program hotline by phone to complain
-- rating a radio show in the radio station's app"""@en ,
-                               """- éteindre le téléviseur
-- passer à une autre chaîne de radio
-- mettre en pause la lecture d'une vidéo provenant d'un portail VOD
-- rechercher un contenu sur un portail de vidéo à la demande
-- liker, partager ou commenter un message sur Twitter
-- commenter une vidéo sur youtube
-- appeler la hotline des programmes du PSM par téléphone pour se plaindre
-- évaluer une émission de radio dans l'application de la station de radio."""@fr .
+- rating a radio show in the radio station's app"""@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Resource
@@ -13732,15 +10509,9 @@ ec:Resource rdf:type owl:Class ;
                               owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                               owl:onDataRange xsd:string
                             ] ;
-            dcterms:description "A resource used or referred to in the workflow (e.g. a document or image or any objects defined as sub-classes of Resource). It has a locator indicating from where the Resource can be retrieved."@en ,
-                                "Eine Resource, die in einem Arbeitsablauf genutzt oder referenziert wird, z.B. ein Dokument, ein Bild, oder ein beliebiges Objekt einer Sub-Klasse von Resource). Die Resource hat einen Locator, der angibt, wo auf die Resource zugegriffen werden kann."@de ,
-                                "une ressource utilisée ou à laquelle il est fait référence dans le workflow (par exemple, un document ou une image ou tout objet défini comme sous-classe de Resource). Elle possède un localisateur indiquant l'endroit où la ressource peut être récupérée."@fr ;
-            rdfs:label "Resource"@de ,
-                       "Resource"@en ,
-                       "Resource"@fr ;
-            skos:definition "a Thing that is created, published, distributed and consumed in a media related workflow"@en ,
-                            "eine Sache, die in einem medienbezogenen Arbeitsablauf erstellt, veröffentlicht, verbreitet und konsumiert wird"@de ,
-                            "une Chose qui est créée, publiée, distribuée et consommée dans un flux de travail lié aux médias"@fr ;
+            dcterms:description "A tangible or digital thing that is used or referred to in a media-related workflow, e.g. a document, an image, or similar. It often has a locator indicating from where it can be retrieved."@en ;
+            rdfs:label "Resource"@en ;
+            skos:definition "a tangible or digital ec:Thing that is used or referred to in a media-related workflow"@en ;
             skos:example """- a paper document
 - a digital document
 - a digital picture
@@ -13748,45 +10519,23 @@ ec:Resource rdf:type owl:Class ;
 - an audio CD
 - an audio tape
 - a video tape
-- a film dvd"""@en ,
-                         """- ein Papierdokument
-- ein digitales Dokument
-- ein digitales Bild
-- eine Schallplatte
-- eine Audio-CD
-- eine Audiokassette
-- eine Videokassette
-- eine Film-DVD"""@de ,
-                         """- un document papier
-- un document numérique
-- une image numérique
-- un disque vynil
-- un CD audio
-- une bande audio
-- une cassette vidéo
-- un dvd de film"""@fr .
+- a film dvd"""@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ResourceType
 ec:ResourceType rdf:type owl:Class ;
                 rdfs:subClassOf skos:Concept ;
-                dcterms:description "Pour définir un type de Resource."@fr ,
-                                    "To define a type of resource."@en ,
-                                    "Um eine Art von Resource zu definieren."@de ;
-                rdfs:label "Resource type"@en ,
-                           "Resourcentyp"@de ,
-                           "Type de Resource"@fr .
+                dcterms:description "An entry from a list of types to classify a relation."@en ;
+                rdfs:label "Resource type"@en ;
+                skos:definition "a skos:Concept identifying the type of a ec:Resource"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Review
 ec:Review rdf:type owl:Class ;
           rdfs:subClassOf ec:Item ;
-          dcterms:description "Pour fournir un examen."@fr ,
-                              "To provide a Review."@en ,
-                              "Um eine Rezension zu erstellen."@de ;
-          rdfs:label "Consulter"@fr ,
-                     "Review"@en ,
-                     "Rezension"@de .
+          dcterms:description "An audio or audio-visual report, in which somebody gives their opinion of a play, film, etc."@en ;
+          rdfs:label "Review"@en ;
+          skos:definition "a ec:Item in which somebody gives their opinion about an ec:EditorialObject"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Rights
@@ -13866,34 +10615,25 @@ ec:Rights rdf:type owl:Class ;
                             owl:onProperty ec:rightsUsageRestrictions ;
                             owl:allValuesFrom rdfs:Literal
                           ] ;
-          dcterms:description "Les droits, Rights, de propriété intellectuelle ou autres droits contractuels (par exemple, de publication) associés à un actif, un contrat ou un PublicationEvent. Les droits proviennent d'un contrat, Contract. Les droits sont associés à des EditorialObjects, MediaResource ou Essences par la définition d'un actif, Asset. Les droits sont liés à des détenteurs de droits, RightsHolders."@fr ,
-                              "The intellectual property or other contractual (e.g. publication) Rights associated with an Asset, a Contract, or a PublicationEvent. Rights originate from a Contract. Rights are associated with EditorialObjects, MediaResource or Essences through the definition of an Asset. Rights have associated RightsHolders."@en ,
-                              "Urheber- oder vertragliches Verwertungsrecht an einem Asset, einem Vertrag oder einem Publikationsereignis. Rechte entstammen einem Vertrag. Rechte sind gebunden an einen Medieninhalt, eine MedienResource oder eine Essenz durch die Definition des Assets. Rechte haben zugeordnete Rechteinhaber."@de ;
-          rdfs:label "Droits"@fr ,
-                     "Recht"@de ,
-                     "Rights"@en .
+          dcterms:description "The entitlement of rights holders to use or publish works as defined by intellectual property legislation or by contracts."@en ;
+          rdfs:label "Rights"@en ;
+          skos:definition "an entitlement of a ec:RightsHolder to use or publish an ec:Asset according to a ec:Contract"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#RightsClearance
 ec:RightsClearance rdf:type owl:Class ;
                    rdfs:subClassOf ec:Rights ;
-                   dcterms:description "Pour signaler que les droits ont été effacés (ou pas)"@fr ,
-                                       "To signal that rights have been cleared (or not)"@en ,
-                                       "Um zu signalisieren, dass die Rechte gelöscht wurden (oder nicht) nicht)"@de ;
-                   rdfs:label "Apurement des droits"@fr ,
-                              "Freigabe der Rechte"@de ,
-                              "Rights Clearance"@en .
+                   dcterms:description "A grant to use the work in any way, issued by the organisation that checked all possible limitations and concluded that there are none."@en ;
+                   rdfs:label "Rights clearance"@en ;
+                   skos:definition "a ec:Rights that allows all uses of the work to the organisation that has checked all possible limitations"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#RightsType
 ec:RightsType rdf:type owl:Class ;
               rdfs:subClassOf skos:Concept ;
-              dcterms:description "Pour définir un type de droits."@fr ,
-                                  "To define a type of Rights."@en ,
-                                  "Um eine Art von Rechten zu definieren."@de ;
-              rdfs:label "Art der Rechte"@de ,
-                         "Rights type"@en ,
-                         "Type de droits"@fr .
+              dcterms:description "An entry from a list of types to classify rights."@en ;
+              rdfs:label "Rights type"@en ;
+              skos:definition "a skos:Concept identifying the type of a ec:Rights"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Rule
@@ -13930,25 +10670,12 @@ ec:Rule rdf:type owl:Class ;
                           owl:onProperty ec:ruleStatement ;
                           owl:allValuesFrom rdfs:Literal
                         ] ;
-        dcterms:description "A Rule defined from legal, technical or editorial, or regulatory requirements."@en ,
-                            "Eine Regel aus gesetzlichen, technischen, inhaltlichen oder regulatorischen Anforderungen."@de ,
-                            "Une règle définie à partir de contraintes légales, techniques, éditoriales ou réglementaires."@fr ;
-        rdfs:label "Regel"@de ,
-                   "Rule"@en ,
-                   "Règle"@fr ,
-                   "Une règle définie à partir de contraintes légales, techniques, éditoriales ou réglementaires."@fr ;
-        skos:definition "a legal, regulatory, technical or editorial guideline"@en ,
-                        "eine rechtliche, regulatorische, technische oder redaktionelle Vorgabe"@de ,
-                        "une directive légale, réglementaire, technique ou éditoriale"@fr ;
-        skos:example """- Die Lautstärke der Tonspur muss unter 0 dB liegen.
-- die Redezeit bei einer Debatte zwischen zwei Kandidaten muss gleich sein
-- der Anteil männlicher/weiblicher Experten in allen Sendungen von BBC One sollte jeweils 50% betragen"""@de ,
-                     """- audio track volume level must be below 0dB
+        dcterms:description "A Rule defined from legal, technical or editorial, or regulatory requirements."@en ;
+        rdfs:label "Rule"@en ;
+        skos:definition "a legal, regulatory, technical or editorial guideline"@en ;
+        skos:example """- audio track volume level must be below 0dB
 - speaker time in a debate between two candidates must be equal
-- the share of male/female experts in all programmes of BBC One should be 50% each"""@en ,
-                     """- le niveau de volume de la piste audio doit être inférieur à 0dB
-- le temps de parole dans un débat entre deux candidats doit être égal
-- la part des experts hommes/femmes dans tous les programmes de BBC One doit être de 50% chacun"""@fr .
+- the share of male/female experts in all programmes of BBC One should be 50% each"""@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Scene
@@ -13968,18 +10695,10 @@ ec:Scene rdf:type owl:Class ;
                          ] ;
          owl:disjointWith ec:Shot ,
                           ec:Take ;
-         dcterms:description "A sequence of continuous action"@en ,
-                             "Eine Sequenz mit kontinuierlicher Handlung"@de ,
-                             "Une séquence d'action continue"@fr ;
-         rdfs:label "Scene"@en ,
-                    "Scène"@fr ,
-                    "Szene"@de ;
-         skos:definition "an EditorialSegment incorporated in an EditorialWork and representing a part of a story without leaps in time or location"@en ,
-                         "ein Mediensegment, das in ein Inhaltsobjekt eingebunden ist und einen Teil einer Geschichte ohne Zeit- oder Ortssprünge darstellt"@de ,
-                         "un segment éditorial incorporé dans un travail éditorial et représentant une partie d'une histoire sans saut dans le temps ou le lieu."@fr ;
-         skos:example "- der letzte Abschied von Humphrey Bogart und Ingrid Bergman auf dem Flughafen von Casablanca im gleichnamigen Film."@de ,
-                      "- le dernier adieu de Humphrey Bogart et Ingrid Bergman à l'aéroport de Casablanca dans le film du même nom."@fr ,
-                      "- the final goodbye of Humphrey Bogart and Ingrid Bergman at the airport of Casablanca in the equally named film."@en .
+         dcterms:description "A (usually small) part of a story that is filmed or recorded without a leap in time or location to represent a continuous action."@en ;
+         rdfs:label "Scene"@en ;
+         skos:definition "an ec:EditorialSegment that contains a small part of a story without leaps in time or location"@en ;
+         skos:example "- the final goodbye of Humphrey Bogart and Ingrid Bergman at the airport of Casablanca in the equally named film."@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Season
@@ -14002,20 +10721,10 @@ ec:Season rdf:type owl:Class ;
                             owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                             owl:onDataRange xsd:integer
                           ] ;
-          dcterms:description "A series can be composed of one or more seasons clustering a certain number of episodes. Fro this reason, seasons are related to series using the isRelatedTo property."@en ,
-                              "Eine Serie kann aus einer oder mehreren Staffeln bestehen die eine bestimmte Anzahl von Episoden zusammenfassen. Aus diesem Grund werden Staffeln mit Serien verknüpft mit Hilfe der Eigenschaft isRelatedTo."@de ,
-                              "Une série peut être composée d'une ou plusieurs saisons regroupant un certain nombre d'épisodes. Pour cette raison, les saisons sont liées aux séries à l'aide de la propriété isRelatedTo."@fr ;
-          rdfs:label "Saison"@fr ,
-                     "Season"@en ,
-                     "Staffel"@de ;
-          skos:definition "a sub-group of episodes of a serial or a series, usually grouped due to a common time frame for production"@en ,
-                          "eine Gruppe von Episoden einer Serie oder einer Reihe, die in der Regel aufgrund eines gemeinsamen Zeitrahmens für die Produktion gruppiert werden"@de ,
-                          "un sous-groupe d'épisodes d'un feuilleton ou d'une série, généralement regroupés en raison d'une période de production commune."@fr ;
-          skos:example """- die 216 Episoden des Jahres 2018 der BBC-Serie \"EastEnder\"
-- Staffel 1 mit 8 Episoden der deutschen Serie \"Babylon Berlin\""""@de ,
-                       """- les 216 épisodes de 2018 de la série \"EastEnder\" de la BBC
-- la saison 1 avec 8 épisodes de la série allemande \"Babylon Berlin\"."""@fr ,
-                       """- the 216 episodes of 2018 of BBC series \"EastEnder\"
+          dcterms:description "A group of works that is produced within one production effort, like episodes 1 to 6 for a new fictional series. Alternatively, grouping can be done by time span, such as all comedy shows by a host in one fiscal year."@en ;
+          rdfs:label "Season"@en ;
+          skos:definition "an ec:EditorialGroup that contains episodes of ec:Series or ec:Serial, usually due to a common production effort or a common production time"@en ;
+          skos:example """- the 216 episodes of 2018 of BBC series \"EastEnder\"
 - season 1 with 8 episodes of German serial \"Babylon Berlin\""""@en .
 
 
@@ -14030,18 +10739,10 @@ ec:Serial rdf:type owl:Class ;
                             owl:onProperty ec:hasSeason ;
                             owl:allValuesFrom ec:Season
                           ] ;
-          dcterms:description "Werke, die (z. B. in einer Zeitschrift oder im Fernsehen) in Teilen erscheinen"@de ,
-                              "a work appearing (as in a magazine or on television) in parts"@en ,
-                              "œuvres apparaissant (comme dans un magazine ou à la télévision) en parties"@fr ;
-          rdfs:label "Serial"@en ,
-                     "Serie"@de ,
-                     "Série"@fr ;
-          skos:definition "an EditorialGroup telling a whole story in parts, each continuing the preceding part"@en ,
-                          "eine Gruppe von Medieninhalten, die eine ganze Geschichte in Teilen erzählt, wobei jeder Teil an den vorangegangenen anknüpft"@de ,
-                          "un groupe éditorial racontant une histoire en plusieurs parties, chacune d'entre elles poursuivant la partie précédente."@fr ;
-          skos:example "- Deutsche Serie \"Babylon Berlin\" mit mehreren Staffeln"@de ,
-                       "- German serial \"Babylon Berlin\" with several seasons"@en ,
-                       "- Série allemande \"Babylon Berlin\" avec plusieurs saisons"@fr .
+          dcterms:description "A group of works that usually sum up sequentially to a common story, like chapters in a novel."@en ;
+          rdfs:label "Serial"@en ;
+          skos:definition "an ec:EditorialGroup telling a whole story in parts, each continuing the preceding part"@en ;
+          skos:example "- German serial \"Babylon Berlin\" with several seasons"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Series
@@ -14055,35 +10756,20 @@ ec:Series rdf:type owl:Class ;
                             owl:onProperty ec:hasSeason ;
                             owl:allValuesFrom ec:Season
                           ] ;
-          dcterms:description "Les séries sont un type particulier de collection. TV ou radio sont composées d'épisodes. Les épisodes suivent souvent un schéma de publication régulier ou traitent de sujets similaires ou des mêmes personnages."@fr ,
-                              "Serien sind eine besondere Art von Sammlungen. TV oder Radio-Serien bestehen aus Episoden. Episoden folgen häufig einem Publikationsschema oder behandeln ähnliche Themen oder beinhalten dieselben Figuren."@de ,
-                              "Series is a particular type of collection. TV or Radio Series are composed of Episodes. Episodes often follow a regular publication scheme or deal with similar topics or the same characters."@en ;
-          rdfs:label "Reihe"@de ,
-                     "Series"@en ,
-                     "Série"@fr ;
-          skos:definition "an EditorialGroup of Programmes, grouped by characters or topics or publication scheme, not by a sequential story"@en ,
-                          "eine Gruppe Medieninhalten, in der Regel gruppiert nach Personen oder Themen oder Veröffentlichungsschemata, nicht unbedingt nach einer fortlaufenden Geschichte"@de ,
-                          "un groupe éditorial de programmes, regroupés par personnages ou sujets ou schéma de publication, et non par une histoire séquentielle"@fr ;
+          dcterms:description "A group of works that are usually grouped by characters (e.g. talk show host) or topics (e.g. sports, news, ...) or publication scheme (weekly), but not by a sequential story."@en ;
+          rdfs:label "Series"@en ;
+          skos:definition "an ec:EditorialGroup of Programmes, that are grouped by characters or topics or publication scheme, but not by a sequential story"@en ;
           skos:example """- ABC serial \"Friends\"
 - BBC's daily news programme \"BBC News\"
-- ARD's Sunday night drama \"Tatort\""""@en ,
-                       """- ABC-Sendereihe \"Friends\"
-- BBCs tägliche Nachrichtensendung \"BBC News\"
-- ARD-Sendereihe \"Tatort\""""@de ,
-                       """- Série ABC \"Friends\" (en anglais)
-- Le programme d'information quotidien de la BBC \"BBC News\".
-- Tatort, le feuilleton du dimanche soir d'ARD"""@fr .
+- ARD's Sunday night drama \"Tatort\""""@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ServiceType
 ec:ServiceType rdf:type owl:Class ;
                rdfs:subClassOf skos:Concept ;
-               dcterms:description "Pour définir un type de service."@fr ,
-                                   "To define a type of service."@en ,
-                                   "Um eine Art von Dienst zu definieren."@de ;
-               rdfs:label "Art der Dienstleistung"@de ,
-                          "Service type"@en ,
-                          "Type de service"@fr .
+               dcterms:description "An entry from a list of types to classify a publication service."@en ;
+               rdfs:label "Service type"@en ;
+               skos:definition "a skos:Concept identifying the type of a ec:PublicationService"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Shot
@@ -14098,29 +10784,18 @@ ec:Shot rdf:type owl:Class ;
                           owl:allValuesFrom ec:Take
                         ] ;
         owl:disjointWith ec:Take ;
-        dcterms:description "A film sequence photographed continuously by one camera"@en ,
-                            "Eine Filmsequenz, die kontinuierlich von einer Kamera aufgenommen wird"@de ,
-                            "Une séquence de film photographiée en continu par une seule caméra."@fr ;
-        rdfs:label "Coup de feu"@fr ,
-                   "Schuss"@de ,
-                   "Shot"@en ;
-        skos:definition "an EditorialSegment filmed with one camera without interruption"@en ,
-                        "ein EditorialSegment mit einer Kamera ohne Unterbrechung gefilmt"@de ,
-                        "un segment éditorial filmé avec une seule caméra, sans interruption."@fr ;
-        skos:example "- a part of the final Scene of \"Casablanca\" showing Humphrey Bogart from behind while watching Ingrid Bergman and Paul Henreid walking to the plane, filmed from one camera without interruption"@en ,
-                     "- ein Ausschnitt aus der Schlussszene von \"Casablanca\", der Humphrey Bogart von hinten zeigt, während er Ingrid Bergman und Paul Henreid beim Gang zum Flugzeug beobachtet, gefilmt von einer einzigen Kamera ohne Unterbrechung"@de ,
-                     "- une partie de la scène finale de \"Casablance\" montrant Humphrey Bogart de dos tout en regardant Ingrid Bergman et Paul Henreid se diriger vers l'avion, filmée par une seule caméra sans interruption"@fr .
+        dcterms:description "A video sequence filmed continuously by one camera."@en ;
+        rdfs:label "Shot"@en ;
+        skos:definition "an ec:EditorialSegment filmed with one camera without interruption"@en ;
+        skos:example "- a part of the final Scene of \"Casablanca\" showing Humphrey Bogart from behind while watching Ingrid Bergman and Paul Henreid walking to the plane, filmed from one camera without interruption"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#SignLanguageCode
 ec:SignLanguageCode rdf:type owl:Class ;
                     rdfs:subClassOf skos:Concept ;
-                    dcterms:description "Eine Zeichensprache anhand ihres Codes zu identifizieren."@de ,
-                                        "Identifier une langue des signes par son code."@fr ,
-                                        "To identify a sign language by its code."@en ;
-                    rdfs:label "Code de la langue des signes"@fr ,
-                               "Code für Zeichensprache"@de ,
-                               "Sign language code"@en .
+                    dcterms:description "An entry from a list of codes to identify a sign language."@en ;
+                    rdfs:label "Sign language code"@en ;
+                    skos:definition "a skos:Concept identifying the code of a sign language"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Signing
@@ -14136,34 +10811,25 @@ ec:Signing rdf:type owl:Class ;
                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                              owl:onClass ec:Agent
                            ] ;
-           dcterms:description "Indicates the presence of sign language interpretation for deaf and hard-of-hearing users. The type and the sign language can be specified using the appropriate properties."@en ,
-                               "Indique la présence d’une interprétation en langue des signes dans le contenu audiovisuel (pour les personnes sourdes et malentendantes). Le type (p. ex. incrustation/in-vision) et la langue des signes peuvent être précisés via les propriétés appropriées."@fr ,
-                               "Kennzeichnet die Präsenz von Gebärdensprachdolmetschen im audiovisuellen Inhalt (für gehörlose und schwerhörige Nutzer*innen). Typ (z. B. In-Vision/Einblendung) und Gebärdensprache können über entsprechende Eigenschaften angegeben werden."@de ;
-           rdfs:label "Gebärdensprache"@de ,
-                      "Langue des signes"@fr ,
-                      "Signing"@en .
+           dcterms:description "A track containing sign language."@en ;
+           rdfs:label "Signing"@en ;
+           skos:definition "a ec:Track containing sign language for deaf and hard of hearing"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#SigningFormat
 ec:SigningFormat rdf:type owl:Class ;
                  rdfs:subClassOf skos:Concept ;
-                 dcterms:description "Beschreibt das Format der Gebärdensprachdolmetschung in audiovisuellen Inhalten (z. B. In-Vision/Einblendung, Vollbild, Overlay, Avatar)."@de ,
-                                     "Represents the format of sign language interpretation in audiovisual media (e.g., in-vision/inset, full-screen, overlay, avatar)."@en ,
-                                     "Représente le format de l’interprétation en langue des signes dans un contenu audiovisuel (p. ex. incrustation/in-vision, plein écran, superposition, avatar)."@fr ;
-                 rdfs:label "Format de langue des signes"@fr ,
-                            "Gebärdensprachformat"@de ,
-                            "Signing format"@en .
+                 dcterms:description "An entry from a list of formats to identify the sign language interpretation in audiovisual media, e.g. in-vision/inset, full-screen, overlay, avatar."@en ;
+                 rdfs:label "Signing format"@en ;
+                 skos:definition "a skos:Concept identifying the format of sign language interpretation"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#StaffMember
 ec:StaffMember rdf:type owl:Class ;
                rdfs:subClassOf ec:Person ;
-               dcterms:description "A member of Staff."@en ,
-                                   "Ein Mitglied der Belegschaft"@de ,
-                                   "Un membre du personnel."@fr ;
-               rdfs:label "Membre du personnel."@fr ,
-                          "Mitarbeiterin"@de ,
-                          "Staff member."@en .
+               dcterms:description "A member of staff is a person in a company's workforce."@en ;
+               rdfs:label "Staff member"@en ;
+               skos:definition "a ec:Person who is a member of the workforce in a company"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Stage
@@ -14188,76 +10854,51 @@ ec:Stage rdf:type owl:Class ;
                            owl:onProperty ec:name ;
                            owl:allValuesFrom rdfs:Literal
                          ] ;
-         dcterms:description "Définit une scène."@fr ,
-                             "Eine Bühne."@de ,
-                             "To define a Stage."@en ;
-         rdfs:label "Bühne"@de ,
-                    "Scène"@fr ,
-                    "Stage"@en .
+         dcterms:description "A space for the performing arts, such as a theatre, a concert hall or a film studio."@en ;
+         rdfs:label "Stage"@en ;
+         skos:definition "a space for the performing arts"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Standard
 ec:Standard rdf:type owl:Class ;
             rdfs:subClassOf ec:Format ;
-            dcterms:description "identifie la norme technique vidéo d'une ressource, c'est-à-dire NTSC ou PAL."@fr ,
-                                "identifies the technical video standard of a resource, i.e. NTSC or PAL."@en ,
-                                "identifiziert den technischen Videostandard einer Resource, d.h. NTSC oder PAL."@de ;
-            rdfs:label "Standard"@de ,
-                       "Standard"@en ,
-                       "Standard"@fr .
+            dcterms:description "An entry from the classification of video standards for media resources, i.e. NTSC or PAL."@en ;
+            rdfs:label "Standard"@en ;
+            skos:definition "a ec:Format classifying the video standard of a ec:MediaResource"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Sticker
 ec:Sticker rdf:type owl:Class ;
            rdfs:subClassOf ec:Picture ;
-           dcterms:description "A sticker associated with a Costume."@en ,
-                               "Ein Aufkleber, der mit einem Kostüm verbunden ist."@de ,
-                               "Un autocollant associé à un Costume."@fr ;
-           rdfs:label "Aufkleber"@de ,
-                      "Autocollant"@fr ,
-                      "Sticker"@en .
+           dcterms:description "A picture that is attached to a piece of clothing worn by an actor."@en ;
+           rdfs:label "Sticker"@en ;
+           skos:definition "a ec:Picture that is attached to a ec:Costume"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#StorageType
 ec:StorageType rdf:type owl:Class ;
                rdfs:subClassOf skos:Concept ;
-               dcterms:description "Die Art der Speicherung, die für das Repository verwendet wird. Dies wird als freier Text in einer Beschriftung oder als Bezeichner angegeben, der auf einen Begriff in einem Klassifizierungsschema verweist."@de ,
-                                   "Le type de stockage utilisé pour le référentiel. Il est fourni sous forme de texte libre dans une étiquette d'annotation ou sous forme d'identifiant pointant vers un terme dans un schéma de classification."@fr ,
-                                   "The type of storage used for the repository. This is provided as free text in an annotation label or as an identifier pointing to a term in a classification scheme."@en ;
-               rdfs:label "Art der Lagerung"@de ,
-                          "Storage type"@en ,
-                          "Type de stockage"@fr .
+               dcterms:description "An entry from a list of types to classify a storage."@en ;
+               rdfs:label "Storage type"@en ;
+               skos:definition "a skos:Concept identifying the type of storage"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Stream
 ec:Stream rdf:type owl:Class ;
           rdfs:subClassOf ec:Component ;
-          dcterms:description "A continuous stream of bits."@en ,
-                              "Ein kontinuierlicher Strom von Bits."@de ,
-                              "Un flux continu de bits."@fr ;
-          rdfs:label "Stream"@de ,
-                     "Stream"@en ,
-                     "Stream"@fr ;
-          skos:definition "a Component in form of a continuous flow of bits"@en ,
-                          "eine Komponente in Form eines kontinuierlichen Flusses von Bits"@de ,
-                          "un Composant sous forme d'un flux continu de bits"@fr ;
+          dcterms:description "A component of a media resource in the form of a continuous flow of bits."@en ;
+          rdfs:label "Stream"@en ;
+          skos:definition "a ec:Component in the form of a continuous flow of bits"@en ;
           skos:example """- an audio stream from an audio on demand service
-- a video stream from a video on demand service"""@en ,
-                       """- einen Audiostream von einem Audio-on-Demand-Dienst
-- einen Videostream von einem Video-on-Demand-Dienst"""@de ,
-                       """- un flux audio provenant d'un service audio à la demande
-- un flux vidéo provenant d'un service de vidéo à la demande"""@fr .
+- a video stream from a video on demand service"""@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Subject
 ec:Subject rdf:type owl:Class ;
            rdfs:subClassOf skos:Concept ;
-           dcterms:description "A term describing the topic covered by the EditorialObject or resource. This is provided as free text in an annotation label or as an identifier pointing to a term in a classification scheme."@en ,
-                               "Ein Begriff, der das Thema beschreibt, das von dem EditorialObject oder der Resource. Er wird als freier Text in einer Beschriftung angegeben oder als ein Bezeichner, der auf einen Begriff in einem Klassifizierungsschema verweist."@de ,
-                               "Un terme décrivant le sujet couvert par l objet éditorial ou la ressource. Il est fourni sous forme de texte libre dans une étiquette d'annotation ou comme un identifiant pointant vers un terme dans un schéma de classification."@fr ;
-           rdfs:label "Subject"@en ,
-                      "Sujet"@fr ,
-                      "Thema"@de .
+           dcterms:description "An entry from the list of subjects to classify the content of a piece of work."@en ;
+           rdfs:label "Subject"@en ;
+           skos:definition "a skos:Concept classifying the topic covered by a ec:EditorialObject"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Subtitling
@@ -14267,23 +10908,17 @@ ec:Subtitling rdf:type owl:Class ;
                                 owl:onProperty ec:hasSubtitlingSource ;
                                 owl:allValuesFrom ec:Agent
                               ] ;
-              dcterms:description "Pour signaler la présence de sous-titres pour traduction dans des langues alternatives."@fr ,
-                                  "To signal the presence of subtitles for translation in alternative languages."@en ,
-                                  "Um das Vorhandensein von Untertiteln für die Übersetzung in andere Sprachen."@de ;
-              rdfs:label "Sous-titrage"@fr ,
-                         "Subtitling"@en ,
-                         "Untertitelung"@de .
+              dcterms:description "A track containing subtitles in some languages."@en ;
+              rdfs:label "Subtitling"@en ;
+              skos:definition "a ec:Track containing subtitles in some language"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#SubtitlingFormat
 ec:SubtitlingFormat rdf:type owl:Class ;
                     rdfs:subClassOf ec:DataFormat ;
-                    dcterms:description "Définir le format du sous-titrage. L'utilisation principale du sous-titrage est la traduction. Celle-ci est fournie sous forme de texte libre dans une étiquette d'annotation ou comme un identifiant pointant vers un terme dans une classification de classification."@fr ,
-                                        "To define the format of subtitling. subtitling's main use is for translation. This is provided as free text in an annotation label or as an identifier pointing to a term in a classification scheme."@en ,
-                                        "Um das Format der Untertitelung zu definieren. Die Untertitelung wird hauptsächlich für die Übersetzung verwendet. Diese wird als freier Text in einer Beschriftung oder als Kennung, die auf einen Begriff in einem Klassifizierungsschema verweist Schema verweist."@de ;
-                    rdfs:label "Format de sous-titrage"@fr ,
-                               "Format der Untertitelung"@de ,
-                               "Subtitling format"@en .
+                    dcterms:description "An entry from the classification of structure schemes for subtitling data, mainly used for translations."@en ;
+                    rdfs:label "Subtitling format"@en ;
+                    skos:definition "a ec:DataFormat classifying the structure of subtitling data"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Take
@@ -14293,18 +10928,10 @@ ec:Take rdf:type owl:Class ;
                           owl:onProperty ec:hasScene ;
                           owl:allValuesFrom ec:Scene
                         ] ;
-        dcterms:description "A particular version of a scene or sequence of sound or vision photographed or recorded continuously at one time"@en ,
-                            "Eine bestimmte Version einer Szene oder einer Bild- oder Tonsequenz, die kontinuierlich zu einem Zeitpunkt fotografiert oder aufgenommen wurde."@de ,
-                            "Une version particulière d'une scène ou d'une séquence sonore ou visuelle photographiée ou enregistrée en continu à un moment donné."@fr ;
-        rdfs:label "Nehmen Sie"@de ,
-                   "Prenez"@fr ,
-                   "Take"@en ;
-        skos:definition "a particular instance of a Shot or a Scene amongst a number of similar instances for selection during post-production"@en ,
-                        "eine bestimmte Aufnahme oder Szene aus einer Reihe ähnlicher Aufnahmen für die Auswahl bei der Nachbearbeitung"@de ,
-                        "une instance particulière d'un plan ou d'une scène parmi un certain nombre d'instances similaires en vue d'une sélection pendant la postproduction."@fr ;
-        skos:example "- an EditorialWork consists of selected Takes, while discarded Takes sometimes are published as \"outtakes\", for which examples can be easily found in the web"@en ,
-                     "- ein EditorialWork besteht aus ausgewählten Takes, während verworfene Takes manchmal als \"Outtakes\" veröffentlicht werden, wofür sich im Internet leicht Beispiele finden lassen"@de ,
-                     "- une ŒuvreRédactionnelle est constituée de prises sélectionnées, tandis que les prises écartées sont parfois publiées comme \"outtakes\", dont on peut facilement trouver des exemples sur le web"@fr .
+        dcterms:description "A shot or a scene filmed repeatedly to provide a choice of takes and allow to select the best fit during post-production."@en ;
+        rdfs:label "Take"@en ;
+        skos:definition "a ec:Shot or a ec:Scene filmed or recorded repeatedly to provide a choice of Takes"@en ;
+        skos:example "- an EditorialWork consists of selected Takes, while discarded Takes sometimes are published as \"outtakes\", for which examples can be easily found in the web"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Team
@@ -14314,35 +10941,25 @@ ec:Team rdf:type owl:Class ;
                           owl:onProperty ec:hasTeamMember ;
                           owl:allValuesFrom ec:Person
                         ] ;
-        dcterms:description "Pour définir une équipe."@fr ,
-                            "So definieren Sie ein Team."@de ,
-                            "To define a Team."@en ;
-        rdfs:label "Team"@de ,
-                   "Team"@en ,
-                   "Équipe"@fr .
+        dcterms:description "A number of people working together, often in different roles, toward a common goal, such as conducting a project, operating a service, executing a process, or similar."@en ;
+        rdfs:label "Team"@en ;
+        skos:definition "a ec:Organisation consisting of ec:Persons as members"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Template
 ec:Template rdf:type owl:Class ;
             rdfs:subClassOf ec:Essence ;
-            dcterms:description "An Essence defined as a Template with all associated technical parameters."@en ,
-                                "Eine Essenz, die als Vorlage mit allen zugehörigen technischen Parametern definiert ist."@de ,
-                                "Une essence définie comme un modèle avec tous les paramètres techniques associés."@fr ;
-            rdfs:label "Modèle"@fr ,
-                       "Template"@en ,
-                       "Vorlage"@de ;
-            skos:definition "An Essence in the form of a template for Essences with all associated technical parameters"@en .
+            dcterms:description "An essence in the form of a template for essences with all associated technical parameters."@en ;
+            rdfs:label "Template"@en ;
+            skos:definition "an ec:Essence in the form of a template for ec:Essences with all associated technical parameters"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#TerritoryCode
 ec:TerritoryCode rdf:type owl:Class ;
                  rdfs:subClassOf skos:Concept ;
-                 dcterms:description "Pour identifier un territoire, par exemple par son code ONU."@fr ,
-                                     "To identify a territory e.g. by its UN code."@en ,
-                                     "Um ein Gebiet z.B. durch seinen UN-Code zu identifizieren."@de ;
-                 rdfs:label "Code du territoire"@fr ,
-                            "Territorialer Code"@de ,
-                            "Territory code"@en .
+                 dcterms:description "An entry from a list of codes identifying territories, e.g. by their UN Code."@en ;
+                 rdfs:label "Territory code"@en ;
+                 skos:definition "a skos:Concept identifying a territory"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#TextAnnotation
@@ -14358,12 +10975,9 @@ ec:TextAnnotation rdf:type owl:Class ;
                                     owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                     owl:onDataRange xsd:integer
                                   ] ;
-                  dcterms:description "A class specific to the annotation of a text or portions of text."@en ,
-                                      "Eine Klasse, die speziell für die Beschriftung eines Textes oder von Teilen eines Textes gedacht ist."@de ,
-                                      "Une classe spécifique à l'annotation d'un texte ou de portions de texte."@fr ;
-                  rdfs:label "Annotation de texte"@fr ,
-                             "Text Annotation"@en ,
-                             "Text-Anmerkung"@de .
+                  dcterms:description "A text annotation adds description, context, comments, or similar to a thing."@en ;
+                  rdfs:label "Text annotation"@en ;
+                  skos:definition "a ec:Annotation containing text or portions of texts"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#TextLine
@@ -14452,56 +11066,41 @@ ec:TextLine rdf:type owl:Class ;
                               owl:onProperty ec:textLineOrder ;
                               owl:maxCardinality "1"^^xsd:nonNegativeInteger
                             ] ;
-            dcterms:description "Pour fournir des lignes de texte extraites de la ressource ou complémentaires à celle-ci."@fr ,
-                                "To provide lines of text extracted from or additional to the resource."@en ,
-                                "Zur Bereitstellung von Textzeilen, die aus der Resource extrahiert wurden oder diese ergänzen."@de ;
-            rdfs:label "Ligne de texte"@fr ,
-                       "Text line"@en ,
-                       "Textzeile"@de .
+            dcterms:description "A line of text that appears within some content on a screen, at a given space and time."@en ;
+            rdfs:label "Text line"@en ;
+            skos:definition "a line of text that is visible in a spatial and timed context together with content"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#TextLineType
 ec:TextLineType rdf:type owl:Class ;
                 rdfs:subClassOf skos:Concept ;
-                dcterms:description "Pour définir un type TextLine."@fr ,
-                                    "To define a TextLine type."@en ,
-                                    "Um einen TextLine-Typ zu definieren."@de ;
-                rdfs:label "Text line type"@en ,
-                           "Typ der Textzeile"@de ,
-                           "Type de ligne de texte"@fr .
+                dcterms:description "An entry from a list of types to classify a text line."@en ;
+                rdfs:label "Text line type"@en ;
+                skos:definition "a skos:Concept identifying the type of a ec:TextLine"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#TextUsageType
 ec:TextUsageType rdf:type owl:Class ;
                  rdfs:subClassOf skos:Concept ;
-                 dcterms:description "Pour spécifier l'usage d'un texte."@fr ,
-                                     "To specify the usage of a text."@en ,
-                                     "Um die Verwendung eines Textes anzugeben."@de ;
-                 rdfs:label "Art der Textverwendung"@de ,
-                            "Text usage type"@en ,
-                            "Type d'utilisation du texte"@fr .
+                 dcterms:description "An entry from a list of types to classify the usage of a text."@en ;
+                 rdfs:label "Text usage type"@en ;
+                 skos:definition "a skos:Concept identifying the type of usage of text"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Theme
 ec:Theme rdf:type owl:Class ;
          rdfs:subClassOf skos:Concept ;
-         dcterms:description "Pour définir un thème associé à un actif."@fr ,
-                             "So definieren Sie ein Thema, das mit einem Asset verknüpft ist."@de ,
-                             "To define a Theme associated with an Asset."@en ;
-         rdfs:label "Thema"@de ,
-                    "Theme"@en ,
-                    "Thème"@fr .
+         dcterms:description "An entry from the list of themes to associate with of a piece of work."@en ;
+         rdfs:label "Theme"@en ;
+         skos:definition "a skos:Concept classifying the theme associated with a ec:Asset"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Thumbnail
 ec:Thumbnail rdf:type owl:Class ;
              rdfs:subClassOf ec:Picture ;
-             dcterms:description "A thumbnail is a low resolution picture that can be associated with EditorialObjects or e.g. MediaResources or Contacts."@en ,
-                                 "Eine Miniaturansicht ist ein Bild mit geringer Auflösung, das mit EditorialObjects oder z.B. MediaResources oder Contacts verknüpft werden kann. Kontakte."@de ,
-                                 "Une vignette est une image de faible résolution qui peut être associée à EditorialObjects, par exemple MediaResources ou Contacts."@fr ;
-             rdfs:label "Thumbnail"@en ,
-                        "Vignette"@fr ,
-                        "Vorschaubild"@de .
+             dcterms:description "A low-resolution picture to save computing and storage resources in user interfaces, e.g. on small-screen devices for consumption."@en ;
+             rdfs:label "Thumbnail"@en ;
+             skos:definition "a ec:Picture in a low resolution instantiation to save computing and storage resources in user interfaces"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#TimeCode
@@ -14512,9 +11111,9 @@ ec:TimeCode rdf:type owl:Class ;
                               owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                               owl:onDataRange xsd:string
                             ] ;
-            rdfs:label "Code temporel"@fr ,
-                       "Time code"@en ,
-                       "Zeitcode"@de .
+            dcterms:description "A point in time within the timeline of a content that is expressed as a timecode."@en ;
+            rdfs:label "Time code"@en ;
+            skos:definition "a ec:TimelinePoint expressed in a timecode expression"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#TimeCodeDropFrame
@@ -14525,53 +11124,41 @@ ec:TimeCodeDropFrame rdf:type owl:Class ;
                                        owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                        owl:onDataRange xsd:string
                                      ] ;
-                     rdfs:label "Code temporel avec dropframe"@fr ,
-                                "Time code with dropframe"@en ,
-                                "Zeitcode mit Dropframe"@de .
+                     dcterms:description "A point in time within the timeline of a content that is expressed as a timecode with dropframe."@en ;
+                     rdfs:label "Time code with dropframe"@en ;
+                     skos:definition "a ec:TimelinePoint expressed in a timecode expression with dropframe"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#TimecodeTrack
 ec:TimecodeTrack rdf:type owl:Class ;
                  rdfs:subClassOf ec:Track ;
-                 dcterms:description "A track with timecode information e.g. in MXF."@en ,
-                                     "Eine Spur mit Timecode-Informationen z.B. in MXF."@de ,
-                                     "Une piste avec des informations de timecode, par exemple en MXF."@fr ;
-                 rdfs:label "Piste de timecode"@fr ,
-                            "Timecode track"@en ,
-                            "Timecode-Spur"@de .
+                 dcterms:description "A track containing timecode information."@en ;
+                 rdfs:label "Timecode track"@en ;
+                 skos:definition "a ec:Track containing timecode information"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#TimedTextAuthoringTechnique
 ec:TimedTextAuthoringTechnique rdf:type owl:Class ;
                                rdfs:subClassOf ec:Format ;
-                               dcterms:description "Définir une technique de création de texte minuté."@fr ,
-                                                   "So definieren Sie eine Technik zum Verfassen von Texten mit Zeitvorgaben."@de ,
-                                                   "To define a timed text authoring technique."@en ;
-                               rdfs:label "Technik zum Verfassen von Texten mit Zeitvorgaben"@de ,
-                                          "Technique de création de textes temporisés"@fr ,
-                                          "Timed text authoring technique"@en .
+                               dcterms:description "An entry from the classification of techniques for the representation of timed text for media resources."@en ;
+                               rdfs:label "Timed text authoring technique"@en ;
+                               skos:definition "a ec:Format classifying the technique to represent time related text for a ec:MediaResource"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#TimedTextContentType
 ec:TimedTextContentType rdf:type owl:Class ;
                         rdfs:subClassOf ec:Format ;
-                        dcterms:description "Pour définir un type de texte minuté."@fr ,
-                                            "To define a type of timed text."@en ,
-                                            "Um eine Art von zeitlich begrenztem Text zu definieren."@de ;
-                        rdfs:label "Inhaltstyp Zeitgesteuerter Text"@de ,
-                                   "Timed text content type"@en ,
-                                   "Type de contenu texte temporisé"@fr .
+                        dcterms:description "An entry from the classification of types of timed text for media resources."@en ;
+                        rdfs:label "Timed text content type"@en ;
+                        skos:definition "a ec:Format classifying the type of timed text for a ec:MediaResource"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#TimedTextSubtitleTargetFormat
 ec:TimedTextSubtitleTargetFormat rdf:type owl:Class ;
                                  rdfs:subClassOf ec:Format ;
-                                 dcterms:description "Pour définir un format de sous-titres en texte minuté."@fr ,
-                                                     "So definieren Sie ein zeitgesteuertes Textuntertitelformat."@de ,
-                                                     "To define a timed text subtitle format."@en ;
-                                 rdfs:label "Format cible des sous-titres en texte minuté"@fr ,
-                                            "Timed text subtitle target format"@en ,
-                                            "Zeitgesteuertes Text-Zielformat für Untertitel"@de .
+                                 dcterms:description "An entry from the classification of types of timed text subtitles for media resources."@en ;
+                                 rdfs:label "Timed text subtitle target format"@en ;
+                                 skos:definition "a ec:Format classifying the format of timed text subtitles for a ec:MediaResource"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#TimelinePoint
@@ -14582,9 +11169,9 @@ ec:TimelinePoint rdf:type owl:Class ;
                                    owl:onDataRange xsd:float
                                  ] ;
                  dc:description "A precise time point  of a media resource"@en ;
-                 rdfs:label "Point de repère chronologique"@fr ,
-                            "Punkt auf der Zeitachse"@de ,
-                            "Timeline point"@en .
+                 dcterms:description "A point in time within the timeline of a content, typically used to mark a specific event, position, or segment boundary in media timing metadata."@en ;
+                 rdfs:label "Timeline point"@en ;
+                 skos:definition "a point in time within the timeline of a content"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#TimelineTrack
@@ -14615,34 +11202,25 @@ ec:TimelineTrack rdf:type owl:Class ;
                                    owl:onProperty ec:name ;
                                    owl:allValuesFrom rdfs:Literal
                                  ] ;
-                 dcterms:description "Definiert den zeitlichen Ablauf von Medieninhalten."@de ,
-                                     "Permet de définir une séquence temporelle d'EditorialObjects."@fr ,
-                                     "To define a timed sequence of EditorialObjects."@en ;
-                 rdfs:label "Piste chronologique"@fr ,
-                            "Timeline track"@en ,
-                            "Zeitachse"@de .
+                 dcterms:description "A temporal scale used as a reference to express the sequence in time for a set of content."@en ;
+                 rdfs:label "Timeline track"@en ;
+                 skos:definition "a temporal scale used as a reference to express the sequence in time of a set of ec:EditorialObjects"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#TimelineTrackType
 ec:TimelineTrackType rdf:type owl:Class ;
                      rdfs:subClassOf skos:Concept ;
-                     dcterms:description "Pour spécifier un type ou un TimelineTrack."@fr ,
-                                         "To specify a type or TimelineTrack."@en ,
-                                         "Um einen Typ oder eine TimelineSpur anzugeben."@de ;
-                     rdfs:label "Timeline track type"@en ,
-                                "Typ der Timeline-Spur"@de ,
-                                "Type de piste de la ligne de temps"@fr .
+                     dcterms:description "An entry from a list of types to classify timeline tracks."@en ;
+                     rdfs:label "Timeline track type"@en ;
+                     skos:definition "a skos:Concept identifying the type of a ec:TimelineTrack"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Topic
 ec:Topic rdf:type owl:Class ;
          rdfs:subClassOf skos:Concept ;
-         dcterms:description "A type subject for use in some contexts. This is provided as free text in an annotation label or as an identifier pointing to a term in a classification scheme."@en ,
-                             "Ein Typ, der in einigen Kontexten verwendet werden kann. Diese wird als freier Text in einer Beschriftung oder als Identifikator angegeben, der auf einen Begriff in einem Klassifikationsschema verweist."@de ,
-                             "Un sujet de type à utiliser dans certains contextes. Ce est fourni comme texte libre dans une étiquette d'annotation ou comme identifiant pointant vers un terme dans un schéma de classification."@fr ;
-         rdfs:label "Sujet"@fr ,
-                    "Thema"@de ,
-                    "Topic"@en .
+         dcterms:description "An entry from the list of topics to classify the content of a piece of work."@en ;
+         rdfs:label "Topic"@en ;
+         skos:definition "a skos:Concept classifying a topic covered in a ec:EditorialObject"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Track
@@ -14662,51 +11240,34 @@ ec:Track rdf:type owl:Class ;
                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                            owl:onClass ec:TrackType
                          ] ;
-         dcterms:description "Cela peut être une piste audio ou video ou timecode ou data provenant de la ressource médiatique, MediaResource."@fr ,
-                             "E.g. audio, video, timcode and/or data Tracks forming the MediaResource."@en ,
-                             "z.B. Audio-, Video-, Timecode- und/oder Datenspuren bilden eine MedienResource."@de ;
-         rdfs:label "Piste"@fr ,
-                    "Spur"@de ,
-                    "Track"@en ;
-         skos:definition "a MediaResource in the form of time-based elements for audio, video or data (\"track\") comprised in an \"aggregated\" MediaResource."@en ,
-                         "eine MedienResource in Form von zeitbasierten Elementen für Audio, Video oder Daten (\"Track\"), die in einer \"aggregierten\" MedienResource enthalten sind."@de ,
-                         "une MediaResource sous forme d'éléments temporels pour l'audio, la vidéo ou les données (\"piste\") comprise dans une MediaResource \"agrégée\"."@fr ;
-         skos:example "- das Audio in einer MPEG4-Videodatei"@de ,
-                      "- l'audio dans un fichier vidéo MPEG4"@fr ,
-                      "- the audio in a MPEG4 video file"@en .
+         dcterms:description "E.g. audio, video, timecode and/or data Tracks forming the MediaResource."@en ;
+         rdfs:label "Track"@en ;
+         skos:definition "a MediaResource in the form of time-based elements for audio, video or data (\"track\") comprised in an \"aggregated\" MediaResource"@en ;
+         skos:example "- the audio in a MPEG4 video file"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#TrackPurpose
 ec:TrackPurpose rdf:type owl:Class ;
                 rdfs:subClassOf skos:Concept ;
-                dcterms:description "Définir le purpose d'une piste."@fr ,
-                                    "To define the purpose of a track."@en ,
-                                    "Um den Zweck eines Titels zu definieren."@de ;
-                rdfs:label "Objectif de la voie"@fr ,
-                           "Track purpose"@en ,
-                           "Zweck der Spur"@de .
+                dcterms:description "An entry from a list of purposes to classify a track."@en ;
+                rdfs:label "Track purpose"@en ;
+                skos:definition "a skos:Concept identifying the purpose of a ec:Track"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#TrackType
 ec:TrackType rdf:type owl:Class ;
              rdfs:subClassOf skos:Concept ;
-             dcterms:description "Pour définir un type de piste."@fr ,
-                                 "To define a type of track."@en ,
-                                 "Um eine Art von Track zu definieren."@de ;
-             rdfs:label "Spur Typ"@de ,
-                        "Track type"@en ,
-                        "Type de voie"@fr .
+             dcterms:description "An entry from a list of types to classify a track, e.g. EBU's classification scheme on Track Type."@en ;
+             rdfs:label "Track type"@en ;
+             skos:definition "a skos:Concept identifying the type of a ec:Track"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Type
 ec:Type rdf:type owl:Class ;
         rdfs:subClassOf skos:Concept ;
-        dcterms:description "An expression of type in textual form or as a term from a classification scheme."@en ,
-                            "Ein Ausdruck des Typs in Textform oder als Begriff aus einem Klassifikationsschema."@de ,
-                            "Une expression de type sous forme textuelle ou en tant que terme d'un schéma de classification."@fr ;
-        rdfs:label "Typ"@de ,
-                   "Type"@en ,
-                   "Type"@fr .
+        dcterms:description "A superclass for classification types of content."@en ;
+        rdfs:label "Type"@en ;
+        skos:definition "a skos:Concept representing the superclass for classification types of content"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#UncertainDate
@@ -14736,78 +11297,57 @@ ec:UncertainDate rdf:type owl:Class ;
                                    owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                  ] ;
                  owl:disjointWith time:DateTimeDescription ;
-                 dcterms:description "Das Datum, ausgedrückt als Intervall zwischen Start und Ende, für unsichere Daten. Zusätzliche Informationen können in der Eigenschaft Beschreibung angegeben werden"@de ,
-                                     "La date exprimée sous la forme d'un intervalle entre le début et la fin, pour les dates incertaines. Des informations supplémentaires peuvent être écrites dans la propriété description."@fr ,
-                                     "The date expressed as an interval between start and end, for uncertain dates. Aditional infomation can be written in the description property"@en ;
-                 rdfs:label "Date incertaine"@fr ,
-                            "Uncertain date"@en ,
-                            "Ungewisses Datum"@de .
+                 dcterms:description "A time stamp that is lacking exactness can be expressed by the following scheme: omit information from small to large time units: omit seconds, then minutes, then hours, then days, then months, then years. To express a period of time with lacking exactness, define a start and end time stamp using the described uncertainty scheme."@en ;
+                 rdfs:label "Uncertain date"@en ;
+                 skos:definition "a time:Instant that can express missing exactness of a time stamp or a period of time"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#UsageRestrictions
 ec:UsageRestrictions rdf:type owl:Class ;
                      rdfs:subClassOf ec:Rights ;
-                     dcterms:description "Pour définir un ensemble de UsageRestrictions."@fr ,
-                                         "So definieren Sie eine Reihe von Nutzungseinschränkungen."@de ,
-                                         "To define a set of UsageRestrictions."@en ;
-                     rdfs:label "Einschränkungen bei der Verwendung"@de ,
-                                "Restrictions d'utilisation"@fr ,
-                                "Usage restrictions"@en .
+                     dcterms:description "A set of constraints on the use of a work."@en ;
+                     rdfs:label "Usage restrictions"@en ;
+                     skos:definition "a ec:Rights that define the constraints on the use of a work"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#UsageRights
 ec:UsageRights rdf:type owl:Class ;
                rdfs:subClassOf ec:Rights ;
-               dcterms:description "Droits d'utilisation associés au contenu."@fr ,
-                                   "Mit den Inhalten verbundene Nutzungsrechte."@de ,
-                                   "Usage rights associated with content."@en ;
-               rdfs:label "Droits d'utilisation"@fr ,
-                          "Nutzungsrechte"@de ,
-                          "Usage rights"@en .
+               dcterms:description "A set of entitlements to the use of work."@en ;
+               rdfs:label "Usage rights"@en ;
+               skos:definition "a ec:Rights that define the entitlements in the use of a work"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#VideoCodec
 ec:VideoCodec rdf:type owl:Class ;
               rdfs:subClassOf ec:Codec ;
-              dcterms:description "Pour fournir des informations sur un codec vidéo."@fr ,
-                                  "To provide information about a video codec."@en ,
-                                  "Zur Bereitstellung von Informationen über einen Videocodec."@de ;
-              rdfs:label "Codec vidéo"@fr ,
-                         "Video codec"@en ,
-                         "Video-Codec"@de .
+              dcterms:description "The codec used in the production of video content."@en ;
+              rdfs:label "Video codec"@en ;
+              skos:definition "a ec:Codec used in the production of a video stream, file or track"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#VideoEncodingFormat
 ec:VideoEncodingFormat rdf:type owl:Class ;
                        rdfs:subClassOf ec:EncodingFormat ;
-                       dcterms:description "Das Kodierungsformat des Videos."@de ,
-                                           "Le format d'encodage de la vidéo."@fr ,
-                                           "The encoding format of the video."@en ;
-                       rdfs:label "Format d'encodage vidéo"@fr ,
-                                  "Format der Videokodierung"@de ,
-                                  "Video encoding format"@en .
+                       dcterms:description "An entry from the classification of transformations that produce digital video resources from audio signals."@en ;
+                       rdfs:label "Video encoding format"@en ;
+                       skos:definition "a ec:EncodingFormat classifying the transformation from a video signal to video data in a ec:MediaResource"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#VideoFormat
 ec:VideoFormat rdf:type owl:Class ;
                rdfs:subClassOf ec:Format ;
-               dcterms:description "Spezifiziert das Videoformat der MedienResource."@de ,
-                                   "Spezifiziert das Videoformat der MedienResource."@fr ,
-                                   "To specify the format used for video."@en ;
-               rdfs:label "Format vidéo"@fr ,
-                          "Video format"@en ,
-                          "Videoformat"@de .
+               dcterms:description "An entry from the classification of types of video formats for media resources."@en ;
+               rdfs:label "Video format"@en ;
+               skos:definition "a ec:Format classifying the format of video in a ec:MediaResource"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#VideoStream
 ec:VideoStream rdf:type owl:Class ;
                rdfs:subClassOf ec:Stream ;
-               dcterms:description "A decodable video stream of bits."@en ,
-                                   "Ein dekodierbarer Videostrom aus Bits."@de ,
-                                   "Un flux vidéo décodable de bits."@fr ;
-               rdfs:label "Flux vidéo"@fr ,
-                          "Video stream"@en ,
-                          "Video-Stream"@de .
+               dcterms:description "A data stream containing a decidable video signal."@en ;
+               rdfs:label "Video stream"@en ;
+               skos:definition "a ec:Stream with encoded video"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#VideoTrack
@@ -14818,28 +11358,24 @@ ec:VideoTrack rdf:type owl:Class ;
                                 owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                 owl:onDataRange xsd:nonNegativeInteger
                               ] ;
-              dcterms:description "A specialisation of Track for Video to provide a link to specific data properties such as frameRate, etc. Signing is another possible example of video track. Specific VideoTracks such as Signing can be defined as sub VideoTracks. In advanced systems, different VideoTracks can be used to provide e.g. different viewing angles."@en ,
-                                  "Eine Spezialisierung von Track für Video zur Bereitstellung einer Verknüpfung zu bestimmten Dateneigenschaften wie FrameRate usw. Gebärdensprache ist ein weiteres mögliches Beispiel für eine Videospur. Spezifische VideoTracks wie Signing können als Unterklassen definiert werden. In fortgeschrittenen Systemen können verschiedene VideoTracks verwendet werden, um z.B. unterschiedliche Blickwinkel zu bieten."@de ,
-                                  "Une spécialisation de Track pour la vidéo afin de fournir un lien vers des propriétés de données spécifiques telles que le frameRate, etc. La langue des signes est un autre exemple possible de piste vidéo. Des VideoTracks spécifiques tels que Signing peuvent être définis comme sous-classes. Dans les systèmes avancés, différents VideoTracks peuvent être utilisés pour fournir par exemple différents angles de vue."@fr ;
-              rdfs:label "Piste vidéo"@fr ,
-                         "Video track"@en ,
-                         "Videospur"@de .
+              dcterms:description "A track containing video."@en ;
+              rdfs:label "Video track"@en ;
+              skos:definition "a ec:Track containing video"@en .
 
 
 ###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#WrappingType
 ec:WrappingType rdf:type owl:Class ;
                 rdfs:subClassOf skos:Concept ;
-                dcterms:description "Pour définir un type d'emballage."@fr ,
-                                    "To define a type of wrapping."@en ,
-                                    "Um eine Art der Umhüllung zu definieren."@de ;
-                rdfs:label "Art der Umhüllung"@de ,
-                           "Type d'emballage"@fr ,
-                           "Wrapping type"@en .
+                dcterms:description "An entry from a list of types for the wrapping, usually of data."@en ;
+                rdfs:label "Wrapping type"@en ;
+                skos:definition "a skos:Concept identifying the type of wrapping"@en .
 
 
 ###  http://www.w3.org/2004/02/skos/core#Concept
 skos:Concept rdf:type owl:Class ;
-             rdfs:isDefinedBy <http://www.w3.org/2004/02/skos/core> .
+             dcterms:description "An entry from a list of complementary notions."@en ;
+             rdfs:isDefinedBy <http://www.w3.org/2004/02/skos/core> ;
+             skos:definition "an entity representing a notion or an idea from a knowledge domain"@en .
 
 
 ###  http://www.w3.org/2006/time#DateTimeDescription
@@ -14857,12 +11393,9 @@ time:DateTimeDescription rdf:type owl:Class ;
                                            owl:onProperty time:year ;
                                            owl:allValuesFrom xsd:gYear
                                          ] ;
-                         dcterms:description "Beschreibung von Datum und Uhrzeit, strukturiert mit separaten Werten für die verschiedenen Elemente eines Kalender-Uhr-Systems. Das zeitliche Bezugssystem ist auf den Gregorianischen Kalender festgelegt und der Bereich der Eigenschaften Jahr, Monat und Tag ist auf die entsprechenden XML-Schema-Typen xsd:gYear, xsd:gMonth bzw. xsd:gDay beschränkt."@de ,
-                                             "Description de la date et de l'heure structurée avec des valeurs distinctes pour les différents éléments d'un système calendrier-horloge. Le système de référence temporel est fixé au calendrier grégorien, et la plage des propriétés année, mois, jour est limitée aux types XML Schema correspondants xsd:gYear, xsd:gMonth et xsd:gDay, respectivement."@fr ,
-                                             "Description of date and time structured with separate values for the various elements of a calendar-clock system. The temporal reference system is fixed to Gregorian Calendar, and the range of year, month, day properties restricted to corresponding XML Schema types xsd:gYear, xsd:gMonth and xsd:gDay, respectively."@en ;
-                         rdfs:label "Date-time description"@en ,
-                                    "Datum-Zeit-Beschreibung"@de ,
-                                    "Description de la date et de l'heure"@fr .
+                         dcterms:description "A point in time that is described by year, month, day, hour, minute, second and milliseconds with respect to the Gregorian calendar."@en ;
+                         rdfs:label "Date-time description"@en ;
+                         skos:definition "a time:Instant that can express a date and a time of day with respect ot a time:TRS"@en .
 
 
 ###  http://www.w3.org/2006/time#Instant
@@ -14876,22 +11409,16 @@ time:Instant rdf:type owl:Class ;
                                owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                owl:onDataRange xsd:dateTimeStamp
                              ] ;
-             dcterms:description "A temporal entity with zero extent or duration"@en ,
-                                 "Eine zeitliche Einheit ohne Ausmaß oder Dauer"@de ,
-                                 "Une entité temporelle dont l'étendue ou la durée est nulle"@fr ;
-             rdfs:label "Time instant"@en ,
-                        "Un instant"@fr ,
-                        "Zeit sofort"@de .
+             dcterms:description "A point in time."@en ;
+             rdfs:label "Time instant"@en ;
+             skos:definition "a temporal entity with zero extent or duration"@en .
 
 
 ###  http://www.w3.org/2006/time#TRS
 time:TRS rdf:type owl:Class ;
-         dcterms:description "A temporal reference system, such as a temporal coordinate reference system (with an origin, direction, and scale), a calendar-clock combination, or a (possibly hierarchical) ordinal system."@en ,
-                             "Ein zeitliches Referenzsystem, wie z.B. ein zeitliches Koordinatenreferenzsystem (mit Ursprung, Richtung und Maßstab), eine Kalender-Uhr-Kombination oder ein (möglicherweise hierarchisches) Ordinalsystem."@de ,
-                             "Un système de référence temporel, tel qu'un système de référence à coordonnées temporelles (avec une origine, une direction et une échelle), une combinaison calendrier-horloge ou un système ordinal (éventuellement hiérarchique)."@fr ;
-         rdfs:label "Système de référence temporel"@fr ,
-                    "Temporal reference system"@en ,
-                    "Zeitliches Bezugssystem"@de .
+         dcterms:description "A reference system for the specification of points in time with an origin, a direction and a scale, such as a calendar-clock combination, e.g. the Gregorian calendar, or a (possibly hierarchical) ordinal system."@en ;
+         rdfs:label "Temporal reference system"@en ;
+         skos:definition "a reference system for the specification of points in time with an origin, a direction and a scale"@en .
 
 
 #################################################################
@@ -14980,12 +11507,8 @@ ec:workingTitle rdf:type owl:NamedIndividual ,
 #    Annotations
 #################################################################
 
-dcterms:contributor dcterms:description "Dans le contexte d'EBUCore, réservé à l'annotation des propriétés RDF."@fr ;
-                     rdfs:label "Beitragender"@de ;
-                     dcterms:description "In the context of EBUCore, reserved for the annotation of RDF properties."@en ,
-                                         "Im Kontext von EBUCore für die Annotation von RDF-Eigenschaften reserviert."@de ;
-                     rdfs:label "Contributor"@en ,
-                                "Contributeur"@fr .
+dcterms:contributor dcterms:description "In the context of EBUCore, reserved for the annotation of RDF properties."@en ;
+                     rdfs:label "Contributor"@en .
 
 
 ###  Generated by the OWL API (version 4.5.9.2019-02-01T07:24:44Z) https://github.com/owlcs/owlapi

--- a/ontology/EBUCorePlus/ebucoreplus_en_de.owl
+++ b/ontology/EBUCorePlus/ebucoreplus_en_de.owl
@@ -1,0 +1,14182 @@
+@prefix : <http://www.ebu.ch/metadata/ontologies/ebucoreplus#> .
+@prefix cc: <http://creativecommons.org/ns#> .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix ec: <http://www.ebu.ch/metadata/ontologies/ebucoreplus#> .
+@prefix vs: <http://www.w3.org/2003/06/sw-vocab-status/ns#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix spin: <http://spinrdf.org/spin#> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix vann: <http://purl.org/vocab/vann/> .
+@prefix xkos: <https://rdf-vocabulary.ddialliance.org/xkos/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@base <http://www.ebu.ch/metadata/ontologies/ebucoreplus> .
+
+<http://www.ebu.ch/metadata/ontologies/ebucoreplus> rdf:type owl:Ontology ;
+                                                     owl:versionIRI <http://www.ebu.ch/metadata/ontologies/ebucoreplus/2.0.0> ;
+                                                     owl:imports <http://www.w3.org/2004/02/skos/core> ;
+                                                     cc:licence "http://creativecommons.org/licenses/by-sa/3.0/" ;
+                                                     dc:contributor "Adam Wead, Penn State University"@en-us ,
+                                                                    "Alexander Schulze, Innotrade"@de ,
+                                                                    "Alexandre Rouxel, EBU"@ch ,
+                                                                    "Are Tverberg, TV2"@no ,
+                                                                    "Casey Davis, WGBH"@en-us ,
+                                                                    "Cedric Klein, Perfect Memory"@fr ,
+                                                                    "Christophe Debruyne, RIA"@ie ,
+                                                                    "Chuck McCallum, WGBH"@en-us ,
+                                                                    "Cliff Ingham, City of Bloomington"@en-us ,
+                                                                    "Dalia R. Levine, HBO"@en-us ,
+                                                                    "Drew Myers, WGBH"@en-us ,
+                                                                    "Glenn Clatworthy, PBS"@en-us ,
+                                                                    "Guillaume Rachez, Perfect Memory"@fr ,
+                                                                    "Hugo Cordier, SetKeeper"@fr ,
+                                                                    "Hugo Manguinhas, Europeana"@nl ,
+                                                                    "Ismail Harrendo, Eurecom"@fr ,
+                                                                    "Jack Brighton, WILL Public Media"@en-us ,
+                                                                    "Julie Hardesty, Indian University Library"@en-us ,
+                                                                    "Jürgen Grupp, SWR"@de ,
+                                                                    "Kara van Malssen, AV Preserve"@en-us ,
+                                                                    "Karen Cariani, WGBH"@en-us ,
+                                                                    "Kim Viljanen, YLE"@fi ,
+                                                                    "Knut-Olav Hoven, NRK"@no ,
+                                                                    "Laurence Cook, metaCirque"@en-us ,
+                                                                    "Marc-Antoine Arnaud, Media-IO"@fr ,
+                                                                    "Mark Guelbahar, IRT"@de ,
+                                                                    "Matthieu Parmentier, francetelevisions"@fr ,
+                                                                    "Michael J. Giarlo, Penn State University"@en-us ,
+                                                                    "Peggy Griesinger, George Mason University Libraries"@en-us ,
+                                                                    "Raphael Troncy, Eurecom"@fr ,
+                                                                    "Rebecca Fraimow, WGBH"@en-us ,
+                                                                    "Rebecca Guenther, Rebecca Guenther Consulting"@en-us ,
+                                                                    "Robert Engels, NRK"@no ,
+                                                                    "Sadie Roosa, WGBH"@en-us ,
+                                                                    "Tormod Vævågen, GluonMedia"@no ,
+                                                                    "Valentine Charles, Europeana"@nl ,
+                                                                    "Valerie J. Miller, PBS"@en-us ,
+                                                                    "Vincent Dabouineau"@fr ;
+                                                     dc:creator "Jean Pierre Evain, EBU"@ch ;
+                                                     dc:description """EBUCorePlus is an ontology for media enterprises, developed as an open source project. It follows-up on two long-standing EBU ontologies: EBUCore and CCDM (Class Conceptual Data Model). The two were merged and thoroughly revisioned. The result is EBUCorePlus, the new standard that can fully replace its predecessors. It inherits both the long-lasting reliability of EBUCore and the end-to-end coverage of the media value chain of CCDM.
+
+EBUCorePlus is strictly semantic. It avoids ambiguities that were introduced when using EBUCore and CCDM classes in one graph. It has its own, new name space therefore it is not backward compatible, but can be mapped to its predecessors. It provides complete documentation of all entities in English, French and German (English being normative).
+
+One major problem of EBUCore and CCDM was the use of ranges: semantically similar object properties needed to be defined in parallel for each class that the property referred to. Another case was the use of multi-range properties, leading to insufficient type safety. EBUCorePlus now uses class restrictions instead, leading to less and more coherent properties.
+
+EBUCorePlus aims to serve as a plug and play framework. It can be used out of the box, either in its entirety or just a subset of its elements. But it may also be adapted and extended to enterprise-specific needs. Especially for system integration tasks and defining requirements, projects benefit from EBUCorePlus as a business – not technology – oriented language.
+
+The ontology is developed by the EBU Metadata Modelling Working Group as an open source project on github. Requests for changes and improvements can be submitted by EBU Members, media organizations or anybody else from the media community. The EBUCorePlus Editorial Committee reviews requests and implements changes.
+
+The EBU Metadata Modelling Working Group provides access, upon request, to a cloud hosted demonstration kit to explore and better understand the whole EBUCorePlus model."""@en ;
+                                                     dc:publisher "European Broadcasting Union (EBU)"@ch ;
+                                                     dc:rights "Copyright 2023 EBU"@en ;
+                                                     vann:preferredNamespaceUri "http://www.ebu.ch/metadata/ontologies/ebucoreplus#" ;
+                                                     owl:versionInfo "Version 2.0.0"@en ;
+                                                     vs:term_status "stable"@en .
+
+#################################################################
+#    Annotation properties
+#################################################################
+
+###  http://creativecommons.org/ns#licence
+cc:licence rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/contributor
+dc:contributor rdf:type owl:AnnotationProperty ;
+               dcterms:description "An Agent who has participated in any phase of management of an Asset."@en ;
+               rdfs:label "Contributor"@en .
+
+
+###  http://purl.org/dc/elements/1.1/creator
+dc:creator rdf:type owl:AnnotationProperty ;
+           dcterms:description "To identify the creator of an Asset."@en ;
+           rdfs:label "Creator"@en .
+
+
+###  http://purl.org/dc/elements/1.1/date
+dc:date rdf:type owl:AnnotationProperty ;
+        dcterms:description "A date associated with a resource."@en ;
+        rdfs:label "Date"@en ;
+        rdfs:range xsd:date .
+
+
+###  http://purl.org/dc/elements/1.1/description
+dc:description rdf:type owl:AnnotationProperty ;
+               dcterms:description "A description of an Asset."@en ;
+               rdfs:label "Description"@en .
+
+
+###  http://purl.org/dc/elements/1.1/format
+dc:format rdf:type owl:AnnotationProperty ;
+          dcterms:description "Information about the Format of a Resource."@en ;
+          rdfs:label "Format"@en .
+
+
+###  http://purl.org/dc/elements/1.1/identifier
+dc:identifier rdf:type owl:AnnotationProperty ;
+              dcterms:description "To provide a simple not strongly structured identifier."@en ;
+              rdfs:label "Identifier"@en .
+
+
+###  http://purl.org/dc/elements/1.1/language
+dc:language rdf:type owl:AnnotationProperty ;
+            dcterms:description "To define languages associated with an Asset."@en ;
+            rdfs:label "Language"@en .
+
+
+###  http://purl.org/dc/elements/1.1/publisher
+dc:publisher rdf:type owl:AnnotationProperty ;
+             dcterms:description "An Agent involved in the distribution of content."@en ;
+             rdfs:label "Publisher"@en .
+
+
+###  http://purl.org/dc/elements/1.1/rights
+dc:rights rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/title
+dc:title rdf:type owl:AnnotationProperty ;
+         dcterms:description "The title by which a EditorialObject is known."@en ;
+         rdfs:label "Title"@en .
+
+
+###  http://purl.org/dc/elements/1.1/type
+dc:type rdf:type owl:AnnotationProperty ;
+        dcterms:description "A concept associated with a resource."@en ;
+        rdfs:label "Type"@en .
+
+
+###  http://purl.org/dc/terms/description
+dcterms:description rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/vocab/vann/preferredNamespaceUri
+vann:preferredNamespaceUri rdf:type owl:AnnotationProperty .
+
+
+###  http://spinrdf.org/spin#imports
+spin:imports rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2000/01/rdf-schema#example
+rdfs:example rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2002/07/owl#maxQualifiedCardinality
+owl:maxQualifiedCardinality rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2003/06/sw-vocab-status/ns#term_status
+vs:term_status rdf:type owl:AnnotationProperty .
+
+
+#################################################################
+#    Datatypes
+#################################################################
+
+###  http://www.w3.org/2001/XMLSchema#date
+xsd:date rdf:type rdfs:Datatype .
+
+
+###  http://www.w3.org/2001/XMLSchema#gDay
+xsd:gDay rdf:type rdfs:Datatype .
+
+
+###  http://www.w3.org/2001/XMLSchema#gMonth
+xsd:gMonth rdf:type rdfs:Datatype .
+
+
+###  http://www.w3.org/2001/XMLSchema#gYear
+xsd:gYear rdf:type rdfs:Datatype .
+
+
+###  http://www.w3.org/2001/XMLSchema#time
+xsd:time rdf:type rdfs:Datatype .
+
+
+#################################################################
+#    Object Properties
+#################################################################
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#accountingTo
+ec:accountingTo rdf:type owl:ObjectProperty ;
+                dcterms:description "A Consumer Account for a particular Service."@en ,
+                                    "Ein Verbraucher-Konto für einen bestimmten Dienst."@de ;
+                rdfs:label "Account"@en ,
+                           "Konto"@de ;
+                skos:definition "an owl:ObjectProperty relating an ec:ConsumptionEvent to an ec:Account"@en ,
+                                "eine owl:ObjectProperty, die ein ec:ConsumptionEvent mit einem ec:Account verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#animates
+ec:animates rdf:type owl:ObjectProperty ;
+            owl:inverseOf ec:isAnimatedBy ;
+            dcterms:description "Gibt an, dass eine Person eine Figur mithilfe eines Artefakts wie einer Puppe oder eines Animations-Rigs animiert."@de ,
+                                "Indicates that a person animates a character through the use of an artefact, such as a puppet or animation rig."@en ;
+            rdfs:label "Animates"@en ,
+                       "Animiert"@de ;
+            skos:definition "an owl:ObjectProperty relating an ec:Person to an ec:Character"@en ,
+                            "eine owl:ObjectProperty, die eine ec:Person mit einer ec:Character verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#applyTo
+ec:applyTo rdf:type owl:ObjectProperty ;
+           dcterms:description "Das Asset, auf das sich die Rechte beziehen."@de ,
+                               "The Asset to which Rights apply."@en ;
+           rdfs:label "Asset"@en ,
+                      "Vermögenswert"@de ;
+           skos:definition "an owl:ObjectProperty relating an ec:Rights to an ec:Asset"@en ,
+                           "eine owl:ObjectProperty, die ec:Rights mit ec:Asset verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#approvedBy
+ec:approvedBy rdf:type owl:ObjectProperty ;
+              dcterms:description "Der Agent, der das EditorialObject zur Veröffentlichung freigegeben hat. Wenn vorhanden, fungiert die Eigenschaft als Auslöser für die Veröffentlichung des EditorialObject."@de ,
+                                  "The Agent who approved the EditorialObject for publishing. When present, the property acts as a trigger for publishing the EditorialObject."@en ;
+              rdfs:label "Agent"@de ,
+                         "Agent"@en ;
+              skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Agent"@en ,
+                              "eine owl:ObjectProperty, die eine ec:EditorialObject mit einem ec:Agent verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#basedOn
+ec:basedOn rdf:type owl:ObjectProperty ;
+           dcterms:description "Das EditorialObject, auf das sich der ProductionJob bezieht."@de ,
+                               "The EditorialObject that the ProductionJob relates to."@en ;
+           rdfs:label "Related editorial object"@en ,
+                      "Verwandtes redaktionelles Objekt"@de ;
+           skos:definition "an owl:ObjectProperty relating an ec:ProductionJob to an ec:EditorialObject"@en ,
+                           "eine owl:ObjectProperty, die eine ec:ProductionJob mit einem ec:EditorialObject verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#belongsToAudience
+ec:belongsToAudience rdf:type owl:ObjectProperty ;
+                     dcterms:description "Die übergeordnete Audience-Gruppe, der ein Consumer angehört."@de ,
+                                         "The parent Audience group to which a Consumer is a member of."@en ;
+                     rdfs:label "Elternpublikum"@de ,
+                                "Parent audience"@en ;
+                     skos:definition "an owl:ObjectProperty relating an ec:Consumer to an ec:Audience"@en ,
+                                     "eine owl:ObjectProperty, die einen ec:Consumer mit einer ec:Audience verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#bringsRights
+ec:bringsRights rdf:type owl:ObjectProperty ;
+                dcterms:description "Die Rechte erscheinen als Folge des Engagements."@de ,
+                                    "The rights appear as a consequence of the engagement."@en ;
+                rdfs:label "Brings rights"@en ,
+                           "Rechte verschafft"@de ;
+                skos:definition "an owl:ObjectProperty relating an ec:Involvement to ec:Rights"@en ,
+                                "eine owl:ObjectProperty, die ec:Involvement mit ec:Rights verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#canAccessPublicationChannel
+ec:canAccessPublicationChannel rdf:type owl:ObjectProperty ;
+                               dcterms:description "A property that indicates whether a consumption device profile can access a publication channel."@en ,
+                                                   "Eine Eigenschaft, die angibt, ob ein Verbrauchsgeräteprofil auf einen Veröffentlichungskanal zugreifen kann."@de ;
+                               rdfs:label "Can access publication channel"@en ,
+                                          "Kann auf den Veröffentlichungskanal zugreifen"@de ;
+                               skos:definition "an owl:ObjectProperty relating an ec:ConsumptionDeviceProfile to an ec:PublicationChannel"@en ,
+                                               "eine owl:ObjectProperty, die eine ec:ConsumptionDeviceProfile mit einer ec:PublicationChannel verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#canAccessPublicationPlatform
+ec:canAccessPublicationPlatform rdf:type owl:ObjectProperty ;
+                                dcterms:description "A property that indicates whether a consumption device profile can access a publication platform."@en ,
+                                                    "Eine Eigenschaft, die angibt, ob ein Verbrauchsgeräteprofil auf eine Veröffentlichungsplattform zugreifen kann."@de ;
+                                rdfs:label "Can access publication platform"@en ,
+                                           "Kann Veröffentlichungsplattform zugreifen"@de ;
+                                skos:definition "an owl:ObjectProperty relating an ec:ConsumptionDeviceProfile to an ec:PublicationPlatform"@en ,
+                                                "eine owl:ObjectProperty, die ec:ConsumptionDeviceProfile mit ec:PublicationPlatform verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#commissions
+ec:commissions rdf:type owl:ObjectProperty ;
+               owl:inverseOf ec:hasCommissioningContract ;
+               dcterms:description "Bezieht ein EditorialObject auf den Contract, über den es in Auftrag gegeben wird."@de ,
+                                   "Relates an EditorialObject to the Contract through which it is commissioned."@en ;
+               rdfs:label "Aufträge"@de ,
+                          "Commissions"@en ;
+               skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Contract"@en ,
+                               "eine owl:ObjectProperty, die ein ec:EditorialObject mit einem ec:Contract verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#compilesResonanceEvents
+ec:compilesResonanceEvents rdf:type owl:ObjectProperty ;
+                           dcterms:description "Eines der ResonanceEvents, die zu einem aussagekräftigen Satz von Resonance-Daten zusammengefasst werden."@de ,
+                                               "One of the ResonanceEvents aggregated into a meaningful set of Resonance data."@en ;
+                           rdfs:label "Resonance"@en ,
+                                      "Resonanz"@de ;
+                           skos:definition "an owl:ObjectProperty relating a ec:ResonanceCount to a ec:ResonanceEvent"@en ,
+                                           "eine owl:ObjectProperty, die eine ec:ResonanceCount mit einem ec:ResonanceEvent verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#compliesWith
+ec:compliesWith rdf:type owl:ObjectProperty ;
+                dcterms:description "Das Profil, dem ein ConsumptionDevice entspricht."@de ,
+                                    "The profile a ConsumptionDevice complies with."@en ;
+                rdfs:label "Device profile"@en ,
+                           "Geräteprofil"@de ;
+                skos:definition "an owl:ObjectProperty relating an ec:ConsumptionDevice to an ec:ConsumptionDeviceProfile"@en ,
+                                "eine owl:ObjectProperty, die eine ec:ConsumptionDevice mit einer ec:ConsumptionDeviceProfile verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#consumesEssence
+ec:consumesEssence rdf:type owl:ObjectProperty ;
+                   dcterms:description "Die Essence, die während eines ConsumptionEvent verbraucht wurde."@de ,
+                                       "The Essence that has been consumed during a ConsumptionEvent."@en ;
+                   rdfs:label "Essence"@en ,
+                              "Essenz"@de ;
+                   skos:definition "an ec:ConsumptionEvent relating to an ec:Essence"@en ,
+                                   "ein ec:ConsumptionEvent, das sich auf ein ec:Essence bezieht"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#coversConsumptionDevice
+ec:coversConsumptionDevice rdf:type owl:ObjectProperty ;
+                           dcterms:description "A device compatible with the ConsumptionLicence."@en ,
+                                               "Ein Gerät, das mit der ConsumptionLicence kompatibel ist."@de ;
+                           rdfs:label "Compatible consumption device"@en ,
+                                      "Kompatibles Verbrauchsgerät"@de ;
+                           skos:definition "an owl:ObjectProperty relating an ec:ConsumptionLicence to an ec:ConsumptionDevice"@en ,
+                                           "eine owl:ObjectProperty, die ec:ConsumptionLicence mit ec:ConsumptionDevice verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#coversEvent
+ec:coversEvent rdf:type owl:ObjectProperty ;
+               rdfs:subPropertyOf ec:hasCoverage ;
+               dcterms:description "A property to identify the Events, all real or fictional, covered by the EditorialObject."@en ,
+                                   "Eine Eigenschaft zur Identifizierung der Ereignisse, sowohl realer als auch fiktiver, die vom EditorialObject erfasst werden."@de ;
+               rdfs:label "Covers event"@en ,
+                          "Deckt Ereignis ab"@de ;
+               skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Event"@en ,
+                               "eine owl:ObjectProperty, die ein ec:EditorialObject mit einem ec:Event verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#coversLocation
+ec:coversLocation rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf ec:hasCoverage ;
+                  dcterms:description "A property to identify the Locations, all real or fictional, covered by the EditorialObject."@en ,
+                                      "Eine Eigenschaft zur Identifizierung der Orte, sowohl realer als auch fiktiver, die vom EditorialObject abgedeckt werden."@de ;
+                  rdfs:label "Covers location"@en ,
+                             "Deckt Standort ab"@de ;
+                  skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Location"@en ,
+                                  "eine owl:ObjectProperty, die eine ec:EditorialObject mit einer ec:Location verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#createsMetadata
+ec:createsMetadata rdf:type owl:ObjectProperty ;
+                   dcterms:description "Used where a production job, e.g. a face recognition service, yields information that can be described using the EditorialObject class."@en ,
+                                       "Wird verwendet, wenn ein Produktionsauftrag, z. B. ein Gesichtserkennungsdienst, Informationen liefert, die mit der Klasse EditorialObject beschrieben werden können."@de ;
+                   rdfs:label "Creates metadata"@en ,
+                              "Metadaten erzeugt"@de ;
+                   skos:definition "an owl:ObjectProperty relating an ec:ProductionJob to an ec:EditorialObject"@en ,
+                                   "eine owl:ObjectProperty, die eine ec:ProductionJob mit einem ec:EditorialObject verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#defines
+ec:defines rdf:type owl:ObjectProperty ;
+           owl:inverseOf ec:isDefinedBy ;
+           dcterms:description "Identifies the contract, agreement, or law that defines a rule."@en ,
+                               "Identifiziert den Vertrag, die Vereinbarung oder das Gesetz, das eine Regel definiert."@de ;
+           rdfs:label "Defines"@en ,
+                      "Definiert"@de ;
+           skos:definition "an owl:ObjectProperty relating an ec:Rule to an ec:Contract"@en ,
+                           "eine owl:ObjectProperty, die eine ec:Rule mit einem ec:Contract verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#derivedTo
+ec:derivedTo rdf:type owl:ObjectProperty ;
+             owl:inverseOf ec:isDerivedFrom ;
+             dcterms:description "A new version derived from the original asset."@en ,
+                                 "Eine neue Version, die vom ursprünglichen Asset abgeleitet wurde."@de ;
+             rdfs:label "Ableitungsziel"@de ,
+                        "Derivation target"@en ;
+             skos:definition "an owl:ObjectProperty relating an ec:Asset to an ec:Asset"@en ,
+                             "eine owl:ObjectProperty, die ein ec:Asset mit einem ec:Asset verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#excludesAudience
+ec:excludesAudience rdf:type owl:ObjectProperty ;
+                    dcterms:description "A defined audience group that is excluded from the audience."@en ,
+                                        "Eine definierte Zielgruppe, die von der Audience ausgeschlossen ist."@de ;
+                    rdfs:label "Excludes audience"@en ,
+                               "Zielgruppe ausschließt"@de ;
+                    skos:definition "an owl:ObjectProperty relating an ec:Audience to an ec:Audience"@en ,
+                                    "eine owl:ObjectProperty, die eine ec:Audience mit einer ec:Audience verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#existsAs
+ec:existsAs rdf:type owl:ObjectProperty ;
+            dcterms:description "Die Beziehung, die ein EditorialObject mit einem alternativen EditorialObject verknüpft, in dem es existieren kann."@de ,
+                                "The relationship that links an EditorialObject to an alternative EditorialObject in which it may exist."@en ;
+            rdfs:label "Editorial object"@en ,
+                       "Redaktionelles Objekt"@de ;
+            skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:EditorialObject"@en ,
+                            "eine owl:ObjectProperty, die eine ec:EditorialObject mit einer ec:EditorialObject in Beziehung setzt"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#grantsApproval
+ec:grantsApproval rdf:type owl:ObjectProperty ;
+                  owl:inverseOf ec:hasApprover ;
+                  dcterms:description "Gibt an, dass ein Agent die Genehmigung für einen Auditbericht erteilt."@de ,
+                                      "Indicates that an Agent grants approval for an Audit Report."@en ;
+                  rdfs:label "Genehmigungen erteilt"@de ,
+                             "Grants approval"@en ;
+                  skos:definition "an owl:ObjectProperty relating an ec:AuditReport to an ec:Agent"@en ,
+                                  "eine owl:ObjectProperty, die ein ec:AuditReport mit einem ec:Agent verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAccessConditions
+ec:hasAccessConditions rdf:type owl:ObjectProperty ;
+                       rdfs:subPropertyOf ec:hasRights ;
+                       dcterms:description "Access conditions or restrictions under which access to content or its publication is granted."@en ,
+                                           "Zugangsbedingungen oder Einschränkungen, unter denen der Zugriff auf Inhalte oder deren Veröffentlichung gewährt wird."@de ;
+                       rdfs:label "Access conditions"@en ,
+                                  "Zugangsbedingungen"@de ;
+                       skos:definition "an owl:ObjectProperty relating an ec:Asset or ec:PublicationEvent to ec:AccessConditions"@en ,
+                                       "eine owl:ObjectProperty, die ein ec:Asset oder ein ec:PublicationEvent mit ec:AccessConditions verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAffiliation
+ec:hasAffiliation rdf:type owl:ObjectProperty ;
+                  owl:inverseOf ec:isAffiliationFor ;
+                  dcterms:description "A property to establish the relation between a Contact/Person and an Organisation."@en ,
+                                      "Eine Eigenschaft zur Herstellung der Beziehung zwischen einem Kontakt/einer Person und einer Organisation."@de ;
+                  rdfs:label "Affiliation"@en ,
+                             "Zugehörigkeit"@de ;
+                  skos:definition "an owl:ObjectProperty relating an ec:Person to an ec:Affiliation"@en ,
+                                  "eine owl:ObjectProperty, die eine ec:Person mit einer ec:Affiliation verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAgent
+ec:hasAgent rdf:type owl:ObjectProperty ;
+            dcterms:description "Bezieht eine Beteiligung auf den Agenten, der daran teilnimmt."@de ,
+                                "Relates an involvement to the agent who participates in it."@en ;
+            rdfs:label "Has agent"@en ,
+                       "Hat Agent"@de ;
+            skos:definition "an owl:ObjectProperty relating an ec:Involvement to an ec:Agent"@en ,
+                            "eine owl:ObjectProperty, die eine ec:Involvement mit einem ec:Agent verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAgentBiography
+ec:hasAgentBiography rdf:type owl:ObjectProperty ;
+                     dcterms:description "A biography of an Agent."@en ,
+                                         "Eine Biografie eines Akteurs."@de ;
+                     rdfs:label "Biografie"@de ,
+                                "Biography"@en ;
+                     skos:definition "an owl:ObjectProperty relating an ec:Agent to an ec:Biography"@en ,
+                                     "eine owl:ObjectProperty, die einen ec:Agent mit einer ec:Biography verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAgentCountryOfResidence
+ec:hasAgentCountryOfResidence rdf:type owl:ObjectProperty ;
+                              dcterms:description "Das Land des Wohnsitzes eines Agents."@de ,
+                                                  "The country of residence of an Agent."@en ;
+                              rdfs:label "Country of residence"@en ,
+                                         "Wohnsitzland"@de ;
+                              skos:definition "an owl:ObjectProperty relating an ec:Agent to an ec:CountryCode"@en ,
+                                              "eine owl:ObjectProperty, die einen ec:Agent mit einem ec:CountryCode verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAgentLanguage
+ec:hasAgentLanguage rdf:type owl:ObjectProperty ;
+                    dcterms:description "Die Sprache oder Sprachen, die mit einem Agenten verbunden sind."@de ,
+                                        "The language or languages associated with an Agent."@en ;
+                    rdfs:label "Language"@en ,
+                               "Sprache"@de ;
+                    skos:definition "an owl:ObjectProperty relating an ec:Agent to an ec:Language"@en ,
+                                    "eine owl:ObjectProperty, die einen ec:Agent mit einer ec:Language verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAgentMember
+ec:hasAgentMember rdf:type owl:ObjectProperty ;
+                  dcterms:description "Der Agent, der Mitglied eines anderen Agenten ist, wie etwa eines Teams."@de ,
+                                      "The Agent that is a member of another Agent, such as a Team."@en ;
+                  rdfs:label "Agent member"@en ,
+                             "Agent-Mitglied"@de ;
+                  skos:definition "an owl:ObjectProperty relating an ec:Agent to an ec:Agent"@en ,
+                                  "eine owl:ObjectProperty, die einen ec:Agent mit einem ec:Agent verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAgentNationality
+ec:hasAgentNationality rdf:type owl:ObjectProperty ;
+                       dcterms:description "Die mit einem Agenten verbundene Nationalität."@de ,
+                                           "The nationality associated with an Agent."@en ;
+                       rdfs:label "Nationality"@en ,
+                                  "Nationalität"@de ;
+                       skos:definition "an owl:ObjectProperty relating an ec:Agent to an ec:CountryCode"@en ,
+                                       "eine owl:ObjectProperty, die einen ec:Agent mit einem ec:CountryCode verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAgentOnStagePosition
+ec:hasAgentOnStagePosition rdf:type owl:ObjectProperty ;
+                           dcterms:description "Die Position eines Akteurs auf der Bühne."@de ,
+                                               "The position of an agent on stage."@en ;
+                           rdfs:label "On stage position"@en ,
+                                      "Position auf der Bühne"@de ;
+                           skos:definition "an owl:ObjectProperty relating an ec:Involvement to an ec:OnStagePosition"@en ,
+                                           "eine owl:ObjectProperty, die ec:Involvement mit ec:OnStagePosition verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAgentPlaceOfResidence
+ec:hasAgentPlaceOfResidence rdf:type owl:ObjectProperty ;
+                            dcterms:description "Der Ort, an dem sich ein Agent aufhält."@de ,
+                                                "The place where an Agent resides."@en ;
+                            rdfs:label "Place of residence"@en ,
+                                       "Wohnort"@de ;
+                            skos:definition "an owl:ObjectProperty relating an ec:Agent to an ec:Location"@en ,
+                                            "eine owl:ObjectProperty, die einen ec:Agent mit einer ec:Location verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAlternativeTitle
+ec:hasAlternativeTitle rdf:type owl:ObjectProperty ;
+                       dcterms:description "Links an editorial object to one of its alternative titles."@en ,
+                                           "Verknüpft ein redaktionelles Objekt mit einem seiner Alternativtitel."@de ;
+                       rdfs:label "Has alternative title"@en ,
+                                  "Hat alternativen Titel"@de ;
+                       skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:AlternativeTitle"@en ,
+                                       "eine owl:ObjectProperty, die ein ec:EditorialObject mit einem ec:AlternativeTitle verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAncillaryData
+ec:hasAncillaryData rdf:type owl:ObjectProperty ;
+                    dcterms:description "Die im Medienressourcen enthaltenen ergänzenden Daten."@de ,
+                                        "The ancillary data contained in the media resource."@en ;
+                    rdfs:label "Ancillary data"@en ,
+                               "Begleitdaten"@de ;
+                    skos:definition "an owl:ObjectProperty relating an ec:Resource to an ec:AncillaryData"@en ,
+                                    "eine owl:ObjectProperty, die eine ec:Resource mit einer ec:AncillaryData verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAncillaryDataFormat
+ec:hasAncillaryDataFormat rdf:type owl:ObjectProperty ;
+                          rdfs:subPropertyOf ec:hasFormat ;
+                          dcterms:description "Das Format der ergänzenden Daten."@de ,
+                                              "The format of ancillary data."@en ;
+                          rdfs:label "Ancillary data format"@en ,
+                                     "Hilfsdatenformat"@de ;
+                          skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:AncillaryDataFormat"@en ,
+                                          "eine owl:ObjectProperty, die eine ec:MediaResource mit einem ec:AncillaryDataFormat verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAnimalBreedCode
+ec:hasAnimalBreedCode rdf:type owl:ObjectProperty ;
+                      dcterms:description "Der Rassecode, der mit einem Tier verknüpft ist."@de ,
+                                          "The breed code associated with an animal."@en ;
+                      rdfs:label "Animal breed code"@en ,
+                                 "Tierzuchtcode"@de ;
+                      skos:definition "an owl:ObjectProperty relating an ec:Animal to an ec:AnimalBreedCode"@en ,
+                                      "eine owl:ObjectProperty, die ec:Animal mit ec:AnimalBreedCode verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAnimalColourCode
+ec:hasAnimalColourCode rdf:type owl:ObjectProperty ;
+                       dcterms:description "Der mit einem Tier verbundene Tierfarbcode."@de ,
+                                           "The animal colour code associated with an animal."@en ;
+                       rdfs:label "Animal colour code"@en ,
+                                  "Tierfarbcode"@de ;
+                       skos:definition "an owl:ObjectProperty relating an ec:Animal to an ec:AnimalColourCode"@en ,
+                                       "eine owl:ObjectProperty, die ec:Animal mit ec:AnimalColourCode verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAnimalGroom
+ec:hasAnimalGroom rdf:type owl:ObjectProperty ;
+                  owl:inverseOf ec:isAnimalGroomFor ;
+                  dcterms:description "Die Person oder der Akteur, der ein Tier pflegt und betreut."@de ,
+                                      "The person or agent who grooms and cares for an animal."@en ;
+                  rdfs:label "Animal groom"@en ,
+                             "Tierpflege"@de ;
+                  skos:definition "an owl:ObjectProperty relating an ec:Animal to an ec:Agent"@en ,
+                                  "eine owl:ObjectProperty, die ein ec:Animal mit einem ec:Agent verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAnimalRole
+ec:hasAnimalRole rdf:type owl:ObjectProperty ;
+                 dcterms:description "Die Rolle eines Tieres bei einer Beteiligung."@de ,
+                                     "The role of an animal in an involvement."@en ;
+                 rdfs:label "Animal role"@en ,
+                            "Tierrolle für Tiere"@de ;
+                 skos:definition "an owl:ObjectProperty relating an ec:Animal to an ec:Involvement"@en ,
+                                 "eine owl:ObjectProperty, die ein ec:Animal mit einer ec:Involvement verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAnnotationAgent
+ec:hasAnnotationAgent rdf:type owl:ObjectProperty ;
+                      dcterms:description "Der mit der Annotation verknüpfte Agent."@de ,
+                                          "The Agent associated with the annotation."@en ;
+                      rdfs:label "Anmerkungsagent"@de ,
+                                 "Annotation agent"@en ;
+                      skos:definition "an owl:ObjectProperty relating an ec:Annotation to an ec:Agent"@en ,
+                                      "eine owl:ObjectProperty, die eine ec:Annotation mit einem ec:Agent verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAnnotationCurationDateTime
+ec:hasAnnotationCurationDateTime rdf:type owl:ObjectProperty ;
+                                 dcterms:description "Das Datum und die Uhrzeit, zu der eine Annotation überprüft wurde."@de ,
+                                                     "The date and time when an Annotation was reviewed."@en ;
+                                 rdfs:label "Annotation curation date & time"@en ,
+                                            "Datum und Uhrzeit der Annotationskurierung"@de ;
+                                 skos:definition "an owl:ObjectProperty relating an ec:Annotation to a time:Instant"@en ,
+                                                 "eine owl:ObjectProperty, die eine ec:Annotation mit einem time:Instant verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAnnotationTarget
+ec:hasAnnotationTarget rdf:type owl:ObjectProperty ;
+                       dcterms:description "Das Zielobjekt, auf das sich die Annotation bezieht."@de ,
+                                           "The target object to which the annotation applies."@en ;
+                       rdfs:label "Annotation target"@en ,
+                                  "Annotationsziel"@de ;
+                       skos:definition "an owl:ObjectProperty relating an ec:Annotation to an owl:Thing"@en ,
+                                       "eine owl:ObjectProperty, die eine ec:Annotation mit einer owl:Thing verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasApprover
+ec:hasApprover rdf:type owl:ObjectProperty ;
+               dcterms:description "An Agent who approved an AuditReport."@en ,
+                                   "Ein Agent, der einen AuditReport genehmigt hat."@de ;
+               rdfs:label "Approved by"@en ,
+                          "Genehmigt von"@de ;
+               skos:definition "an owl:ObjectProperty relating an ec:AuditReport to an ec:Agent"@en ,
+                               "eine owl:ObjectProperty, die ein ec:AuditReport mit einem ec:Agent verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasArtefactBuyer
+ec:hasArtefactBuyer rdf:type owl:ObjectProperty ;
+                    dcterms:description "Der Agent, der das Artefakt gekauft hat."@de ,
+                                        "The Agent who bought the Artefact."@en ;
+                    rdfs:label "Buyer"@en ,
+                               "Käufer"@de ;
+                    skos:definition "an owl:ObjectProperty relating an ec:Artefact to an ec:Agent"@en ,
+                                    "eine owl:ObjectProperty, die ec:Artefact mit ec:Agent verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasArtefactDateOfPurchase
+ec:hasArtefactDateOfPurchase rdf:type owl:ObjectProperty ;
+                             rdfs:subPropertyOf ec:hasDate ;
+                             dcterms:description "Das Datum, an dem ein Artefakt gekauft wurde."@de ,
+                                                 "The date when an Artefact was purchased. ."@en ;
+                             rdfs:label "Artefact date of purchase"@en ,
+                                        "Artefakt-Kaufdatum"@de ;
+                             skos:definition "an owl:ObjectProperty relating an ec:Artefact to a time:Instant"@en ,
+                                             "eine owl:ObjectProperty, die ein ec:Artefact mit einem time:Instant verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasArtefactDateOfSale
+ec:hasArtefactDateOfSale rdf:type owl:ObjectProperty ;
+                         rdfs:subPropertyOf ec:hasDate ;
+                         dcterms:description "Das Datum, an dem ein Artefakt verkauft wurde."@de ,
+                                             "The date when an Artefact was sold."@en ;
+                         rdfs:label "Artefact date of sale"@en ,
+                                    "Artefaktdatum des Verkaufs"@de ;
+                         skos:definition "an owl:ObjectProperty relating an ec:Artefact to a time:Instant"@en ,
+                                         "eine owl:ObjectProperty, die ec:Artefact mit time:Instant verbindet"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasArtefactOwner
+ec:hasArtefactOwner rdf:type owl:ObjectProperty ;
+                    dcterms:description "Die Person oder Organisation, der ein Artefakt gehört."@de ,
+                                        "The person or organisation that owns an Artefact."@en ;
+                    rdfs:label "Eigentümer"@de ,
+                               "Owner"@en ;
+                    skos:definition "an owl:ObjectProperty relating an ec:Artefact to an ec:Agent"@en ,
+                                    "eine owl:ObjectProperty, die ein ec:Artefact mit einem ec:Agent verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasArtefactPriceCurrency
+ec:hasArtefactPriceCurrency rdf:type owl:ObjectProperty ;
+                            dcterms:description "Die Währung, in der der Preis eines Artefakts ausgedrückt ist."@de ,
+                                                "The currency in which an Artefact’s price is expressed."@en ;
+                            rdfs:label "Artefact price currency"@en ,
+                                       "Artefakt-Preiskährung"@de ;
+                            skos:definition "an owl:ObjectProperty relating an ec:Artefact to an ec:CurrencyCode"@en ,
+                                            "eine owl:ObjectProperty, die eine ec:Artefact mit einem ec:CurrencyCode verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasArtefactRelatedLocation
+ec:hasArtefactRelatedLocation rdf:type owl:ObjectProperty ;
+                              dcterms:description "Associates an Artefact with a Location."@en ,
+                                                  "Ordnet ein Artefakt einem Ort zu."@de ;
+                              rdfs:label "Associated location"@en ,
+                                         "Zugehöriger Standort"@de ;
+                              skos:definition "an owl:ObjectProperty relating an ec:Artefact to an ec:Location"@en ,
+                                              "eine owl:ObjectProperty, die eine ec:Artefact mit einer ec:Location verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasArtefactRelatedPhysicalResource
+ec:hasArtefactRelatedPhysicalResource rdf:type owl:ObjectProperty ;
+                                      dcterms:description "Associates an artefact or prop with a physical resource."@en ,
+                                                          "Verknüpft ein Artefakt oder Requisit mit einer physischen Ressource."@de ;
+                                      rdfs:label "Associated physical resource"@en ,
+                                                 "Zugehörige physische Ressource"@de ;
+                                      skos:definition "an owl:ObjectProperty relating an ec:Artefact to an ec:PhysicalResource"@en ,
+                                                      "eine owl:ObjectProperty, die eine ec:Artefact mit einer ec:PhysicalResource verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasArtefactRetailer
+ec:hasArtefactRetailer rdf:type owl:ObjectProperty ;
+                       dcterms:description "Der Händler eines Artefakts."@de ,
+                                           "The retailer of an Artefact."@en ;
+                       rdfs:label "Händler"@de ,
+                                  "Retailer"@en ;
+                       skos:definition "an owl:ObjectProperty relating an ec:Artefact to an ec:Agent"@en ,
+                                       "eine owl:ObjectProperty, die ein ec:Artefact mit einem ec:Agent verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasArtefactSupplier
+ec:hasArtefactSupplier rdf:type owl:ObjectProperty ;
+                       dcterms:description "Der Lieferant eines Artefakts."@de ,
+                                           "The supplier of an Artefact."@en ;
+                       rdfs:label "Lieferant"@de ,
+                                  "Supplier"@en ;
+                       skos:definition "an owl:ObjectProperty relating an ec:Artefact to an ec:Agent"@en ,
+                                       "eine owl:ObjectProperty, die ec:Artefact mit ec:Agent verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasArticle
+ec:hasArticle rdf:type owl:ObjectProperty ;
+              dcterms:description "Indicates that an Item has an associated Article. It is used to link content intended for incorporation into an article with the resulting article resource."@en ,
+                                  "Kennzeichnet, dass ein Item ein zugehöriges Article hat. Es wird verwendet, um Inhalte zu verknüpfen, die in einen Artikel aufgenommen werden sollen, mit der resultierenden Article-Ressource."@de ;
+              rdfs:label "Has article"@en ,
+                         "Hat Artikel"@de ;
+              skos:definition "an owl:ObjectProperty relating an ec:Item to an ec:Article"@en ,
+                              "eine owl:ObjectProperty, die ein ec:Item mit einem ec:Article verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAsset
+ec:hasAsset rdf:type owl:ObjectProperty ;
+            dcterms:description "Die mit einem PublicationPlan verbundenen Assets."@de ,
+                                "The assets related to a PublicationPlan."@en ;
+            rdfs:label "Asset"@en ,
+                       "Vermögenswert"@de ;
+            skos:definition "an owl:ObjectProperty relating an ec:PublicationPlan to an ec:Asset"@en ,
+                            "eine owl:ObjectProperty, die ec:PublicationPlan mit ec:Asset verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAssetValue
+ec:hasAssetValue rdf:type owl:ObjectProperty ;
+                 dcterms:description "Associates an Asset with its AssetValue."@en ,
+                                     "Verknüpft ein Asset mit seinem AssetValue."@de ;
+                 rdfs:label "Asset value"@en ,
+                            "Assetwert"@de ;
+                 skos:definition "an owl:ObjectProperty relating an ec:Asset to an ec:AssetValue"@en ,
+                                 "eine owl:ObjectProperty, die ec:Asset mit ec:AssetValue verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAssetValueCurrency
+ec:hasAssetValueCurrency rdf:type owl:ObjectProperty ;
+                         dcterms:description "Die Währung, in der der Asset-Wert angegeben ist."@de ,
+                                             "The currency in which the asset value is given."@en ;
+                         rdfs:label "Asset value currency"@en ,
+                                    "Währung des Asset-Werts"@de ;
+                         skos:definition "an owl:ObjectProperty relating an ec:AssetValue to a skos:Concept"@en ,
+                                         "eine owl:ObjectProperty, die eine ec:AssetValue mit einem skos:Concept verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAssociatedArtefact
+ec:hasAssociatedArtefact rdf:type owl:ObjectProperty ;
+                         dcterms:description "An Artefact related to an Agent."@en ,
+                                             "Ein Artefakt, das mit einem Agenten verbunden ist."@de ;
+                         rdfs:label "Related artefact"@en ,
+                                    "Zugehöriges Artefakt"@de ;
+                         skos:definition "an owl:ObjectProperty relating an ec:Agent to an ec:Artefact"@en ,
+                                         "eine owl:ObjectProperty, die einen ec:Agent mit einem ec:Artefact verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAssociatedConsumer
+ec:hasAssociatedConsumer rdf:type owl:ObjectProperty ;
+                         dcterms:description "A consumer associated with a ResonanceEvent."@en ,
+                                             "Ein Verbraucher, der mit einem ResonanceEvent verbunden ist."@de ;
+                         rdfs:label "Associated consumer"@en ,
+                                    "Zugeordneter Verbraucher"@de ;
+                         skos:definition "an owl:ObjectProperty relating an ec:ResonanceEvent to an ec:Consumer"@en ,
+                                         "eine owl:ObjectProperty, die ec:ResonanceEvent mit ec:Consumer verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAssociatedConsumptionEvent
+ec:hasAssociatedConsumptionEvent rdf:type owl:ObjectProperty ;
+                                 dcterms:description "Das ConsumptionEvent, das einem Consumer zugeordnet ist."@de ,
+                                                     "The ConsumptionEvent associated with a Consumer."@en ;
+                                 rdfs:label "Consumption event"@en ,
+                                            "Konsumereignis"@de ;
+                                 skos:definition "an owl:ObjectProperty relating an ec:Consumer to an ec:ConsumptionEvent"@en ,
+                                                 "eine owl:ObjectProperty, die einen ec:Consumer mit einem ec:ConsumptionEvent verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAssociatedProductionJob
+ec:hasAssociatedProductionJob rdf:type owl:ObjectProperty ;
+                              dcterms:description "An associated ProductionJob for the realisation of an EditorialObject."@en ,
+                                                  "Ein zugehöriger ProductionJob zur Realisierung eines EditorialObject."@de ;
+                              rdfs:label "Production job"@en ,
+                                         "Produktionsauftrag"@de ;
+                              skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:ProductionJob"@en ,
+                                              "eine owl:ObjectProperty, die ec:EditorialObject mit ec:ProductionJob verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAssociatedProductionOrder
+ec:hasAssociatedProductionOrder rdf:type owl:ObjectProperty ;
+                                dcterms:description "Der Produktionsauftrag, der mit einem Veröffentlichungsplan verknüpft ist."@de ,
+                                                    "The production order associated with a publication plan."@en ;
+                                rdfs:label "Production order"@en ,
+                                           "Produktionsauftrag"@de ;
+                                skos:definition "an owl:ObjectProperty relating an ec:PublicationPlan to an ec:ProductionOrder"@en ,
+                                                "eine owl:ObjectProperty, die eine ec:PublicationPlan mit einer ec:ProductionOrder verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAssociatedRelation
+ec:hasAssociatedRelation rdf:type owl:ObjectProperty ;
+                         dcterms:description "A relation associated with the resource."@en ,
+                                             "Eine Relation, die mit der Ressource verknüpft ist."@de ;
+                         rdfs:label "Relation"@de ,
+                                    "Relation"@en ;
+                         skos:definition "an owl:ObjectProperty relating an ec:Resource to an ec:Relation"@en ,
+                                         "eine owl:ObjectProperty, die eine ec:Resource mit einer ec:Relation verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAudience
+ec:hasAudience rdf:type owl:ObjectProperty ;
+               dcterms:description "Gibt das Publikum an, das mit einer Verbrauchszählung verbunden ist."@de ,
+                                   "Indicates the audience associated with a consumption count."@en ;
+               rdfs:label "Has audience"@en ,
+                          "Hat Publikum"@de ;
+               skos:definition "an owl:ObjectProperty relating an ec:ConsumptionCount to an ec:Audience"@en ,
+                               "eine owl:ObjectProperty, die ec:ConsumptionCount mit ec:Audience verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAudienceScoreRecordingTechnique
+ec:hasAudienceScoreRecordingTechnique rdf:type owl:ObjectProperty ;
+                                      dcterms:description "Die zur Messung einer Publikumsbewertung verwendete Technik."@de ,
+                                                          "The technique used to measure an audience score."@en ;
+                                      rdfs:label "Audience score recording technique"@en ,
+                                                 "Technik zur Erfassung des Publikumsratings"@de ;
+                                      skos:definition "an owl:ObjectProperty relating an ec:AudienceRating to a skos:Concept"@en ,
+                                                      "eine owl:ObjectProperty, die ec:AudienceRating mit skos:Concept verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAudioCodec
+ec:hasAudioCodec rdf:type owl:ObjectProperty ;
+                 rdfs:subPropertyOf ec:hasCodec ;
+                 dcterms:description "Der mit der Medienressource verknüpfte Audiocodec."@de ,
+                                     "The audio codec associated with the media resource."@en ;
+                 rdfs:label "Audio codec"@en ,
+                            "Audio-Codec"@de ;
+                 skos:definition "an ec:ObjectProperty relating an ec:MediaResource to an ec:AudioCodec"@en ,
+                                 "eine ec:ObjectProperty, die eine ec:MediaResource mit einem ec:AudioCodec verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAudioDescription
+ec:hasAudioDescription rdf:type owl:ObjectProperty ;
+                       dcterms:description "Signalisiert das Vorhandensein einer Audiodeskription."@de ,
+                                           "Signals the presence of audio description."@en ;
+                       rdfs:label "Audio description"@en ,
+                                  "Audiodeskription"@de ;
+                       skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:AudioDescription"@en ,
+                                       "eine owl:ObjectProperty, die eine ec:EditorialObject mit einer ec:AudioDescription verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAudioEncodingFormat
+ec:hasAudioEncodingFormat rdf:type owl:ObjectProperty ;
+                          rdfs:subPropertyOf ec:hasFormat ;
+                          dcterms:description "An audio encoding format associated with a media resource."@en ,
+                                              "Ein Audio-Codierungsformat, das mit einer Medienressource verbunden ist."@de ;
+                          rdfs:label "Audio encoding format"@en ,
+                                     "Audio-Kodierungsformat"@de ;
+                          skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:AudioEncodingFormat"@en ,
+                                          "eine owl:ObjectProperty, die eine ec:MediaResource mit einer ec:AudioEncodingFormat verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAudioTrack
+ec:hasAudioTrack rdf:type owl:ObjectProperty ;
+                 dcterms:description "A property that identifies the audio track associated with a media resource."@en ,
+                                     "Eine Eigenschaft, die den mit einer Medienressource verbundenen Audiotrack identifiziert."@de ;
+                 rdfs:label "Audio track"@en ,
+                            "Audiospur"@de ;
+                 skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:AudioTrack"@en ,
+                                 "eine owl:ObjectProperty, die eine ec:MediaResource mit einem ec:AudioTrack verbindet"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAuditJobRelatedAuditReport
+ec:hasAuditJobRelatedAuditReport rdf:type owl:ObjectProperty ;
+                                 dcterms:description "An audit report associated with an audit job."@en ,
+                                                     "Ein Prüfbericht, der einem Audit-Job zugeordnet ist."@de ;
+                                 rdfs:label "Related audit report"@en ,
+                                            "Zugehöriger Prüfbericht"@de ;
+                                 skos:definition "an owl:ObjectProperty relating an ec:AuditJob to an ec:AuditReport"@en ,
+                                                 "eine owl:ObjectProperty, die ec:AuditJob mit ec:AuditReport verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAuditReportDate
+ec:hasAuditReportDate rdf:type owl:ObjectProperty ;
+                      dcterms:description "Das Veröffentlichungsdatum eines AuditReports."@de ,
+                                          "The date of release of an AuditReport."@en ;
+                      rdfs:label "Audit report date"@en ,
+                                 "Auditberichtdatum"@de ;
+                      skos:definition "an owl:ObjectProperty relating an ec:AuditReport to a time:Instant"@en ,
+                                      "eine owl:ObjectProperty, die ein ec:AuditReport mit einem time:Instant verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAuthor
+ec:hasAuthor rdf:type owl:ObjectProperty ;
+             owl:inverseOf ec:isAuthorOf ;
+             dcterms:description "Links an Annotation to the Agent who created it."@en ,
+                                 "Verknüpft eine Annotation mit dem Agenten, der sie erstellt hat."@de ;
+             rdfs:label "Agent"@en ,
+                        "Akteur"@de ;
+             skos:definition "an owl:ObjectProperty relating an ec:Annotation to an ec:Agent"@en ,
+                             "eine owl:ObjectProperty, die eine ec:Annotation mit einem ec:Agent verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAwardDate
+ec:hasAwardDate rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf ec:hasDate ;
+                dcterms:description "Das Datum, an dem ein Award übergeben wurde."@de ,
+                                    "The date when an Award was delivered."@en ;
+                rdfs:label "Award date"@en ,
+                           "Preisdatum"@de ;
+                skos:definition "an ec:hasDate relating an ec:Award to a time:Instant"@en ,
+                                "eine ec:hasDate, die ein ec:Award mit einem time:Instant verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasBrand
+ec:hasBrand rdf:type owl:ObjectProperty ;
+            dcterms:description "A brand associated with the editorial object or publication service."@en ,
+                                "Eine Marke, die mit dem redaktionellen Objekt oder dem Veröffentlichungsdienst verbunden ist."@de ;
+            rdfs:label "Brand"@en ,
+                       "Marke"@de ;
+            skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:MarketingBrand"@en ,
+                            "eine owl:ObjectProperty, die eine ec:EditorialObject mit einem ec:MarketingBrand verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasBusinessContract
+ec:hasBusinessContract rdf:type owl:ObjectProperty ;
+                       dcterms:description "Der mit einem Veröffentlichungsplan verbundene Vertrag."@de ,
+                                           "The contract associated with a publication plan."@en ;
+                       rdfs:label "Business contract"@en ,
+                                  "Geschäftsvertrag"@de ;
+                       skos:definition "an owl:ObjectProperty relating an ec:PublicationPlan to an ec:Contract"@en ,
+                                       "eine owl:ObjectProperty, die eine ec:PublicationPlan mit einem ec:Contract verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasCaptioning
+ec:hasCaptioning rdf:type owl:ObjectProperty ;
+                 dcterms:description "A captioning track for transcribed dialogue or audio descriptions for the hard of hearing."@en ,
+                                     "Eine Untertitelspur für transkribierte Dialoge oder Audiodeskriptionen für Hörgeschädigte."@de ;
+                 rdfs:label "Captioning"@en ,
+                            "Untertitelung"@de ;
+                 skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Captioning"@en ,
+                                 "eine owl:ObjectProperty, die ein ec:EditorialObject mit einem ec:Captioning verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasCaptioningFormat
+ec:hasCaptioningFormat rdf:type owl:ObjectProperty ;
+                       rdfs:subPropertyOf ec:hasFormat ;
+                       dcterms:description "Das Format der Untertitelung."@de ,
+                                           "The format of Captioning."@en ;
+                       rdfs:label "Captioning format"@en ,
+                                  "Untertitelungsformat"@de ;
+                       skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:CaptioningFormat"@en ,
+                                       "eine owl:ObjectProperty, die eine ec:MediaResource mit einer ec:CaptioningFormat verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasCaptioningSource
+ec:hasCaptioningSource rdf:type owl:ObjectProperty ;
+                       dcterms:description "Die Quelle der mit der Medienressource verbundenen Untertitelung."@de ,
+                                           "The source of the captioning associated with the media resource."@en ;
+                       rdfs:label "Captioning source"@en ,
+                                  "Untertitelungsquelle"@de ;
+                       skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:Agent"@en ,
+                                       "eine owl:ObjectProperty, die eine ec:MediaResource mit einem ec:Agent verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasCastMember
+ec:hasCastMember rdf:type owl:ObjectProperty ;
+                 dcterms:description "A member of the cast."@en ,
+                                     "Ein Mitglied der Besetzung."@de ;
+                 rdfs:label "Besetzungsmitglied"@de ,
+                            "Cast member"@en ;
+                 skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:CastMember"@en ,
+                                 "eine owl:ObjectProperty, die eine ec:EditorialObject mit einem ec:CastMember verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasCharacter
+ec:hasCharacter rdf:type owl:ObjectProperty ;
+                dcterms:description "Identifies one or more fictional characters associated with an editorial object."@en ,
+                                    "Identifiziert eine oder mehrere fiktive Figuren, die mit einem redaktionellen Objekt verbunden sind."@de ;
+                rdfs:label "Character"@en ,
+                           "Charakter"@de ;
+                skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Character"@en ,
+                                "eine owl:ObjectProperty, die ec:EditorialObject mit ec:Character verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasChild
+ec:hasChild rdf:type owl:ObjectProperty ;
+            owl:inverseOf ec:isChildOf ;
+            dcterms:description "Links an Asset to its parent Asset."@en ,
+                                "Verknüpft ein Asset mit seinem übergeordneten Asset."@de ;
+            rdfs:label "Child"@en ,
+                       "Kind"@de ;
+            skos:definition "an owl:ObjectProperty relating an ec:Asset to an ec:Asset"@en ,
+                            "eine owl:ObjectProperty, die einen ec:Asset mit einem ec:Asset verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasClip
+ec:hasClip rdf:type owl:ObjectProperty ;
+           dcterms:description "Indicates a clip associated with the resource."@en ,
+                               "Kennzeichnet einen Clip, der mit der Ressource verknüpft ist."@de ;
+           rdfs:label "Has clip"@en ,
+                      "Hat Clip"@de ;
+           skos:definition "an owl:ObjectProperty relating a resource to an associated clip"@en ,
+                           "eine owl:ObjectProperty, die eine Ressource mit einem zugehörigen Clip verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasClone
+ec:hasClone rdf:type owl:ObjectProperty ;
+            owl:inverseOf ec:isCloneOf ;
+            dcterms:description "Beschreibt die Beziehung zwischen einer digitalen Instanziierung einer MediaResource und ihrer direkten Kopie ohne Generationsverlust."@de ,
+                                "Identifies relationship between a digital instantiation of a MediaResource and its direct copy, with no generational loss."@en ;
+            rdfs:label "Cloned to"@en ,
+                       "Geklont an"@de ;
+            skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:MediaResource"@en ,
+                            "eine owl:ObjectProperty, die eine ec:MediaResource mit einer ec:MediaResource verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasCodec
+ec:hasCodec rdf:type owl:ObjectProperty ;
+            dcterms:description "Der Codec, der verwendet wird, um eine Ressource zu erstellen."@de ,
+                                "The codec used to create a resource."@en ;
+            rdfs:label "Codec"@de ,
+                       "Codec"@en ;
+            skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:Codec"@en ,
+                            "eine owl:ObjectProperty, die eine ec:MediaResource mit einem ec:Codec verbindet"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasCodecVendor
+ec:hasCodecVendor rdf:type owl:ObjectProperty ;
+                  dcterms:description "Der Anbieter des Codecs."@de ,
+                                      "The vendor of the codec."@en ;
+                  rdfs:label "Codec vendor"@en ,
+                             "Codec-Anbieter"@de ;
+                  skos:definition "an owl:ObjectProperty relating an ec:Codec to an ec:Agent"@en ,
+                                  "eine owl:ObjectProperty, die ec:Codec mit ec:Agent verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasColourSpace
+ec:hasColourSpace rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf ec:hasFormat ;
+                  dcterms:description "Der mit der Medienressource verbundene Farbraum."@de ,
+                                      "The colour space associated with the media resource."@en ;
+                  rdfs:label "Colour space"@en ,
+                             "Farbraum"@de ;
+                  skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:ColourSpace"@en ,
+                                  "eine owl:ObjectProperty, die ein ec:MediaResource mit einem ec:ColourSpace verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasCommissioningContract
+ec:hasCommissioningContract rdf:type owl:ObjectProperty ;
+                            dcterms:description "Der Vertrag, über den ein EditorialObject in Auftrag gegeben wird."@de ,
+                                                "The Contract through which an EditorialObject is commissioned."@en ;
+                            rdfs:label "Contract"@en ,
+                                       "Vertrag"@de ;
+                            skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Contract"@en ,
+                                            "eine owl:ObjectProperty, die ein ec:EditorialObject mit einem ec:Contract verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasConsumer
+ec:hasConsumer rdf:type owl:ObjectProperty ;
+               dcterms:description "Links a ConsumptionEvent to the consumer."@en ,
+                                   "Verknüpft ein ConsumptionEvent mit dem Verbraucher."@de ;
+               rdfs:label "Has consumer"@en ,
+                          "Hat Verbraucher"@de ;
+               skos:definition "an owl:ObjectProperty relating a ec:ConsumptionEvent to a ec:Consumer"@en ,
+                               "eine owl:ObjectProperty, die eine ec:ConsumptionEvent mit einem ec:Consumer verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasConsumptionContract
+ec:hasConsumptionContract rdf:type owl:ObjectProperty ;
+                          dcterms:description "A contract related to an account."@en ,
+                                              "Ein Vertrag, der mit einem Konto in Verbindung steht."@de ;
+                          rdfs:label "Consumption contract"@en ,
+                                     "Verbrauchsvertrag"@de ;
+                          skos:definition "an owl:ObjectProperty relating an ec:Account to an ec:Contract"@en ,
+                                          "eine owl:ObjectProperty, die ec:Account mit ec:Contract verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasConsumptionCount
+ec:hasConsumptionCount rdf:type owl:ObjectProperty ;
+                       dcterms:description "Die Zählung und der Bezug zum realen Publikum."@de ,
+                                           "The count of and relation to the real audience."@en ;
+                       rdfs:label "Has consumption count"@en ,
+                                  "Hat Verbrauchszahl"@de ;
+                       skos:definition "an owl:ObjectProperty relating an ec:Campaign to an ec:ConsumptionCount"@en ,
+                                       "eine owl:ObjectProperty, die ec:Campaign mit ec:ConsumptionCount verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasConsumptionDeviceManufacturer
+ec:hasConsumptionDeviceManufacturer rdf:type owl:ObjectProperty ;
+                                    dcterms:description "Der Hersteller eines ConsumptionDevice."@de ,
+                                                        "The manufacturer of a ConsumptionDevice."@en ;
+                                    rdfs:label "Consumption device manufacturer"@en ,
+                                               "Hersteller des Verbrauchsgeräts"@de ;
+                                    skos:definition "an owl:ObjectProperty relating an ec:ConsumptionDevice to an ec:Agent"@en ,
+                                                    "eine owl:ObjectProperty, die ec:ConsumptionDevice mit ec:Agent verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasConsumptionEvent
+ec:hasConsumptionEvent rdf:type owl:ObjectProperty ;
+                       dcterms:description "An event in which a consumer uses a device to consume an editorial object published in a publication event within a media service."@en ,
+                                           "Ein Ereignis, bei dem ein Konsument ein Gerät verwendet, um ein redaktionelles Objekt zu konsumieren, das in einem Veröffentlichungsevent innerhalb eines Mediendienstes veröffentlicht wurde."@de ;
+                       rdfs:label "Consumption event"@en ,
+                                  "Verbrauchsereignis"@de ;
+                       skos:definition "an owl:ObjectProperty relating an ec:ConsumptionCount to an ec:ConsumptionEvent"@en ,
+                                       "eine owl:ObjectProperty, die ec:ConsumptionCount mit ec:ConsumptionEvent verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasConsumptionEventResumePoint
+ec:hasConsumptionEventResumePoint rdf:type owl:ObjectProperty ;
+                                  dcterms:description "Der Datum- und Zeitpunkt, an dem die Nutzung wieder aufgenommen wurde."@de ,
+                                                      "The date and time point at which consumption has resumed."@en ;
+                                  rdfs:label "Consumption event resume point"@en ,
+                                             "Wiedereinstiegspunkt für Konsumereignisse"@de ;
+                                  skos:definition "an owl:ObjectProperty relating an ec:ConsumptionEvent to an ec:TimelinePoint"@en ,
+                                                  "eine owl:ObjectProperty, die ec:ConsumptionEvent mit ec:TimelinePoint verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasConsumptionLicenceLink
+ec:hasConsumptionLicenceLink rdf:type owl:ObjectProperty ;
+                             dcterms:description "A link to the terms of a ConsumptionLicence."@en ,
+                                                 "Ein Verweis auf die Bedingungen einer ConsumptionLicence."@de ;
+                             rdfs:label "Consumption licence link"@en ,
+                                        "Verbrauchslizenz-Link"@de ;
+                             skos:definition "an owl:ObjectProperty relating an ec:ConsumptionLicence to an ec:Contract"@en ,
+                                             "eine owl:ObjectProperty, die ec:ConsumptionLicence mit ec:Contract verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContact
+ec:hasContact rdf:type owl:ObjectProperty ;
+              dcterms:description "Information about a contact for an organisation or a person, such as the agent of an actor."@en ,
+                                  "Informationen über einen Kontakt für eine Organisation oder eine Person, wie etwa den Vertreter eines Akteurs."@de ;
+              rdfs:label "Contact"@en ,
+                         "Kontakt"@de ;
+              skos:definition "an owl:ObjectProperty relating an ec:Agent to an ec:Contact"@en ,
+                              "eine owl:ObjectProperty, die einen ec:Agent mit einem ec:Contact verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContainerCodec
+ec:hasContainerCodec rdf:type owl:ObjectProperty ;
+                     rdfs:subPropertyOf ec:hasCodec ;
+                     dcterms:description "Der in einem Inhaltscontainer verwendete Codec."@de ,
+                                         "The codec used in a content container."@en ;
+                     rdfs:label "Container codec"@en ,
+                                "Container-Codec"@de ;
+                     skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:ContainerCodec"@en ,
+                                     "eine owl:ObjectProperty, die eine ec:MediaResource mit einem ec:ContainerCodec verbindet"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContainerEncodingFormat
+ec:hasContainerEncodingFormat rdf:type owl:ObjectProperty ;
+                              rdfs:subPropertyOf ec:hasFormat ;
+                              dcterms:description "Das mit der Medienressource verknüpfte Container-Kodierungsformat."@de ,
+                                                  "The container encoding format associated with the media resource."@en ;
+                              rdfs:label "Container encoding format"@en ,
+                                         "Container-Encodierungsformat"@de ;
+                              skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:ContainerEncodingFormat"@en ,
+                                              "eine owl:ObjectProperty, die eine ec:MediaResource mit einem ec:ContainerEncodingFormat verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContainerMimeType
+ec:hasContainerMimeType rdf:type owl:ObjectProperty ;
+                        rdfs:subPropertyOf ec:hasFormat ;
+                        dcterms:description "Der mit der Ressource verknüpfte MIME-Typ."@de ,
+                                            "The MIME type associated with the resource."@en ;
+                        rdfs:label "Mime type"@en ,
+                                   "Mime-Typ"@de ;
+                        skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:MimeType"@en ,
+                                        "eine owl:ObjectProperty, die ein ec:MediaResource mit einem ec:MimeType verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContentEditorialFormat
+ec:hasContentEditorialFormat rdf:type owl:ObjectProperty ;
+                             dcterms:description "Beschreibt ein redaktionelles Inhaltsformat, wie z. B. ein Magazin."@de ,
+                                                 "Describes a content editorial format, such as magazine."@en ;
+                             rdfs:label "Editorial format"@en ,
+                                        "Redaktionelles Format"@de ;
+                             skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:ContentEditorialFormat"@en ,
+                                             "eine owl:ObjectProperty, die ein ec:EditorialObject mit einem ec:ContentEditorialFormat verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContractCostAmountCurrency
+ec:hasContractCostAmountCurrency rdf:type owl:ObjectProperty ;
+                                 dcterms:description "Die Währung des Betrags der ContractCost."@de ,
+                                                     "The currency of the amount of the ContractCost."@en ;
+                                 rdfs:label "Cost currency"@en ,
+                                            "Kostenwährung"@de ;
+                                 skos:definition "an owl:ObjectProperty relating an ec:ContractCost to a skos:Concept"@en ,
+                                                 "eine owl:ObjectProperty, die eine ec:ContractCost mit einem skos:Concept verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContractLink
+ec:hasContractLink rdf:type owl:ObjectProperty ;
+                   dcterms:description "A link to a location where information can be found about a Contract."@en ,
+                                       "Ein Verweis auf einen Ort, an dem Informationen zu einem Vertrag gefunden werden können."@de ;
+                   rdfs:label "Contract link"@en ,
+                              "Vertragsverknüpfung"@de ;
+                   skos:definition "an owl:ObjectProperty relating an ec:Contract to an ec:Resource"@en ,
+                                   "eine owl:ObjectProperty, die eine ec:Contract mit einer ec:Resource verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContractRelatedCost
+ec:hasContractRelatedCost rdf:type owl:ObjectProperty ;
+                          dcterms:description "Die mit einem Vertrag verbundenen finanziellen Kosten."@de ,
+                                              "The financial costs associated with a contract."@en ;
+                          rdfs:label "Contract related cost"@en ,
+                                     "Vertragsbezogene Kosten"@de ;
+                          skos:definition "an owl:ObjectProperty relating an ec:Contract to an ec:ContractCost"@en ,
+                                          "eine owl:ObjectProperty, die ec:Contract mit ec:ContractCost verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContractTemplate
+ec:hasContractTemplate rdf:type owl:ObjectProperty ;
+                       dcterms:description "A Contract used as a template for another Contract."@en ,
+                                           "Ein Vertrag, der als Vorlage für einen anderen Vertrag verwendet wird."@de ;
+                       rdfs:label "Contract template"@en ,
+                                  "Vertragsvorlage"@de ;
+                       skos:definition "an owl:ObjectProperty relating an ec:Contract to an ec:Contract"@en ,
+                                       "eine owl:ObjectProperty, die ein ec:Contract mit einem ec:Contract verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContractualParty
+ec:hasContractualParty rdf:type owl:ObjectProperty ;
+                       dcterms:description "Die verschiedenen Parteien, die an einem Vertrag beteiligt sind."@de ,
+                                           "The different parties involved in a contract."@en ;
+                       rdfs:label "Contract party"@en ,
+                                  "Vertragspartei"@de ;
+                       skos:definition "an owl:ObjectProperty relating an ec:Contract to an ec:Agent"@en ,
+                                       "eine owl:ObjectProperty, die ec:Contract mit ec:Agent verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContributor
+ec:hasContributor rdf:type owl:ObjectProperty ;
+                  dcterms:description "An agent or organization that contributes to a Resource, EditorialObject, or Event."@en ,
+                                      "Eine Person oder Organisation, die zu einer Resource, einem EditorialObject oder einem Event beiträgt."@de ;
+                  rdfs:label "Contributor"@en ,
+                             "Mitwirkender"@de ;
+                  skos:definition "an owl:ObjectProperty relating an ec:EditorialObject or ec:ProductionJob to an ec:Involvement"@en ,
+                                  "eine owl:ObjectProperty, die ein ec:EditorialObject oder ec:ProductionJob mit einer ec:Involvement verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasCopyright
+ec:hasCopyright rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf ec:hasRights ;
+                dcterms:description "Die Rechte, die die Bedingungen festlegen, unter denen das zugehörige Asset kopiert werden darf."@de ,
+                                    "The rights that define the conditions under which the associated asset may be copied."@en ;
+                rdfs:label "Copyright"@en ,
+                           "Urheberrecht"@de ;
+                skos:definition "an owl:ObjectProperty relating an ec:Asset to an ec:Copyright"@en ,
+                                "eine owl:ObjectProperty, die ein ec:Asset mit einem ec:Copyright verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasCountryOfBirth
+ec:hasCountryOfBirth rdf:type owl:ObjectProperty ;
+                     dcterms:description "Das Land, in dem eine Person geboren wird."@de ,
+                                         "The country where a person is born."@en ;
+                     rdfs:label "Country of birth"@en ,
+                                "Geburtsland"@de ;
+                     skos:definition "an owl:ObjectProperty relating an ec:Person to an ec:CountryCode"@en ,
+                                     "eine owl:ObjectProperty, die ec:Person mit ec:CountryCode verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasCountryOfDeath
+ec:hasCountryOfDeath rdf:type owl:ObjectProperty ;
+                     dcterms:description "Das Land, in dem die Person gestorben ist."@de ,
+                                         "The country where the person died."@en ;
+                     rdfs:label "Country of death"@en ,
+                                "Land des Todes"@de ;
+                     skos:definition "an owl:ObjectProperty relating an ec:Person to an ec:CountryCode"@en ,
+                                     "eine owl:ObjectProperty, die eine ec:Person mit einem ec:CountryCode verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasCoverage
+ec:hasCoverage rdf:type owl:ObjectProperty ;
+               dcterms:description "Coverage information associated with the editorial object."@en ,
+                                   "Informationen zur Abdeckung, die dem redaktionellen Objekt zugeordnet sind."@de ;
+               rdfs:label "Abdeckung"@de ,
+                          "Coverage"@en ;
+               skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Event or ec:Location"@en ,
+                               "eine owl:ObjectProperty, die ein ec:EditorialObject mit einem ec:Event oder einem ec:Location verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasCoverageRestrictions
+ec:hasCoverageRestrictions rdf:type owl:ObjectProperty ;
+                           rdfs:subPropertyOf ec:hasRights ;
+                           dcterms:description "Die Einschränkungen der Abdeckung für ein Asset oder ein Veröffentlichungsevent, etwa hinsichtlich zeitlicher oder räumlicher Abdeckung."@de ,
+                                               "The limitations on coverage for an asset or publication event, such as time or spatial coverage."@en ;
+                           rdfs:label "Coverage restrictions"@en ,
+                                      "Einschränkungen der Abdeckung"@de ;
+                           skos:definition "an owl:ObjectProperty relating an ec:Asset to an ec:CoverageRestrictions"@en ,
+                                           "eine owl:ObjectProperty, die eine ec:Asset mit einer ec:CoverageRestrictions verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasCreativeCommons
+ec:hasCreativeCommons rdf:type owl:ObjectProperty ;
+                      rdfs:subPropertyOf ec:hasRights ;
+                      dcterms:description "A property linking an asset to its Creative Commons license or licensing conditions."@en ,
+                                          "Eine Eigenschaft, die ein Asset mit seiner Creative-Commons-Lizenz oder seinen Lizenzbedingungen verknüpft."@de ;
+                      rdfs:label "Creative Commons"@de ,
+                                 "Creative commons"@en ;
+                      skos:definition "an owl:ObjectProperty relating an ec:Asset to ec:CreativeCommons"@en ,
+                                      "eine owl:ObjectProperty, die ein ec:Asset mit ec:CreativeCommons verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasCreator
+ec:hasCreator rdf:type owl:ObjectProperty ;
+              dcterms:description "An Agent involved in the creation of the Resource or EditorialObject."@en ,
+                                  "Eine Agentin oder ein Agent, der an der Erstellung der Resource oder des EditorialObject beteiligt ist."@de ;
+              rdfs:label "Creator"@en ,
+                         "Ersteller"@de ;
+              skos:definition "an owl:ObjectProperty relating an ec:Artefact or ec:EditorialObject to an ec:Involvement"@en ,
+                              "eine owl:ObjectProperty, die ein ec:Artefact oder ein ec:EditorialObject mit einer ec:Involvement verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasCrewMember
+ec:hasCrewMember rdf:type owl:ObjectProperty ;
+                 dcterms:description "A member of the crew."@en ,
+                                     "Ein Mitglied der Crew."@de ;
+                 rdfs:label "Crew member"@en ,
+                            "Crewmitglied"@de ;
+                 skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:CrewMember"@en ,
+                                 "eine owl:ObjectProperty, die ein ec:EditorialObject mit einem ec:CrewMember verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasCuisineOrigin
+ec:hasCuisineOrigin rdf:type owl:ObjectProperty ;
+                    dcterms:description "Das Herkunftsland bzw. die Herkunftsregion der Küche."@de ,
+                                        "The country/region of origin of the cuisine."@en ;
+                    rdfs:label "Cuisine origin"@en ,
+                               "Küchenherkunft"@de ;
+                    skos:definition "an owl:ObjectProperty relating an ec:Food to an ec:CountryCode"@en ,
+                                    "eine owl:ObjectProperty, die ec:Food mit ec:CountryCode verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasCuisineStyle
+ec:hasCuisineStyle rdf:type owl:ObjectProperty ;
+                   dcterms:description "Der Stil der Küche."@de ,
+                                       "The style of the cuisine."@en ;
+                   rdfs:label "Cuisine style"@en ,
+                              "Küchenstil"@de ;
+                   skos:definition "an owl:ObjectProperty relating an ec:Food to an ec:CuisineStyle"@en ,
+                                   "eine owl:ObjectProperty, die ein ec:Food mit einem ec:CuisineStyle verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDataFormat
+ec:hasDataFormat rdf:type owl:ObjectProperty ;
+                 rdfs:subPropertyOf ec:hasFormat ;
+                 dcterms:description "Das Format der in einer Ressource übertragenen Daten."@de ,
+                                     "The format of data carried in a resource."@en ;
+                 rdfs:label "Data format"@en ,
+                            "Datenformat"@de ;
+                 skos:definition "an owl:ObjectProperty relating an ec:DataTrack to an ec:DataFormat"@en ,
+                                 "eine owl:ObjectProperty, die ec:DataTrack mit ec:DataFormat verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDataTrack
+ec:hasDataTrack rdf:type owl:ObjectProperty ;
+                dcterms:description "Der mit der Ressource verknüpfte Datentrack."@de ,
+                                    "The data track associated with the resource."@en ;
+                rdfs:label "Data track"@en ,
+                           "Datentrack"@de ;
+                skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:DataTrack"@en ,
+                                "eine owl:ObjectProperty, die eine ec:MediaResource mit einer ec:DataTrack verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDate
+ec:hasDate rdf:type owl:ObjectProperty ;
+           dc:description "Range: Litteral, on the instance level, this can be restricted to dateTime, date or another suitable format."@en ;
+           dcterms:description "A date associated with an Asset. Range: Literal, on the instance level, this can be restricted to dateTime, date or another suitable format."@en ,
+                               "Ein Datum, das mit einem Asset verknüpft ist. Bereich: Literal; auf Instanzebene kann dies auf dateTime, date oder ein anderes geeignetes Format eingeschränkt werden."@de ;
+           rdfs:isDefinedBy dc:date ;
+           rdfs:label "Date"@en ,
+                      "Datum"@de ;
+           skos:definition "an owl:ObjectProperty relating an ec:Asset to a time:Instant"@en ,
+                           "eine owl:ObjectProperty, die ein ec:Asset mit einem time:Instant verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateArchived
+ec:hasDateArchived rdf:type owl:ObjectProperty ;
+                   rdfs:subPropertyOf ec:hasDate ;
+                   dcterms:description "Das Datum, an dem das Asset archiviert wurde."@de ,
+                                       "The date when the Asset was archived."@en ;
+                   rdfs:label "Archivierungsdatum"@de ,
+                              "Archiving date"@en ;
+                   skos:definition "an owl:ObjectProperty relating an ec:Asset to a time:Instant"@en ,
+                                   "eine owl:ObjectProperty, die ec:Asset mit time:Instant verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateBroadcast
+ec:hasDateBroadcast rdf:type owl:ObjectProperty ;
+                    rdfs:subPropertyOf ec:hasDate ;
+                    dcterms:description "Das Datum, an dem das Asset erstmals öffentlich im Fernsehen, im Radio oder per Streaming ausgestrahlt wurde."@de ,
+                                        "The date when the Asset was first broadcast publicly on television or radio or via streaming."@en ;
+                    rdfs:label "Broadcast date"@en ,
+                               "Sendetermin"@de ;
+                    skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to a time:Instant"@en ,
+                                    "eine owl:ObjectProperty, die ein ec:EditorialObject mit einem time:Instant verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateCreated
+ec:hasDateCreated rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf ec:hasDate ;
+                  dcterms:description "Das Erstellungsdatum des Assets."@de ,
+                                      "The date of creation of the Asset."@en ;
+                  rdfs:label "Creation date/time"@en ,
+                             "Erstellungsdatum/-zeit"@de ;
+                  skos:definition "an owl:ObjectProperty relating an ec:Asset to a time:Instant"@en ,
+                                  "eine owl:ObjectProperty, die ein ec:Asset mit einem time:Instant verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateDeleted
+ec:hasDateDeleted rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf ec:hasDate ;
+                  dcterms:description "Das Datum, an dem die Ressource gelöscht wurde."@de ,
+                                      "The date when the Resource was deleted."@en ;
+                  rdfs:label "Deletion date"@en ,
+                             "Löschdatum"@de ;
+                  skos:definition "an owl:ObjectProperty relating an ec:Asset to a time:Instant"@en ,
+                                  "eine owl:ObjectProperty, die ein ec:Asset mit einem time:Instant verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateDigitised
+ec:hasDateDigitised rdf:type owl:ObjectProperty ;
+                    rdfs:subPropertyOf ec:hasDate ;
+                    dcterms:description "Das Datum, an dem die Ressource digitalisiert wurde."@de ,
+                                        "The date when the Resource was digitised."@en ;
+                    rdfs:label "Digitalisierungsdatum"@de ,
+                               "Digitisation date"@en ;
+                    skos:definition "an owl:ObjectProperty relating an ec:MediaResource to a time:Instant"@en ,
+                                    "eine owl:ObjectProperty, die ec:MediaResource mit time:Instant verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateDistributed
+ec:hasDateDistributed rdf:type owl:ObjectProperty ;
+                      rdfs:subPropertyOf ec:hasDate ;
+                      dcterms:description "Das Datum, an dem die Ressource erstmals für den Kauf, den Download oder den Online-Zugriff der Öffentlichkeit zur Verfügung gestellt wurde."@de ,
+                                          "The date when the Resource was first made available to the public for purchase, download, or online access."@en ;
+                      rdfs:label "Distribution date"@en ,
+                                 "Verteilungsdatum"@de ;
+                      skos:definition "an ec:hasDate relation relating an ec:Asset to a time:Instant"@en ,
+                                      "eine ec:hasDate-Beziehung, die eine ec:Asset mit einem time:Instant verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateIngested
+ec:hasDateIngested rdf:type owl:ObjectProperty ;
+                   rdfs:subPropertyOf ec:hasDate ;
+                   dcterms:description "Das Datum, an dem die Ressource in institutionelle Bestände aufgenommen bzw. erworben wurde."@de ,
+                                       "The date when the Resource was ingested/acquired in institutional holdings."@en ;
+                   rdfs:label "Ingest date"@en ,
+                              "Ingest-Datum"@de ;
+                   skos:definition "an owl:ObjectProperty relating an ec:MediaResource to a time:Instant"@en ,
+                                   "eine owl:ObjectProperty, die eine ec:MediaResource mit einer time:Instant verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateIssued
+ec:hasDateIssued rdf:type owl:ObjectProperty ;
+                 rdfs:subPropertyOf ec:hasDate ;
+                 dcterms:description "Das Datum, an dem das Asset ausgegeben wurde."@de ,
+                                     "The date when the Asset was issued."@en ;
+                 rdfs:label "Ausgabedatum"@de ,
+                            "Date issued"@en ;
+                 skos:definition "an ec:hasDate relation relating an ec:EditorialObject to a time:Instant"@en ,
+                                 "eine ec:hasDate-Relation, die ein ec:EditorialObject mit einem time:Instant verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateLicenseEnd
+ec:hasDateLicenseEnd rdf:type owl:ObjectProperty ;
+                     rdfs:subPropertyOf ec:hasDate ;
+                     dcterms:description "Das Datum, an dem die Lizenz für das Asset endet."@de ,
+                                         "The date when the licence for the Asset ends."@en ;
+                     rdfs:label "Licence end date"@en ,
+                                "Lizenzenddatum"@de ;
+                     skos:definition "an owl:ObjectProperty relating an ec:Asset to a time:Instant"@en ,
+                                     "eine owl:ObjectProperty, die ein ec:Asset mit einem time:Instant verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateLicensedStart
+ec:hasDateLicensedStart rdf:type owl:ObjectProperty ;
+                        rdfs:subPropertyOf ec:hasDate ;
+                        dcterms:description "Das Datum, an dem die Lizenz für das Asset beginnt."@de ,
+                                            "The date when the licence for the Asset begins."@en ;
+                        rdfs:label "Licence start date"@en ,
+                                   "Lizenzbeginn"@de ;
+                        skos:definition "an owl:ObjectProperty relating an ec:Asset to a time:Instant"@en ,
+                                        "eine owl:ObjectProperty, die eine ec:Asset mit einer time:Instant verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateMigrated
+ec:hasDateMigrated rdf:type owl:ObjectProperty ;
+                   rdfs:subPropertyOf ec:hasDate ;
+                   dcterms:description "Das Datum, an dem die Ressource aus einem veralteten oder gefährdeten Originalformat zur Erhaltung in ein aktuelleres Format kopiert oder konvertiert wurde."@de ,
+                                       "The date when the Resource was copied or converted from an obsolete or endangered original format to a more updated format for preservation."@en ;
+                   rdfs:label "Migration date"@en ,
+                              "Migrationsdatum"@de ;
+                   skos:definition "an owl:ObjectProperty relating an ec:MediaResource to a time:Instant"@en ,
+                                   "eine owl:ObjectProperty, die eine ec:MediaResource mit einem time:Instant verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateModified
+ec:hasDateModified rdf:type owl:ObjectProperty ;
+                   rdfs:subPropertyOf ec:hasDate ;
+                   dcterms:description "Das Datum und die Uhrzeit, zu denen das Asset geändert wurde."@de ,
+                                       "The date and time when the Asset was modified."@en ;
+                   rdfs:label "Modification date/time"@en ,
+                              "Änderungsdatum/-zeit"@de ;
+                   skos:definition "an owl:ObjectProperty relating an ec:Asset to a time:Instant"@en ,
+                                   "eine owl:ObjectProperty, die ein ec:Asset mit einem time:Instant verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateNormalized
+ec:hasDateNormalized rdf:type owl:ObjectProperty ;
+                     rdfs:subPropertyOf ec:hasDate ;
+                     dcterms:description "Das Datum, an dem die Ressource von ihrem ursprünglichen Format in ein von der Institution zur Bewahrung ausgewähltes Format konvertiert wurde."@de ,
+                                         "The date when the Resource was converted from its original format into a format selected by the institution for preservation."@en ;
+                     rdfs:label "Normalisierungsdatum"@de ,
+                                "Normalization date"@en ;
+                     skos:definition "an ec:hasDate relation relating an ec:MediaResource to a time:Instant"@en ,
+                                     "eine ec:hasDate-Relation, die eine ec:MediaResource mit einer time:Instant verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateOfBirth
+ec:hasDateOfBirth rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf ec:hasDate ;
+                  dcterms:description "Das Datum, an dem eine Kontaktperson geboren wird."@de ,
+                                      "The date when a Contact/Person is born."@en ;
+                  rdfs:label "Date of birth"@en ,
+                             "Geburtsdatum"@de ;
+                  skos:definition "an owl:ObjectProperty relating an ec:Person to a time:Instant"@en ,
+                                  "eine owl:ObjectProperty, die ec:Person mit einem time:Instant verbindet"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateOfDeath
+ec:hasDateOfDeath rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf ec:hasDate ;
+                  dcterms:description "Das Datum, an dem ein Kontakt/eine Person verstorben ist."@de ,
+                                      "The date when a Contact/Person has passed away."@en ;
+                  rdfs:label "Date of death"@en ,
+                             "Tod des Todes"@de ;
+                  skos:definition "an owl:ObjectProperty relating an ec:Person to a time:Instant"@en ,
+                                  "eine owl:ObjectProperty, die eine ec:Person mit einem time:Instant verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateOfRetirement
+ec:hasDateOfRetirement rdf:type owl:ObjectProperty ;
+                       rdfs:subPropertyOf ec:hasDate ;
+                       dcterms:description "Das Datum, an dem sich eine Contact/Person zurückgezogen hat."@de ,
+                                           "The date when a Contact/Person has retired."@en ;
+                       rdfs:label "Date of retirement"@en ,
+                                  "Datum des Ruhestands"@de ;
+                       skos:definition "an owl:ObjectProperty relating an ec:Person to a time:Instant"@en ,
+                                       "eine owl:ObjectProperty, die eine ec:Person mit einem time:Instant verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateProduced
+ec:hasDateProduced rdf:type owl:ObjectProperty ;
+                   rdfs:subPropertyOf ec:hasDate ;
+                   dcterms:description "Das Datum der Produktion des Assets."@de ,
+                                       "The date of production of the Asset."@en ;
+                   rdfs:label "Production date"@en ,
+                              "Produktionsdatum"@de ;
+                   skos:definition "an owl:ObjectProperty relating an ec:Asset to a time:Instant"@en ,
+                                   "eine owl:ObjectProperty, die ein ec:Asset mit einem time:Instant verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateReleased
+ec:hasDateReleased rdf:type owl:ObjectProperty ;
+                   rdfs:subPropertyOf ec:hasDate ;
+                   dcterms:description "Das Datum, an dem die Ressource erstmals der Öffentlichkeit zum Kauf, Download oder Online-Zugriff zur Verfügung gestellt wurde."@de ,
+                                       "The date when the Resource was first made available to the public for purchase, download, or online access."@en ;
+                   rdfs:label "Release date"@en ,
+                              "Veröffentlichungsdatum"@de ;
+                   skos:definition "an owl:ObjectProperty relating an ec:Asset to a time:Instant"@en ,
+                                   "eine owl:ObjectProperty, die ein ec:Asset mit einem time:Instant verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateTransferred
+ec:hasDateTransferred rdf:type owl:ObjectProperty ;
+                      rdfs:subPropertyOf ec:hasDate ;
+                      dcterms:description "Das Datum, an dem das Asset von einem digitalen oder physischen Ort an einen anderen verschoben wurde."@de ,
+                                          "The date when the Asset was moved from one digital or physical location to another."@en ;
+                      rdfs:label "Transfer date"@en ,
+                                 "Übertragungsdatum"@de ;
+                      skos:definition "an ec:hasDate relation relating an ec:MediaResource to a time:Instant"@en ,
+                                      "eine ec:hasDate-Beziehung, die eine ec:MediaResource mit einem time:Instant verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateValidated
+ec:hasDateValidated rdf:type owl:ObjectProperty ;
+                    rdfs:subPropertyOf ec:hasDate ;
+                    dcterms:description "Das jüngste Datum, an dem die Resource durch manuelle oder digitale Qualitätskontrolle als gültig bestätigt wurde."@de ,
+                                        "The most recent date when the Resource was confirmed to be valid through manual or digital QC."@en ;
+                    rdfs:label "Validation date"@en ,
+                               "Validierungsdatum"@de ;
+                    skos:definition "an owl:ObjectProperty relating an ec:Resource to a time:Instant"@en ,
+                                    "eine owl:ObjectProperty, die eine ec:Resource mit einer time:Instant verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDepartment
+ec:hasDepartment rdf:type owl:ObjectProperty ;
+                 dcterms:description "Die einer Organisation zugeordnete Abteilung."@de ,
+                                     "The department associated with an organisation."@en ;
+                 rdfs:label "Abteilung"@de ,
+                            "Department"@en ;
+                 skos:definition "an owl:ObjectProperty relating an ec:Organisation to an ec:Department"@en ,
+                                 "eine owl:ObjectProperty, die eine ec:Organisation mit einer ec:Department verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDevice
+ec:hasDevice rdf:type owl:ObjectProperty ;
+             dcterms:description "Das bei einem ConsumptionEvent verwendete ConsumptionDevice."@de ,
+                                 "The ConsumptionDevice used during a ConsumptionEvent."@en ;
+             rdfs:label "Has device"@en ,
+                        "Hat Gerät"@de ;
+             skos:definition "an owl:ObjectProperty relating an ec:ConsumptionEvent to an ec:ConsumptionDevice"@en ,
+                             "eine owl:ObjectProperty, die eine ec:ConsumptionEvent mit einer ec:ConsumptionDevice verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDisclaimer
+ec:hasDisclaimer rdf:type owl:ObjectProperty ;
+                 rdfs:subPropertyOf ec:hasRights ;
+                 dcterms:description "A right or claim that is intentionally waived for an asset."@en ,
+                                     "Ein Recht oder Anspruch, auf das für ein Asset absichtlich verzichtet wird."@de ;
+                 rdfs:label "Disclaimer"@en ,
+                            "Haftungsausschluss"@de ;
+                 skos:definition "an owl:ObjectProperty relating an ec:Asset to an ec:Disclaimer"@en ,
+                                 "eine owl:ObjectProperty, die ein ec:Asset mit einem ec:Disclaimer verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDisplayAspectRatio
+ec:hasDisplayAspectRatio rdf:type owl:ObjectProperty ;
+                         dcterms:description "Das Seitenverhältnis bei der Anzeige."@de ,
+                                             "The aspect ratio when displayed."@en ;
+                         rdfs:label "Bildseitenverhältnis"@de ,
+                                    "Display aspect ratio"@en ;
+                         skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:ActiveFormatDescriptorCode"@en ,
+                                         "eine owl:ObjectProperty, die eine ec:MediaResource mit einem ec:ActiveFormatDescriptorCode verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDocumentFormat
+ec:hasDocumentFormat rdf:type owl:ObjectProperty ;
+                     rdfs:subPropertyOf ec:hasFormat ;
+                     dcterms:description "Das Format eines Dokuments."@de ,
+                                         "The format of a document."@en ;
+                     rdfs:label "Document format"@en ,
+                                "Dokumentenformat"@de ;
+                     skos:definition "an owl:ObjectProperty relating an ec:Document to an ec:DocumentFormat"@en ,
+                                     "eine owl:ObjectProperty, die ein ec:Document mit einem ec:DocumentFormat verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDopesheet
+ec:hasDopesheet rdf:type owl:ObjectProperty ;
+                dcterms:description "Das Dopesheet eines NewsItems."@de ,
+                                    "The dopesheet of a NewsItem."@en ;
+                rdfs:label "Datenblatt"@de ,
+                           "Dopesheet"@en ;
+                skos:definition "an ec:ObjectProperty relating an ec:Item to an ec:Dopesheet"@en ,
+                                "eine ec:ObjectProperty, die ein ec:Item mit einem ec:Dopesheet verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDub
+ec:hasDub rdf:type owl:ObjectProperty ;
+          owl:inverseOf ec:isDubOf ;
+          dcterms:description "Die Ressource hat eine weitere Sprachversion."@de ,
+                              "The resource have another language version."@en ;
+          rdfs:label "Dubbed to"@en ,
+                     "Synchronisiert mit"@de ;
+          skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:MediaResource"@en ,
+                          "eine owl:ObjectProperty, die eine ec:MediaResource mit einer ec:MediaResource verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDubbedLanguage
+ec:hasDubbedLanguage rdf:type owl:ObjectProperty ;
+                     rdfs:subPropertyOf ec:hasLanguage ;
+                     dcterms:description "Die für das Asset verfügbaren synchronisierten Sprachen."@de ,
+                                         "The dubbed languages available for the asset."@en ;
+                     rdfs:label "Dubbed language"@en ,
+                                "Synchronisierte Sprache"@de ;
+                     skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Language"@en ,
+                                     "eine owl:ObjectProperty, die ein ec:EditorialObject mit einer ec:Language verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDuration
+ec:hasDuration rdf:type owl:ObjectProperty ;
+               dcterms:description "A property that links an editorial object to its duration on a timeline."@en ,
+                                   "Eine Eigenschaft, die ein redaktionelles Objekt mit seiner Dauer auf einer Zeitachse verknüpft."@de ;
+               rdfs:label "Has duration"@en ,
+                          "Hat Dauer"@de ;
+               skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:TimelinePoint"@en ,
+                               "eine owl:ObjectProperty, die ein ec:EditorialObject mit einem ec:TimelinePoint verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasEditorialFormat
+ec:hasEditorialFormat rdf:type owl:ObjectProperty ;
+                      dcterms:description "Bezieht ein EditorialObject auf das EditorialFormat, das es verwendet."@de ,
+                                          "Relates an EditorialObject to the EditorialFormat it uses."@en ;
+                      rdfs:label "Has editorial format"@en ,
+                                 "Hat redaktionelles Format"@de ;
+                      skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:EditorialFormat"@en ,
+                                      "eine owl:ObjectProperty, die ein ec:EditorialObject mit einem ec:EditorialFormat verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasEditorialFormatOf
+ec:hasEditorialFormatOf rdf:type owl:ObjectProperty ;
+                        dcterms:description "An editorial object based on the same editorial format."@en ,
+                                            "Ein redaktionelles Objekt, das auf demselben redaktionellen Format basiert."@de ;
+                        rdfs:label "Gleicher redaktioneller Format"@de ,
+                                   "Same editorial format"@en ;
+                        skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:EditorialObject with the same editorial format"@en ,
+                                        "eine owl:ObjectProperty, die ein ec:EditorialObject mit einem ec:EditorialObject im selben redaktionellen Format verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasEditorialGroup
+ec:hasEditorialGroup rdf:type owl:ObjectProperty ;
+                     rdfs:subPropertyOf ec:isMemberOf ;
+                     dcterms:description "Diese Eigenschaft identifiziert eine Editorial Group, zu der ein Editorial Object gehört."@de ,
+                                         "This property identifies an editorial group that an editorial object belongs to."@en ;
+                     rdfs:label "Has editorial group"@en ,
+                                "Hat eine Redaktionsgruppe"@de ;
+                     skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:EditorialGroup"@en ,
+                                     "ein owl:ObjectProperty, das ein ec:EditorialObject mit einem ec:EditorialGroup verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasEditorialWork
+ec:hasEditorialWork rdf:type owl:ObjectProperty ;
+                    rdfs:subPropertyOf ec:isMemberOf ;
+                    dcterms:description "Identifies an editorial work associated with this property, typically an ec:EditorialWork linked from an ec:EditorialSegment."@en ,
+                                        "Identifiziert ein redaktionelles Werk, das mit dieser Eigenschaft verbunden ist, typischerweise ein ec:EditorialWork, das von einem ec:EditorialSegment aus verknüpft ist."@de ;
+                    rdfs:label "Has editorial work"@en ,
+                               "Hat redaktionelles Werk"@de ;
+                    skos:definition "an owl:ObjectProperty relating an ec:EditorialSegment to an ec:EditorialWork"@en ,
+                                    "eine owl:ObjectProperty, die ein ec:EditorialSegment mit einem ec:EditorialWork verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasEmbodyingArtefact
+ec:hasEmbodyingArtefact rdf:type owl:ObjectProperty ;
+                        owl:inverseOf ec:isEmbodiedBy ;
+                        dcterms:description "Character depicted by an Artifact."@en ,
+                                            "Von einem Artefakt dargestellte Figur."@de ;
+                        rdfs:label "Is embodied by"@en ,
+                                   "Ist verkörpert durch"@de ;
+                        skos:definition "an owl:ObjectProperty relating an ec:Character to an ec:Artefact"@en ,
+                                        "eine owl:ObjectProperty, die eine ec:Character mit einem ec:Artefact verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasEncodingFormat
+ec:hasEncodingFormat rdf:type owl:ObjectProperty ;
+                     rdfs:subPropertyOf ec:hasFormat ;
+                     dcterms:description "An encoding format used to produce content."@en ,
+                                         "Ein Codierungsformat, das zur Erzeugung von Inhalten verwendet wird."@de ;
+                     rdfs:label "Encoding format"@en ,
+                                "Kodierungsformat"@de ;
+                     skos:definition "an owl:ObjectProperty relating an ec:Document, ec:MediaResource, or ec:Picture to an ec:EncodingFormat"@en ,
+                                     "eine owl:ObjectProperty, die ec:Document, ec:MediaResource oder ec:Picture mit einem ec:EncodingFormat verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasEnd
+ec:hasEnd rdf:type owl:ObjectProperty ;
+          dcterms:description "A property that links an action or content-related entity to its ending timeline point."@en ,
+                              "Eine Eigenschaft, die eine Aktion oder eine inhaltsbezogene Entität mit ihrem Endpunkt auf der Zeitachse verknüpft."@de ;
+          rdfs:label "Has end"@en ,
+                     "Hat Ende"@de ;
+          skos:definition "an owl:ObjectProperty relating an ec:Action to an ec:TimelinePoint"@en ,
+                          "eine owl:ObjectProperty, die eine ec:Action mit einem ec:TimelinePoint verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasEndDateTime
+ec:hasEndDateTime rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf ec:hasDate ;
+                  dcterms:description "Beschreibt das Ende eines Intervalls."@de ,
+                                      "Describing an end of an interval."@en ;
+                  rdfs:label "End date time"@en ,
+                             "Enddatum und Uhrzeit"@de ;
+                  skos:definition "an owl:ObjectProperty relating an ec:Affiliation to a time:Instant"@en ,
+                                  "eine owl:ObjectProperty, die eine ec:Affiliation mit einem time:Instant verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasEpisode
+ec:hasEpisode rdf:type owl:ObjectProperty ;
+              dcterms:description "Identifies episodes in a series."@en ,
+                                  "Kennzeichnet Episoden in einer Serie."@de ;
+              rdfs:label "Episode"@de ,
+                         "Episode"@en ;
+              skos:definition "an owl:ObjectProperty relating an ec:Season, ec:Serial or ec:Series to an ec:Programme"@en ,
+                              "eine owl:ObjectProperty, die ein ec:Season, ec:Serial oder ec:Series mit einem ec:Programme verbindet"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasExploitationIssues
+ec:hasExploitationIssues rdf:type owl:ObjectProperty ;
+                         rdfs:subPropertyOf ec:hasRights ;
+                         dcterms:description "A potential problem arising from the use of a work."@en ,
+                                             "Ein potenzielles Problem, das sich aus der Verwendung eines Werks ergibt."@de ;
+                         rdfs:label "Exploitation issues"@en ,
+                                    "Verwertungsprobleme"@de ;
+                         skos:definition "an owl:ObjectProperty relating an ec:Asset to ec:ExploitationIssues"@en ,
+                                         "eine owl:ObjectProperty, die eine ec:Asset mit ec:ExploitationIssues verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasFictitiousPerson
+ec:hasFictitiousPerson rdf:type owl:ObjectProperty ;
+                       dcterms:description "Gibt an, dass die zugehörige Person fiktiv ist."@de ,
+                                           "Indicates that the associated person is fictitious."@en ;
+                       rdfs:label "Fictitious contact"@en ,
+                                  "Fiktiver Kontakt"@de ;
+                       skos:definition "an owl:ObjectProperty relating an ec:Character to an ec:Person"@en ,
+                                       "eine owl:ObjectProperty, die eine ec:Character mit einer ec:Person verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasFileFormat
+ec:hasFileFormat rdf:type owl:ObjectProperty ;
+                 dcterms:description "Das Format einer Datei."@de ,
+                                     "The format of a file."@en ;
+                 rdfs:label "Dateiformat"@de ,
+                            "File format"@en ;
+                 skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:FileFormat"@en ,
+                                 "eine owl:ObjectProperty, die eine ec:MediaResource mit einem ec:FileFormat verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasFoodStyle
+ec:hasFoodStyle rdf:type owl:ObjectProperty ;
+                dcterms:description "Die Art von Lebensmitteln."@de ,
+                                    "The style of Food."@en ;
+                rdfs:label "Food style"@en ,
+                           "Speisestil"@de ;
+                skos:definition "an owl:ObjectProperty relating an ec:Food to an ec:FoodStyle"@en ,
+                                "eine owl:ObjectProperty, die eine ec:Food mit einer ec:FoodStyle verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasFormat
+ec:hasFormat rdf:type owl:ObjectProperty ;
+             dcterms:description "Das mit einer Ressource verknüpfte Format."@de ,
+                                 "The format associated with a resource."@en ;
+             rdfs:label "Format"@de ,
+                        "Format"@en ;
+             skos:definition "an owl:ObjectProperty relating an ec:Resource to an ec:Format"@en ,
+                             "eine owl:ObjectProperty, die eine ec:Resource mit einer ec:Format verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasFormatId
+ec:hasFormatId rdf:type owl:ObjectProperty ;
+               dcterms:description "An identifier attributed to a Format."@en ,
+                                   "Eine Kennung, die einem Format zugeordnet ist."@de ;
+               rdfs:label "Format identifier"@en ,
+                          "Formatkennung"@de ;
+               skos:definition "an owl:ObjectProperty relating an ec:Format to an ec:Identifier"@en ,
+                               "eine owl:ObjectProperty, die einen ec:Format mit einem ec:Identifier verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasFormatVersionId
+ec:hasFormatVersionId rdf:type owl:ObjectProperty ;
+                      dcterms:description "A version identifier attributed to a Format."@en ,
+                                          "Eine Versionskennung, die einem Format zugeordnet ist."@de ;
+                      rdfs:label "Format version identifier"@en ,
+                                 "Formatversionskennung"@de ;
+                      skos:definition "an owl:ObjectProperty relating an ec:Format to an ec:Identifier"@en ,
+                                      "eine owl:ObjectProperty, die ein ec:Format mit einem ec:Identifier verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasGeneration
+ec:hasGeneration rdf:type owl:ObjectProperty ;
+                 dcterms:description "Identifies the generation of a version of a resource, i.e. master, edit master, distribution copy, etc."@en ,
+                                     "Kennzeichnet die Generation einer Version einer Ressource, also z. B. Master, Edit-Master, Distributionskopie usw."@de ;
+                 rdfs:label "Generation"@en ,
+                            "Generierung"@de ;
+                 skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:MediaResource"@en ,
+                                 "eine owl:ObjectProperty, die eine ec:MediaResource mit einer ec:MediaResource verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasGenre
+ec:hasGenre rdf:type owl:ObjectProperty ;
+            dcterms:description "Das Genre oder die Kategorie, die dem EditorialObject zugeordnet ist."@de ,
+                                "The genre or category associated with the EditorialObject."@en ;
+            rdfs:label "Genre"@de ,
+                       "Genre"@en ;
+            skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to a skos:Concept"@en ,
+                            "eine owl:ObjectProperty, die eine ec:EditorialObject mit einem skos:Concept verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasGeoBlockingBlacklist
+ec:hasGeoBlockingBlacklist rdf:type owl:ObjectProperty ;
+                           dcterms:description "Checking a users IP-address against a blacklist."@en ,
+                                               "Überprüfung der IP-Adresse eines Benutzers anhand einer Blacklist."@de ;
+                           rdfs:label "Geo-Blocking-Blacklist"@de ,
+                                      "Geo-blocking blacklist"@en ;
+                           skos:definition "an owl:ObjectProperty relating an ec:AccessConditions to a skos:Concept"@en ,
+                                           "eine owl:ObjectProperty, die ec:AccessConditions mit einem skos:Concept verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasGeoBlockingWhitelist
+ec:hasGeoBlockingWhitelist rdf:type owl:ObjectProperty ;
+                           dcterms:description "Checking a users IP-address against a whitelist."@en ,
+                                               "Überprüfung der IP-Adresse eines Benutzers anhand einer Whitelist."@de ;
+                           rdfs:label "Geo-Blocking-Whitelist"@de ,
+                                      "Geo-blocking whitelist"@en ;
+                           skos:definition "an owl:ObjectProperty relating an ec:AccessConditions to a skos:Concept"@en ,
+                                           "eine owl:ObjectProperty, die eine ec:AccessConditions mit einem skos:Concept verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasGeoLocation
+ec:hasGeoLocation rdf:type owl:ObjectProperty ;
+                  dcterms:description "Der Standort eines ConsumptionDevice."@de ,
+                                      "The Location of a ConsumptionDevice."@en ;
+                  rdfs:label "Device location"@en ,
+                             "Gerätestandort"@de ;
+                  skos:definition "an owl:ObjectProperty relating an ec:ConsumptionDeviceProfile to an ec:Location"@en ,
+                                  "eine owl:ObjectProperty, die ec:ConsumptionDeviceProfile mit ec:Location verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasGroupMember
+ec:hasGroupMember rdf:type owl:ObjectProperty ;
+                  dcterms:description "Bezieht einen Agenten auf einen anderen Agenten, der Mitglied derselben Gruppe ist."@de ,
+                                      "Relates an Agent to another Agent that is a member of the same group."@en ;
+                  rdfs:label "Group member"@en ,
+                             "Gruppenmitglied"@de ;
+                  skos:definition "an owl:ObjectProperty relating an ec:Agent to an ec:Agent"@en ,
+                                  "eine owl:ObjectProperty, die einen ec:Agent mit einem ec:Agent verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasIPRRestrictions
+ec:hasIPRRestrictions rdf:type owl:ObjectProperty ;
+                      rdfs:subPropertyOf ec:hasRights ;
+                      dcterms:description "A property that links an asset to its intellectual property restrictions."@en ,
+                                          "Eine Eigenschaft, die ein Asset mit seinen urheberrechtlichen Beschränkungen verknüpft."@de ;
+                      rdfs:label "IPR restrictions"@en ,
+                                 "IPR-Beschränkungen"@de ;
+                      skos:definition "an owl:ObjectProperty relating an ec:Asset to an ec:IPRRestrictions"@en ,
+                                      "eine owl:ObjectProperty, die eine ec:Asset mit ec:IPRRestrictions verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasIdPicture
+ec:hasIdPicture rdf:type owl:ObjectProperty ;
+                dcterms:description "A link to an identification picture associated with a person."@en ,
+                                    "Ein Link zu einem Identifikationsbild, das einer Person zugeordnet ist."@de ;
+                rdfs:label "Identification picture"@en ,
+                           "Identifikationsbild"@de ;
+                skos:definition "an owl:ObjectProperty relating an ec:Person to an ec:Picture"@en ,
+                                "eine owl:ObjectProperty, die eine ec:Person mit einem ec:Picture verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasIdentifier
+ec:hasIdentifier rdf:type owl:ObjectProperty ;
+                 dcterms:description "An identifier associated with an asset."@en ,
+                                     "Eine Kennung, die mit einem Asset verbunden ist."@de ;
+                 rdfs:label "Identifier"@en ,
+                            "Kennung"@de ;
+                 skos:definition "an owl:ObjectProperty relating an ec:Asset to an ec:Identifier"@en ,
+                                 "eine owl:ObjectProperty, die ein ec:Asset mit einem ec:Identifier verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasImageCodec
+ec:hasImageCodec rdf:type owl:ObjectProperty ;
+                 dcterms:description "Der für ein Bild verwendete Codec."@de ,
+                                     "The codec used for an image."@en ;
+                 rdfs:label "Bildcodec"@de ,
+                            "Image codec"@en ;
+                 skos:definition "an owl:ObjectProperty relating an ec:MediaResource or ec:Picture to an ec:ImageCodec"@en ,
+                                 "eine owl:ObjectProperty, die eine ec:MediaResource oder ec:Picture mit einem ec:ImageCodec verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasImageFormat
+ec:hasImageFormat rdf:type owl:ObjectProperty ;
+                  dcterms:description "Das Format eines Bildes, etwa das Seitenverhältnis eines Bildes."@de ,
+                                      "The format of an image, such as an image aspect ratio."@en ;
+                  rdfs:label "Bildformat"@de ,
+                             "Image format"@en ;
+                  skos:definition "an owl:ObjectProperty relating an ec:MediaResource or ec:Picture to an ec:ImageFormat"@en ,
+                                  "eine owl:ObjectProperty, die eine ec:MediaResource oder ec:Picture mit einem ec:ImageFormat verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasInputMediaResource
+ec:hasInputMediaResource rdf:type owl:ObjectProperty ;
+                         dcterms:description "Die als Eingabe für einen ProductionJob oder Prozess verwendete MediaResource."@de ,
+                                             "The MediaResource used as an input to a ProductionJob or process."@en ;
+                         rdfs:label "Resource input"@en ,
+                                    "Ressourceneingabe"@de ;
+                         skos:definition "an owl:ObjectProperty relating an ec:ProductionJob to an ec:MediaResource"@en ,
+                                         "eine owl:ObjectProperty, die ec:ProductionJob mit ec:MediaResource verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasInputResonance
+ec:hasInputResonance rdf:type owl:ObjectProperty ;
+                     dcterms:description "A set of Resonance data used as input to influence the definition of a better targeted Campaign."@en ,
+                                         "Eine Menge von Resonanzdaten, die als Eingabe verwendet werden, um die Definition einer besser zielgerichteten Kampagne zu beeinflussen."@de ;
+                     rdfs:label "Eingangsresonanz"@de ,
+                                "Input resonance"@en ;
+                     skos:definition "an owl:ObjectProperty relating an ec:Campaign to an ec:ResonanceCount"@en ,
+                                     "eine owl:ObjectProperty, die ec:Campaign mit ec:ResonanceCount verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasInputResource
+ec:hasInputResource rdf:type owl:ObjectProperty ;
+                    dcterms:description "A resource used as an input to a production job or process."@en ,
+                                        "Eine Ressource, die als Eingabe für einen Produktionsjob oder Prozess verwendet wird."@de ;
+                    rdfs:label "Resource input"@en ,
+                               "Ressourceneingabe"@de ;
+                    skos:definition "an owl:ObjectProperty relating an ec:ProductionJob to an ec:Resource"@en ,
+                                    "eine owl:ObjectProperty, die eine ec:ProductionJob mit einer ec:Resource verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasIssuer
+ec:hasIssuer rdf:type owl:ObjectProperty ;
+             dcterms:description "Der Aussteller eines Identifikators."@de ,
+                                 "The issuer of an identifier."@en ;
+             rdfs:label "Emittent"@de ,
+                        "Issuer"@en ;
+             skos:definition "an owl:ObjectProperty relating an ec:Identifier to an ec:Agent"@en ,
+                             "eine owl:ObjectProperty, die ein ec:Identifier mit einem ec:Agent verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasJob
+ec:hasJob rdf:type owl:ObjectProperty ;
+          owl:inverseOf ec:isOrderedBy ;
+          dcterms:description "A property that links a production job to the contract by which it is ordered."@en ,
+                              "Eine Eigenschaft, die einen Produktionsauftrag mit dem Vertrag verknüpft, durch den er bestellt wird."@de ;
+          rdfs:label "Has job"@en ,
+                     "Hat Job"@de ;
+          skos:definition "an owl:ObjectProperty relating a ec:Contract to an ec:ProductionJob"@en ,
+                          "eine owl:ObjectProperty, die ein ec:Contract mit einem ec:ProductionJob verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasKeyCareerEvent
+ec:hasKeyCareerEvent rdf:type owl:ObjectProperty ;
+                     dcterms:description "Die wichtigsten Karriereereignisse, die mit einer Person verbunden sind."@de ,
+                                         "The key career events associated with a person."@en ;
+                     rdfs:label "Career event"@en ,
+                                "Karriereereignis"@de ;
+                     skos:definition "an owl:ObjectProperty relating an ec:Person to an ec:KeyCareerEvent"@en ,
+                                     "eine owl:ObjectProperty, die eine ec:Person mit einem ec:KeyCareerEvent verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasKeyPersonalEvent
+ec:hasKeyPersonalEvent rdf:type owl:ObjectProperty ;
+                       dcterms:description "Die wichtigsten persönlichen Ereignisse, die mit einer Person verbunden sind."@de ,
+                                           "The key personal events associated with a Person."@en ;
+                       rdfs:label "Personal event"@en ,
+                                  "Persönliches Ereignis"@de ;
+                       skos:definition "an owl:ObjectProperty relating an ec:Person to an ec:KeyPersonalEvent"@en ,
+                                       "eine owl:ObjectProperty, die eine ec:Person mit einem ec:KeyPersonalEvent verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasKeyword
+ec:hasKeyword rdf:type owl:ObjectProperty ;
+              dcterms:description "Associates a concept, descriptive phrase, or keyword that specifies the topic of an editorial object."@en ,
+                                  "Verknüpft ein Konzept, eine beschreibende Formulierung oder ein Stichwort, das das Thema eines redaktionellen Objekts spezifiziert."@de ;
+              rdfs:label "Keyword"@en ,
+                         "Schlüsselwort"@de ;
+              skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Keyword"@en ,
+                              "eine owl:ObjectProperty, die ec:EditorialObject mit ec:Keyword verbindet"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasLanguage
+ec:hasLanguage rdf:type owl:ObjectProperty ;
+               dcterms:description "Die mit einem redaktionellen Objekt verknüpfte Sprache. Eine auf BCP 47 basierende kontrollierte Vokabularliste wird empfohlen. Diese Eigenschaft kann auch verwendet werden, um das Vorhandensein von Gebärdensprache (RFC 5646) anzugeben. Durch Vererbung gilt sie auf den Ebenen MediaResource, Fragment und Track, auf denen die Sprachverwendung definiert ist. Als Best Practice sollte die möglichst spezifische Granularität verwendet werden, um die Sprachverwendung innerhalb einer MediaResource zu beschreiben, einschließlich der Ebenen Fragment und Track."@de ,
+                                   "The language associated with an editorial object. A controlled vocabulary based on BCP 47 is recommended. This property can also be used to indicate the presence of sign language (RFC 5646). By inheritance, it applies at the MediaResource, Fragment, and Track levels where language usage is defined. Best practice is to use the most specific level of granularity possible to describe language usage within a MediaResource, including Fragment and Track levels."@en ;
+               rdfs:label "Language"@en ,
+                          "Sprache"@de ;
+               skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Language"@en ,
+                               "eine owl:ObjectProperty, die ec:EditorialObject mit ec:Language verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasLicensing
+ec:hasLicensing rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf ec:hasRights ;
+                dcterms:description "Links an asset to the licensing conditions that apply to it."@en ,
+                                    "Verknüpft ein Asset mit den für es geltenden Lizenzbedingungen."@de ;
+                rdfs:label "Licensing"@en ,
+                           "Lizenzierung"@de ;
+                skos:definition "an owl:ObjectProperty relating an ec:Asset to an ec:Licensing"@en ,
+                                "eine owl:ObjectProperty, die ein ec:Asset mit einem ec:Licensing verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasLocation
+ec:hasLocation rdf:type owl:ObjectProperty ;
+               dcterms:description "A location associated with the object or concept."@en ,
+                                   "Ein Ort, der mit dem Objekt oder Konzept verbunden ist."@de ;
+               rdfs:example "Der Ort, an dem Inhalte erfasst wurden."@de ,
+                            "The Location where content has been captured."@en ;
+               rdfs:label "Location"@en ,
+                          "Ort"@de ;
+               skos:definition "an owl:ObjectProperty relating an ec:Annotation to an ec:Location"@en ,
+                               "eine owl:ObjectProperty, die eine ec:Annotation mit einer ec:Location verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasLocationCode
+ec:hasLocationCode rdf:type owl:ObjectProperty ;
+                   dcterms:description "Den Code eines Ortes angeben."@de ,
+                                       "To give the code of a Location."@en ;
+                   rdfs:label "Locationcode"@en ,
+                              "Standortcode"@de ;
+                   skos:definition "an owl:ObjectProperty relating an ec:Location to an ec:LocationCode"@en ,
+                                   "eine owl:ObjectProperty, die ec:Location mit ec:LocationCode verbindet"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasLocationPicture
+ec:hasLocationPicture rdf:type owl:ObjectProperty ;
+                      dcterms:description "A picture associated with a Location."@en ,
+                                          "Ein Bild, das mit einem Ort verbunden ist."@de ;
+                      rdfs:label "Bild"@de ,
+                                 "Picture"@en ;
+                      skos:definition "an owl:ObjectProperty relating an ec:Location to an ec:Picture"@en ,
+                                      "eine owl:ObjectProperty, die eine ec:Location mit einer ec:Picture verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasLocator
+ec:hasLocator rdf:type owl:ObjectProperty ;
+              dcterms:description "A locator from where the Resource can be accessed."@en ,
+                                  "Ein Locator, von dem aus die Ressource abgerufen werden kann."@de ;
+              rdfs:label "Locator"@de ,
+                         "Locator"@en ;
+              skos:definition "an owl:ObjectProperty relating an ec:Resource to an ec:Locator"@en ,
+                              "eine owl:ObjectProperty, die eine ec:Resource mit einem ec:Locator verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasLogo
+ec:hasLogo rdf:type owl:ObjectProperty ;
+           dcterms:description "A link to a logo representing an organisation, award, brand, publication platform, publication channel, publication service, or rating."@en ,
+                               "Ein Verweis auf ein Logo, das eine Organisation, einen Preis, eine Marke, eine Publikationsplattform, einen Publikationskanal, einen Publikationsdienst oder eine Bewertung repräsentiert."@de ;
+           rdfs:label "Logo"@de ,
+                      "Logo"@en ;
+           skos:definition "an owl:ObjectProperty relating an ec:Award, ec:Costume, ec:MarketingBrand, ec:Organisation, ec:PublicationChannel, ec:PublicationPlatform, ec:PublicationService, or ec:Rating to an ec:Logo"@en ,
+                           "eine owl:ObjectProperty, die ec:Award, ec:Costume, ec:MarketingBrand, ec:Organisation, ec:PublicationChannel, ec:PublicationPlatform, ec:PublicationService oder ec:Rating mit ec:Logo verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasManifestation
+ec:hasManifestation rdf:type owl:ObjectProperty ;
+                    dcterms:description "A manifestation is the physical embodiment of work e.g. a tape, a file..."@en ,
+                                        "Eine Manifestation ist die physische Verkörperung eines Werks, z. B. ein Band, eine Datei..."@de ;
+                    rdfs:label "Manifestation"@de ,
+                               "Manifestation"@en ;
+                    skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Resource"@en ,
+                                    "eine owl:ObjectProperty, die eine ec:EditorialObject mit einer ec:Resource verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasMaster
+ec:hasMaster rdf:type owl:ObjectProperty ;
+             owl:inverseOf ec:isMasterOf ;
+             dcterms:description "Der zu einer Medienressource gehörende Master."@de ,
+                                 "The master associated with a media resource."@en ;
+             rdfs:label "Master"@de ,
+                        "Master"@en ;
+             skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:MediaResource"@en ,
+                             "ein owl:ObjectProperty, das eine ec:MediaResource mit einer ec:MediaResource verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasMeasurementAgent
+ec:hasMeasurementAgent rdf:type owl:ObjectProperty ;
+                       dcterms:description "Der Agent, der Daten analysiert, um eine Resonanz zu definieren."@de ,
+                                           "The Agent who analyses data to define a Resonance."@en ;
+                       rdfs:label "Gemessen von"@de ,
+                                  "Measured by"@en ;
+                       skos:definition "an owl:ObjectProperty relating an ec:ResonanceCount to an ec:Agent"@en ,
+                                       "eine owl:ObjectProperty, die eine ec:ResonanceCount mit einem ec:Agent verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasMediaFragment
+ec:hasMediaFragment rdf:type owl:ObjectProperty ;
+                    owl:inverseOf ec:isMediaFragmentOf ;
+                    dcterms:description "Bezieht eine Medienressource auf einen darin enthaltenen Medienfragment."@de ,
+                                        "Relates a media resource to a media fragment contained within it."@en ;
+                    rdfs:label "Fragment"@de ,
+                               "Fragment"@en ;
+                    skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:MediaFragment"@en ,
+                                    "eine owl:ObjectProperty, die ein ec:MediaResource mit einem ec:MediaFragment verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasMedium
+ec:hasMedium rdf:type owl:ObjectProperty ;
+             rdfs:subPropertyOf ec:hasFormat ;
+             dcterms:description "Das Medium, auf dem die Ressource verfügbar ist."@de ,
+                                 "The medium on which the resource is available."@en ;
+             rdfs:label "Medium"@de ,
+                        "Medium"@en ;
+             skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:Medium"@en ,
+                             "eine owl:ObjectProperty, die eine ec:MediaResource mit einem ec:Medium verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasMember
+ec:hasMember rdf:type owl:ObjectProperty ;
+             owl:inverseOf ec:isMemberOf ;
+             dcterms:description "To establish group/collection relationship between EditorialObjects."@en ,
+                                 "Zur Herstellung einer Gruppen-/Sammlungsbeziehung zwischen EditorialObjects."@de ;
+             rdfs:label "Member"@en ,
+                        "Mitglied"@de ;
+             skos:definition "an owl:ObjectProperty relating an ec:EditorialGroup to an ec:EditorialObject"@en ,
+                             "eine owl:ObjectProperty, die eine ec:EditorialGroup mit einem ec:EditorialObject verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasMemberAudience
+ec:hasMemberAudience rdf:type owl:ObjectProperty ;
+                     dcterms:description "An audience member included in the current audience group."@en ,
+                                         "Ein Zuschauer, der in die aktuelle Zuschauergruppe aufgenommen ist."@de ;
+                     rdfs:label "Member audience"@en ,
+                                "Mitgliederpublikum"@de ;
+                     skos:definition "an owl:ObjectProperty relating an ec:AudienceGroup to an ec:AudienceMember"@en ,
+                                     "eine owl:ObjectProperty, die eine ec:AudienceGroup mit einem ec:AudienceMember verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasMetadataTrack
+ec:hasMetadataTrack rdf:type owl:ObjectProperty ;
+                    dcterms:description "Die Eigenschaft, die den mit einer Medienressource verbundenen Metadatentrack identifiziert."@de ,
+                                        "The property that identifies the metadata track associated with a media resource."@en ;
+                    rdfs:label "Metadata track"@en ,
+                               "Metadaten-Track"@de ;
+                    skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:MetadataTrack"@en ,
+                                    "eine owl:ObjectProperty, die eine ec:MediaResource mit einer ec:MetadataTrack verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasMimeType
+ec:hasMimeType rdf:type owl:ObjectProperty ;
+               rdfs:subPropertyOf ec:hasFormat ;
+               dcterms:description "Der MIME-Typ einer Medienressource."@de ,
+                                   "The MIME type of a media resource."@en ;
+               rdfs:label "MIME-Typ"@de ,
+                          "Mime type"@en ;
+               skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:MimeType"@en ,
+                               "eine owl:ObjectProperty, die eine ec:MediaResource mit einem ec:MimeType verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasObjectType
+ec:hasObjectType rdf:type owl:ObjectProperty ;
+                 dcterms:description "Die Art oder Gattung der Ressource."@de ,
+                                     "The kind or genre of the resource."@en ;
+                 rdfs:label "Typ"@de ,
+                            "Type"@en ;
+                 skos:definition "an owl:ObjectProperty relating a resource to a skos:Concept classifying its kind or genre"@en ,
+                                 "eine owl:ObjectProperty, die eine Ressource mit einem skos:Concept verknüpft, der ihre Art oder ihr Genre klassifiziert"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasOrganisationStaff
+ec:hasOrganisationStaff rdf:type owl:ObjectProperty ;
+                        dcterms:description "Die Mitarbeiterinnen und Mitarbeiter in einer Organisation."@de ,
+                                            "The staff members in an organisation."@en ;
+                        rdfs:label "Personal"@de ,
+                                   "Staff"@en ;
+                        skos:definition "an owl:ObjectProperty relating an ec:Organisation to an ec:StaffMember"@en ,
+                                        "eine owl:ObjectProperty, die eine ec:Organisation mit einem ec:StaffMember verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasOriginalLanguage
+ec:hasOriginalLanguage rdf:type owl:ObjectProperty ;
+                       rdfs:subPropertyOf ec:hasLanguage ;
+                       dcterms:description "Die ursprüngliche Sprache eines redaktionellen Objekts."@de ,
+                                           "The original language of an editorial object."@en ;
+                       rdfs:label "Original language"@en ,
+                                  "Originalsprache"@de ;
+                       skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Language"@en ,
+                                       "eine owl:ObjectProperty, die eine ec:EditorialObject mit einer ec:Language verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasOutputEssence
+ec:hasOutputEssence rdf:type owl:ObjectProperty ;
+                    dcterms:description "An Essence resulting from a ProductionJob."@en ,
+                                        "Eine Essenz, die aus einem ProductionJob resultiert."@de ;
+                    rdfs:label "Output essence"@en ,
+                               "Output-Essenz"@de ;
+                    skos:definition "an owl:ObjectProperty relating an ec:ProductionJob to an ec:Essence"@en ,
+                                    "eine owl:ObjectProperty, die eine ec:ProductionJob mit einer ec:Essence verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasOutputMediaResource
+ec:hasOutputMediaResource rdf:type owl:ObjectProperty ;
+                          dcterms:description "A media resource resulting from a production job."@en ,
+                                              "Eine Medienressource, die aus einem Produktionsauftrag hervorgeht."@de ;
+                          rdfs:label "Ausgabemedienressource"@de ,
+                                     "Output media resource"@en ;
+                          skos:definition "an owl:ObjectProperty relating an ec:ProductionJob to an ec:MediaResource"@en ,
+                                          "eine owl:ObjectProperty, die ec:ProductionJob mit ec:MediaResource verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasOutputResource
+ec:hasOutputResource rdf:type owl:ObjectProperty ;
+                     dcterms:description "A resource resulting from a ProductionJob."@en ,
+                                         "Eine Ressource, die aus einem ProductionJob resultiert."@de ;
+                     rdfs:label "Ausgaberesource"@de ,
+                                "Output resource"@en ;
+                     skos:definition "an owl:ObjectProperty relating an ec:ProductionJob to an ec:Resource"@en ,
+                                     "eine owl:ObjectProperty, die ec:ProductionJob mit ec:Resource verbindet"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasOwner
+ec:hasOwner rdf:type owl:ObjectProperty ;
+            dcterms:description "Der Besitzer eines Tieres."@de ,
+                                "The owner of an animal."@en ;
+            rdfs:label "Animal owner"@en ,
+                       "Tierhalter"@de ;
+            skos:definition "an owl:ObjectProperty relating an ec:Animal to an ec:Agent"@en ,
+                            "eine owl:ObjectProperty, die eine ec:Animal mit einem ec:Agent verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasParentEditorialObject
+ec:hasParentEditorialObject rdf:type owl:ObjectProperty ;
+                            dcterms:description "Links an EditorialObject to its parent editorial object."@en ,
+                                                "Verknüpft ein EditorialObject mit seinem übergeordneten EditorialObject."@de ;
+                            rdfs:label "Parent editorial object"@en ,
+                                       "Übergeordnetes redaktionelles Objekt"@de ;
+                            skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:EditorialObject"@en ,
+                                            "eine owl:ObjectProperty, die ein ec:EditorialObject mit einem ec:EditorialObject verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasParentEditorialSegment
+ec:hasParentEditorialSegment rdf:type owl:ObjectProperty ;
+                             dcterms:description "Links an editorial segment to its parent editorial segment."@en ,
+                                                 "Verknüpft ein redaktionelles Segment mit seinem übergeordneten redaktionellen Segment."@de ;
+                             rdfs:label "Has parent editorial segment"@en ,
+                                        "Hat übergeordneten redaktionellen Abschnitt"@de ;
+                             skos:definition "an owl:ObjectProperty relating an ec:EditorialSegment to an ec:EditorialSegment"@en ,
+                                             "eine owl:ObjectProperty, die ein ec:EditorialSegment mit einem ec:EditorialSegment verbindet"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasParentMediaResource
+ec:hasParentMediaResource rdf:type owl:ObjectProperty ;
+                          dcterms:description "Links a media resource to its parent media resource."@en ,
+                                              "Verknüpft eine Medienressource mit ihrer übergeordneten Medienressource."@de ;
+                          rdfs:label "Elternressource"@de ,
+                                     "Parent resource"@en ;
+                          skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:MediaResource"@en ,
+                                          "eine owl:ObjectProperty, die eine ec:MediaResource mit einer ec:MediaResource verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasPart
+ec:hasPart rdf:type owl:ObjectProperty ;
+           owl:inverseOf ec:isPartOf ;
+           dcterms:description "Defines Parts (segments, fragments, shots, etc.) within an EditorialObject."@en ,
+                               "Definiert Teile (Segmente, Fragmente, Shots usw.) innerhalb eines EditorialObject."@de ;
+           rdfs:label "Part"@en ,
+                      "Teil"@de ;
+           skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:EditorialSegment"@en ,
+                           "eine owl:ObjectProperty, die ein ec:EditorialObject mit einem ec:EditorialSegment verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasParticipatingAgent
+ec:hasParticipatingAgent rdf:type owl:ObjectProperty ;
+                         dcterms:description "Identifies the agent participating in the asset."@en ,
+                                             "Identifiziert den Agenten, der am Asset beteiligt ist."@de ;
+                         rdfs:label "Participating agent"@en ,
+                                    "Teilnehmender Agent"@de ;
+                         skos:definition "an owl:ObjectProperty relating an ec:Asset to an ec:Agent"@en ,
+                                         "eine owl:ObjectProperty, die eine ec:Asset mit einem ec:Agent verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasPictogram
+ec:hasPictogram rdf:type owl:ObjectProperty ;
+                dcterms:description "A visual representation used for a Rating, AudienceRating, or AudienceLevel."@en ,
+                                    "Eine visuelle Darstellung, die für eine Bewertung, AudienceRating oder AudienceLevel verwendet wird."@de ;
+                rdfs:label "Pictogram"@en ,
+                           "Piktogramm"@de ;
+                skos:definition "an owl:ObjectProperty relating an ec:Rating to an ec:Picture"@en ,
+                                "eine owl:ObjectProperty, die ec:Rating mit ec:Picture verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasPlaceOfBirth
+ec:hasPlaceOfBirth rdf:type owl:ObjectProperty ;
+                   dcterms:description "Der Ort, an dem eine Person geboren wurde."@de ,
+                                       "The place where a person was born."@en ;
+                   rdfs:label "Birth place"@en ,
+                              "Geburtsort"@de ;
+                   skos:definition "an owl:ObjectProperty relating an ec:Person to an ec:Location"@en ,
+                                   "eine owl:ObjectProperty, die ec:Person mit ec:Location verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasPlaceOfDeath
+ec:hasPlaceOfDeath rdf:type owl:ObjectProperty ;
+                   dcterms:description "Der Ort, an dem eine Person gestorben ist."@de ,
+                                       "The place where a person died."@en ;
+                   rdfs:label "Death place"@en ,
+                              "Sterbeort"@de ;
+                   skos:definition "an owl:ObjectProperty relating an ec:Person to an ec:Location"@en ,
+                                   "eine owl:ObjectProperty, die eine ec:Person mit einer ec:Location verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasPost
+ec:hasPost rdf:type owl:ObjectProperty ;
+           dcterms:description "Connects an item to a post it is associated with or incorporated into."@en ,
+                               "Verknüpft ein Item mit einem Post, mit dem es assoziiert ist oder in den es eingebettet ist."@de ;
+           rdfs:label "Has post"@en ,
+                      "Hat Post"@de ;
+           skos:definition "an owl:ObjectProperty relating an ec:Item to an ec:Post"@en ,
+                           "eine owl:ObjectProperty, die ein ec:Item mit einem ec:Post verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasPreviousRelated
+ec:hasPreviousRelated rdf:type owl:ObjectProperty ;
+                      dcterms:description "Der zuvor zugehörige ProductionJob."@de ,
+                                          "The previous associated ProductionJob."@en ;
+                      rdfs:label "Previous job"@en ,
+                                 "Vorheriger Job"@de ;
+                      skos:definition "an owl:ObjectProperty relating an ec:ProductionJob to an ec:ProductionJob"@en ,
+                                      "eine owl:ObjectProperty, die eine ec:ProductionJob mit einer ec:ProductionJob verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasPriority
+ec:hasPriority rdf:type owl:ObjectProperty ;
+               dcterms:description "Der einem Rule zugeordnete Prioritätswert."@de ,
+                                   "The priority associated with a Rule."@en ;
+               rdfs:label "Regelpriorität"@de ,
+                          "Rule priority"@en ;
+               skos:definition "an owl:ObjectProperty relating an ec:Rule to a skos:Concept"@en ,
+                               "eine owl:ObjectProperty, die eine ec:Rule mit einem skos:Concept verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasProducer
+ec:hasProducer rdf:type owl:ObjectProperty ;
+               dcterms:description "Der am Produktionsprozess der Ressource oder des EditorialObject beteiligte Agent."@de ,
+                                   "The Agent involved in the production of the Resource or EditorialObject."@en ;
+               rdfs:label "Producer"@en ,
+                          "Produzent"@de ;
+               skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Agent"@en ,
+                               "eine owl:ObjectProperty, die ein ec:EditorialObject mit einem ec:Agent verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasProductionContract
+ec:hasProductionContract rdf:type owl:ObjectProperty ;
+                         dcterms:description "Diese Eigenschaft verknüpft einen Produktionsauftrag mit den ihm zugeordneten Verträgen."@de ,
+                                             "This property links a production order to the contracts associated with it."@en ;
+                         rdfs:label "Contract"@en ,
+                                    "Vertrag"@de ;
+                         skos:definition "an owl:ObjectProperty relating an ec:ProductionOrder to an ec:Contract"@en ,
+                                         "eine owl:ObjectProperty, die eine ec:ProductionOrder mit einem ec:Contract verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasProductionDevice
+ec:hasProductionDevice rdf:type owl:ObjectProperty ;
+                       dcterms:description "A production device associated with a media resource."@en ,
+                                           "Ein Produktionsgerät, das mit einer Medienressource verknüpft ist."@de ;
+                       rdfs:label "Production device"@en ,
+                                  "Produktionsgerät"@de ;
+                       skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:ProductionDevice"@en ,
+                                       "eine owl:ObjectProperty, die eine ec:MediaResource mit einem ec:ProductionDevice verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasProductionDeviceOnStagePosition
+ec:hasProductionDeviceOnStagePosition rdf:type owl:ObjectProperty ;
+                                      dcterms:description "Die OnStagePosition eines ProductionDevice auf der Bühne."@de ,
+                                                          "The OnStagePosition of a ProductionDevice on Stage."@en ;
+                                      rdfs:label "Production device"@en ,
+                                                 "Produktionsgerät"@de ;
+                                      skos:definition "an owl:ObjectProperty relating an ec:ProductionDevice to an ec:OnStagePosition"@en ,
+                                                      "eine owl:ObjectProperty, die ein ec:ProductionDevice mit einer ec:OnStagePosition verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasProductionJobEvent
+ec:hasProductionJobEvent rdf:type owl:ObjectProperty ;
+                         dcterms:description "An event associated with a production job."@en ,
+                                             "Ein mit einem Produktionsauftrag verbundenes Ereignis."@de ;
+                         rdfs:label "Production job event"@en ,
+                                    "Produktionsauftrag-Ereignis"@de ;
+                         skos:definition "an owl:ObjectProperty relating an ec:ProductionJob to an ec:Event"@en ,
+                                         "ein owl:ObjectProperty, das eine ec:ProductionJob mit einem ec:Event verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasProductionJobLocation
+ec:hasProductionJobLocation rdf:type owl:ObjectProperty ;
+                            dcterms:description "Der Ort, an dem ein ProductionJob stattgefunden hat oder stattfinden soll."@de ,
+                                                "The location where a ProductionJob has taken place or is scheduled to take place."@en ;
+                            rdfs:label "Ort des Produktionsauftrags"@de ,
+                                       "Production job location"@en ;
+                            skos:definition "an owl:ObjectProperty relating an ec:ProductionJob to an ec:Location"@en ,
+                                            "eine owl:ObjectProperty, die ec:ProductionJob mit ec:Location verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasProgramme
+ec:hasProgramme rdf:type owl:ObjectProperty ;
+                dcterms:description "Bezieht eine Ressource auf ein Programm, das sie als Teil ihres Inhalts hat oder enthält. Es wird für redaktionelle Extras, Inhalte und Szenen verwendet, die mit einem Programm verbunden sind."@de ,
+                                    "Relates a resource to a programme it has or includes as part of its content. It is used for editorial extras, items, and scenes that are associated with a programme."@en ;
+                rdfs:label "Has programme"@en ,
+                           "Hat Programm"@de ;
+                skos:definition "an owl:ObjectProperty relating an ec:EditorialExtra, ec:Item or ec:Scene to an ec:Programme"@en ,
+                                "eine owl:ObjectProperty, die ec:EditorialExtra, ec:Item oder ec:Scene mit einem ec:Programme verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasPromotion
+ec:hasPromotion rdf:type owl:ObjectProperty ;
+                dcterms:description "A reminder that refers to a previous promotion and helps remind the consumer of the advertised object."@en ,
+                                    "Eine Erinnerung, die sich auf eine frühere Promotion bezieht und den Verbraucher an das beworbene Objekt erinnert."@de ;
+                rdfs:label "Has promotion"@en ,
+                           "Hat Förderung"@de ;
+                skos:definition "an owl:ObjectProperty relating an ec:Reminder to an ec:Promotion"@en ,
+                                "eine owl:ObjectProperty, die ec:Reminder mit ec:Promotion verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasProvenance
+ec:hasProvenance rdf:type owl:ObjectProperty ;
+                 owl:inverseOf ec:hasProvenanceTarget ;
+                 dcterms:description "Die Person oder das Unternehmen, das die Metadaten bereitstellt."@de ,
+                                     "The person or company providing the metadata."@en ;
+                 rdfs:label "Provenance"@en ,
+                            "Provenienz"@de ;
+                 skos:definition "an owl:ObjectProperty relating an ec:Provenance to an owl:Thing"@en ,
+                                 "eine owl:ObjectProperty, die eine ec:Provenance mit einem owl:Thing verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasProvenanceTarget
+ec:hasProvenanceTarget rdf:type owl:ObjectProperty ;
+                       dcterms:description "Die Instanz eines Objekts, das durch die Provenienz erfasst wurde."@de ,
+                                           "The instance of an object sourced by the Provenance."@en ;
+                       rdfs:label "Provenance target"@en ,
+                                  "Provenienz-Ziel"@de ;
+                       skos:definition "an owl:ObjectProperty relating an ec:Provenance to an owl:Thing"@en ,
+                                       "eine owl:ObjectProperty, die ec:Provenance mit owl:Thing verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasPublication
+ec:hasPublication rdf:type owl:ObjectProperty ;
+                  owl:inverseOf ec:publishes ;
+                  dcterms:description "Der PublicationEvent, in dem ein EditorialObject zur Nutzung bereitgestellt wird."@de ,
+                                      "The PublicationEvent in which an EditorialObject is made available for consumption."@en ;
+                  rdfs:label "Publication event"@en ,
+                             "Publikationsereignis"@de ;
+                  skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:PublicationEvent"@en ,
+                                  "eine owl:ObjectProperty, die eine ec:EditorialObject mit einem ec:PublicationEvent verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasPublicationChannel
+ec:hasPublicationChannel rdf:type owl:ObjectProperty ;
+                         dcterms:description "An object property that links a publication event or publication platform to a publication channel used for technical access to a service."@en ,
+                                             "Eine Objekt-Eigenschaft, die ein Veröffentlichungsereignis oder eine Veröffentlichungsplattform mit einem Veröffentlichungskanal verknüpft, der für den technischen Zugriff auf einen Dienst verwendet wird."@de ;
+                         rdfs:label "Has publication channel"@en ,
+                                    "Hat Veröffentlichungskanal"@de ;
+                         skos:definition "an owl:ObjectProperty relating an ec:PublicationEvent or ec:PublicationPlatform to an ec:PublicationChannel"@en ,
+                                         "eine owl:ObjectProperty, die eine ec:PublicationEvent oder ec:PublicationPlatform mit einer ec:PublicationChannel verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasPublicationEvent
+ec:hasPublicationEvent rdf:type owl:ObjectProperty ;
+                       dcterms:description "Associates publication events with publication channels, publication histories, or publication plans."@en ,
+                                           "Verknüpft Veröffentlichungsvorgänge mit Veröffentlichungskanälen, Veröffentlichungshistorien oder Veröffentlichungsplänen."@de ;
+                       rdfs:label "Publication event"@en ,
+                                  "Publikationsereignis"@de ;
+                       skos:definition "an owl:ObjectProperty relating an ec:PublicationEvent to an ec:PublicationEvent"@en ,
+                                       "eine owl:ObjectProperty, die eine ec:PublicationEvent mit einer ec:PublicationEvent verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasPublicationHistory
+ec:hasPublicationHistory rdf:type owl:ObjectProperty ;
+                         dcterms:description "Die Publikationshistorie eines EditorialObject oder MediaResource."@de ,
+                                             "The publication history of an EditorialObject or MediaResource."@en ;
+                         rdfs:label "Publication history"@en ,
+                                    "Veröffentlichungshistorie"@de ;
+                         skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:PublicationHistory"@en ,
+                                         "eine owl:ObjectProperty, die ein ec:EditorialObject mit einer ec:PublicationHistory verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasPublicationMedium
+ec:hasPublicationMedium rdf:type owl:ObjectProperty ;
+                        dcterms:description "Das mit dem Veröffentlichungsvorgang verbundene Veröffentlichungsmedium."@de ,
+                                            "The publication medium associated with the publication event."@en ;
+                        rdfs:label "Publication medium"@en ,
+                                   "Veröffentlichungsmedium"@de ;
+                        skos:definition "an owl:ObjectProperty relating an ec:PublicationEvent to an ec:PublicationMedium"@en ,
+                                        "eine owl:ObjectProperty, die eine ec:PublicationEvent mit einer ec:PublicationMedium verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasPublicationPlan
+ec:hasPublicationPlan rdf:type owl:ObjectProperty ;
+                      dcterms:description "A PublicationPlan associated with a Campaign."@en ,
+                                          "Eine mit einer Campaign verknüpfte PublicationPlan."@de ;
+                      rdfs:label "Publication plan"@en ,
+                                 "Veröffentlichungsplan"@de ;
+                      skos:definition "an owl:ObjectProperty relating an ec:Campaign to an ec:PublicationPlan"@en ,
+                                      "eine owl:ObjectProperty, die eine ec:Campaign mit einem ec:PublicationPlan verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasPublicationPlanMember
+ec:hasPublicationPlanMember rdf:type owl:ObjectProperty ;
+                            dcterms:description "Identifies a sub-plan of a publication plan."@en ,
+                                                "Identifiziert einen Unterplan eines Veröffentlichungsplans."@de ;
+                            rdfs:label "Mitglied des Veröffentlichungsplans"@de ,
+                                       "Publication plan member"@en ;
+                            skos:definition "an owl:ObjectProperty relating an ec:PublicationPlan to an ec:PublicationPlan"@en ,
+                                            "eine owl:ObjectProperty, die eine ec:PublicationPlan mit einer ec:PublicationPlan verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasPublicationPlanStatus
+ec:hasPublicationPlanStatus rdf:type owl:ObjectProperty ;
+                            dcterms:description "Der Status, der mit einem Veröffentlichungsplan verbunden ist."@de ,
+                                                "The status associated with a publication plan."@en ;
+                            rdfs:label "PublicationPlan status"@en ,
+                                       "Status des Publication Plans"@de ;
+                            skos:definition "an owl:ObjectProperty relating an ec:PublicationPlan to a skos:Collection"@en ,
+                                            "eine owl:ObjectProperty, die eine ec:PublicationPlan mit einer skos:Collection verbindet"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasPublicationRegion
+ec:hasPublicationRegion rdf:type owl:ObjectProperty ;
+                        dcterms:description "Die Region, in der die Veröffentlichung stattfindet."@de ,
+                                            "The region where the publication takes place."@en ;
+                        rdfs:label "Publication region"@en ,
+                                   "Publikationsregion"@de ;
+                        skos:definition "an owl:ObjectProperty relating an ec:PublicationEvent to an ec:Location"@en ,
+                                        "eine owl:ObjectProperty, die eine ec:PublicationEvent mit einer ec:Location verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasPublisher
+ec:hasPublisher rdf:type owl:ObjectProperty ;
+                dcterms:description "An agent involved in the publication of an editorial object."@en ,
+                                    "Ein Akteur, der an der Veröffentlichung eines redaktionellen Objekts beteiligt ist."@de ;
+                rdfs:label "Publisher"@de ,
+                           "Publisher"@en ;
+                skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Involvement"@en ,
+                                "eine owl:ObjectProperty, die eine ec:EditorialObject mit einer ec:Involvement verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRating
+ec:hasRating rdf:type owl:ObjectProperty ;
+             dcterms:description "Das Vorhandensein einer Rating, die einem EditorialObject zugeordnet ist."@de ,
+                                 "The presence of a Rating attributed to an EditorialObject."@en ;
+             rdfs:label "Bewertung"@de ,
+                        "Rating"@en ;
+             skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Rating"@en ,
+                             "eine owl:ObjectProperty, die ec:EditorialObject mit ec:Rating verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRatingProvider
+ec:hasRatingProvider rdf:type owl:ObjectProperty ;
+                     dcterms:description "An Agent who provided the Rating."@en ,
+                                         "Eine Agentin oder ein Agent, die bzw. der die Bewertung bereitgestellt hat."@de ;
+                     rdfs:label "Bewertungsquelle / Agent"@de ,
+                                "Rating source / agent"@en ;
+                     skos:definition "an owl:ObjectProperty relating an ec:Rating to an ec:Agent"@en ,
+                                     "eine owl:ObjectProperty, die ec:Rating mit ec:Agent verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRegionCode
+ec:hasRegionCode rdf:type owl:ObjectProperty ;
+                 dcterms:description "A region code associated with a location."@en ,
+                                     "Ein Regionencode, der mit einem Standort verbunden ist."@de ;
+                 rdfs:label "Region"@de ,
+                            "Region"@en ;
+                 skos:definition "an owl:ObjectProperty relating an ec:Location to an ec:RegionCode"@en ,
+                                 "eine owl:ObjectProperty, die eine ec:Location mit einem ec:RegionCode verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRegistration
+ec:hasRegistration rdf:type owl:ObjectProperty ;
+                   dcterms:description "Die Kontodaten eines registrierten Verbrauchers."@de ,
+                                       "The account details of a registered consumer."@en ;
+                   rdfs:label "Registration"@en ,
+                              "Registrierung"@de ;
+                   skos:definition "an owl:ObjectProperty relating an ec:Consumer to an ec:Account"@en ,
+                                   "eine owl:ObjectProperty, die einen ec:Consumer mit einem ec:Account verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedAccount
+ec:hasRelatedAccount rdf:type owl:ObjectProperty ,
+                              owl:IrreflexiveProperty ;
+                     dcterms:description "Links one account to related accounts."@en ,
+                                         "Verknüpft ein Konto mit verwandten Konten."@de ;
+                     rdfs:label "Related account"@en ,
+                                "Zugehöriges Konto"@de ;
+                     skos:definition "an owl:ObjectProperty relating an ec:Account to an ec:Account"@en ,
+                                     "eine owl:ObjectProperty, die eine ec:Account mit einer ec:Account verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedAgent
+ec:hasRelatedAgent rdf:type owl:ObjectProperty ;
+                   owl:inverseOf ec:isRelatedAgent ;
+                   rdf:type owl:IrreflexiveProperty ;
+                   dcterms:description "Links an entity to a related Agent, such as a Person or Character."@en ,
+                                       "Verknüpft eine Entität mit einem zugehörigen Agenten, wie etwa einer Person oder Figur."@de ;
+                   rdfs:label "Related agent"@en ,
+                              "Verwandter Agent"@de ;
+                   skos:definition "an owl:ObjectProperty relating an ec:Action to an ec:Agent"@en ,
+                                   "eine owl:ObjectProperty, die eine ec:Action mit einem ec:Agent verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedAnimal
+ec:hasRelatedAnimal rdf:type owl:ObjectProperty ;
+                    dcterms:description "Animals related to the editorial object or depicted in it."@en ,
+                                        "Tiere, die mit dem redaktionellen Objekt verbunden sind oder in ihm dargestellt sind."@de ;
+                    rdfs:label "Related animal"@en ,
+                               "Verwandtes Tier"@de ;
+                    skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Animal"@en ,
+                                    "eine owl:ObjectProperty, die ec:EditorialObject mit ec:Animal verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedArtefact
+ec:hasRelatedArtefact rdf:type owl:ObjectProperty ;
+                      dcterms:description "An artefact related to an annotation, asset, event, involvement, or location."@en ,
+                                          "Ein Artefakt, das mit einer Annotation, einem Asset, einem Ereignis, einer Beteiligung oder einem Ort verknüpft ist."@de ;
+                      rdfs:label "Related artefact"@en ,
+                                 "Verwandtes Artefakt"@de ;
+                      skos:definition "an owl:ObjectProperty relating an ec:Annotation or ec:Asset, ec:Event, ec:Involvement, or ec:Location to an ec:Artefact"@en ,
+                                      "eine owl:ObjectProperty, die eine ec:Annotation oder ein ec:Asset, ec:Event, ec:Involvement oder ec:Location mit einem ec:Artefact verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedAsset
+ec:hasRelatedAsset rdf:type owl:ObjectProperty ,
+                            owl:IrreflexiveProperty ;
+                   dcterms:description "Links an Asset to another related Asset."@en ,
+                                       "Verknüpft ein Asset mit einem anderen verwandten Asset."@de ;
+                   rdfs:label "Related asset"@en ,
+                              "Verknüpftes Asset"@de ;
+                   skos:definition "an owl:ObjectProperty relating an ec:Asset to an ec:Asset"@en ,
+                                   "eine owl:ObjectProperty, die eine ec:Asset mit einer ec:Asset verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedAudioContent
+ec:hasRelatedAudioContent rdf:type owl:ObjectProperty ,
+                                   owl:IrreflexiveProperty ;
+                          dcterms:description "Related audio content associated with the editorial object."@en ,
+                                              "Verwandte Audiinhalte, die dem redaktionellen Objekt zugeordnet sind."@de ;
+                          rdfs:label "Audio content"@en ,
+                                     "Audioinhalt"@de ;
+                          skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:AudioContent"@en ,
+                                          "eine owl:ObjectProperty, die ein ec:EditorialObject mit einem ec:AudioContent verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedAudioObject
+ec:hasRelatedAudioObject rdf:type owl:ObjectProperty ;
+                         dcterms:description "A property that identifies a related audio object."@en ,
+                                             "Eine Eigenschaft, die ein zugehöriges Audioobjekt identifiziert."@de ;
+                         rdfs:label "Audio object"@en ,
+                                    "Audioobjekt"@de ;
+                         skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:AudioObject"@en ,
+                                         "eine owl:ObjectProperty, die eine ec:MediaResource mit einem ec:AudioObject verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedAudioProgramme
+ec:hasRelatedAudioProgramme rdf:type owl:ObjectProperty ,
+                                     owl:IrreflexiveProperty ;
+                            dcterms:description "A related audio programme."@en ,
+                                                "Ein zugehöriges Audioprogramm."@de ;
+                            rdfs:label "Audio programme"@en ,
+                                       "Audio-Programm"@de ;
+                            skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:AudioProgramme"@en ,
+                                            "eine owl:ObjectProperty, die ein ec:EditorialObject mit einem ec:AudioProgramme verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedAudioTrack
+ec:hasRelatedAudioTrack rdf:type owl:ObjectProperty ;
+                        dcterms:description "A related audio track associated with the media resource."@en ,
+                                            "Ein zugehöriger Audiotrack, der mit der Medienressource verbunden ist."@de ;
+                        rdfs:label "Audio track"@en ,
+                                   "Audiotrack"@de ;
+                        skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:AudioTrack"@en ,
+                                        "eine owl:ObjectProperty, die eine ec:MediaResource mit einer ec:AudioTrack verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedAuditJob
+ec:hasRelatedAuditJob rdf:type owl:ObjectProperty ;
+                      dcterms:description "Das AuditJob oder die AuditJobs, die mit einem AuditReport verknüpft sind."@de ,
+                                          "The AuditJob or AuditJobs related to an AuditReport."@en ;
+                      rdfs:label "Audit job(s)"@en ,
+                                 "Auditaufgabe(n)"@de ;
+                      skos:definition "an owl:ObjectProperty relating an ec:AuditReport to an ec:AuditJob"@en ,
+                                      "eine owl:ObjectProperty, die ec:AuditReport mit ec:AuditJob verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedAuditReport
+ec:hasRelatedAuditReport rdf:type owl:ObjectProperty ;
+                         dcterms:description "An audit report associated with an asset."@en ,
+                                             "Ein Prüfbericht, der mit einem Asset verknüpft ist."@de ;
+                         rdfs:label "Related audit report"@en ,
+                                    "Verwandter Prüfbericht"@de ;
+                         skos:definition "an owl:ObjectProperty relating an ec:Asset to an ec:AuditReport"@en ,
+                                         "eine owl:ObjectProperty, die ein ec:Asset mit einem ec:AuditReport verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedAward
+ec:hasRelatedAward rdf:type owl:ObjectProperty ;
+                   dcterms:description "An award related to an EditorialObject."@en ,
+                                       "Ein Preis, der mit einem EditorialObject verbunden ist."@de ;
+                   rdfs:label "Related award"@en ,
+                              "Verwandter Preis"@de ;
+                   skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Award"@en ,
+                                   "eine owl:ObjectProperty, die ein ec:EditorialObject mit einem ec:Award verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedCharacter
+ec:hasRelatedCharacter rdf:type owl:ObjectProperty ;
+                       dcterms:description "Das mit dem Konzept verknüpfte Zeichen."@de ,
+                                           "The Character related to the concept."@en ;
+                       rdfs:label "Related character"@en ,
+                                  "Verwandte Figur"@de ;
+                       skos:definition "an owl:ObjectProperty relating an ec:TextLine to an ec:Character"@en ,
+                                       "eine owl:ObjectProperty, die eine ec:TextLine mit einem ec:Character verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedConsumptionEvent
+ec:hasRelatedConsumptionEvent rdf:type owl:ObjectProperty ,
+                                       owl:IrreflexiveProperty ;
+                              dcterms:description "A related consumption event."@en ,
+                                                  "Ein zugehöriges Verbrauchsereignis."@de ;
+                              rdfs:label "Related consumption event"@en ,
+                                         "Zugehöriges Konsumereignis"@de ;
+                              skos:definition "an owl:ObjectProperty relating an ec:ConsumptionEvent to an ec:ConsumptionEvent"@en ,
+                                              "eine owl:ObjectProperty, die eine ec:ConsumptionEvent mit einer ec:ConsumptionEvent verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedEditorialObject
+ec:hasRelatedEditorialObject rdf:type owl:ObjectProperty ,
+                                      owl:IrreflexiveProperty ;
+                             dcterms:description "Mit dieser Eigenschaft verknüpfte verwandte redaktionelle Objekte."@de ,
+                                                 "Related editorial objects associated with this property."@en ;
+                             rdfs:label "Related editorial object"@en ,
+                                        "Verwandtes redaktionelles Objekt"@de ;
+                             skos:definition "an owl:ObjectProperty relating an ec:Artefact, ec:Asset, or ec:EditorialObject to an ec:EditorialObject"@en ,
+                                             "eine owl:ObjectProperty, die ein ec:Artefact, ec:Asset oder ec:EditorialObject mit einem ec:EditorialObject verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedEssence
+ec:hasRelatedEssence rdf:type owl:ObjectProperty ,
+                              owl:IrreflexiveProperty ;
+                     dcterms:description "To establish a relation between a MediaResource and an Essence."@en ,
+                                         "Zur Herstellung einer Beziehung zwischen einer MediaResource und einer Essence."@de ;
+                     rdfs:label "Related essence"@en ,
+                                "Verwandte Essenz"@de ;
+                     skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:Essence"@en ,
+                                     "eine owl:ObjectProperty, die eine ec:MediaResource mit einer ec:Essence in Beziehung setzt"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedEvent
+ec:hasRelatedEvent rdf:type owl:ObjectProperty ,
+                            owl:IrreflexiveProperty ;
+                   dcterms:description "An event associated with the concept."@en ,
+                                       "Ein Ereignis, das mit dem Konzept verbunden ist."@de ;
+                   rdfs:label "Related event"@en ,
+                              "Veranstaltungsbezogen"@de ;
+                   skos:definition "an owl:ObjectProperty relating an ec:Annotation to an ec:Event"@en ,
+                                   "eine owl:ObjectProperty, die eine ec:Annotation mit einem ec:Event verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedMediaFragment
+ec:hasRelatedMediaFragment rdf:type owl:ObjectProperty ,
+                                    owl:IrreflexiveProperty ;
+                           dcterms:description "Associates a resource with a related media fragment, such as a temporal or spatial segment of that resource."@en ,
+                                               "Ordnet eine Ressource einem zugehörigen Medienfragment zu, etwa einem zeitlichen oder räumlichen Segment dieser Ressource."@de ;
+                           rdfs:label "Media fragment"@en ,
+                                      "Medienfragment"@de ;
+                           skos:definition "an owl:ObjectProperty relating an ec:Resource to an ec:MediaFragment"@en ,
+                                           "eine owl:ObjectProperty, die eine ec:Resource mit einem ec:MediaFragment verbindet"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedMediaResource
+ec:hasRelatedMediaResource rdf:type owl:ObjectProperty ;
+                           dcterms:description "A media resource associated with an editorial object."@en ,
+                                               "Eine Medienressource, die mit einem redaktionellen Objekt verknüpft ist."@de ;
+                           rdfs:label "Related media resource"@en ,
+                                      "Verwandte Medienressource"@de ;
+                           skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:MediaResource"@en ,
+                                           "eine owl:ObjectProperty, die eine ec:EditorialObject mit einer ec:MediaResource verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedPicture
+ec:hasRelatedPicture rdf:type owl:ObjectProperty ;
+                     dcterms:description "Associates a Picture with an EditorialObject."@en ,
+                                         "Verknüpft ein Bild mit einem EditorialObject."@de ;
+                     rdfs:label "Bild"@de ,
+                                "Picture"@en ;
+                     skos:definition "an owl:ObjectProperty relating an ec:Asset to an ec:Picture"@en ,
+                                     "eine owl:ObjectProperty, die ein ec:Asset mit einem ec:Picture verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedPublicationChannel
+ec:hasRelatedPublicationChannel rdf:type owl:ObjectProperty ,
+                                         owl:IrreflexiveProperty ;
+                                dcterms:description "A property that identifies a related publication channel."@en ,
+                                                    "Eine Eigenschaft, die einen verwandten Veröffentlichungskanal identifiziert."@de ;
+                                rdfs:label "Publication channel"@en ,
+                                           "Publikationskanal"@de ;
+                                skos:definition "an owl:ObjectProperty relating an ec:PublicationChannel to an ec:PublicationChannel"@en ,
+                                                "eine owl:ObjectProperty, die eine ec:PublicationChannel mit einer ec:PublicationChannel verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedPublicationEvent
+ec:hasRelatedPublicationEvent rdf:type owl:ObjectProperty ,
+                                       owl:IrreflexiveProperty ;
+                              dcterms:description "Die mit der Ressource verknüpfte PublicationEvent."@de ,
+                                                  "The PublicationEvent associated with the resource."@en ;
+                              rdfs:label "Publication event"@en ,
+                                         "Veröffentlichungsereignis"@de ;
+                              skos:definition "an ec:ObjectProperty relating an ec:ConsumptionEvent or ec:Essence to an ec:PublicationEvent"@en ,
+                                              "eine ec:ObjectProperty, die ein ec:ConsumptionEvent oder eine ec:Essence mit einem ec:PublicationEvent verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedPublicationService
+ec:hasRelatedPublicationService rdf:type owl:ObjectProperty ,
+                                         owl:IrreflexiveProperty ;
+                                dcterms:description "To establish a relation to publication services."@en ,
+                                                    "Zur Herstellung einer Beziehung zu Veröffentlichungsdiensten."@de ;
+                                rdfs:label "Related publication service"@en ,
+                                           "Zugehöriger Veröffentlichungsdienst"@de ;
+                                skos:definition "an owl:ObjectProperty relating an ec:PublicationPlatform to an ec:PublicationService"@en ,
+                                                "eine owl:ObjectProperty, die eine ec:PublicationPlatform mit einer ec:PublicationService verbindet"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedRecord
+ec:hasRelatedRecord rdf:type owl:ObjectProperty ,
+                             owl:IrreflexiveProperty ;
+                    dcterms:description "Der mit einem Asset verknüpfte Datensatz."@de ,
+                                        "The record associated with an asset."@en ;
+                    rdfs:label "Related record"@en ,
+                               "Verknüpfter Datensatz"@de ;
+                    skos:definition "an owl:ObjectProperty relating an ec:Asset to an ec:Record"@en ,
+                                    "eine owl:ObjectProperty, die eine ec:Asset mit einem ec:Record verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedResonanceEvent
+ec:hasRelatedResonanceEvent rdf:type owl:ObjectProperty ;
+                            dcterms:description "Associates a ResonanceEvent with an EditorialObject."@en ,
+                                                "Ordnet ein ResonanceEvent einem EditorialObject zu."@de ;
+                            rdfs:label "Related resonance event"@en ,
+                                       "Verwandtes Resonanzereignis"@de ;
+                            skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:ResonanceEvent"@en ,
+                                            "eine owl:ObjectProperty, die ein ec:EditorialObject mit einem ec:ResonanceEvent verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedResource
+ec:hasRelatedResource rdf:type owl:ObjectProperty ;
+                      dcterms:description "A resource associated with an asset, editorial object, publication event, or another resource."@en ,
+                                          "Eine Ressource, die mit einem Asset, einem redaktionellen Objekt, einem Veröffentlichungsereignis oder einer anderen Ressource verbunden ist."@de ;
+                      rdfs:label "Related resource"@en ,
+                                 "Verwandte Ressource"@de ;
+                      skos:definition "an owl:ObjectProperty relating an ec:Asset or ec:EditorialObject or ec:PublicationEvent or ec:Resource to an ec:Resource"@en ,
+                                      "eine owl:ObjectProperty, die eine ec:Asset oder ec:EditorialObject oder ec:PublicationEvent oder ec:Resource mit einer ec:Resource verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedRule
+ec:hasRelatedRule rdf:type owl:ObjectProperty ;
+                  dcterms:description "References to a Rule."@en ,
+                                      "Verweise auf eine Regel."@de ;
+                  rdfs:label "Regelverweis"@de ,
+                             "Rule reference"@en ;
+                  skos:definition "an owl:ObjectProperty relating an ec:Rule to an ec:Rule"@en ,
+                                  "eine owl:ObjectProperty, die eine ec:Rule mit einer ec:Rule verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedScene
+ec:hasRelatedScene rdf:type owl:ObjectProperty ;
+                   dcterms:description "A property that associates a concept with a scene."@en ,
+                                       "Eine Eigenschaft, die ein Konzept mit einer Szene verknüpft."@de ;
+                   rdfs:label "Related scene"@en ,
+                              "Verwandte Szene"@de ;
+                   skos:definition "an owl:ObjectProperty relating an ec:Action, ec:Emotion, or ec:TextLine to an ec:Scene"@en ,
+                                   "eine owl:ObjectProperty, die eine ec:Action, ec:Emotion oder ec:TextLine mit einer ec:Scene verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedStage
+ec:hasRelatedStage rdf:type owl:ObjectProperty ;
+                   dcterms:description "A relationship that links an on-stage position to the stage it is on."@en ,
+                                       "Eine Beziehung, die eine Position auf der Bühne mit der Bühne verknüpft, auf der sie sich befindet."@de ;
+                   rdfs:label "Related stage"@en ,
+                              "Zugehörige Bühne"@de ;
+                   skos:definition "an owl:ObjectProperty relating an ec:OnStagePosition to an ec:Stage"@en ,
+                                   "eine owl:ObjectProperty, die eine ec:OnStagePosition mit einer ec:Stage verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedTextLine
+ec:hasRelatedTextLine rdf:type owl:ObjectProperty ;
+                      dcterms:description "A TextLine or free text related to an EditorialObject."@en ,
+                                          "Eine TextLine oder freier Text, der sich auf ein EditorialObject bezieht."@de ;
+                      rdfs:label "Related text line"@en ,
+                                 "Verwandte Textzeile"@de ;
+                      skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:TextLine"@en ,
+                                      "eine owl:ObjectProperty, die eine ec:EditorialObject mit einer ec:TextLine verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelationLink
+ec:hasRelationLink rdf:type owl:ObjectProperty ;
+                   dcterms:description "A link within a Relation."@en ,
+                                       "Ein Link innerhalb einer Relation."@de ;
+                   rdfs:label "Link"@en ,
+                              "Verknüpfung"@de ;
+                   skos:definition "an owl:ObjectProperty relating an ec:Relation to an owl:Thing"@en ,
+                                   "eine owl:ObjectProperty, die eine ec:Relation mit einem owl:Thing verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelationSource
+ec:hasRelationSource rdf:type owl:ObjectProperty ;
+                     dcterms:description "Die Quelle einer Relation."@de ,
+                                         "The source of a relation."@en ;
+                     rdfs:label "Relation source"@en ,
+                                "Relationsquelle"@de ;
+                     skos:definition "an owl:ObjectProperty relating an ec:Relation to an ec:Agent"@en ,
+                                     "eine owl:ObjectProperty, die eine ec:Relation mit einem ec:Agent verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasResourceOffset
+ec:hasResourceOffset rdf:type owl:ObjectProperty ;
+                     dcterms:description "Der Start-Offset innerhalb einer Ressource."@de ,
+                                         "The start offset within a Resource."@en ;
+                     rdfs:label "Resource offset"@en ,
+                                "Ressourcen-Offset"@de ;
+                     skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:TimelinePoint"@en ,
+                                     "eine owl:ObjectProperty, die ein ec:EditorialObject mit einem ec:TimelinePoint verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRestrictedAudience
+ec:hasRestrictedAudience rdf:type owl:ObjectProperty ;
+                         dcterms:description "An Audience for which access is restricted."@en ,
+                                             "Eine Audience, für die der Zugriff eingeschränkt ist."@de ;
+                         rdfs:label "Eingeschränktes Publikum"@de ,
+                                    "Restricted audience"@en ;
+                         skos:definition "an owl:ObjectProperty relating an ec:PublicationEvent to an ec:Audience"@en ,
+                                         "eine owl:ObjectProperty, die ec:PublicationEvent mit ec:Audience verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasReview
+ec:hasReview rdf:type owl:ObjectProperty ;
+             dcterms:description "An audio or audio-visual report in which somebody gives their opinion of a play, film, or other editorial object."@en ,
+                                 "Ein Audio- oder audio-visueller Bericht, in dem jemand seine Meinung zu einem Theaterstück, Film oder einem anderen redaktionellen Objekt äußert."@de ;
+             rdfs:label "Review"@en ,
+                        "Rezension"@de ;
+             skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Review"@en ,
+                             "eine owl:ObjectProperty, die ein ec:EditorialObject mit einem ec:Review verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRights
+ec:hasRights rdf:type owl:ObjectProperty ;
+             dcterms:description "An object property that links an asset or publication event to the rights that cover it."@en ,
+                                 "Eine Objekt-Eigenschaft, die ein Asset oder ein Veröffentlichungsereignis mit den Rechten verknüpft, die es abdecken."@de ;
+             rdfs:label "Is covered by"@en ,
+                        "Ist abgedeckt von"@de ;
+             skos:definition "an owl:ObjectProperty relating an ec:Asset to ec:Rights"@en ,
+                             "eine owl:ObjectProperty, die ein ec:Asset mit ec:Rights verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRightsClearance
+ec:hasRightsClearance rdf:type owl:ObjectProperty ;
+                      rdfs:subPropertyOf ec:hasRights ;
+                      dcterms:description "Die dem Asset zugeordnete Rechtefreigabe."@de ,
+                                          "The rights clearance associated with an asset."@en ;
+                      rdfs:label "Rechtefreigabe"@de ,
+                                 "Rights clearance"@en ;
+                      skos:definition "an owl:ObjectProperty relating an ec:Asset to an ec:RightsClearance"@en ,
+                                      "eine owl:ObjectProperty, die eine ec:Asset mit einer ec:RightsClearance verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRightsHolder
+ec:hasRightsHolder rdf:type owl:ObjectProperty ;
+                   dcterms:description "Der Agent, der die mit der Ressource verbundenen Rechte hält oder verwaltet."@de ,
+                                       "The agent that holds or manages the rights associated with the resource."@en ;
+                   rdfs:label "Rechteinhaber"@de ,
+                              "Rights holder"@en ;
+                   skos:definition "an owl:ObjectProperty relating an ec:Rights to an ec:Agent"@en ,
+                                   "eine owl:ObjectProperty, die ec:Rights mit ec:Agent verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRightsTargetService
+ec:hasRightsTargetService rdf:type owl:ObjectProperty ;
+                          dcterms:description "Der mit den Rechten verbundene Dienst."@de ,
+                                              "The service associated with the rights."@en ;
+                          rdfs:label "Target service"@en ,
+                                     "Zieldienst"@de ;
+                          skos:definition "an owl:ObjectProperty relating an ec:Rights to an ec:PublicationService"@en ,
+                                          "eine owl:ObjectProperty, die ec:Rights mit ec:PublicationService verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRightsTerritoryExcludes
+ec:hasRightsTerritoryExcludes rdf:type owl:ObjectProperty ;
+                              dcterms:description "A list of country or region codes to which Rights do not apply."@en ,
+                                                  "Eine Liste von Länder- oder Regionscodes, für die Rechte nicht gelten."@de ;
+                              rdfs:label "Ausgeschlossene Gebiete"@de ,
+                                         "Excluded territories"@en ;
+                              skos:definition "an owl:ObjectProperty relating an ec:Rights to an ec:CountryCode"@en ,
+                                              "eine owl:ObjectProperty, die eine ec:Rights mit einem ec:CountryCode verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRightsTerritoryIncludes
+ec:hasRightsTerritoryIncludes rdf:type owl:ObjectProperty ;
+                              dcterms:description "A list of country or region codes to which Rights apply."@en ,
+                                                  "Eine Liste von Länder- oder Regionscodes, auf die die Rechte Anwendung finden."@de ;
+                              rdfs:label "Eingeschlossene Gebiete"@de ,
+                                         "Included territories"@en ;
+                              skos:definition "an owl:ObjectProperty relating an ec:Rights to an ec:CountryCode"@en ,
+                                              "eine owl:ObjectProperty, die ec:Rights mit ec:CountryCode verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasScene
+ec:hasScene rdf:type owl:ObjectProperty ;
+            rdfs:subPropertyOf ec:hasPart ;
+            dcterms:description "Identifies a scene that is part of a shot or take."@en ,
+                                "Identifiziert eine Szene, die Teil einer Einstellung oder Aufnahme ist."@de ;
+            rdfs:label "Has scene"@en ,
+                       "Hat Szene"@de ;
+            skos:definition "an owl:ObjectProperty relating an ec:Shot or ec:Take to an ec:Scene"@en ,
+                            "eine owl:ObjectProperty, die eine ec:Shot oder ein ec:Take mit einer ec:Scene verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasScheduleDate
+ec:hasScheduleDate rdf:type owl:ObjectProperty ;
+                   dcterms:description "Das mit einem PublicationEvent verbundene Sendungsdatum, insbesondere wenn die Sendezeit nach Mitternacht liegt. So kann das Sendungsdatum beispielsweise der 29. Mai sein, während das Programm um 1 Uhr am 30. Mai veröffentlicht wird und dennoch im Sendeplan weiterhin der Nacht des 29. Mai zugeordnet bleibt."@de ,
+                                       "The schedule date associated with a PublicationEvent, especially when the broadcast time is after midnight. For example, the schedule date may be May 29th while the programme is published at 1 am on May 30th, yet remains associated in the schedule with the night of May 29th."@en ;
+                   rdfs:label "Plantermin"@de ,
+                              "Schedule date"@en ;
+                   skos:definition "an owl:ObjectProperty relating an ec:PublicationEvent to a time:Instant"@en ,
+                                   "eine owl:ObjectProperty, die ec:PublicationEvent mit time:Instant verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasSeason
+ec:hasSeason rdf:type owl:ObjectProperty ;
+             dcterms:description "Associates a serial or series with a season."@en ,
+                                 "Verknüpft eine Serial oder Serie mit einer Staffel."@de ;
+             rdfs:label "Season"@en ,
+                        "Staffel"@de ;
+             skos:definition "an owl:ObjectProperty relating an ec:Serial or ec:Series to an ec:Season"@en ,
+                             "eine owl:ObjectProperty, die ein ec:Serial oder eine ec:Series mit einer ec:Season verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasSerial
+ec:hasSerial rdf:type owl:ObjectProperty ;
+             dcterms:description "A property that links a season to the serial it contains or is associated with."@en ,
+                                 "Eine Eigenschaft, die eine Season mit dem Serial verknüpft, das sie enthält oder mit dem sie verbunden ist."@de ;
+             rdfs:label "Has serial"@en ,
+                        "Hat Serie"@de ;
+             skos:definition "an owl:ObjectProperty relating an ec:Season to an ec:Serial"@en ,
+                             "eine owl:ObjectProperty, die eine ec:Season mit einem ec:Serial verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasServiceGenre
+ec:hasServiceGenre rdf:type owl:ObjectProperty ;
+                   dcterms:description "Die Genreart der mit dem Service verbundenen Inhalte."@de ,
+                                       "The genre of content associated with the Service."@en ;
+                   rdfs:label "Service genre"@en ,
+                              "Service-Genre"@de ;
+                   skos:definition "an owl:ObjectProperty relating an ec:PublicationService to a skos:Concept"@en ,
+                                   "eine owl:ObjectProperty, die eine ec:PublicationService mit einem skos:Concept verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasShot
+ec:hasShot rdf:type owl:ObjectProperty ;
+           rdfs:subPropertyOf ec:hasPart ;
+           dcterms:description "Identifies a shot that is part of a scene."@en ,
+                               "Kennzeichnet eine Aufnahme, die Teil einer Szene ist."@de ;
+           rdfs:label "Has shot"@en ,
+                      "Hat Aufnahme"@de ;
+           skos:definition "an owl:ObjectProperty relating an ec:Scene to an ec:Shot"@en ,
+                           "eine owl:ObjectProperty, die eine ec:Scene mit einer ec:Shot verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasSigning
+ec:hasSigning rdf:type owl:ObjectProperty ;
+              dcterms:description "Presence of signing associated with the editorial object."@en ,
+                                  "Vorhandensein von Gebärdensprache, die mit dem redaktionellen Objekt verbunden ist."@de ;
+              rdfs:label "Accessibility - signing"@en ,
+                         "Barrierefreiheit - Gebärdensprache"@de ;
+              skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Signing"@en ,
+                              "eine owl:ObjectProperty, die ein ec:EditorialObject mit einem ec:Signing verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasSigningFormat
+ec:hasSigningFormat rdf:type owl:ObjectProperty ;
+                    dcterms:description "Das verwendete Format für die Gebärdensprachdolmetschung."@de ,
+                                        "The format used for sign language interpretation."@en ;
+                    rdfs:label "Gebärdensprachformat"@de ,
+                               "Signing format"@en ;
+                    skos:definition "an owl:ObjectProperty relating an ec:Signing to an ec:SigningFormat"@en ,
+                                    "eine owl:ObjectProperty, die ec:Signing mit ec:SigningFormat verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasSigningSource
+ec:hasSigningSource rdf:type owl:ObjectProperty ;
+                    dcterms:description "Die Quelle, die für die Unterzeichnung verwendet wird."@de ,
+                                        "The source used for signing."@en ;
+                    rdfs:label "Signierungsquelle"@de ,
+                               "Signing source"@en ;
+                    skos:definition "an owl:ObjectProperty relating an ec:Signing to an ec:Agent"@en ,
+                                    "eine owl:ObjectProperty, die eine ec:Signing mit einem ec:Agent verbindet"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasSource
+ec:hasSource rdf:type owl:ObjectProperty ;
+             dcterms:description "Die Quelle, die mit einer MediaResource verknüpft ist."@de ,
+                                 "The source associated with a MediaResource."@en ;
+             rdfs:label "Quelle"@de ,
+                        "Source"@en ;
+             skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:MediaResource"@en ,
+                             "eine owl:ObjectProperty, die eine ec:MediaResource mit einer ec:MediaResource verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasStaffMember
+ec:hasStaffMember rdf:type owl:ObjectProperty ;
+                  dcterms:description "A person who is a member of staff in an organisation."@en ,
+                                      "Eine Person, die in einer Organisation Mitglied des Personals ist."@de ;
+                  rdfs:label "Member of staff"@en ,
+                             "Mitarbeiter"@de ;
+                  skos:definition "an owl:ObjectProperty relating an ec:Organisation to an ec:StaffMember"@en ,
+                                  "eine owl:ObjectProperty, die eine ec:Organisation mit einem ec:StaffMember verbindet"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasStageLocation
+ec:hasStageLocation rdf:type owl:ObjectProperty ;
+                    dcterms:description "Der mit einer Bühne verbundene Ort."@de ,
+                                        "The location associated with a stage."@en ;
+                    rdfs:label "Bühnenort"@de ,
+                               "Stage location"@en ;
+                    skos:definition "an owl:ObjectProperty relating an ec:Stage to an ec:Location"@en ,
+                                    "eine owl:ObjectProperty, die eine ec:Stage mit einer ec:Location verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasStakeholder
+ec:hasStakeholder rdf:type owl:ObjectProperty ;
+                  dcterms:description "An Agent related to a PublicationPlan."@en ,
+                                      "Ein Agent, der mit einem PublicationPlan in Beziehung steht."@de ;
+                  rdfs:label "Publication plan stakeholder"@en ,
+                             "Veranstaltungsplan-Beteiligter"@de ;
+                  skos:definition "an owl:ObjectProperty relating an ec:PublicationPlan to an ec:Agent"@en ,
+                                  "eine owl:ObjectProperty, die ec:PublicationPlan mit ec:Agent verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasStandard
+ec:hasStandard rdf:type owl:ObjectProperty ;
+               rdfs:subPropertyOf ec:hasFormat ;
+               dcterms:description "Identifies the technical video standard of a MediaResource, i.e. NTSC or PAL."@en ,
+                                   "Identifiziert den technischen Videostandard einer MediaResource, z. B. NTSC oder PAL."@de ;
+               rdfs:label "Standard"@de ,
+                          "Standard"@en ;
+               skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:Standard"@en ,
+                               "eine owl:ObjectProperty, die ein ec:MediaResource mit einem ec:Standard verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasStart
+ec:hasStart rdf:type owl:ObjectProperty ;
+            dcterms:description "A property that links an action, event, or related content entity to its starting point on a timeline."@en ,
+                                "Eine Eigenschaft, die eine Handlung, ein Ereignis oder ein verbundenes Inhaltselement mit seinem Startpunkt auf einer Zeitachse verknüpft."@de ;
+            rdfs:label "Beginn"@de ,
+                       "Start"@en ;
+            skos:definition "an owl:ObjectProperty relating an ec:Action to an ec:TimelinePoint"@en ,
+                            "eine owl:ObjectProperty, die eine ec:Action mit einem ec:TimelinePoint verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasStartDateTime
+ec:hasStartDateTime rdf:type owl:ObjectProperty ;
+                    rdfs:subPropertyOf ec:hasDate ;
+                    dcterms:description "A point of time or start of an interval."@en ,
+                                        "Ein Zeitpunkt oder der Beginn eines Intervalls."@de ;
+                    rdfs:label "Start date time"@en ,
+                               "Startdatum und -zeit"@de ;
+                    skos:definition "an owl:ObjectProperty relating an ec:Affiliation to a time:Instant"@en ,
+                                    "eine owl:ObjectProperty, die eine ec:Affiliation mit einem time:Instant verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasSticker
+ec:hasSticker rdf:type owl:ObjectProperty ;
+              dcterms:description "A link to a Sticker associated with a Costume."@en ,
+                                  "Eine Verknüpfung zu einem Sticker, der mit einem Kostüm verbunden ist."@de ;
+              rdfs:label "Link to sticker"@en ,
+                         "Link zu Sticker"@de ;
+              skos:definition "an owl:ObjectProperty relating an ec:Costume to an ec:Sticker"@en ,
+                              "eine owl:ObjectProperty, die ein ec:Costume mit einem ec:Sticker verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasStorageId
+ec:hasStorageId rdf:type owl:ObjectProperty ;
+                dcterms:description "Der Speicher, der mit einem Locator verknüpft ist, über den auf eine Ressource zugegriffen oder sie abgerufen werden kann."@de ,
+                                    "The storage associated with a locator from which a resource can be accessed or retrieved."@en ;
+                rdfs:label "Speicherkennung"@de ,
+                           "Storage identifier"@en ;
+                skos:definition "an owl:ObjectProperty relating an ec:Resource to an ec:Identifier"@en ,
+                                "eine owl:ObjectProperty, die eine ec:Resource mit einem ec:Identifier verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasStorageType
+ec:hasStorageType rdf:type owl:ObjectProperty ;
+                  dcterms:description "A storage type associated with a locator from which a resource can be accessed or retrieved."@en ,
+                                      "Ein Speichertyp, der mit einem Locator verbunden ist, von dem aus auf eine Ressource zugegriffen oder sie abgerufen werden kann."@de ;
+                  rdfs:label "Speichertyp"@de ,
+                             "Storage type"@en ;
+                  skos:definition "an owl:ObjectProperty relating an ec:Resource to an ec:StorageType"@en ,
+                                  "eine owl:ObjectProperty, die eine ec:Resource mit einem ec:StorageType verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasSubJob
+ec:hasSubJob rdf:type owl:ObjectProperty ;
+             dcterms:description "A production job that is part of a complex production job."@en ,
+                                 "Ein Produktionsjob, der Teil eines komplexen Produktionsjobs ist."@de ;
+             rdfs:label "Production job"@en ,
+                        "Produktionstätigkeit"@de ;
+             skos:definition "an owl:ObjectProperty relating an ec:ProductionJob to an ec:ProductionJob"@en ,
+                             "eine owl:ObjectProperty, die eine ec:ProductionJob mit einer ec:ProductionJob verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasSubject
+ec:hasSubject rdf:type owl:ObjectProperty ;
+              dcterms:description "Diese Eigenschaft ermöglicht es, ein Asset mit einem Subject zu verknüpfen, das entweder ein String oder eine URI sein kann, die auf einen Begriff aus einem kontrollierten Vokabular verweist."@de ,
+                                  "This property enables to associate an Asset with a subject which can be a string or a URI pointing to a term from a controlled vocabulary."@en ;
+              rdfs:label "Subject"@en ,
+                         "Thema"@de ;
+              skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Subject"@en ,
+                              "eine owl:ObjectProperty, die ein ec:EditorialObject mit einem ec:Subject verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasSubtitling
+ec:hasSubtitling rdf:type owl:ObjectProperty ;
+                 dcterms:description "Existing subtitling for the editorial object."@en ,
+                                     "Vorhandene Untertitelung für das redaktionelle Objekt."@de ;
+                 rdfs:label "Subtitling"@en ,
+                            "Untertitelung"@de ;
+                 skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Subtitling"@en ,
+                                 "eine owl:ObjectProperty, die ein ec:EditorialObject mit einem ec:Subtitling verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasSubtitlingFormat
+ec:hasSubtitlingFormat rdf:type owl:ObjectProperty ;
+                       rdfs:subPropertyOf ec:hasFormat ;
+                       dcterms:description "Das Format der Untertitelung."@de ,
+                                           "The format of Subtitling."@en ;
+                       rdfs:label "Subtitling format"@en ,
+                                  "Untertitelungsformat"@de ;
+                       skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:SubtitlingFormat"@en ,
+                                       "eine owl:ObjectProperty, die eine ec:MediaResource mit einem ec:SubtitlingFormat verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasSubtitlingSource
+ec:hasSubtitlingSource rdf:type owl:ObjectProperty ;
+                       dcterms:description "Die Quelle der Untertitelungsressource."@de ,
+                                           "The source of the subtitling resource."@en ;
+                       rdfs:label "Subtitling source"@en ,
+                                  "Untertitelquelle"@de ;
+                       skos:definition "an owl:ObjectProperty relating an ec:Subtitling to an ec:Agent"@en ,
+                                       "eine owl:ObjectProperty, die eine ec:Subtitling mit einem ec:Agent verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasTake
+ec:hasTake rdf:type owl:ObjectProperty ;
+           rdfs:subPropertyOf ec:hasPart ;
+           dcterms:description "Diese Eigenschaft verknüpft eine Szene oder eine Einstellung mit einer ihrer Takes. Sie ist eine Untereigenschaft von ec:hasPart und wird verwendet, um wiederholte Aufnahmen einer Szene oder einer Einstellung zu identifizieren."@de ,
+                               "This property relates a scene or shot to one of its takes. It is a sub-property of ec:hasPart and is used to identify repeated recordings of a scene or shot."@en ;
+           rdfs:label "Has take"@en ,
+                      "Hat Take"@de ;
+           skos:definition "an owl:ObjectProperty relating an ec:Scene or ec:Shot to an ec:Take"@en ,
+                           "eine owl:ObjectProperty, die ein ec:Scene oder ec:Shot mit einem ec:Take verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasTargetAudience
+ec:hasTargetAudience rdf:type owl:ObjectProperty ;
+                     dcterms:description "Die Zielgruppe, die mit einem redaktionellen Objekt, einer Kampagne, einem Veröffentlichungsereignis, einem Veröffentlichungskanal, einer Veröffentlichungsplattform oder einem Veröffentlichungsdienst verbunden ist."@de ,
+                                         "The target audience associated with an editorial object, campaign, publication event, publication channel, publication platform, or publication service."@en ;
+                     rdfs:label "Target audience"@en ,
+                                "Zielgruppe"@de ;
+                     skos:definition "an owl:ObjectProperty relating an ec:EditorialObject or ec:Campaign to an ec:Audience"@en ,
+                                     "eine owl:ObjectProperty, die ein ec:EditorialObject oder eine ec:Campaign mit einer ec:Audience verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasTargetChannel
+ec:hasTargetChannel rdf:type owl:ObjectProperty ;
+                    dcterms:description "Der Zielkanal für die Veröffentlichung."@de ,
+                                        "The target channel for publication."@en ;
+                    rdfs:label "Has target channel"@en ,
+                               "Hat Zielkanal"@de ;
+                    skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:PublicationChannel"@en ,
+                                    "eine owl:ObjectProperty, die ein ec:EditorialObject mit einem ec:PublicationChannel verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasTargetPlatform
+ec:hasTargetPlatform rdf:type owl:ObjectProperty ;
+                     dcterms:description "Die Plattform, die für die Veröffentlichung oder Verbreitung des redaktionellen Objekts verwendet wird."@de ,
+                                         "The platform used for publication or distribution of the editorial object."@en ;
+                     rdfs:label "Target platform"@en ,
+                                "Zielplattform"@de ;
+                     skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:PublicationPlatform"@en ,
+                                     "eine owl:ObjectProperty, die ein ec:EditorialObject mit einer ec:PublicationPlatform verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasTargetService
+ec:hasTargetService rdf:type owl:ObjectProperty ;
+                    dcterms:description "Das Zielservice für die Veröffentlichung."@de ,
+                                        "The target service for publication."@en ;
+                    rdfs:label "Has target service"@en ,
+                               "Hat Zielservice"@de ;
+                    skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:PublicationService"@en ,
+                                    "eine owl:ObjectProperty, die eine ec:EditorialObject mit einer ec:PublicationService verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasTeamMember
+ec:hasTeamMember rdf:type owl:ObjectProperty ;
+                 dcterms:description "Die Mitglieder eines Teams."@de ,
+                                     "The members of a Team."@en ;
+                 rdfs:label "Team member"@en ,
+                            "Teammitglied"@de ;
+                 skos:definition "an owl:ObjectProperty relating an ec:Team to an ec:Person"@en ,
+                                 "eine owl:ObjectProperty, die eine ec:Team mit einer ec:Person verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasTerritoryExcludes
+ec:hasTerritoryExcludes rdf:type owl:ObjectProperty ;
+                        dcterms:description "Der Ort, etwa ein Land oder eine Region, in dem die Bewertung und die Zielgruppe nicht gelten."@de ,
+                                            "The location, such as a country or region, where the rating and target audience do not apply."@en ;
+                        rdfs:label "Ausschlussgebiet"@de ,
+                                   "Exclusion area"@en ;
+                        skos:definition "an owl:ObjectProperty relating an ec:Rating to an ec:CountryCode"@en ,
+                                        "eine owl:ObjectProperty, die eine ec:Rating mit einem ec:CountryCode verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasTerritoryIncludes
+ec:hasTerritoryIncludes rdf:type owl:ObjectProperty ;
+                        dcterms:description "Das Asset, auf das sich die Bewertung bezieht."@de ,
+                                            "The asset to which the rating applies."@en ;
+                        rdfs:label "Applies to"@en ,
+                                   "Gilt für"@de ;
+                        skos:definition "an owl:ObjectProperty relating an ec:Rating to an ec:CountryCode"@en ,
+                                        "eine owl:ObjectProperty, die eine ec:Rating mit einem ec:CountryCode verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasTextLineSource
+ec:hasTextLineSource rdf:type owl:ObjectProperty ;
+                     dcterms:description "Die Quelle einer TextLine."@de ,
+                                         "The source of a TextLine."@en ;
+                     rdfs:label "Text line source"@en ,
+                                "Textzeilenquelle"@de ;
+                     skos:definition "an owl:ObjectProperty relating an ec:TextLine to an ec:Agent"@en ,
+                                     "eine owl:ObjectProperty, die eine ec:TextLine mit einem ec:Agent verbindet"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasTheme
+ec:hasTheme rdf:type owl:ObjectProperty ;
+            dcterms:description "Diese Eigenschaft ermöglicht es, dass einem Asset ein Thema zugeordnet wird, das als Zeichenkette oder als URI vorliegen kann, die auf einen Begriff aus einem kontrollierten Vokabular verweist. Ein typisches Beispiel ist die Eurostat-NACE-Klassifikation."@de ,
+                                "This property enables an Asset to be associated with a theme, which can be a string or a URI pointing to a term from a controlled vocabulary. A typical example is the Eurostat NACE classification."@en ;
+            rdfs:label "Thema"@de ,
+                       "Theme"@en ;
+            skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Theme"@en ,
+                            "eine owl:ObjectProperty, die ec:EditorialObject mit ec:Theme verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasTimecodeTrack
+ec:hasTimecodeTrack rdf:type owl:ObjectProperty ;
+                    dcterms:description "A track that identifies the timecode track associated with a MediaResource."@en ,
+                                        "Ein Track, der den mit einer MediaResource verbundenen Timecode-Track identifiziert."@de ;
+                    rdfs:label "Timecode track"@en ,
+                               "Timecode-Spur"@de ;
+                    skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:TimecodeTrack"@en ,
+                                    "eine owl:ObjectProperty, die eine ec:MediaResource mit einer ec:TimecodeTrack verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasTimelineTrack
+ec:hasTimelineTrack rdf:type owl:ObjectProperty ;
+                    dcterms:description "Associates a TimelineTrack with an EditorialObject."@en ,
+                                        "Ordnet einen TimelineTrack einem EditorialObject zu."@de ;
+                    rdfs:label "Timeline track"@en ,
+                               "Timeline-Spur"@de ;
+                    skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:TimelineTrack"@en ,
+                                    "eine owl:ObjectProperty, die eine ec:EditorialObject mit einer ec:TimelineTrack verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasTimelineTrackPart
+ec:hasTimelineTrackPart rdf:type owl:ObjectProperty ;
+                        owl:inverseOf ec:isTimelineTrackPartOf ;
+                        dcterms:description "An EditorialObject associated with a TimelineTrack as a TimelineTrack part."@en ,
+                                            "Ein EditorialObject, das mit einem TimelineTrack als Teil eines TimelineTrack verbunden ist."@de ;
+                        rdfs:label "Teil des Zeitstrahls"@de ,
+                                   "Timeline track part"@en ;
+                        skos:definition "an owl:ObjectProperty relating an ec:TimelineTrack to an ec:EditorialObject"@en ,
+                                        "eine owl:ObjectProperty, die ein ec:TimelineTrack mit einem ec:EditorialObject verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasTopic
+ec:hasTopic rdf:type owl:ObjectProperty ;
+            dcterms:description "Diese Eigenschaft ermöglicht es, ein Asset mit einem Thema zu verknüpfen, das eine Zeichenkette oder eine URI sein kann, die auf einen Begriff aus einem kontrollierten Vokabular verweist. Ein typisches Beispiel ist die Verwendung der IPTC Media Topics, die unter http://cv.iptc.org/newscodes/mediatopic/ definiert sind."@de ,
+                                "This property enables to associate an Asset with a topic which can be a string or a URI pointing to a term from a controlled vocabulary. A typical example is to make use of the IPTC Media Topics defined at http://cv.iptc.org/newscodes/mediatopic/."@en ;
+            rdfs:label "Thema"@de ,
+                       "Topic"@en ;
+            skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Topic"@en ,
+                            "eine owl:ObjectProperty, die ein ec:EditorialObject mit einem ec:Topic verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasTrack
+ec:hasTrack rdf:type owl:ObjectProperty ;
+            dcterms:description "Associates audio, video, or data tracks with a media resource."@en ,
+                                "Verknüpft Audio-, Video- oder Datenspuren mit einer Medienressource."@de ;
+            rdfs:label "Spur"@de ,
+                       "Track"@en ;
+            skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:Track"@en ,
+                            "eine owl:ObjectProperty, die eine ec:MediaResource mit einer ec:Track verbindet"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasTrackPart
+ec:hasTrackPart rdf:type owl:ObjectProperty ;
+                owl:inverseOf ec:isTrackPartOf ;
+                dcterms:description "An element to identify a part of a track by a title, a start time and an end time in both the media source and media destination."@en ,
+                                    "Ein Element zur Identifizierung eines Teils eines Tracks anhand eines Titels, einer Startzeit und einer Endzeit sowohl in der Medienquelle als auch im Medienziel."@de ;
+                rdfs:label "Spurteilquelle"@de ,
+                           "Track part source"@en ;
+                skos:definition "an owl:ObjectProperty relating an ec:Track to an ec:MediaResource"@en ,
+                                "eine owl:ObjectProperty, die ein ec:Track mit einer ec:MediaResource verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasTrackPurpose
+ec:hasTrackPurpose rdf:type owl:ObjectProperty ;
+                   dcterms:description "Der Zweck, für den der Track bereitgestellt wird."@de ,
+                                       "The purpose for which the Track is provided."@en ;
+                   rdfs:label "Spurzweck"@de ,
+                              "Track purpose"@en ;
+                   skos:definition "an owl:ObjectProperty relating an ec:Track to an ec:TrackPurpose"@en ,
+                                   "eine owl:ObjectProperty, die ec:Track mit ec:TrackPurpose verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasTrackType
+ec:hasTrackType rdf:type owl:ObjectProperty ;
+                dcterms:description "Der einem Track zugeordnete Typ."@de ,
+                                    "The type attributed to a Track."@en ;
+                rdfs:label "Spurname"@de ,
+                           "Track name"@en ;
+                skos:definition "an owl:ObjectProperty relating an ec:Track to an ec:TrackType"@en ,
+                                "eine owl:ObjectProperty, die ec:Track mit ec:TrackType verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasUnit
+ec:hasUnit rdf:type owl:ObjectProperty ;
+           dcterms:description "Die Einheit, in der der Wert einer Measure ausgedrückt wird, sofern zutreffend."@de ,
+                               "The unit in which the value of a Measure is expressed, when applicable."@en ;
+           rdfs:label "Maßeinheit"@de ,
+                      "Measure unit"@en ;
+           skos:definition "an owl:ObjectProperty relating an ec:Measure to a skos:Concept"@en ,
+                           "eine owl:ObjectProperty, die ein ec:Measure mit einem skos:Concept verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasUsageContract
+ec:hasUsageContract rdf:type owl:ObjectProperty ;
+                    dcterms:description "Die vertraglichen Bedingungen, unter denen ein ProductionDevice verwendet werden soll."@de ,
+                                        "The contractual terms under which a ProductionDevice shall be used."@en ;
+                    rdfs:label "Nutzungsvertrag"@de ,
+                               "Usage contract"@en ;
+                    skos:definition "an owl:ObjectProperty relating an ec:ProductionDevice to an ec:Contract"@en ,
+                                    "eine owl:ObjectProperty, die eine ec:ProductionDevice mit einem ec:Contract verbindet"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasUsageRestrictions
+ec:hasUsageRestrictions rdf:type owl:ObjectProperty ;
+                        rdfs:subPropertyOf ec:hasRights ;
+                        dcterms:description "Die mit einem Asset oder einem Veröffentlichungsevent verbundenen Nutzungsbeschränkungen."@de ,
+                                            "The usage restrictions associated with an asset or publication event."@en ;
+                        rdfs:label "Nutzungsbeschränkungen"@de ,
+                                   "Usage restrictions"@en ;
+                        skos:definition "an owl:ObjectProperty relating an ec:Asset to ec:UsageRestrictions"@en ,
+                                        "eine owl:ObjectProperty, die ec:Asset mit ec:UsageRestrictions verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasUsageRights
+ec:hasUsageRights rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf ec:hasRights ;
+                  dcterms:description "Die mit einem Asset verbundenen Nutzungsrechte."@de ,
+                                      "The usage rights associated with an asset."@en ;
+                  rdfs:label "Nutzungsrechte"@de ,
+                             "Usage rights"@en ;
+                  skos:definition "an owl:ObjectProperty relating an ec:Asset to an ec:UsageRights"@en ,
+                                  "eine owl:ObjectProperty, die ein ec:Asset mit einem ec:UsageRights verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasVersion
+ec:hasVersion rdf:type owl:ObjectProperty ;
+              owl:inverseOf ec:isVersionOf ;
+              dcterms:description "An asset, editorial object, or resource that represents another version of the current entity."@en ,
+                                  "Ein Asset, redaktionelles Objekt oder eine Ressource, die eine andere Version der aktuellen Entität darstellt."@de ;
+              rdfs:label "Version"@de ,
+                         "Version"@en ;
+              skos:definition "an owl:ObjectProperty relating an ec:Asset, ec:EditorialObject or resource to another version of that same entity"@en ,
+                              "eine owl:ObjectProperty, die ein ec:Asset, ec:EditorialObject oder eine Ressource mit einer anderen Version desselben Entitäts verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasVersionType
+ec:hasVersionType rdf:type owl:ObjectProperty ;
+                  dcterms:description "Legt den Typ der mit einem EditorialObject verbundenen Version fest."@de ,
+                                      "Specifies the type of version associated with an EditorialObject."@en ;
+                  rdfs:label "Version type"@en ,
+                             "Versionstyp"@de ;
+                  skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to a skos:Concept"@en ,
+                                  "eine owl:ObjectProperty, die ein ec:EditorialObject mit einem skos:Concept verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasVideoCodec
+ec:hasVideoCodec rdf:type owl:ObjectProperty ;
+                 rdfs:subPropertyOf ec:hasCodec ;
+                 dcterms:description "Der zur Kodierung einer Medienressource verwendete Videocodec."@de ,
+                                     "The video codec used to encode a media resource."@en ;
+                 rdfs:label "Video codec"@en ,
+                            "Videocodec"@de ;
+                 skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:VideoCodec"@en ,
+                                 "eine owl:ObjectProperty, die eine ec:MediaResource mit einer ec:VideoCodec verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasVideoEncodingFormat
+ec:hasVideoEncodingFormat rdf:type owl:ObjectProperty ;
+                          rdfs:subPropertyOf ec:hasFormat ;
+                          dcterms:description "Das mit einer Medienressource verbundene Video-Codierungsformat."@de ,
+                                              "The video encoding format associated with a media resource."@en ;
+                          rdfs:label "Audio encoding format"@en ,
+                                     "Audio-Kodierungsformat"@de ;
+                          skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:VideoEncodingFormat"@en ,
+                                          "eine owl:ObjectProperty, die eine ec:MediaResource mit einem ec:VideoEncodingFormat verbindet"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasVideoTrack
+ec:hasVideoTrack rdf:type owl:ObjectProperty ;
+                 dcterms:description "A video track associated with the media resource."@en ,
+                                     "Ein Videospur, die mit der Medienressource verbunden ist."@de ;
+                 rdfs:label "Video track"@en ,
+                            "Videospur"@de ;
+                 skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:VideoTrack"@en ,
+                                 "eine owl:ObjectProperty, die eine ec:MediaResource mit einem ec:VideoTrack verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasWrappingType
+ec:hasWrappingType rdf:type owl:ObjectProperty ;
+                   dcterms:description "Der Typ der Verpackung, die mit der Ressource verbunden ist."@de ,
+                                       "The type of wrapping associated with the resource."@en ;
+                   rdfs:label "Umschlagtyp"@de ,
+                              "Wrapping type"@en ;
+                   skos:definition "an owl:ObjectProperty relating an ec:AncillaryData to an ec:WrappingType"@en ,
+                                   "eine owl:ObjectProperty, die eine ec:AncillaryData mit einer ec:WrappingType verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#holdsAward
+ec:holdsAward rdf:type owl:ObjectProperty ;
+              owl:inverseOf ec:isAwardedTo ;
+              dcterms:description "An Award held by an Agent, representing an award relationship from the agent to the award."@en ,
+                                  "Ein von einem Agenten gehaltener Award, der eine Award-Beziehung vom Agenten zum Award repräsentiert."@de ;
+              rdfs:label "Holds"@en ,
+                         "Hält"@de ;
+              skos:definition "an owl:ObjectProperty relating an ec:Agent to an ec:Award"@en ,
+                              "eine owl:ObjectProperty, die einen ec:Agent mit einem ec:Award verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#holdsLicence
+ec:holdsLicence rdf:type owl:ObjectProperty ;
+                dcterms:description "Die Bedingungen einer ConsumptionLicence, die mit einem Contract verbunden ist."@de ,
+                                    "The terms of a ConsumptionLicence associated with a Contract."@en ;
+                rdfs:label "Consumption licence"@en ,
+                           "Verbrauchslizenz"@de ;
+                skos:definition "an owl:ObjectProperty relating an ec:Account to an ec:ConsumptionLicence"@en ,
+                                "eine owl:ObjectProperty, die ein ec:Account mit einer ec:ConsumptionLicence verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#includesAudience
+ec:includesAudience rdf:type owl:ObjectProperty ;
+                    dcterms:description "A defined audience group that is included in the audience."@en ,
+                                        "Eine definierte Zielgruppe, die in der Audience enthalten ist."@de ;
+                    rdfs:label "Beinhaltet Publikum"@de ,
+                               "Includes audience"@en ;
+                    skos:definition "an owl:ObjectProperty relating an ec:Audience to an ec:Audience"@en ,
+                                    "eine owl:ObjectProperty, die eine ec:Audience mit einer ec:Audience verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#instantiates
+ec:instantiates rdf:type owl:ObjectProperty ;
+                owl:inverseOf ec:isInstantiatedBy ;
+                dcterms:description "A particular manifestation of an EditorialObject linked to its corresponding Resource."@en ,
+                                    "Eine bestimmte Ausprägung eines EditorialObject, die mit der entsprechenden Resource verknüpft ist."@de ;
+                rdfs:label "Editorial object"@en ,
+                           "Redaktionelles Objekt"@de ;
+                skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:EditorialObject"@en ,
+                                "eine owl:ObjectProperty, die eine ec:MediaResource mit einem ec:EditorialObject verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isAbout
+ec:isAbout rdf:type owl:ObjectProperty ;
+           rdfs:range ec:Asset ;
+           dcterms:description "Diese Eigenschaft wird verwendet, wenn ein anderes redaktionelles Objekt, z. B. ein Buch, ein Film oder ein Programm, das Thema des redaktionellen Objekts ist."@de ,
+                               "This property is used when another editorial object, e.g. a book, a movie or a programme is the topic of the editorial object."@en ;
+           rdfs:label "Bezieht sich auf"@de ,
+                      "Is about"@en ;
+           skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Asset"@en ,
+                           "eine owl:ObjectProperty, die ec:EditorialObject mit ec:Asset verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isAffiliatedTo
+ec:isAffiliatedTo rdf:type owl:ObjectProperty ;
+                  dcterms:description "Beziehung zu der Organisation, die die Zugehörigkeit repräsentiert."@de ,
+                                      "Relation to the organisation the affiliation represents."@en ;
+                  rdfs:label "Is affiliated to"@en ,
+                             "Ist verbunden mit"@de ;
+                  skos:definition "an owl:ObjectProperty relating an ec:Affiliation to an ec:Organisation"@en ,
+                                  "eine owl:ObjectProperty, die ec:Affiliation mit ec:Organisation verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isAffiliationFor
+ec:isAffiliationFor rdf:type owl:ObjectProperty ;
+                    dcterms:description "A property that relates an Affiliation to the Person for whom it is valid."@en ,
+                                        "Eine Eigenschaft, die eine Affiliation mit der Person verknüpft, für die sie gültig ist."@de ;
+                    rdfs:label "Affiliation for"@en ,
+                               "Zugehörigkeit zu"@de ;
+                    skos:definition "an owl:ObjectProperty relating an ec:Affiliation to an ec:Person"@en ,
+                                    "eine owl:ObjectProperty, die eine ec:Affiliation mit einer ec:Person verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isAnimalGroomFor
+ec:isAnimalGroomFor rdf:type owl:ObjectProperty ;
+                    dcterms:description "Das Tier, das vom zugehörigen Agenten gepflegt oder betreut wird."@de ,
+                                        "The animal groomed or cared for by the associated agent."@en ;
+                    rdfs:label "Animal groom for"@en ,
+                               "Tierpflege für Tiere"@de ;
+                    skos:definition "an owl:ObjectProperty inverse of ec:hasAnimalGroom relating an ec:Agent to an ec:Animal"@en ,
+                                    "eine owl:ObjectProperty, die die inverse von ec:hasAnimalGroom ist und einen ec:Agent mit einem ec:Animal verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isAnimatedBy
+ec:isAnimatedBy rdf:type owl:ObjectProperty ;
+                dcterms:description "Character, animated by a person using an artifact."@en ,
+                                    "Figur, die von einer Person mithilfe eines Artefakts animiert wird."@de ;
+                rdfs:label "Is animated by"@en ,
+                           "Wird animiert von"@de ;
+                skos:definition "an owl:ObjectProperty relating an ec:Character to an ec:Person"@en ,
+                                "eine owl:ObjectProperty, die eine ec:Character mit einer ec:Person verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isAnnotatedMediaResource
+ec:isAnnotatedMediaResource rdf:type owl:ObjectProperty ;
+                            dcterms:description "Links an Annotation to a MediaResource."@en ,
+                                                "Verknüpft eine Annotation mit einer MediaResource."@de ;
+                            rdfs:label "Media resource"@en ,
+                                       "Medienressource"@de ;
+                            skos:definition "an owl:ObjectProperty relating an ec:Annotation to an ec:MediaResource"@en ,
+                                            "eine owl:ObjectProperty, die eine ec:Annotation mit einer ec:MediaResource verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isAttributedTo
+ec:isAttributedTo rdf:type owl:ObjectProperty ;
+                  dcterms:description "An association between a Provenance instance and the Agent it is attributed to."@en ,
+                                      "Eine Zuordnung zwischen einer Provenienz-Instanz und dem Agenten, dem sie zugeschrieben wird."@de ;
+                  rdfs:label "Provenance target"@en ,
+                             "Provenienz-Ziel"@de ;
+                  skos:definition "an owl:ObjectProperty relating an ec:Provenance to an ec:Agent"@en ,
+                                  "eine owl:ObjectProperty, die eine ec:Provenance mit einem ec:Agent verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isAuthorOf
+ec:isAuthorOf rdf:type owl:ObjectProperty ;
+              dcterms:description "An object property that links an Agent to the Annotation it authored."@en ,
+                                  "Eine Objekt-Eigenschaft, die einen Agenten mit der Annotation verknüpft, die er verfasst hat."@de ;
+              rdfs:label "Author of"@en ,
+                         "Autor von"@de ;
+              skos:definition "an owl:ObjectProperty relating an ec:Agent to an ec:Annotation"@en ,
+                              "eine owl:ObjectProperty, die einen ec:Agent mit einer ec:Annotation verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isAwardedTo
+ec:isAwardedTo rdf:type owl:ObjectProperty ;
+               dcterms:description "Identifies the agent to whom an award is given."@en ,
+                                   "Identifiziert den Agenten, dem eine Auszeichnung verliehen wird."@de ;
+               rdfs:label "Awarded to"@en ,
+                          "Zugewiesen an"@de ;
+               skos:definition "an owl:ObjectProperty relating an ec:Award to an ec:Agent"@en ,
+                               "eine owl:ObjectProperty, die ein ec:Award mit einem ec:Agent verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isChildOf
+ec:isChildOf rdf:type owl:ObjectProperty ;
+             dcterms:description "Das übergeordnete Asset dieses Assets."@de ,
+                                 "The parent asset of this asset."@en ;
+             rdfs:label "Elternteil"@de ,
+                        "Parent"@en ;
+             skos:definition "an owl:ObjectProperty relating an ec:Asset to an ec:Asset"@en ,
+                             "eine owl:ObjectProperty, die ein ec:Asset mit einem ec:Asset verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isCloneOf
+ec:isCloneOf rdf:type owl:ObjectProperty ;
+             dcterms:description "Die Quell-MediaResource eines Klons."@de ,
+                                 "The source MediaResource of a clone."@en ;
+             rdfs:label "Clone source"@en ,
+                        "Klonquelle"@de ;
+             skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:MediaResource"@en ,
+                             "eine owl:ObjectProperty, die eine ec:MediaResource mit einer ec:MediaResource verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isCommissionedBy
+ec:isCommissionedBy rdf:type owl:ObjectProperty ;
+                    dcterms:description "Der Vertrag, durch den eine Ressource in Auftrag gegeben wird."@de ,
+                                        "The Contract through which a Resource is commissioned."@en ;
+                    rdfs:label "Contract"@en ,
+                               "Vertrag"@de ;
+                    skos:definition "an owl:ObjectProperty relating an ec:Resource to an ec:Contract"@en ,
+                                    "eine owl:ObjectProperty, die eine ec:Resource mit einem ec:Contract verbindet"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isComposedOf
+ec:isComposedOf rdf:type owl:ObjectProperty ;
+                dcterms:description "Die Medienressourcen, die zur Erstellung einer Essence verwendet werden."@de ,
+                                    "The media resources used to compose an Essence."@en ;
+                rdfs:label "Media resource"@en ,
+                           "Medienressource"@de ;
+                skos:definition "an owl:ObjectProperty relating an ec:Essence to an ec:MediaResource"@en ,
+                                "ein owl:ObjectProperty, das eine ec:Essence mit einer ec:MediaResource verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isDefinedBy
+ec:isDefinedBy rdf:type owl:ObjectProperty ;
+               dcterms:description "Der Vertrag, durch den eine Regel definiert wurde."@de ,
+                                   "The Contract by which a Rule has been defined."@en ;
+               rdfs:label "Related contract"@en ,
+                          "Zugehöriger Vertrag"@de ;
+               skos:definition "an owl:ObjectProperty relating an ec:Rule to an ec:Contract"@en ,
+                               "eine owl:ObjectProperty, die ec:Rule mit ec:Contract verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isDerivedFrom
+ec:isDerivedFrom rdf:type owl:ObjectProperty ;
+                 dcterms:description "Identifies a content-based relationship between two resources."@en ,
+                                     "Kennzeichnet eine inhaltsbasierte Beziehung zwischen zwei Ressourcen."@de ;
+                 rdfs:label "Abgeleitet von"@de ,
+                            "Derived from"@en ;
+                 skos:definition "an owl:ObjectProperty relating an ec:Asset to an ec:Asset"@en ,
+                                 "eine owl:ObjectProperty, die ein ec:Asset mit einem ec:Asset verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isDistributedOn
+ec:isDistributedOn rdf:type owl:ObjectProperty ;
+                   dcterms:description "Die Plattform, auf der der Inhalt verbreitet wird."@de ,
+                                       "The platform on which the content is distributed."@en ;
+                   rdfs:label "Platform/service/publication channel"@en ,
+                              "Plattform-/Dienst-/Publikationskanal"@de ;
+                   skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:PublicationService"@en ,
+                                   "eine owl:ObjectProperty, die ein ec:EditorialObject mit einer ec:PublicationService verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isDubOf
+ec:isDubOf rdf:type owl:ObjectProperty ;
+           dcterms:description "Die Herkunft einer synchronisierten MediaResource."@de ,
+                               "The origin of a dubbed MediaResource."@en ;
+           rdfs:label "Dubbed from"@en ,
+                      "Synchronisiert von"@de ;
+           skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:MediaResource"@en ,
+                           "eine owl:ObjectProperty, die eine ec:MediaResource mit einer ec:MediaResource verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isEmbodiedBy
+ec:isEmbodiedBy rdf:type owl:ObjectProperty ;
+                dcterms:description "Bezeichnet, dass eine Figur in einem Produktionskontext durch ein Artefakt verkörpert wird."@de ,
+                                    "Indicates that a character is embodied by an artefact in a production context."@en ;
+                rdfs:label "Is embodied by"@en ,
+                           "Ist verkörpert durch"@de ;
+                skos:definition "an owl:ObjectProperty relating an ec:Character to an ec:Artefact"@en ,
+                                "eine owl:ObjectProperty, die eine ec:Character mit einem ec:Artefact verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isEpisodeOfSeason
+ec:isEpisodeOfSeason rdf:type owl:ObjectProperty ;
+                     dcterms:description "Die Episode einer Staffel."@de ,
+                                         "The Episode of a Season."@en ;
+                     rdfs:label "Parent season"@en ,
+                                "Übergeordnete Staffel"@de ;
+                     skos:definition "an owl:ObjectProperty relating an ec:Programme to an ec:Season"@en ,
+                                     "eine owl:ObjectProperty, die ein ec:Programme mit einem ec:Season verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isEpisodeOfSerial
+ec:isEpisodeOfSerial rdf:type owl:ObjectProperty ;
+                     dcterms:description "Gibt an, dass ein Programm eine Episode eines Serials ist."@de ,
+                                         "Indicates that a programme is an episode of a serial."@en ;
+                     rdfs:label "Is episode of serial"@en ,
+                                "Ist Episode einer Serie"@de ;
+                     skos:definition "an owl:ObjectProperty relating an ec:Programme to an ec:Serial"@en ,
+                                     "eine owl:ObjectProperty, die ein ec:Programme mit einem ec:Serial verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isEpisodeOfSeries
+ec:isEpisodeOfSeries rdf:type owl:ObjectProperty ;
+                     dcterms:description "Die Episode einer Serie."@de ,
+                                         "The Episode of a Series."@en ;
+                     rdfs:label "Parent series"@en ,
+                                "Übergeordnete Serie"@de ;
+                     skos:definition "an owl:ObjectProperty relating an ec:Programme to an ec:Series"@en ,
+                                     "eine owl:ObjectProperty, die ein ec:Programme mit einem ec:Series verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isExtractOf
+ec:isExtractOf rdf:type owl:ObjectProperty ;
+               dcterms:description "Used for representing an extract, i. e. the playout of a part or the whole of some archived material on the playout. For attributes like duration and start, the data is placed in the instance representing the abstract. Other metadata is read from the original instance that is extracted."@en ,
+                                   "Wird zur Darstellung eines Exzerpts verwendet, d. h. der Ausspielung eines Teils oder des gesamten archivierten Materials in der Ausspielung. Für Attribute wie Dauer und Start werden die Daten in der Instanz abgelegt, die das Abstrakte repräsentiert. Weitere Metadaten werden aus der ursprünglichen Instanz gelesen, aus der das Exzerpt gewonnen wurde."@de ;
+               rdfs:label "Is extract of"@en ,
+                          "Ist Auszug von"@de ;
+               skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:EditorialObject"@en ,
+                               "eine owl:ObjectProperty, die ein ec:EditorialObject mit einem ec:EditorialObject verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isInstantiatedBy
+ec:isInstantiatedBy rdf:type owl:ObjectProperty ;
+                    dcterms:description "An object property that links an EditorialObject to the MediaResource it instantiates."@en ,
+                                        "Eine Objekt-Eigenschaft, die ein EditorialObject mit der MediaResource verknüpft, die es instanziiert."@de ;
+                    rdfs:label "Media resource"@en ,
+                               "Medienressource"@de ;
+                    skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:MediaResource"@en ,
+                                    "eine owl:ObjectProperty, die ein ec:EditorialObject mit einem ec:MediaResource verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isMasterOf
+ec:isMasterOf rdf:type owl:ObjectProperty ;
+              dcterms:description "Die Master-Ressource einer abgeleiteten Medienressource."@de ,
+                                  "The master resource of a derived media resource."@en ;
+              rdfs:label "Abgeleitete Medienressource"@de ,
+                         "Derived media resource"@en ;
+              skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:MediaResource"@en ,
+                              "eine owl:ObjectProperty, die eine ec:MediaResource mit einer ec:MediaResource verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isMediaFragmentOf
+ec:isMediaFragmentOf rdf:type owl:ObjectProperty ;
+                     dcterms:description "Die Medienressource, zu der ein Media Fragment gehört."@de ,
+                                         "The Media Resource to which a Media Fragment belongs."@en ;
+                     rdfs:label "Media fragment source"@en ,
+                                "Medienfragmentquelle"@de ;
+                     skos:definition "an owl:ObjectProperty relating an ec:MediaFragment to an ec:MediaResource"@en ,
+                                     "eine owl:ObjectProperty, die eine ec:MediaFragment mit einer ec:MediaResource verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isMemberOf
+ec:isMemberOf rdf:type owl:ObjectProperty ;
+              dcterms:description "A group to which an EditorialObject belongs."@en ,
+                                  "Eine Gruppe, zu der ein EditorialObject gehört."@de ;
+              rdfs:label "Member of"@en ,
+                         "Mitglied von"@de ;
+              skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:EditorialGroup"@en ,
+                              "eine owl:ObjectProperty, die ein ec:EditorialObject mit einer ec:EditorialGroup verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isNextInSequence
+ec:isNextInSequence rdf:type owl:ObjectProperty ;
+                    owl:inverseOf ec:isPreviousInSequence ;
+                    dcterms:description "A link to an Editorial Object following the current Editorial Object in an ordered sequence."@en ,
+                                        "Eine Verknüpfung zu einem Editorial Object, das in einer geordneten Sequenz auf das aktuelle Editorial Object folgt."@de ;
+                    rdfs:label "Next"@en ,
+                               "Nächste"@de ;
+                    skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:EditorialObject"@en ,
+                                    "eine owl:ObjectProperty, die ein ec:EditorialObject mit einem ec:EditorialObject verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isOfferedBy
+ec:isOfferedBy rdf:type owl:ObjectProperty ;
+               owl:inverseOf ec:offers ;
+               dcterms:description "Associates a PublicationEvent with the PublicationService that offers it."@en ,
+                                   "Verknüpft ein PublicationEvent mit dem PublicationService, der es anbietet."@de ;
+               rdfs:label "Dienst"@de ,
+                          "Service"@en ;
+               skos:definition "an owl:ObjectProperty relating an ec:PublicationEvent to an ec:PublicationService"@en ,
+                               "eine owl:ObjectProperty, die eine ec:PublicationEvent mit einer ec:PublicationService verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isOperatedBy
+ec:isOperatedBy rdf:type owl:ObjectProperty ;
+                dcterms:description "A service that operates the publication channel."@en ,
+                                    "Ein Dienst, der den Veröffentlichungskanal betreibt."@de ;
+                rdfs:label "Betreiber, Eigentümer"@de ,
+                           "Operator, owner"@en ;
+                skos:definition "an owl:ObjectProperty relating a ec:PublicationChannel to a ec:PublicationService"@en ,
+                                "eine owl:ObjectProperty, die eine ec:PublicationChannel mit einer ec:PublicationService verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isOrderedBy
+ec:isOrderedBy rdf:type owl:ObjectProperty ;
+               dcterms:description "Der Vertrag, über den ein ProductionJob bestellt wird."@de ,
+                                   "The Contract through which an ProductionJob is ordered."@en ;
+               rdfs:label "Contract"@en ,
+                          "Vertrag"@de ;
+               skos:definition "an owl:ObjectProperty relating an ec:ProductionJob to an ec:Contract"@en ,
+                               "eine owl:ObjectProperty, die eine ec:ProductionJob mit einem ec:Contract verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isOwnedBy
+ec:isOwnedBy rdf:type owl:ObjectProperty ;
+             owl:inverseOf ec:owns ;
+             dcterms:description "Der Agent (Kontakt, Person oder Organisation), dem eine MarketingBrand, PublicationChannel, PublicationPlatform oder PublicationService gehört."@de ,
+                                 "The Agent (Contact, Person, or Organisation) that owns a MarketingBrand, PublicationChannel, PublicationPlatform, or PublicationService."@en ;
+             rdfs:label "Is owned by"@en ,
+                        "Ist im Besitz von"@de ;
+             skos:definition "an owl:ObjectProperty relating an ec:MarketingBrand, ec:PublicationChannel, ec:PublicationPlatform, or ec:PublicationService to an ec:Agent"@en ,
+                             "eine owl:ObjectProperty, die ein ec:MarketingBrand, ec:PublicationChannel, ec:PublicationPlatform oder ec:PublicationService mit einem ec:Agent verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isPartOf
+ec:isPartOf rdf:type owl:ObjectProperty ;
+            dcterms:description "Das redaktionelle Objekt, das einen Teil enthält."@de ,
+                                "The editorial object that contains a part."@en ;
+            rdfs:label "Editorial object"@en ,
+                       "Redaktionelles Objekt"@de ;
+            skos:definition "an owl:ObjectProperty relating an ec:EditorialSegment to an ec:EditorialObject"@en ,
+                            "eine owl:ObjectProperty, die ein ec:EditorialSegment mit einem ec:EditorialObject verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isPlayedBy
+ec:isPlayedBy rdf:type owl:ObjectProperty ;
+              owl:inverseOf ec:playsCharacter ;
+              owl:propertyDisjointWith ec:isPortrayedBy ;
+              dcterms:description "Beziehung zwischen einer fiktiven Figur und dem Schauspieler, der die Rolle spielt."@de ,
+                                  "Relationship between a fictional character and the actor playing the part."@en ;
+              rdfs:label "Is played by"@en ,
+                         "Wird gespielt von"@de ;
+              skos:definition "an owl:ObjectProperty relating an ec:Character to an ec:Involvement"@en ,
+                              "eine owl:ObjectProperty, die eine ec:Character mit einer ec:Involvement verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isPortrayedBy
+ec:isPortrayedBy rdf:type owl:ObjectProperty ;
+                 owl:inverseOf ec:portrays ;
+                 dcterms:description "Beziehung zwischen einer fiktiven Figur und dem Tier, das in der Szene dargestellt wird."@de ,
+                                     "Relationship between a fictional character and the animal that is depicted in the scene."@en ;
+                 rdfs:label "Is portrayed by"@en ,
+                            "Ist dargestellt von"@de ;
+                 skos:definition "an owl:ObjectProperty relating an ec:Character to an ec:Animal"@en ,
+                                 "eine owl:ObjectProperty, die eine ec:Character mit einem ec:Animal verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isPreviousInSequence
+ec:isPreviousInSequence rdf:type owl:ObjectProperty ;
+                        dcterms:description "A link to an Editorial Object preceding the current Editorial Object in an ordered sequence."@en ,
+                                            "Eine Verknüpfung zu einem Editorial Object, das das aktuelle Editorial Object in einer geordneten Sequenz vorausgeht."@de ;
+                        rdfs:label "Preceding"@en ,
+                                   "Vorangehend"@de ;
+                        skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:EditorialObject"@en ,
+                                        "eine owl:ObjectProperty, die ein ec:EditorialObject mit einem ec:EditorialObject verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isReferencedBy
+ec:isReferencedBy rdf:type owl:ObjectProperty ;
+                  owl:inverseOf ec:references ;
+                  dcterms:description "A related resource that references, cites, or otherwise points to the described resource."@en ,
+                                      "Eine verwandte Ressource, die auf die beschriebene Ressource verweist, sie zitiert oder anderweitig auf sie zeigt."@de ;
+                  rdfs:label "Reference source"@en ,
+                             "Referenzquelle"@de ;
+                  skos:definition "an owl:ObjectProperty relating a resource to a related resource that references, cites, or otherwise points to it"@en ,
+                                  "eine owl:ObjectProperty, die eine Ressource mit einer verwandten Ressource verknüpft, die auf sie verweist, sie zitiert oder anderweitig auf sie verweist"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isRelatedAgent
+ec:isRelatedAgent rdf:type owl:ObjectProperty ;
+                  dcterms:description "To relate an Agent to a concept associated with it, such as a Person or Character."@en ,
+                                      "Um einen Agenten mit einem ihm zugehörigen Konzept zu verknüpfen, etwa einer Person oder Figur."@de ;
+                  rdfs:label "Related agent"@en ,
+                             "Verwandter Agent"@de ;
+                  skos:definition "an owl:ObjectProperty relating an ec:Concept to an ec:Agent"@en ,
+                                  "eine owl:ObjectProperty, die ein ec:Concept mit einem ec:Agent verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isReplacedBy
+ec:isReplacedBy rdf:type owl:ObjectProperty ;
+                owl:inverseOf ec:replaces ;
+                dcterms:description "Identifies an asset that is substituted by another asset."@en ,
+                                    "Kennzeichnet ein Asset, das durch ein anderes Asset ersetzt wird."@de ;
+                rdfs:label "Ersatz"@de ,
+                           "Replacement"@en ;
+                skos:definition "an owl:ObjectProperty relating an ec:Asset to an ec:Asset"@en ,
+                                "eine owl:ObjectProperty, die eine ec:Asset mit einer ec:Asset verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isRequiredBy
+ec:isRequiredBy rdf:type owl:ObjectProperty ;
+                owl:inverseOf ec:requires ;
+                dcterms:description "Starke Beziehung zwischen EditorialObjects."@de ,
+                                    "Strong relation between EditorialObjects."@en ;
+                rdfs:label "Erforderlich"@de ,
+                           "Required"@en ;
+                skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:EditorialObject"@en ,
+                                "eine owl:ObjectProperty, die ein ec:EditorialObject mit einem ec:EditorialObject verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isSeasonOf
+ec:isSeasonOf rdf:type owl:ObjectProperty ;
+              dcterms:description "Associates a season with the series to which it belongs."@en ,
+                                  "Ordnet eine Season der Serie zu, zu der sie gehört."@de ;
+              rdfs:label "Serie"@de ,
+                         "Series"@en ;
+              skos:definition "an owl:ObjectProperty relating an ec:Season to an ec:Series"@en ,
+                              "eine owl:ObjectProperty, die ec:Season mit ec:Series verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isTimelineTrackPartOf
+ec:isTimelineTrackPartOf rdf:type owl:ObjectProperty ;
+                         dcterms:description "Associates an EditorialObject with a part of a TimelineTrack."@en ,
+                                             "Verknüpft ein EditorialObject mit einem Teil eines TimelineTrack."@de ;
+                         rdfs:label "Timeline track part"@en ,
+                                    "Timeline-Track-Teil"@de ;
+                         skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to a ec:TimelineTrack"@en ,
+                                         "eine owl:ObjectProperty, die ein ec:EditorialObject mit einem ec:TimelineTrack verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isTrackPartOf
+ec:isTrackPartOf rdf:type owl:ObjectProperty ;
+                 dcterms:description "An element to identify a part of a track by a title, a start time and an end time in both the media source and media destination."@en ,
+                                     "Ein Element zur Identifizierung eines Teils eines Tracks anhand eines Titels, einer Startzeit und einer Endzeit sowohl in der Medienquelle als auch im Medienziel."@de ;
+                 rdfs:label "Spurteilquelle"@de ,
+                            "Track part source"@en ;
+                 skos:definition "an owl:ObjectProperty relating an ec:Track to an ec:MediaResource"@en ,
+                                 "eine owl:ObjectProperty, die eine ec:Track mit einer ec:MediaResource verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isVersionOf
+ec:isVersionOf rdf:type owl:ObjectProperty ;
+               dcterms:description "Related versions of an EditorialObject or Resource."@en ,
+                                   "Verwandte Versionen eines EditorialObject oder einer Ressource."@de ;
+               rdfs:label "Version of"@en ,
+                          "Version von"@de ;
+               skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:EditorialObject"@en ,
+                               "eine owl:ObjectProperty, die ein ec:EditorialObject mit einem ec:EditorialObject verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#logs
+ec:logs rdf:type owl:ObjectProperty ;
+        dcterms:description "Links a publication log to its publication events."@en ,
+                            "Verknüpft ein Publikationsprotokoll mit seinen Publikationsereignissen."@de ;
+        rdfs:label "Logs"@en ,
+                   "Protokolle"@de ;
+        skos:definition "an owl:ObjectProperty relating an ec:PublicationLog to an ec:PublicationEvent"@en ,
+                        "eine owl:ObjectProperty, die eine ec:PublicationLog mit einem ec:PublicationEvent verbindet"@de ;
+        skos:note "logs publication event"@en ,
+                  "protokolliert ein Publikationsereignis"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#measures
+ec:measures rdf:type owl:ObjectProperty ;
+            dcterms:description "Associates a Measure with a Rule."@en ,
+                                "Verknüpft eine Measure mit einer Rule."@de ;
+            rdfs:label "Related rule"@en ,
+                       "Verwandte Regel"@de ;
+            skos:definition "an owl:ObjectProperty relating an ec:Measure to an ec:Rule"@en ,
+                            "eine owl:ObjectProperty, die eine ec:Measure mit einer ec:Rule verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#occursIn
+ec:occursIn rdf:type owl:ObjectProperty ;
+            dcterms:description "A property that links a consumption event to the publication channel or publication service in which it occurs."@en ,
+                                "Eine Eigenschaft, die ein Konsumereignis mit dem Veröffentlichungskanal oder dem Veröffentlichungsdienst verknüpft, in dem es stattfindet."@de ;
+            rdfs:label "Erscheint in"@de ,
+                       "Occurs in"@en ;
+            skos:definition "an owl:ObjectProperty relating an ec:ConsumptionEvent to a ec:PublicationService or ec:PublicationChannel"@en ,
+                            "eine owl:ObjectProperty, die ein ec:ConsumptionEvent mit einem ec:PublicationService oder ec:PublicationChannel verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#occursOn
+ec:occursOn rdf:type owl:ObjectProperty ;
+            dcterms:description "A property that links a consumption event to the publication platform on which it occurs."@en ,
+                                "Eine Eigenschaft, die ein Nutzungsereignis mit der Veröffentlichungsplattform verknüpft, auf der es stattfindet."@de ;
+            rdfs:label "Occurs on"@en ,
+                       "Trifft zu auf"@de ;
+            skos:definition "an owl:ObjectProperty relating an ec:ConsumptionEvent to an ec:PublicationPlatform"@en ,
+                            "eine owl:ObjectProperty, die ec:ConsumptionEvent mit ec:PublicationPlatform verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#offers
+ec:offers rdf:type owl:ObjectProperty ;
+          dcterms:description "Die über einen Dienst verfügbaren Veröffentlichungsvorgänge."@de ,
+                              "The publication events available through a service."@en ;
+          rdfs:label "Bietet Dienst"@de ,
+                     "Offers service"@en ;
+          skos:definition "an owl:ObjectProperty relating an ec:PublicationPlatform to an ec:PublicationService"@en ,
+                          "eine owl:ObjectProperty, die eine ec:PublicationPlatform mit einer ec:PublicationService verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#originatesFrom
+ec:originatesFrom rdf:type owl:ObjectProperty ;
+                  dcterms:description "Der Vertrag, aus dem die Rechte stammen."@de ,
+                                      "The Contract from which the Rights originate."@en ;
+                  rdfs:label "Contract"@en ,
+                             "Vertrag"@de ;
+                  skos:definition "an owl:ObjectProperty relating an ec:Rights to an ec:Contract"@en ,
+                                  "eine owl:ObjectProperty, die ec:Rights mit ec:Contract verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#owns
+ec:owns rdf:type owl:ObjectProperty ;
+        dcterms:description "Die MarketingBrand, der PublicationChannel, die PublicationPlatform oder der PublicationService, die einem gegebenen Agenten (Contact, Person oder Organisation) gehören."@de ,
+                            "The MarketingBrand, PublicationChannel, PublicationPlatform, or PublicationService owned by a given Agent (Contact, Person, or Organisation)."@en ;
+        rdfs:label "Besitzt"@de ,
+                   "Owns"@en ;
+        skos:definition "an owl:ObjectProperty relating an ec:Agent to an ec:MarketingBrand, ec:PublicationChannel, ec:PublicationPlatform, or ec:PublicationService"@en ,
+                        "eine owl:ObjectProperty, die einen ec:Agent mit einem ec:MarketingBrand, ec:PublicationChannel, ec:PublicationPlatform oder ec:PublicationService verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#playsCharacter
+ec:playsCharacter rdf:type owl:ObjectProperty ;
+                  dcterms:description "A character played by a person. The relationship implies that the person has intellectual rights to the performance of the character."@en ,
+                                      "Eine von einer Person gespielte Figur. Die Beziehung impliziert, dass die Person intellektuelle Rechte an der Darbietung der Figur hat."@de ;
+                  rdfs:label "Plays character"@en ,
+                             "Spielt Rolle"@de ;
+                  skos:definition "an owl:ObjectProperty relating an ec:Involvement to an ec:Character"@en ,
+                                  "eine owl:ObjectProperty, die eine ec:Involvement mit einem ec:Character verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#playsOut
+ec:playsOut rdf:type owl:ObjectProperty ;
+            dcterms:description "Beschreibt die Essence, die in einem PublicationEvent verwendet wird."@de ,
+                                "Describes the Essence used in a PublicationEvent."@en ;
+            rdfs:label "Essence"@en ,
+                       "Essenz"@de ;
+            skos:definition "an owl:ObjectProperty relating an ec:PublicationEvent to an ec:Essence"@en ,
+                            "eine owl:ObjectProperty, die ein ec:PublicationEvent mit einer ec:Essence verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#portrays
+ec:portrays rdf:type owl:ObjectProperty ;
+            dcterms:description "An animal that appears as a character other than itself."@en ,
+                                "Ein Tier, das als eine andere Figur als sich selbst auftritt."@de ;
+            rdfs:label "Portrays"@en ,
+                       "Porträtiert"@de ;
+            skos:definition "an owl:ObjectProperty relating an ec:Animal to an ec:Character"@en ,
+                            "eine owl:ObjectProperty, die ein ec:Animal mit einem ec:Character verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#promotes
+ec:promotes rdf:type owl:ObjectProperty ;
+            dcterms:description "Der Inhalt bewirbt andere Inhalte."@de ,
+                                "The content promotes some other content."@en ;
+            rdfs:label "Fördert"@de ,
+                       "Promotes"@en ;
+            skos:definition "an owl:ObjectProperty relating an ec:EditorialWork to an ec:EditorialGroup or ec:EditorialWork"@en ,
+                            "eine owl:ObjectProperty, die ein ec:EditorialWork mit einer ec:EditorialGroup oder ec:EditorialWork verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#publishes
+ec:publishes rdf:type owl:ObjectProperty ;
+             dcterms:description "Das mit einem PublicationEvent verbundene redaktionelle Objekt."@de ,
+                                 "The editorial object associated with a PublicationEvent."@en ;
+             rdfs:label "Editorial object"@en ,
+                        "Redaktionelles Objekt"@de ;
+             skos:definition "an owl:ObjectProperty relating an ec:PublicationEvent to an ec:EditorialObject"@en ,
+                             "eine owl:ObjectProperty, die eine ec:PublicationEvent mit einem ec:EditorialObject verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#references
+ec:references rdf:type owl:ObjectProperty ;
+              dcterms:description "A related resource that is referenced, cited, or otherwise pointed to by the described resource."@en ,
+                                  "Eine verwandte Ressource, auf die von der beschriebenen Ressource verwiesen, die von ihr zitiert oder auf die anderweitig verwiesen wird."@de ;
+              rdfs:label "References"@en ,
+                         "Verweise"@de ;
+              skos:definition "an owl:ObjectProperty relating a resource to a referenced resource"@en ,
+                              "eine owl:ObjectProperty, die eine Ressource mit einer referenzierten Ressource verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#referencesRule
+ec:referencesRule rdf:type owl:ObjectProperty ;
+                  dcterms:description "A reference to the rule against which an audit report was produced through an associated measure."@en ,
+                                      "Eine Referenz auf die Regel, anhand derer ein Auditbericht über eine zugehörige Messung erstellt wurde."@de ;
+                  rdfs:label "Referenced rule"@en ,
+                             "Verwiesene Regel"@de ;
+                  skos:definition "an owl:ObjectProperty relating an ec:AuditReport to an ec:Rule"@en ,
+                                  "eine owl:ObjectProperty, die eine ec:AuditReport mit einer ec:Rule verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#renders
+ec:renders rdf:type owl:ObjectProperty ;
+           dcterms:description "A property that relates a consumption device to the essence it renders."@en ,
+                               "Eine Eigenschaft, die ein Verbrauchsgerät mit der Essenz verknüpft, die es wiedergibt."@de ;
+           rdfs:label "Renders"@en ,
+                      "Wird gerendert"@de ;
+           skos:definition "an owl:ObjectProperty relating an ec:ConsumptionDevice to an ec:Essence"@en ,
+                           "eine owl:ObjectProperty, die eine ec:ConsumptionDevice mit einer ec:Essence verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#replaces
+ec:replaces rdf:type owl:ObjectProperty ;
+            dcterms:description "Identifies that one asset replaces another."@en ,
+                                "Kennzeichnet, dass ein Asset ein anderes ersetzt."@de ;
+            rdfs:label "Ersetzt"@de ,
+                       "Replaces"@en ;
+            skos:definition "an owl:ObjectProperty relating an ec:Asset to an ec:Asset"@en ,
+                            "eine owl:ObjectProperty, die ec:Asset mit ec:Asset verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#represents
+ec:represents rdf:type owl:ObjectProperty ;
+              dcterms:description "To establish a relation between an EditorialObject and an Asset."@en ,
+                                  "Um eine Beziehung zwischen einem EditorialObject und einem Asset herzustellen."@de ;
+              rdfs:label "Related asset"@en ,
+                         "Verknüpftes Asset"@de ;
+              skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Asset"@en ,
+                              "ein owl:ObjectProperty, das eine ec:EditorialObject mit einem ec:Asset verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#requires
+ec:requires rdf:type owl:ObjectProperty ;
+            dcterms:description "Bezeichnet eine Abhängigkeit zwischen einem EditorialObject und der Ressource oder dem Objekt, das es benötigt."@de ,
+                                "Indicates a dependency between an EditorialObject and the resource or object it requires."@en ;
+            rdfs:label "Erfordert"@de ,
+                       "Requires"@en ;
+            skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:MediaResource"@en ,
+                            "eine owl:ObjectProperty, die ein ec:EditorialObject mit einem ec:MediaResource verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#requiresLicence
+ec:requiresLicence rdf:type owl:ObjectProperty ;
+                   dcterms:description "Die von einem ConsumptionEvent erforderliche ConsumptionLicence."@de ,
+                                       "The ConsumptionLicence required by a ConsumptionEvent."@en ;
+                   rdfs:label "Erforderliche Lizenz"@de ,
+                              "Required licence"@en ;
+                   skos:definition "an owl:ObjectProperty relating an ec:ConsumptionEvent to an ec:ConsumptionLicence"@en ,
+                                   "eine owl:ObjectProperty, die eine ec:ConsumptionEvent mit einer ec:ConsumptionLicence verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#resultsIn
+ec:resultsIn rdf:type owl:ObjectProperty ;
+             dcterms:description "A link between a ResonanceEvent and a ConsumptionEvent."@en ,
+                                 "Eine Verbindung zwischen einem ResonanceEvent und einem ConsumptionEvent."@de ;
+             rdfs:label "Resonance event"@en ,
+                        "Resonanzereignis"@de ;
+             skos:definition "an owl:ObjectProperty relating a ec:ConsumptionEvent to a ec:ResonanceEvent"@en ,
+                             "eine owl:ObjectProperty, die eine ec:ConsumptionEvent mit einer ec:ResonanceEvent verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#supportsConsumptionDeviceProfile
+ec:supportsConsumptionDeviceProfile rdf:type owl:ObjectProperty ;
+                                    dcterms:description "Das Profil eines Konsumgeräts."@de ,
+                                                        "The profile of a consumption device."@en ;
+                                    rdfs:label "Device profile"@en ,
+                                               "Geräteprofil"@de ;
+                                    skos:definition "an owl:ObjectProperty relating an ec:PublicationPlatform to an ec:ConsumptionDeviceProfile"@en ,
+                                                    "eine owl:ObjectProperty, die ec:PublicationPlatform mit ec:ConsumptionDeviceProfile verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#transports
+ec:transports rdf:type owl:ObjectProperty ;
+              dcterms:description "A connection through which a publication service can be transported to a consumption device. For example, it may be a cable receiver, an FM receiver, a website, or an application used to access a service."@en ,
+                                  "Eine Verbindung, über die ein Veröffentlichungsdienst zu einem Endgerät übertragen werden kann. Zum Beispiel kann dies ein Kabelreceiver, ein FM-Empfänger, eine Website oder eine Anwendung sein, die zum Zugriff auf einen Dienst verwendet wird."@de ;
+              rdfs:label "Transportiert"@de ,
+                         "Transports"@en ;
+              skos:definition "an owl:ObjectProperty relating an ec:PublicationChannel to an ec:PublicationService"@en ,
+                              "eine owl:ObjectProperty, die eine ec:PublicationChannel mit einer ec:PublicationService verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#usesConsumptionDevice
+ec:usesConsumptionDevice rdf:type owl:ObjectProperty ;
+                         dcterms:description "Die von einem Consumer verwendeten Consumption devices."@de ,
+                                             "The Consumption devices used by a Consumer."@en ;
+                         rdfs:label "Consumption device"@en ,
+                                    "Verbrauchsgerät"@de ;
+                         skos:definition "an owl:ObjectProperty relating an ec:Consumer to an ec:ConsumptionDevice"@en ,
+                                         "eine owl:ObjectProperty, die einen ec:Consumer mit einem ec:ConsumptionDevice verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#usesMeasure
+ec:usesMeasure rdf:type owl:ObjectProperty ;
+               dcterms:description "Die mit einem Audit-Job verbundene Messgröße."@de ,
+                                   "The measure associated with an audit job."@en ;
+               rdfs:label "Related measure"@en ,
+                          "Zugehörige Messung"@de ;
+               skos:definition "an owl:ObjectProperty relating an ec:AuditJob to an ec:Measure"@en ,
+                               "eine owl:ObjectProperty, die eine ec:AuditJob mit einer ec:Measure verknüpft"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#usesProductionDevice
+ec:usesProductionDevice rdf:type owl:ObjectProperty ;
+                        dcterms:description "A device used in a ProductionJob to create or process a MediaResource."@en ,
+                                            "Ein Gerät, das in einem ProductionJob verwendet wird, um eine MediaResource zu erstellen oder zu verarbeiten."@de ;
+                        rdfs:label "Production device"@en ,
+                                   "Produktionsgerät"@de ;
+                        skos:definition "an owl:ObjectProperty relating an ec:ProductionJob to an ec:ProductionDevice"@en ,
+                                        "eine owl:ObjectProperty, die ec:ProductionJob mit ec:ProductionDevice verknüpft"@de .
+
+
+###  http://www.w3.org/2000/01/rdf-schema#related
+rdfs:related rdf:type owl:ObjectProperty .
+
+
+###  http://www.w3.org/2006/time#hasTRS
+time:hasTRS rdf:type owl:ObjectProperty ;
+            dcterms:description "The temporal reference system used by a temporal position or extent description."@en ;
+            rdfs:label "Has TRS"@en .
+
+
+###  http://www.w3.org/ns/ma-ont#hasPermissions
+<http://www.w3.org/ns/ma-ont#hasPermissions> rdf:type owl:ObjectProperty ;
+                                             dcterms:description "To set permissions as defined in the W3C Media Ontology (ma-ont)."@en ;
+                                             rdfs:label "Permissions"@en ;
+                                             skos:prefLabel "Permissions"^^xsd:string .
+
+
+###  https://rdf-vocabulary.ddialliance.org/xkos/after
+xkos:after rdf:type owl:ObjectProperty ;
+           rdfs:subPropertyOf xkos:temporal ;
+           rdfs:label "after"@en .
+
+
+###  https://rdf-vocabulary.ddialliance.org/xkos/before
+xkos:before rdf:type owl:ObjectProperty ;
+            rdfs:subPropertyOf xkos:temporal ;
+            rdfs:label "before"@en .
+
+
+###  https://rdf-vocabulary.ddialliance.org/xkos/next
+xkos:next rdf:type owl:ObjectProperty ;
+          rdfs:subPropertyOf xkos:succeeds ;
+          rdfs:label "next"@en .
+
+
+###  https://rdf-vocabulary.ddialliance.org/xkos/precedes
+xkos:precedes rdf:type owl:ObjectProperty ;
+              rdfs:subPropertyOf xkos:sequential ;
+              rdfs:label "precedes"@en .
+
+
+###  https://rdf-vocabulary.ddialliance.org/xkos/previous
+xkos:previous rdf:type owl:ObjectProperty ;
+              rdfs:subPropertyOf xkos:precedes ;
+              rdfs:label "previous"@en .
+
+
+###  https://rdf-vocabulary.ddialliance.org/xkos/sequential
+xkos:sequential rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf skos:related ;
+                rdfs:label "sequential"@en .
+
+
+###  https://rdf-vocabulary.ddialliance.org/xkos/succeeds
+xkos:succeeds rdf:type owl:ObjectProperty ;
+              rdfs:subPropertyOf xkos:sequential ;
+              rdfs:label "succeeds"@en .
+
+
+###  https://rdf-vocabulary.ddialliance.org/xkos/temporal
+xkos:temporal rdf:type owl:ObjectProperty ;
+              rdfs:subPropertyOf xkos:sequential ;
+              rdfs:label "temporal"@en .
+
+
+#################################################################
+#    Data properties
+#################################################################
+
+###  http://purl.org/dc/elements/1.1/source
+dc:source rdf:type owl:DatatypeProperty ;
+          rdfs:range rdfs:Literal ;
+          dcterms:description "To identify a Resource as the source of another Resource."@en ;
+          rdfs:label "Source"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#DID
+ec:DID rdf:type owl:DatatypeProperty ;
+       rdfs:range xsd:integer ;
+       dcterms:description "Das Data Identifier-Wort (zusammen mit dem SDID, falls verwendet) gibt den Typ der begleitenden Daten an, zu denen das Paket gehört."@de ,
+                           "The Data Identifier word (along with the SDID, if used), indicates the type of ancillary data that the packet corresponds to."@en ;
+       rdfs:label "Data identifier word"@en ,
+                  "Datenidentifikatorwort"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#SDID
+ec:SDID rdf:type owl:DatatypeProperty ;
+        rdfs:range xsd:integer ;
+        dcterms:description "Secondary data identification word for ancillary data. Send mode identifier. An identifier which indicates the transmission timing for closed caption data."@en ,
+                            "Sekundäres Datenidentifikationswort für Begleitdaten. Sende-Modus-Identifikator. Ein Identifikator, der den Übertragungszeitpunkt für Untertiteldaten angibt."@de ;
+        rdfs:label "Send mode identifier"@en ,
+                   "Sende-Modus-Kennung"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#abstract
+ec:abstract rdf:type owl:DatatypeProperty ;
+            rdfs:subPropertyOf ec:contentDescription ;
+            rdfs:range rdfs:Literal ;
+            dcterms:description "An abstract summarizing the content."@en ,
+                                "Eine Zusammenfassung des Inhalts."@de ;
+            rdfs:label "Abstract"@en ,
+                       "Abstrakt"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#age
+ec:age rdf:type owl:DatatypeProperty ;
+       rdfs:range xsd:integer ;
+       dcterms:description "Das Alter in Jahren einer Kontakt-/Person."@de ,
+                           "The age in years of a Contact/Person."@en ;
+       rdfs:label "Age"@en ,
+                  "Alter"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#agentDbpedia
+ec:agentDbpedia rdf:type owl:DatatypeProperty ;
+                rdfs:subPropertyOf ec:agentLinkedData ;
+                rdfs:range xsd:anyURI ;
+                dcterms:description "A link to a DBPedia page."@en ,
+                                    "Ein Link zu einer DBPedia-Seite."@de ;
+                rdfs:label "DBpedia"@de ,
+                           "Dbpedia"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#agentEmailAddress
+ec:agentEmailAddress rdf:type owl:DatatypeProperty ;
+                     rdfs:range xsd:string ;
+                     dcterms:description "Die E-Mail-Adresse eines Agents."@de ,
+                                         "The email address of an Agent."@en ;
+                     rdfs:label "E-Mail"@de ,
+                                "Email"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#agentFacebook
+ec:agentFacebook rdf:type owl:DatatypeProperty ;
+                 rdfs:subPropertyOf ec:agentSocialMedia ;
+                 rdfs:range xsd:anyURI ;
+                 dcterms:description "Links to an Agent's Facebook page or profile as a URI."@en ,
+                                     "Verweist als URI auf die Facebook-Seite oder das Facebook-Profil eines Agenten."@de ;
+                 rdfs:label "Facebook"@de ,
+                            "Facebook"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#agentFee
+ec:agentFee rdf:type owl:DatatypeProperty ;
+            rdfs:range rdfs:Literal ;
+            dcterms:description "Die Gebühr eines Agenten."@de ,
+                                "The fee of an Agent."@en ;
+            rdfs:label "Agent fee"@en ,
+                       "Agentengebühr"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#agentFlickr
+ec:agentFlickr rdf:type owl:DatatypeProperty ;
+               rdfs:subPropertyOf ec:agentSocialMedia ;
+               rdfs:range xsd:anyURI ;
+               dcterms:description "Links to an Agent's Flickr account."@en ,
+                                   "Verweist auf das Flickr-Konto eines Agenten."@de ;
+               rdfs:label "Flickr"@de ,
+                          "Flickr"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#agentImdb
+ec:agentImdb rdf:type owl:DatatypeProperty ;
+             rdfs:subPropertyOf ec:agentLinkedData ;
+             rdfs:range xsd:anyURI ;
+             dcterms:description "A link to an imdb page."@en ,
+                                 "Ein Link zu einer IMDb-Seite."@de ;
+             rdfs:label "IMDB"@de ,
+                        "IMDB"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#agentInstagram
+ec:agentInstagram rdf:type owl:DatatypeProperty ;
+                  rdfs:subPropertyOf ec:agentSocialMedia ;
+                  rdfs:range xsd:anyURI ;
+                  dcterms:description "Links to an Agent’s Instagram account URI."@en ,
+                                      "Verweist auf die URI des Instagram-Kontos eines Agents."@de ;
+                  rdfs:label "Instagram"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#agentLinkedData
+ec:agentLinkedData rdf:type owl:DatatypeProperty ;
+                   rdfs:range xsd:anyURI ;
+                   dcterms:description "A link to linked data for the agent, expressed as a URL or URI."@en ,
+                                       "Ein Verweis auf Linked Data für den Agenten, ausgedrückt als URL oder URI."@de ;
+                   rdfs:label "Agent linked data"@en ,
+                              "Verknüpfte Agentendaten"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#agentLinkedIn
+ec:agentLinkedIn rdf:type owl:DatatypeProperty ;
+                 rdfs:subPropertyOf ec:agentSocialMedia ;
+                 rdfs:range xsd:anyURI ;
+                 dcterms:description "Links to an Agent's LinkedIn profile."@en ,
+                                     "Verweist auf das LinkedIn-Profil eines Agents."@de ;
+                 rdfs:label "LinkedIn profile"@en ,
+                            "LinkedIn-Profil"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#agentMobileTelephoneNumber
+ec:agentMobileTelephoneNumber rdf:type owl:DatatypeProperty ;
+                              rdfs:subPropertyOf ec:agentTelephoneNumber ;
+                              rdfs:range xsd:string ;
+                              dcterms:description "Die Mobiltelefonnummer eines Agenten (Kontakt/Person oder Organisation)."@de ,
+                                                  "The mobile telephone number of an Agent (Contact/Person or Organisation)."@en ;
+                              rdfs:label "Mobil"@de ,
+                                         "Mobile"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#agentPreviousName
+ec:agentPreviousName rdf:type owl:DatatypeProperty ;
+                     rdfs:range rdfs:Literal ;
+                     dcterms:description "Der frühere Name eines Agenten."@de ,
+                                         "The previous name of an Agent."@en ;
+                     rdfs:label "Previous name"@en ,
+                                "Vorheriger Name"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#agentRelatedInformationLink
+ec:agentRelatedInformationLink rdf:type owl:DatatypeProperty ;
+                               rdfs:subPropertyOf ec:agentRelatedLink ;
+                               rdfs:range xsd:anyURI ;
+                               dcterms:description "A link to a web resource containing information related to an Agent (Contact/Person or Organisation)."@en ,
+                                                   "Ein Link zu einer Webressource, die Informationen über einen Agenten (Kontakt/Person oder Organisation) enthält."@de ;
+                               rdfs:label "Related information link"@en ,
+                                          "Verknüpfung zu verwandten Informationen"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#agentRelatedLink
+ec:agentRelatedLink rdf:type owl:DatatypeProperty ;
+                    rdfs:range xsd:anyURI ;
+                    dcterms:description "A link to a web resource related to an Agent."@en ,
+                                        "Ein Link zu einer Webressource, die mit einem Agenten in Verbindung steht."@de ;
+                    rdfs:label "Related link"@en ,
+                               "Verwandter Link"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#agentRelatedPressLink
+ec:agentRelatedPressLink rdf:type owl:DatatypeProperty ;
+                         rdfs:subPropertyOf ec:agentRelatedLink ;
+                         rdfs:range xsd:anyURI ;
+                         dcterms:description "A link to a web resource containing information related to an Agent (Contact/Person or Organisation)."@en ,
+                                             "Ein Link zu einer Webressource mit Informationen zu einem Agenten (Kontakt/Person oder Organisation)."@de ;
+                         rdfs:label "Related press link"@en ,
+                                    "Verknüpfung mit Pressebezug"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#agentSocialMedia
+ec:agentSocialMedia rdf:type owl:DatatypeProperty ;
+                    rdfs:range xsd:anyURI ;
+                    dcterms:description "Links to an Agent's social media."@en ,
+                                        "Verweist auf die sozialen Medien eines Agents."@de ;
+                    rdfs:label "Social media"@en ,
+                               "Soziale Medien"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#agentTelephoneNumber
+ec:agentTelephoneNumber rdf:type owl:DatatypeProperty ;
+                        rdfs:range xsd:string ;
+                        dcterms:description "Die Telefonnummer eines Agents (Kontakt/Person oder Organisation)."@de ,
+                                            "The telephone number of an Agent (Contact/Person or Organisation)."@en ;
+                        rdfs:label "Telefon"@de ,
+                                   "Telephone"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#agentTwitter
+ec:agentTwitter rdf:type owl:DatatypeProperty ;
+                rdfs:subPropertyOf ec:agentSocialMedia ;
+                rdfs:range xsd:anyURI ;
+                dcterms:description "Links to an Agent’s Twitter account URL."@en ,
+                                    "Verweist auf die URL des Twitter-Kontos eines Agents."@de ;
+                rdfs:label "Twitter"@de ,
+                           "Twitter"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#agentWebHomepage
+ec:agentWebHomepage rdf:type owl:DatatypeProperty ;
+                    rdfs:range xsd:anyURI ;
+                    dcterms:description "Die Webadresse eines Agents (Kontakt/Person oder Organisation)."@de ,
+                                        "The webpage address of an Agent (Contact/Person or Organisation)."@en ;
+                    rdfs:label "Homepage"@de ,
+                               "Homepage"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#agentWikidata
+ec:agentWikidata rdf:type owl:DatatypeProperty ;
+                 rdfs:subPropertyOf ec:agentLinkedData ;
+                 rdfs:range xsd:anyURI ;
+                 dcterms:description "A link to a wikidata page."@en ,
+                                     "Ein Link zu einer Wikidata-Seite."@de ;
+                 rdfs:label "Wikidata"@de ,
+                            "Wikidata"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#agentWikipedia
+ec:agentWikipedia rdf:type owl:DatatypeProperty ;
+                  rdfs:subPropertyOf ec:agentSocialMedia ;
+                  rdfs:range xsd:anyURI ;
+                  dcterms:description "Links to an Agent's Wikipedia page."@en ,
+                                      "Verweist auf die Wikipedia-Seite eines Agenten."@de ;
+                  rdfs:label "Wikipedia"@de ,
+                             "Wikipedia"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#animalCharacterName
+ec:animalCharacterName rdf:type owl:DatatypeProperty ;
+                       rdfs:range rdfs:Literal ;
+                       dcterms:description "Der fiktive Charaktername, der mit einem Tier verbunden ist."@de ,
+                                           "The fictitious character name associated with an animal."@en ;
+                       rdfs:label "Animal character name"@en ,
+                                  "Name der Tierfigur"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#animalCode
+ec:animalCode rdf:type owl:DatatypeProperty ;
+              rdfs:range rdfs:Literal ;
+              dcterms:description "Der einem Tier zugeordnete Code."@de ,
+                                  "The code associated with an animal."@en ;
+              rdfs:label "Animal code"@en ,
+                         "Tiercode"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#animalPassport
+ec:animalPassport rdf:type owl:DatatypeProperty ;
+                  rdfs:range rdfs:Literal ;
+                  dcterms:description "Das Pass des Tieres zu replizieren."@de ,
+                                      "To replicate the passport of an animal."@en ;
+                  rdfs:label "Animal passport"@en ,
+                             "Tierpass"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#annotationConfidence
+ec:annotationConfidence rdf:type owl:DatatypeProperty ;
+                        rdfs:range rdfs:Literal ;
+                        dcterms:description "To estimate the confidence in an Annotation."@en ,
+                                            "Zur Schätzung des Vertrauens in eine Annotation."@de ;
+                        rdfs:label "Anmerkungssicherheit"@de ,
+                                   "Annotation confidence"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#annotationPurpose
+ec:annotationPurpose rdf:type owl:DatatypeProperty ;
+                     rdfs:range rdfs:Literal ;
+                     dcterms:description "Der Zweck, der mit einer Annotation verbunden ist."@de ,
+                                         "The purpose associated with an annotation."@en ;
+                     rdfs:label "Anmerkungszweck"@de ,
+                                "Annotation purpose"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#annotationSaliency
+ec:annotationSaliency rdf:type owl:DatatypeProperty ;
+                      rdfs:range rdfs:Literal ;
+                      dcterms:description "Die Salienz einer Annotation zu schätzen."@de ,
+                                          "To estimate the saliency of an Annotation."@en ;
+                      rdfs:label "Anmerkungsbedeutung"@de ,
+                                 "Annotation saliency"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#artefactAvailability
+ec:artefactAvailability rdf:type owl:DatatypeProperty ;
+                        rdfs:range xsd:boolean ;
+                        dcterms:description "To flag the availability of an Artefact."@en ,
+                                            "Zur Kennzeichnung der Verfügbarkeit eines Artefakts."@de ;
+                        rdfs:label "Artefact availability flag"@en ,
+                                   "Artefakt-Verfügbarkeitsflag"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#artefactBoxHeight
+ec:artefactBoxHeight rdf:type owl:DatatypeProperty ;
+                     rdfs:range xsd:nonNegativeInteger ;
+                     dcterms:description "Die Höhe der Box, die das Artefakt enthält."@de ,
+                                         "The height of the box containing the Artefact."@en ;
+                     rdfs:label "Artefact box height"@en ,
+                                "Artefakt-Box-Höhe"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#artefactBoxTopLeftCornerLineNumber
+ec:artefactBoxTopLeftCornerLineNumber rdf:type owl:DatatypeProperty ;
+                                      rdfs:range xsd:nonNegativeInteger ;
+                                      dcterms:description "Die Koordinaten auf einer vertikalen Achse der Position der oberen linken Ecke der den Artefakt enthaltenden Box."@de ,
+                                                          "The coordinates on a vertical axis of the position of the top left corner of the box containing the Artefact."@en ;
+                                      rdfs:label "Artefact box top left corner Y position"@en ,
+                                                 "Artefakt-Box: Y-Position der linken oberen Ecke"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#artefactBoxTopLeftCornerPixelNumber
+ec:artefactBoxTopLeftCornerPixelNumber rdf:type owl:DatatypeProperty ;
+                                       rdfs:range xsd:nonNegativeInteger ;
+                                       dcterms:description "Die Koordinaten auf der horizontalen Achse der Position der linken oberen Ecke der den Artefakt enthaltenden Box."@de ,
+                                                           "The coordinates on an horizontal axis of the position of the top left corner of the box containing the Artefact."@en ;
+                                       rdfs:label "Artefact box top left corner X position"@en ,
+                                                  "Artefaktbox linke obere Ecke X-Position"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#artefactBoxWidth
+ec:artefactBoxWidth rdf:type owl:DatatypeProperty ;
+                    rdfs:range xsd:nonNegativeInteger ;
+                    dcterms:description "Die Breite der Box, die das Artefakt enthält."@de ,
+                                        "The width of the box containing the Artefact."@en ;
+                    rdfs:label "Artefact box width"@en ,
+                               "Breite der Artefaktbox"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#artefactBrand
+ec:artefactBrand rdf:type owl:DatatypeProperty ;
+                 rdfs:range rdfs:Literal ;
+                 dcterms:description "Die Marke eines Artefakts."@de ,
+                                     "The brand of an artefact."@en ;
+                 rdfs:label "Artefact brand"@en ,
+                            "Artefaktmarke"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#artefactColour
+ec:artefactColour rdf:type owl:DatatypeProperty ;
+                  rdfs:range rdfs:Literal ;
+                  dcterms:description "Die Farbe oder Farben eines Artefakts."@de ,
+                                      "The colour or colours of an artefact."@en ;
+                  rdfs:label "Artefact colour(s)"@en ,
+                             "Artefaktfarbe(n)"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#artefactComment
+ec:artefactComment rdf:type owl:DatatypeProperty ;
+                   rdfs:range rdfs:Literal ;
+                   dcterms:description "A contextual comment about an Artefact."@en ,
+                                       "Ein kontextueller Kommentar zu einem Artefakt."@de ;
+                   rdfs:label "Artefact comment"@en ,
+                              "Artefaktkommentar"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#artefactModel
+ec:artefactModel rdf:type owl:DatatypeProperty ;
+                 rdfs:range rdfs:Literal ;
+                 dcterms:description "Das mit einem Artefakt verbundene Modell."@de ,
+                                     "The model associated with an Artefact."@en ;
+                 rdfs:label "Artefact model"@en ,
+                            "Artefaktmodell"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#artefactPeriod
+ec:artefactPeriod rdf:type owl:DatatypeProperty ;
+                  rdfs:range rdfs:Literal ;
+                  dcterms:description "Der mit einem Artefakt verbundene Zeitraum."@de ,
+                                      "The period associated with an Artefact."@en ;
+                  rdfs:label "Artefact period"@en ,
+                             "Artefaktzeitraum"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#artefactPriceAmount
+ec:artefactPriceAmount rdf:type owl:DatatypeProperty ;
+                       rdfs:range rdfs:Literal ;
+                       dcterms:description "Der mit einem Artefakt verbundene Preisbetrag."@de ,
+                                           "The price amount associated with an Artefact."@en ;
+                       rdfs:label "Artefact price"@en ,
+                                  "Artefaktpreis"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#artefactReference
+ec:artefactReference rdf:type owl:DatatypeProperty ;
+                     rdfs:range xsd:anyURI ;
+                     dcterms:description "A reference identifying the Artefact, expressed as a URI."@en ,
+                                         "Eine Referenz zur Identifizierung des Artefakts, ausgedrückt als URI."@de ;
+                     rdfs:label "Artefact reference"@en ,
+                                "Artefakt-Referenz"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#artefactStyle
+ec:artefactStyle rdf:type owl:DatatypeProperty ;
+                 rdfs:range rdfs:Literal ;
+                 dcterms:description "Der mit einem Artefakt verbundene Stil."@de ,
+                                     "The style associated with an Artefact."@en ;
+                 rdfs:label "Artefact style"@en ,
+                            "Artefaktstil"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#artefactUsageHistory
+ec:artefactUsageHistory rdf:type owl:DatatypeProperty ;
+                        rdfs:range rdfs:Literal ;
+                        dcterms:description "Information about the usage history of an artefact."@en ,
+                                            "Informationen über die Nutzungshistorie eines Artefakts."@de ;
+                        rdfs:label "Artefact usage history"@en ,
+                                   "Artefaktnutzungshistorie"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#artefactWebsite
+ec:artefactWebsite rdf:type owl:DatatypeProperty ;
+                   rdfs:range xsd:anyURI ;
+                   dcterms:description "A website with more information about the artefact."@en ,
+                                       "Eine Website mit weiteren Informationen über das Artefakt."@de ;
+                   rdfs:label "Artefact website"@en ,
+                              "Artefakt-Website"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#aspectRatio
+ec:aspectRatio rdf:type owl:DatatypeProperty ;
+               rdfs:range xsd:string ;
+               dcterms:description "Das mit der Medienressource oder dem Bild verknüpfte Seitenverhältnis."@de ,
+                                   "The aspect ratio associated with the media resource or picture."@en ;
+               rdfs:label "Aspect ratio"@en ,
+                          "Seitenverhältnis"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#assetValue
+ec:assetValue rdf:type owl:DatatypeProperty ;
+              dcterms:description "Der geschätzte oder tatsächliche Wert eines Vermögenswerts."@de ,
+                                  "The estimated or actual value of an asset."@en ;
+              rdfs:label "Asset value"@en ,
+                         "Vermögenswert"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#audienceAgeHigh
+ec:audienceAgeHigh rdf:type owl:DatatypeProperty ;
+                   dcterms:description "Das Höchstalter eines Publikums."@de ,
+                                       "The maximum age of an Audience."@en ;
+                   rdfs:label "Audience age high"@en ,
+                              "Zielgruppenalter hoch"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#audienceAgeLow
+ec:audienceAgeLow rdf:type owl:DatatypeProperty ;
+                  dcterms:description "Das Mindestalter eines Publikums."@de ,
+                                      "The minimum age of an Audience."@en ;
+                  rdfs:label "Altersgrenze für das Publikum"@de ,
+                             "Audience age low"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#audienceCount
+ec:audienceCount rdf:type owl:DatatypeProperty ;
+                 dcterms:description "Die Zuschauerreichweite in Zahlen oder Prozent."@de ,
+                                     "The Audience reach in numbers or percent."@en ;
+                 rdfs:label "Audience number"@en ,
+                            "Publikumszahl"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#audienceInterest
+ec:audienceInterest rdf:type owl:DatatypeProperty ;
+                    dcterms:description "Die Punkte von Interesse eines Publikums."@de ,
+                                        "The points of interest of an Audience."@en ;
+                    rdfs:label "Audience interest"@en ,
+                               "Publikumsinteresse"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#audioBitRate
+ec:audioBitRate rdf:type owl:DatatypeProperty ;
+                rdfs:range xsd:nonNegativeInteger ;
+                dcterms:description "Die numerische Bitrate der Audiokomponente, ausgedrückt als nichtnegative Ganzzahl."@de ,
+                                    "The numerical bitrate of the audio component, expressed as a non-negative integer."@en ;
+                rdfs:label "Audio bitrate"@en ,
+                           "Audiobitrate"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#audioBitRateMax
+ec:audioBitRateMax rdf:type owl:DatatypeProperty ;
+                   rdfs:range xsd:nonNegativeInteger ;
+                   dcterms:description "Die maximale Audio-Bitrate."@de ,
+                                       "The max audio bitrate."@en ;
+                   rdfs:label "Audio bitrate max"@en ,
+                              "Audio-Bitrate max"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#audioBitRateMode
+ec:audioBitRateMode rdf:type owl:DatatypeProperty ;
+                    rdfs:range rdfs:Literal ;
+                    dcterms:description "Der Audiobitrate-Modus."@de ,
+                                        "The audio bitrate mode."@en ;
+                    rdfs:label "Audio bitrate mode"@en ,
+                               "Audiobitrate-Modus"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#audioEncodingLevel
+ec:audioEncodingLevel rdf:type owl:DatatypeProperty ;
+                      rdfs:subPropertyOf ec:encodingLevel ;
+                      rdfs:range rdfs:Literal ;
+                      dcterms:description "Die Kodierungsebene, wie in den Spezifikationen definiert."@de ,
+                                          "The encoding level as defined in specifications."@en ;
+                      rdfs:label "Audio encoding level"@en ,
+                                 "Audio-Codierungsstufe"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#audioEncodingProfile
+ec:audioEncodingProfile rdf:type owl:DatatypeProperty ;
+                        rdfs:subPropertyOf ec:encodingProfile ;
+                        rdfs:range rdfs:Literal ;
+                        dcterms:description "Das Encoding-Profil gemäß den in den Spezifikationen definierten Vorgaben."@de ,
+                                            "The encoding profile as defined in specifications."@en ;
+                        rdfs:label "Audio encoding profile"@en ,
+                                   "Audio-Kodierungsprofil"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#audioTrackConfiguration
+ec:audioTrackConfiguration rdf:type owl:DatatypeProperty ;
+                           rdfs:range rdfs:Literal ;
+                           dcterms:description "Die Konfiguration der in der MediaResource enthaltenen Audiotracks."@de ,
+                                               "The configuration of audio tracks contained in the MediaResource."@en ;
+                           rdfs:label "Audio track configuration"@en ,
+                                      "Audiotrack-Konfiguration"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#audioTrackNumber
+ec:audioTrackNumber rdf:type owl:DatatypeProperty ;
+                    rdfs:range xsd:nonNegativeInteger ;
+                    dcterms:description "Die Nummer der Tonspur, die verwendet wird, um eine Spur von einer anderen in einer Medienressource zu unterscheiden."@de ,
+                                        "The audio track number used to distinguish one track from another in a media resource."@en ;
+                    rdfs:label "Audio track number"@en ,
+                               "Audiospurnummer"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#auditReportResults
+ec:auditReportResults rdf:type owl:DatatypeProperty ;
+                      dcterms:description "Die zusammengefassten Ergebnisse eines oder mehrerer Audit-Jobs."@de ,
+                                          "The combined results of one or more audit jobs."@en ;
+                      rdfs:label "Audit report results"@en ,
+                                 "Prüfergebnisbericht"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#awardCeremony
+ec:awardCeremony rdf:type owl:DatatypeProperty ;
+                 rdfs:range rdfs:Literal ;
+                 dcterms:description "Der Name der Preisverleihung."@de ,
+                                     "The award ceremony name."@en ;
+                 rdfs:label "Award ceremony"@en ,
+                            "Preisverleihung"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#bitDepth
+ec:bitDepth rdf:type owl:DatatypeProperty ;
+            rdfs:range xsd:nonNegativeInteger ;
+            dcterms:description "Die Bittiefe, mit der die Medienressource codiert wurde."@de ,
+                                "The bit depth at which the media resource has been encoded."@en ;
+            rdfs:label "Bit depth"@en ,
+                       "Bittiefe"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#bitRate
+ec:bitRate rdf:type owl:DatatypeProperty ;
+           rdfs:range xsd:nonNegativeInteger ;
+           dcterms:description "Die Bitrate, mit der die MediaResource wiedergegeben werden kann, in Bits pro Sekunde. Verwenden Sie die aktuelle Bitrate, wenn sie konstant ist, oder die durchschnittliche Bitrate, wenn sie variabel ist."@de ,
+                               "The bitrate at which the MediaResource can be played, in bits per second. Use the current bitrate if constant, or the average bitrate if variable."@en ;
+           rdfs:label "Bit rate"@en ,
+                      "Bitrate"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#bitRateMax
+ec:bitRateMax rdf:type owl:DatatypeProperty ;
+              rdfs:range xsd:nonNegativeInteger ;
+              dcterms:description "Die maximale Bitrate, wenn variabel, in Bits pro Sekunde."@de ,
+                                  "The maximum bitrate when variable, in bits per second."@en ;
+              rdfs:label "Maximale Bitrate"@de ,
+                         "Maximum bitrate"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#bitRateMode
+ec:bitRateMode rdf:type owl:DatatypeProperty ;
+               rdfs:range rdfs:Literal ;
+               dcterms:description "A flag to indicate if the bit rate is fixed or variable."@en ,
+                                   "Ein Kennzeichen, das angibt, ob die Bitrate fest oder variabel ist."@de ;
+               rdfs:label "Bitrate mode"@en ,
+                          "Bitratenmodus"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#bitRateOverall
+ec:bitRateOverall rdf:type owl:DatatypeProperty ;
+                  rdfs:range xsd:nonNegativeInteger ;
+                  dcterms:description "Die Gesamtbitrate, mit der die MediaResource wiedergegeben werden kann, in Bits pro Sekunde. Verwenden Sie die aktuelle Bitrate, wenn sie konstant ist, und die durchschnittliche Bitrate, wenn sie variabel ist."@de ,
+                                      "The overall bitrate at which the MediaResource can be played, in bits per second. Use the current bitrate if constant, and the average bitrate if variable."@en ;
+                  rdfs:label "Gesamte Bitrate"@de ,
+                             "Overall bitrate"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#bookmark
+ec:bookmark rdf:type owl:DatatypeProperty ;
+            rdfs:subPropertyOf ec:contentDescription ;
+            rdfs:range rdfs:Literal ;
+            dcterms:description "A bookmark value associated with an editorial object."@en ,
+                                "Ein Lesezeichenwert, der mit einem redaktionellen Objekt verknüpft ist."@de ;
+            rdfs:label "Bookmark"@en ,
+                       "Lesezeichen"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#characterEndIndex
+ec:characterEndIndex rdf:type owl:DatatypeProperty ;
+                     rdfs:range xsd:integer ;
+                     dcterms:description "Der Endzeichenindex des Textabschnitts, auf den die Annotation angewendet wird."@de ,
+                                         "The end character index of the portion of text to which the annotation applies."@en ;
+                     rdfs:label "Anmerkungs-Startindex des Zeichens"@de ,
+                                "Annotation character start index"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#characterStartIndex
+ec:characterStartIndex rdf:type owl:DatatypeProperty ;
+                       rdfs:range xsd:integer ;
+                       dcterms:description "Der Startzeichenindex des Textabschnitts, auf den die Annotation angewendet wird."@de ,
+                                           "The start character index of the portion of text to which the annotation applies."@en ;
+                       rdfs:label "Annotation text character start index"@en ,
+                                  "Startindex des Zeichens in der Anmerkungstext"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#codecFamily
+ec:codecFamily rdf:type owl:DatatypeProperty ;
+               rdfs:range rdfs:Literal ;
+               dcterms:description "Die Produktfamilie des Codecs."@de ,
+                                   "The product family of the codec."@en ;
+               rdfs:label "Codec family"@en ,
+                          "Codec-Familie"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#codecVersion
+ec:codecVersion rdf:type owl:DatatypeProperty ;
+                rdfs:range rdfs:Literal ;
+                dcterms:description "Die Version des Codecs."@de ,
+                                    "The version of the codec."@en ;
+                rdfs:label "Codec version"@en ,
+                           "Codec-Version"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#comments
+ec:comments rdf:type owl:DatatypeProperty ;
+            rdfs:subPropertyOf ec:contentDescription ;
+            rdfs:range rdfs:Literal ;
+            dcterms:description "A comment associated with the editorial object."@en ,
+                                "Ein Kommentar, der mit dem redaktionellen Objekt verknüpft ist."@de ;
+            rdfs:label "Comments"@en ,
+                       "Kommentare"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#consumptionDeviceBrand
+ec:consumptionDeviceBrand rdf:type owl:DatatypeProperty ;
+                          dcterms:description "Die Marke eines ConsumptionDevice."@de ,
+                                              "The brand of a ConsumptionDevice."@en ;
+                          rdfs:label "Consumption device brand"@en ,
+                                     "Marke des Verbrauchsgeräts"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#consumptionDeviceBrowser
+ec:consumptionDeviceBrowser rdf:type owl:DatatypeProperty ;
+                            dcterms:description "Der mit einem ConsumptionDevice kompatible Browser."@de ,
+                                                "The browser compatible with a ConsumptionDevice."@en ;
+                            rdfs:label "Browser des Verbrauchsgeräts"@de ,
+                                       "Consumption device browser"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#consumptionDeviceModel
+ec:consumptionDeviceModel rdf:type owl:DatatypeProperty ;
+                          dcterms:description "Das Modell eines ConsumptionDevice."@de ,
+                                              "The model of a ConsumptionDevice."@en ;
+                          rdfs:label "Consumption device model"@en ,
+                                     "Verbrauchsgerätmodell"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#consumptionDeviceOS
+ec:consumptionDeviceOS rdf:type owl:DatatypeProperty ;
+                       dcterms:description "Das Betriebssystem eines ConsumptionDevice."@de ,
+                                           "The operating system of a ConsumptionDevice."@en ;
+                       rdfs:label "Consumption device OS"@en ,
+                                  "Verbrauchsgeräte-OS"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#consumptionLicenceText
+ec:consumptionLicenceText rdf:type owl:DatatypeProperty ;
+                          dcterms:description "Die Bedingungen einer ConsumptionLicence."@de ,
+                                              "The terms of a ConsumptionLicence."@en ;
+                          rdfs:label "Consumption licence"@en ,
+                                     "Verbrauchslizenz"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#contentDescription
+ec:contentDescription rdf:type owl:DatatypeProperty ;
+                      rdfs:range rdfs:Literal ;
+                      dcterms:description "Dies kann durch Verwendung von Untereigenschaften spezifiziert werden, wie sie in https://github.com/ebu/ebu_cs/blob/main/metadata/cs/ebu_DescriptionTypeCodeCS.xml definiert sind, beispielsweise mit Einträgen wie \"summary\" oder \"script\"."@de ,
+                                          "This can be specialized by using sub-properties like defined in https://github.com/ebu/ebu_cs/blob/main/metadata/cs/ebu_DescriptionTypeCodeCS.xml implemented as examples such as 'summary' or 'script'."@en ;
+                      rdfs:isDefinedBy <dc:description> ;
+                      rdfs:label "Content description"@en ,
+                                 "Inhaltsbeschreibung"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#contractCostAmount
+ec:contractCostAmount rdf:type owl:DatatypeProperty ;
+                      dcterms:description "Der Betrag der ContractCost."@de ,
+                                          "The amount of the ContractCost."@en ;
+                      rdfs:label "Cost amount"@en ,
+                                 "Kostenbetrag"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#costumeSizeInformation
+ec:costumeSizeInformation rdf:type owl:DatatypeProperty ;
+                          rdfs:range rdfs:Literal ;
+                          dcterms:description "To collect all information available useful to determine the size of a Costume."@en ,
+                                              "Zur Sammlung aller verfügbaren Informationen, die nützlich sind, um die Größe eines Kostüms zu bestimmen."@de ;
+                          rdfs:label "Costume size information"@en ,
+                                     "Kostümgrößeninformationen"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#costumeTexture
+ec:costumeTexture rdf:type owl:DatatypeProperty ;
+                  rdfs:range rdfs:Literal ;
+                  dcterms:description "Bereich: ein String oder ein Concept-Code aus einem Vokabular, z. B. Getty. Zur Definition der Textur eines Kostüms."@de ,
+                                      "Range: a string or a Concept code from a vocabulary, e.g. Getty To define the texture of a Costume."@en ;
+                  rdfs:label "Costume texture"@en ,
+                             "Kostümtextur"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#day
+ec:day rdf:type owl:DatatypeProperty ;
+       rdfs:range xsd:integer ;
+       dcterms:description "Der Tagesbestandteil eines Datums- oder Datum-Uhrzeit-Werts, ausgedrückt als ganze Zahl."@de ,
+                           "The day component of a date or date-time value, expressed as an integer."@en ;
+       rdfs:label "Day"@en ,
+                  "Tag"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#description
+ec:description rdf:type owl:DatatypeProperty ;
+               rdfs:range rdfs:Literal ;
+               dcterms:description "A summary of the resource."@en ,
+                                   "Eine Zusammenfassung der Ressource."@de ;
+               rdfs:label "Beschreibung"@de ,
+                          "Description"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dimensions
+ec:dimensions rdf:type owl:DatatypeProperty ;
+              rdfs:range rdfs:Literal ;
+              dcterms:description "Beschreibt die physischen Abmessungen einer MediaResource, wobei Maßeinheiten angehängt und als Teil des Werts gespeichert werden."@de ,
+                                  "Describes the physical dimensions of a MediaResource, with units of measure concatenated to become part of the value."@en ;
+              rdfs:label "Dimensionen"@de ,
+                         "Dimensions"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#displayOrder
+ec:displayOrder rdf:type owl:DatatypeProperty ;
+                rdfs:range rdfs:Literal ;
+                dcterms:description "Die Reihenfolge, in der ein Agent in einer Szene erscheint."@de ,
+                                    "The order in which an Agent appears in a scene."@en ;
+                rdfs:label "Anzeigereihenfolge"@de ,
+                           "Display order"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#editUnit
+ec:editUnit rdf:type owl:DatatypeProperty ;
+            rdfs:range xsd:long ;
+            dcterms:description "Die Edit-Einheit ist z. B. der Kehrwert der Audio-Samplerate oder der Videobildrate."@de ,
+                                "The edit unit is e.g. the inverse of the audio sample rate or video frame rate."@en ;
+            rdfs:label "Edit unit"@en ,
+                       "Schnitt-Einheit"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#editUnitNumbering
+ec:editUnitNumbering rdf:type owl:DatatypeProperty ;
+                     rdfs:range xsd:long ;
+                     dcterms:description "Time expressed as the number of edit units or samples."@en ,
+                                         "Zeit, ausgedrückt als Anzahl von Schnitt-Einheiten oder Samples."@de ;
+                     rdfs:label "Edit unit numbering"@en ,
+                                "Schnittstellenzählnummerierung"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#education
+ec:education rdf:type owl:DatatypeProperty ;
+             rdfs:range rdfs:Literal ;
+             dcterms:description "Information about a person's education."@en ,
+                                 "Informationen über die Ausbildung einer Person."@de ;
+             rdfs:label "Bildung"@de ,
+                        "Education"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#encodingLevel
+ec:encodingLevel rdf:type owl:DatatypeProperty ;
+                 rdfs:range rdfs:Literal ;
+                 dcterms:description "Die dem Medienobjekt zugeordnete Kodierungsebene."@de ,
+                                     "The encoding level associated with a media resource."@en ;
+                 rdfs:label "Encoding level"@en ,
+                            "Kodierungsstufe"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#encodingProfile
+ec:encodingProfile rdf:type owl:DatatypeProperty ;
+                   rdfs:range rdfs:Literal ;
+                   dcterms:description "Das Codierungsprofil, wie es in Spezifikationen definiert ist."@de ,
+                                       "The encoding profile as defined in specifications."@en ;
+                   rdfs:label "Encoding profile"@en ,
+                              "Kodierungsprofil"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#episodeNumber
+ec:episodeNumber rdf:type owl:DatatypeProperty ;
+                 rdfs:range xsd:integer ;
+                 dcterms:description "Die ganzzahlige Episodennummer, die einem Programme zugewiesen ist."@de ,
+                                     "The integer episode number assigned to a Programme."@en ;
+                 rdfs:label "Episode number"@en ,
+                            "Episodennummer"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#episodeNumberInSeason
+ec:episodeNumberInSeason rdf:type owl:DatatypeProperty ;
+                         rdfs:range xsd:integer ;
+                         dcterms:description "Die Episodennummer in einer Staffel."@de ,
+                                             "The Episode Number in a season."@en ;
+                         rdfs:label "Episode number in season"@en ,
+                                    "Episodennummer in Staffel"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#episodeNumberInSerial
+ec:episodeNumberInSerial rdf:type owl:DatatypeProperty ;
+                         rdfs:range xsd:integer ;
+                         dcterms:description "An integer giving the episode number of a programme within a serial."@en ,
+                                             "Eine ganze Zahl, die die Episodennummer eines Programms innerhalb einer Serie angibt."@de ;
+                         rdfs:label "Episode number of serial"@en ,
+                                    "Episodennummer der Serie"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#episodeNumberInSeries
+ec:episodeNumberInSeries rdf:type owl:DatatypeProperty ;
+                         rdfs:range xsd:integer ;
+                         dcterms:description "Die Episodennummer in einer Serie."@de ,
+                                             "The Episode Number in a series."@en ;
+                         rdfs:label "Episode number in series"@en ,
+                                    "Episodennummer in Serie"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#equivalentTime
+ec:equivalentTime rdf:type owl:DatatypeProperty ;
+                  rdfs:range xsd:float ;
+                  dc:description "Notation of time in seconds compares different ways to denote time, like timecode or sample count."@en ;
+                  dcterms:description "A numeric value indicating the equivalent time for a timeline point."@en ,
+                                      "Ein numerischer Wert, der die äquivalente Zeit für einen Zeitachsenpunkt angibt."@de ;
+                  rdfs:label "Equivalent time"@en ,
+                             "Äquivalente Zeit"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#familyInformation
+ec:familyInformation rdf:type owl:DatatypeProperty ;
+                     rdfs:range rdfs:Literal ;
+                     dcterms:description "Information about a person's family."@en ,
+                                         "Informationen über die Familie einer Person."@de ;
+                     rdfs:label "Familieninformation"@de ,
+                                "Family information"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#familyName
+ec:familyName rdf:type owl:DatatypeProperty ;
+              rdfs:range rdfs:Literal ;
+              dcterms:description "Der Familienname einer Person."@de ,
+                                  "The family name of a Person."@en ;
+              rdfs:label "Familienname"@de ,
+                         "Family name"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#fileName
+ec:fileName rdf:type owl:DatatypeProperty ,
+                     owl:FunctionalProperty ;
+            rdfs:range xsd:string ;
+            dcterms:description "Der Name der Datei, die die Ressource enthält."@de ,
+                                "The name of the file containing the Resource."@en ;
+            rdfs:label "Dateiname"@de ,
+                       "File name"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#fileSize
+ec:fileSize rdf:type owl:DatatypeProperty ;
+            rdfs:range xsd:nonNegativeInteger ;
+            dcterms:description "Gibt die Größe einer Ressource in Bytes an."@de ,
+                                "Provides the size of a Resource in bytes."@en ;
+            rdfs:label "Dateigröße"@de ,
+                       "File size"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#firstShowing
+ec:firstShowing rdf:type owl:DatatypeProperty ,
+                         owl:FunctionalProperty ;
+                rdfs:range xsd:boolean ;
+                dcterms:description "Kennzeichnen, dass dies ein PublicationEvent der ersten Ausstrahlung ist."@de ,
+                                    "To flag this is a first showing PublicationEvent."@en ;
+                rdfs:label "First showing flag"@en ,
+                           "Kennzeichnung der ersten Ausstrahlung"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#firstShowingThisService
+ec:firstShowingThisService rdf:type owl:DatatypeProperty ,
+                                    owl:FunctionalProperty ;
+                           rdfs:range xsd:boolean ;
+                           dcterms:description "Kennzeichnet, dass dies auf diesem Dienst ein First-Showing-PublicationEvent ist."@de ,
+                                               "To flag this is a first showing PublicationEvent on this service."@en ;
+                           rdfs:label "Erstsendung auf dem Dienst-Flag"@de ,
+                                      "First showing on service flag"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#folksonomy
+ec:folksonomy rdf:type owl:DatatypeProperty ;
+              rdfs:range rdfs:Literal ;
+              dcterms:description "Bietet eine von Benutzerinnen/Benutzern bzw. dem Publikum erzeugte Beschreibung, ein Tag oder ein Label für den Inhalt einer Ressource."@de ,
+                                  "Provides a user/audience-generated description, tag, or label for resource content."@en ;
+              rdfs:label "Folksonomie"@de ,
+                         "Folksonomy"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#foodCategory
+ec:foodCategory rdf:type owl:DatatypeProperty ;
+                rdfs:range rdfs:Literal ;
+                dcterms:description "A category of food."@en ,
+                                    "Eine Kategorie von Lebensmitteln."@de ;
+                rdfs:label "Food category"@en ,
+                           "Lebensmittelkategorie"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#foodIngredient
+ec:foodIngredient rdf:type owl:DatatypeProperty ;
+                  rdfs:range rdfs:Literal ;
+                  dcterms:description "Die Nahrungszutaten oder Nahrungsmittel."@de ,
+                                      "The Food ingredients or Food items."@en ;
+                  rdfs:label "Food ingredient"@en ,
+                             "Lebensmittelzutat"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#formatId
+ec:formatId rdf:type owl:DatatypeProperty ;
+            rdfs:range [ rdf:type rdfs:Datatype ;
+                         owl:unionOf ( xsd:anyURI
+                                       xsd:string
+                                     )
+                       ] ;
+            dcterms:description "An Id attributed to a Format."@en ,
+                                "Eine Kennung, die einem Format zugeordnet ist."@de ;
+            rdfs:label "Format id"@en ,
+                       "Format-ID"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#frameHeight
+ec:frameHeight rdf:type owl:DatatypeProperty ;
+               rdfs:subPropertyOf ec:height ;
+               rdfs:range xsd:integer ;
+               dcterms:description "Die Höhe eines Videobildrahmens."@de ,
+                                   "The height of a video frame."@en ;
+               rdfs:label "Frame height"@en ,
+                          "Framehöhe"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#frameHeightUnit
+ec:frameHeightUnit rdf:type owl:DatatypeProperty ;
+                   rdfs:subPropertyOf ec:heightUnit ;
+                   rdfs:range rdfs:Literal ;
+                   dcterms:description "Die Einheit, mit der die Höhe eines Bildes gemessen wird."@de ,
+                                       "The unit used to measure the height of a frame."@en ;
+                   rdfs:label "Einheit der Frame-Höhe"@de ,
+                              "Frame height unit"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#frameRate
+ec:frameRate rdf:type owl:DatatypeProperty ;
+             rdfs:range rdfs:Literal ;
+             dcterms:description "Die Einheit, die verwendet wird, um die Bildrate einer MediaResource in Bildern pro Sekunde auszudrücken."@de ,
+                                 "The unit used to express the frame rate of a MediaResource in frames/second."@en ;
+             rdfs:label "Bildrate"@de ,
+                        "Frame rate"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#frameSizeUnit
+ec:frameSizeUnit rdf:type owl:DatatypeProperty ;
+                 rdfs:range rdfs:Literal ;
+                 dcterms:description "Die Einheit, die verwendet wird, um die Breite oder Höhe des Bildrahmens anzugeben. Die Standardeinheit ist „Pixel“."@de ,
+                                     "The unit used to express the frame width or height. The unit by default is 'pixel'."@en ;
+                 rdfs:label "Frame size unit"@en ,
+                            "Frame-Größeneinheit"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#frameWidth
+ec:frameWidth rdf:type owl:DatatypeProperty ;
+              rdfs:subPropertyOf ec:width ;
+              rdfs:range xsd:integer ;
+              dcterms:description "Die Breite eines Videobildes."@de ,
+                                  "The width of a video frame."@en ;
+              rdfs:label "Frame width"@en ,
+                         "Framebreite"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#frameWidthUnit
+ec:frameWidthUnit rdf:type owl:DatatypeProperty ;
+                  rdfs:subPropertyOf ec:widthUnit ;
+                  rdfs:range rdfs:Literal ;
+                  dcterms:description "Die Einheit, mit der die Breite eines Bildrahmens gemessen wird."@de ,
+                                      "The unit used to measure the width of a frame."@en ;
+                  rdfs:label "Frame width unit"@en ,
+                             "Rahmenbreiten-Einheit"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#free
+ec:free rdf:type owl:DatatypeProperty ,
+                 owl:FunctionalProperty ;
+        rdfs:range xsd:boolean ;
+        dcterms:description "A flag to indicate that the access to the PublicationEvent is 'free'."@en ,
+                            "Ein Kennzeichen, das anzeigt, dass der Zugriff auf das PublicationEvent „free“ ist."@de ;
+        rdfs:label "Free access"@en ,
+                   "Freier Zugang"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#gender
+ec:gender rdf:type owl:DatatypeProperty ;
+          rdfs:range rdfs:Literal ;
+          dcterms:description "Das Geschlecht einer Person, z. B. männlich oder weiblich."@de ,
+                              "The gender of a Person e.g. male or female."@en ;
+          rdfs:label "Gender"@en ,
+                     "Geschlecht"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#givenName
+ec:givenName rdf:type owl:DatatypeProperty ;
+             rdfs:range rdfs:Literal ;
+             dcterms:description "Der Vorname einer Person."@de ,
+                                 "The given name of a Person."@en ;
+             rdfs:label "Given name"@en ,
+                        "Vorname"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hashValue
+ec:hashValue rdf:type owl:DatatypeProperty ;
+             rdfs:range xsd:string ;
+             dcterms:description "Der mit einer Ressource verbundene Hashwert. Es gibt verschiedene Methoden/Algorithmen zur Berechnung von Hashwerten, die als Untereigenschaften definiert werden können."@de ,
+                                 "The hash value associated with a Resource. There are different methods / algorithms to calculate hash values, which can be defined as sub-properties."@en ;
+             rdfs:label "Hash code"@en ,
+                        "Hash-Code"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#height
+ec:height rdf:type owl:DatatypeProperty ;
+          rdfs:range xsd:integer ;
+          dcterms:description "Die Höhe z. B. eines Videobilds, typischerweise ausgedrückt als Anzahl von Zeilen, oder die Höhe eines Bildes/Fotos, ausgedrückt in Millimetern oder Ähnlichem."@de ,
+                              "The height of e.g. a video frame typically expressed as a number of lines or the height of a picture/image expressed in millimeters or else."@en ;
+          rdfs:label "Height"@en ,
+                     "Höhe"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#heightUnit
+ec:heightUnit rdf:type owl:DatatypeProperty ;
+              rdfs:range rdfs:Literal ;
+              dcterms:description "Die Einheit, die zur Angabe der Höhe verwendet wird."@de ,
+                                  "The unit used to express height."@en ;
+              rdfs:label "Height unit"@en ,
+                         "Höheneinheit"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#highlights
+ec:highlights rdf:type owl:DatatypeProperty ;
+              rdfs:subPropertyOf ec:contentDescription ;
+              rdfs:range rdfs:Literal ;
+              dcterms:description "Provides highlights for an editorial object as a concise content description."@en ,
+                                  "Stellt Highlights für ein redaktionelles Objekt als knappe Inhaltsbeschreibung bereit."@de ;
+              rdfs:label "Hervorhebungen"@de ,
+                         "Highlights"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hobbies
+ec:hobbies rdf:type owl:DatatypeProperty ;
+           rdfs:range rdfs:Literal ;
+           dcterms:description "Die Hobbys einer Person."@de ,
+                               "The hobbies of a Person."@en ;
+           rdfs:label "Hobbies"@en ,
+                      "Hobbys"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#iFrameSize
+ec:iFrameSize rdf:type owl:DatatypeProperty ;
+              rdfs:range xsd:int ;
+              dcterms:description "Der Abstand zwischen zwei I-Frames, auch als GOP-Größe bekannt."@de ,
+                                  "The distance between 2 I-frames also known as the gop size."@en ;
+              rdfs:label "I-Frame/GOP-Größe"@de ,
+                         "I-frame/GOP size"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#identifierValue
+ec:identifierValue rdf:type owl:DatatypeProperty ;
+                   rdfs:range rdfs:Literal ;
+                   dcterms:description "Der mit einem Bezeichner verknüpfte Wert. Er kann ein String oder anyURI sein."@de ,
+                                       "The value associated with an identifier. It may be a string or anyURI."@en ;
+                   rdfs:label "Identifier value"@en ,
+                              "Identifikatorwert"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#inchesPerSecond
+ec:inchesPerSecond rdf:type owl:DatatypeProperty ;
+                   rdfs:subPropertyOf ec:playbackSpeed ;
+                   rdfs:range xsd:double ;
+                   dcterms:description "Gibt die Anzahl der Inches pro Sekunde an, mit der ein analoges Audioband für die menschliche Wiedergabe abgespielt werden soll."@de ,
+                                       "Identifies the inches per second at which an analog audio tape should be played back for human consumption."@en ;
+                   rdfs:label "Inches per second"@en ,
+                              "Zoll pro Sekunde"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#internetConnectivity
+ec:internetConnectivity rdf:type owl:DatatypeProperty ,
+                                 owl:FunctionalProperty ;
+                        dcterms:description "Gibt an, ob der Dienst eine Internetverbindung benötigt."@de ,
+                                            "Indicates whether the service requires Internet connectivity."@en ;
+                        rdfs:label "Internet connectivity"@en ,
+                                   "Internetverbindung"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isoDuration
+ec:isoDuration rdf:type owl:DatatypeProperty ;
+               rdfs:range xsd:string ;
+               dcterms:description "A duration expressed as a string formatted as ISO8601 ie PT3M23S."@en ,
+                                   "Eine Dauer, ausgedrückt als Zeichenkette im ISO8601-Format, z. B. PT3M23S."@de ;
+               rdfs:label "ISO duration"@en ,
+                          "ISO-Dauer"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#lineNumber
+ec:lineNumber rdf:type owl:DatatypeProperty ;
+              rdfs:range xsd:integer ;
+              dcterms:description "Die Nummer der Zeile, auf der Zusatzdaten im digitalen Bereich geführt werden."@de ,
+                                  "The number of the line on which ancillary data is carried in the digital domain."@en ;
+              rdfs:label "Line number"@en ,
+                         "Zeilennummer"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#live
+ec:live rdf:type owl:DatatypeProperty ,
+                 owl:FunctionalProperty ;
+        rdfs:range xsd:boolean ;
+        dcterms:description "A flag to signal that content is live."@en ,
+                            "Ein Kennzeichen, das signalisiert, dass der Inhalt live ist."@de ;
+        rdfs:label "Live"@de ,
+                   "Live"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#locationAddressApartmentNumber
+ec:locationAddressApartmentNumber rdf:type owl:DatatypeProperty ;
+                                  rdfs:range xsd:string ;
+                                  dcterms:description "Die Nummer, die eine Wohnung in einem Haus identifiziert."@de ,
+                                                      "The number identifying an apartment in a house."@en ;
+                                  rdfs:label "Apartment number"@en ,
+                                             "Wohnungsnummer"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#locationAddressArea
+ec:locationAddressArea rdf:type owl:DatatypeProperty ;
+                       rdfs:range rdfs:Literal ;
+                       dcterms:description "Der Bereichsteil einer mit einem Ort verknüpften Adresse."@de ,
+                                           "The area part of an address associated with a location."@en ;
+                       rdfs:label "Area"@en ,
+                                  "Bereich"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#locationAddressCountry
+ec:locationAddressCountry rdf:type owl:DatatypeProperty ;
+                          rdfs:range rdfs:Literal ;
+                          dcterms:description "Der Ländername oder Ländercode für den Standort."@de ,
+                                              "The country name or country code for the location."@en ;
+                          rdfs:label "Country"@en ,
+                                     "Land"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#locationAddressHouseNumber
+ec:locationAddressHouseNumber rdf:type owl:DatatypeProperty ;
+                              rdfs:range xsd:string ;
+                              dcterms:description "Die Nummer, die dem Haus oder einem Eingang in einer Straße zugewiesen wird."@de ,
+                                                  "The number given to the house or an entrance in a street."@en ;
+                              rdfs:label "Hausnummer"@de ,
+                                         "House number"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#locationAddressMunicipality
+ec:locationAddressMunicipality rdf:type owl:DatatypeProperty ;
+                               rdfs:range rdfs:Literal ;
+                               dcterms:description "Gibt den Namen einer Stadt, eines Dorfes usw. an."@de ,
+                                                   "Provides the name of a city, village, etc."@en ;
+                               rdfs:label "Gemeinde"@de ,
+                                          "Municipality"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#locationAddressPostalCode
+ec:locationAddressPostalCode rdf:type owl:DatatypeProperty ;
+                             rdfs:range rdfs:Literal ;
+                             dcterms:description "Die mit einem Ort verknüpfte Postleitzahl."@de ,
+                                                 "The postal code associated with a location."@en ;
+                             rdfs:label "Postal code"@en ,
+                                        "Postleitzahl"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#locationAddressStreetName
+ec:locationAddressStreetName rdf:type owl:DatatypeProperty ;
+                             rdfs:range rdfs:Literal ;
+                             dcterms:description "Der Name der Straße, des Platzes oder des Blocks in einer Adresse."@de ,
+                                                 "The name of the street, square or block in an address."@en ;
+                             rdfs:label "Straßenname"@de ,
+                                        "Street name"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#locationAltitude
+ec:locationAltitude rdf:type owl:DatatypeProperty ;
+                    rdfs:range xsd:float ;
+                    dcterms:description "Die Höhe einer Location in Metern."@de ,
+                                        "The altitude of a Location in meters."@en ;
+                    rdfs:label "Altitude"@en ,
+                               "Höhe"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#locationCoordinateSystemName
+ec:locationCoordinateSystemName rdf:type owl:DatatypeProperty ;
+                                rdfs:range rdfs:Literal ;
+                                dcterms:description "Der Name des GPS-Koordinatensystems, das für einen Ort verwendet wird."@de ,
+                                                    "The name of the GPS coordinate system used for a location."@en ;
+                                rdfs:label "Coordinate system"@en ,
+                                           "Koordinatensystem"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#locationLatitude
+ec:locationLatitude rdf:type owl:DatatypeProperty ;
+                    rdfs:range xsd:float ;
+                    dcterms:description "Der Breitengrad des Standorts."@de ,
+                                        "The latitude of the Location."@en ;
+                    rdfs:label "Breite"@de ,
+                               "Latitude"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#locationLongitude
+ec:locationLongitude rdf:type owl:DatatypeProperty ;
+                     rdfs:range xsd:float ;
+                     dcterms:description "Der Längengrad des Standorts."@de ,
+                                         "The longitude of the Location."@en ;
+                     rdfs:label "Longitude"@en ,
+                                "Längengrad"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#locatorTargetInformation
+ec:locatorTargetInformation rdf:type owl:DatatypeProperty ;
+                            rdfs:range rdfs:Literal ;
+                            dcterms:description "Information on the locator target."@en ,
+                                                "Informationen über das Ziel des Locators."@de ;
+                            rdfs:label "Locator target information"@en ,
+                                       "Locator-Zielinformationen"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#log
+ec:log rdf:type owl:DatatypeProperty ;
+       rdfs:subPropertyOf ec:contentDescription ;
+       rdfs:range rdfs:Literal ;
+       dcterms:description "Alles im Inhalt nach vordefinierten Regeln und Kriterien als neutrale Folge von (möglicherweise zeitlich markierten) textuellen Beschreibungen protokollieren."@de ,
+                           "To log everything in the content following predefined rules and criteria, as a neutral sequence of (possibly timed) textual descriptions."@en ;
+       rdfs:label "Log"@en ,
+                  "Protokoll"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#loudnessIntegratedLoudness
+ec:loudnessIntegratedLoudness rdf:type owl:DatatypeProperty ;
+                              rdfs:range xsd:float ;
+                              dcterms:description "Der Wert der integrierten Lautheit, gemessen auf Ebene von AudioProgramme oder AudioContent."@de ,
+                                                  "The value for integrated loudness measured at AudioProgramme or AudioContent level."@en ;
+                              rdfs:label "Integrated loudness"@en ,
+                                         "Integrierte Lautheit"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#loudnessMaxMomentary
+ec:loudnessMaxMomentary rdf:type owl:DatatypeProperty ;
+                        rdfs:range xsd:float ;
+                        dcterms:description "Der Wert für die maximale momentane Lautheit, gemessen auf Ebene von AudioProgramme oder AudioContent."@de ,
+                                            "The value for maximum momentary loudness measured at AudioProgramme or AudioContent level."@en ;
+                        rdfs:label "Max momentary loudness"@en ,
+                                   "Maximale momentane Lautstärke"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#loudnessMaxShortTerm
+ec:loudnessMaxShortTerm rdf:type owl:DatatypeProperty ;
+                        rdfs:range xsd:float ;
+                        dcterms:description "Der Wert für die maximale maximale Kurzzeit-Lautheit, gemessen auf Ebene von AudioProgramme oder AudioContent."@de ,
+                                            "The value for maximum max short term loudness measured at AudioProgramme or AudioContent level."@en ;
+                        rdfs:label "Max short term loudness"@en ,
+                                   "Maximale Kurzzeit-Lautheit"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#loudnessMaxTruepeak
+ec:loudnessMaxTruepeak rdf:type owl:DatatypeProperty ;
+                       rdfs:range xsd:float ;
+                       dcterms:description "Der Wert für die maximale True-Peak-Lautheit, gemessen auf Ebene von AudioProgramme oder AudioContent."@de ,
+                                           "The value for maximum true peak loudness measured at AudioProgramme or AudioContent level."@en ;
+                       rdfs:label "Max true peak loudness"@en ,
+                                  "Maximale wahre Spitzlautheit"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#loudnessMethod
+ec:loudnessMethod rdf:type owl:DatatypeProperty ;
+                  rdfs:range rdfs:Literal ;
+                  dcterms:description "Die Methode zur Lautheitsmessung auf Ebene von AudioProgramme oder AudioContent."@de ,
+                                      "The method for loudness measurement at AudioProgramme or AudioContent level."@en ;
+                  rdfs:label "Lautheitsmethode"@de ,
+                             "Loudness method"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#loudnessRange
+ec:loudnessRange rdf:type owl:DatatypeProperty ;
+                 rdfs:range xsd:float ;
+                 dcterms:description "Der gemessene Lautheitsbereich auf AudioProgramme- oder AudioContent-Ebene."@de ,
+                                     "The loudness range measured at AudioProgramme or AudioContent level."@en ;
+                 rdfs:label "Lautheitsbereich"@de ,
+                            "Loudness range"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#maritalStatus
+ec:maritalStatus rdf:type owl:DatatypeProperty ;
+                 rdfs:range rdfs:Literal ;
+                 dcterms:description "Der mit einer Person verbundene Familienstand."@de ,
+                                     "The marital status associated with a person."@en ;
+                 rdfs:label "Familienstand"@de ,
+                            "Marital status"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#measureValue
+ec:measureValue rdf:type owl:DatatypeProperty ;
+                dcterms:description "Der Wert der Measure als Literal."@de ,
+                                    "The value of the Measure as a literal."@en ;
+                rdfs:label "Measure value"@en ,
+                           "Messwert"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#measureValueMax
+ec:measureValueMax rdf:type owl:DatatypeProperty ;
+                   dcterms:description "Der maximale Wert einer Measure, falls anwendbar."@de ,
+                                       "The maximum value of a Measure when applicable."@en ;
+                   rdfs:label "Maximalwert messen"@de ,
+                              "Measure maximum value"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#measureValueMin
+ec:measureValueMin rdf:type owl:DatatypeProperty ;
+                   dcterms:description "Der Mindestwert eines Measures, sofern anwendbar."@de ,
+                                       "The minimum value of a Measure, when applicable."@en ;
+                   rdfs:label "Measure minimum value"@en ,
+                              "Minimalwert messen"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#microphone
+ec:microphone rdf:type owl:DatatypeProperty ,
+                       owl:FunctionalProperty ;
+              dcterms:description "Gibt an, ob das Verbrauchsgeräteprofil ein Mikrofon erfordert."@de ,
+                                  "Indicates whether the consumption device profile requires a microphone."@en ;
+              rdfs:label "Microphone"@en ,
+                         "Mikrofon"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#midRollAdAllowed
+ec:midRollAdAllowed rdf:type owl:DatatypeProperty ,
+                             owl:FunctionalProperty ;
+                    rdfs:range xsd:boolean ;
+                    dcterms:description "A flag to indicate whether it is allowed to insert ad breaks in mid-roll."@en ,
+                                        "Eine Kennzeichnung, die angibt, ob das Einfügen von Werbeunterbrechungen in der Mid-Roll erlaubt ist."@de ;
+                    rdfs:label "Midroll ad allowed"@en ,
+                               "Midroll-Werbung erlaubt"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#middleName
+ec:middleName rdf:type owl:DatatypeProperty ;
+              rdfs:range rdfs:Literal ;
+              dcterms:description "Ein oder mehrere zweite Vornamen, die einer Person zugeordnet sind."@de ,
+                                  "One or more middle names associated with a Person."@en ;
+              rdfs:label "Middle name"@en ,
+                         "Zweiter Vorname"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#month
+ec:month rdf:type owl:DatatypeProperty ;
+         rdfs:range xsd:integer ;
+         dcterms:description "An integer representing the month of the year."@en ,
+                             "Eine Ganzzahl, die den Monat des Jahres angibt."@de ;
+         rdfs:label "Monat"@de ,
+                    "Month"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#name
+ec:name rdf:type owl:DatatypeProperty ;
+        rdfs:range rdfs:Literal ;
+        dcterms:description "Die Bezeichnung der Ressource."@de ,
+                            "The designation of the resource."@en ;
+        rdfs:label "Name"@de ,
+                   "Name"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#nickName
+ec:nickName rdf:type owl:DatatypeProperty ;
+            rdfs:range rdfs:Literal ;
+            dcterms:description "Der Spitzname einer Person."@de ,
+                                "The nickname of a Person."@en ;
+            rdfs:label "Nickname"@en ,
+                       "Spitzname"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#noiseFilter
+ec:noiseFilter rdf:type owl:DatatypeProperty ,
+                        owl:FunctionalProperty ;
+               rdfs:range xsd:boolean ;
+               dcterms:description "A flag to signal that a noise filter has been used."@en ,
+                                   "Ein Kennzeichen, das signalisiert, dass ein Rauschfilter verwendet wurde."@de ;
+               rdfs:label "Noise filter"@en ,
+                          "Rauschfilter"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#notRated
+ec:notRated rdf:type owl:DatatypeProperty ;
+            rdfs:range xsd:boolean ;
+            dcterms:description "A flag to indicate that the EditorialObject has not been rated."@en ,
+                                "Ein Kennzeichen, das anzeigt, dass das EditorialObject nicht bewertet wurde."@de ;
+            rdfs:label "Nicht bewertet"@de ,
+                       "Not rated"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#occupation
+ec:occupation rdf:type owl:DatatypeProperty ;
+              rdfs:range rdfs:Literal ;
+              dcterms:description "Der Berufs- oder Tätigkeitsname einer Person."@de ,
+                                  "The job / occupation name of a Person."@en ;
+              rdfs:label "Beruf"@de ,
+                         "Occupation"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#officeEmailAddress
+ec:officeEmailAddress rdf:type owl:DatatypeProperty ;
+                      rdfs:subPropertyOf ec:agentEmailAddress ;
+                      rdfs:range xsd:string ;
+                      dcterms:description "Die geschäftliche oder Büro-E-Mail-Adresse einer Person."@de ,
+                                          "The professional or office email address of a Person."@en ;
+                      rdfs:label "Büro-E-Mail"@de ,
+                                 "Office email"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#officeMobileTelephoneNumber
+ec:officeMobileTelephoneNumber rdf:type owl:DatatypeProperty ;
+                               rdfs:subPropertyOf ec:agentTelephoneNumber ;
+                               rdfs:range xsd:string ;
+                               dcterms:description "Die geschäftliche Mobiltelefonnummer einer Person."@de ,
+                                                   "The office mobile telephone number of a Person."@en ;
+                               rdfs:label "Telefon (Büro)"@de ,
+                                          "Telephone (office)"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#officeTelephoneNumber
+ec:officeTelephoneNumber rdf:type owl:DatatypeProperty ;
+                         rdfs:subPropertyOf ec:agentTelephoneNumber ;
+                         rdfs:range xsd:string ;
+                         dcterms:description "Die Büro-Telefonnummer einer Person."@de ,
+                                             "The office telephone number of a Person."@en ;
+                         rdfs:label "Telefon (Büro)"@de ,
+                                    "Telephone (office)"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#onStagePositionCoordinateX
+ec:onStagePositionCoordinateX rdf:type owl:DatatypeProperty ;
+                              dcterms:description "Die x-Koordinaten innerhalb eines räumlichen Koordinatensystems mit drei Achsen."@de ,
+                                                  "The x coordinates within a 3 axis spatial coordinates space."@en ;
+                              rdfs:label "X coordinate"@en ,
+                                         "X-Koordinate"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#onStagePositionCoordinateY
+ec:onStagePositionCoordinateY rdf:type owl:DatatypeProperty ;
+                              dcterms:description "Die y-Koordinaten innerhalb eines dreiachsigen räumlichen Koordinatensystems."@de ,
+                                                  "The y coordinates within a 3 axis spatial coordinates space."@en ;
+                              rdfs:label "Y coordinate"@en ,
+                                         "Y-Koordinate"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#onStagePositionCoordinateZ
+ec:onStagePositionCoordinateZ rdf:type owl:DatatypeProperty ;
+                              dcterms:description "Die Z-Koordinaten innerhalb eines räumlichen Koordinatensystems mit drei Achsen."@de ,
+                                                  "The z coordinates within a 3 axis spatial coordinates space."@en ;
+                              rdfs:label "Z coordinate"@en ,
+                                         "Z-Koordinate"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#onStagePositionCoordinatesReferencePoint
+ec:onStagePositionCoordinatesReferencePoint rdf:type owl:DatatypeProperty ;
+                                            dcterms:description "Der Referenzpunkt, der verwendet wird, um einen Satz von Koordinaten für eine Position auf der Bühne festzulegen."@de ,
+                                                                "The reference point used to define a set of coordinates for a position on stage."@en ;
+                                            rdfs:label "On stage position coordinates reference point"@en ,
+                                                       "Referenzpunkt der Koordinaten der Bühnenposition"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#orderedFlag
+ec:orderedFlag rdf:type owl:DatatypeProperty ,
+                        owl:FunctionalProperty ;
+               rdfs:range xsd:boolean ;
+               dcterms:description "A flag to indicate that a EditorialObject is member of an ordered group or is an ordered group (e.g. Series)."@en ,
+                                   "Ein Kennzeichen, das anzeigt, dass ein EditorialObject Teil einer geordneten Gruppe ist oder selbst eine geordnete Gruppe ist (z. B. Series)."@de ;
+               rdfs:label "Ordered"@en ,
+                          "Ordnet"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#orientation
+ec:orientation rdf:type owl:DatatypeProperty ;
+               rdfs:range rdfs:Literal ;
+               dcterms:description "Die Ausrichtung eines Dokuments oder eines Bildes, also Querformat oder Hochformat."@de ,
+                                   "The orientation of a Document or an Image i.e. landscape or portrait."@en ;
+               rdfs:label "Ausrichtung"@de ,
+                          "Orientation"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#packageByteSize
+ec:packageByteSize rdf:type owl:DatatypeProperty ;
+                   rdfs:range xsd:long ;
+                   dcterms:description "Die Größe eines Medienpakets in Bytes."@de ,
+                                       "The size of a media package in Bytes."@en ;
+                   rdfs:label "Package size (in bytes)"@en ,
+                              "Paketgröße (in Bytes)"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#packageName
+ec:packageName rdf:type owl:DatatypeProperty ;
+               rdfs:range rdfs:Literal ;
+               dcterms:description "Der Name eines Medienpakets in Bytes."@de ,
+                                   "The name of a media package in Bytes."@en ;
+               rdfs:label "Package name"@en ,
+                          "Paketname"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#partTotalNumber
+ec:partTotalNumber rdf:type owl:DatatypeProperty ;
+                   rdfs:range xsd:integer ;
+                   dcterms:description "Die Gesamtzahl der Parts, die mit einem EditorialObject verknüpft sind."@de ,
+                                       "The total number of Parts associated with an EditorialObject."@en ;
+                   rdfs:label "Part total number"@en ,
+                              "Teile Gesamtzahl"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#period
+ec:period rdf:type owl:DatatypeProperty ;
+          rdfs:range rdfs:Literal ;
+          dcterms:description "Der Zeitraum, in dem ein Ereignis stattgefunden hat."@de ,
+                              "The period of time during which an Event has occurred."@en ;
+          rdfs:label "Period"@en ,
+                     "Zeitraum"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#personHeight
+ec:personHeight rdf:type owl:DatatypeProperty ;
+                rdfs:range rdfs:Literal ;
+                dcterms:description "Die Körpergröße einer Person."@de ,
+                                    "The height of a person."@en ;
+                rdfs:label "Person height"@en ,
+                           "Personenhöhe"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#personWeight
+ec:personWeight rdf:type owl:DatatypeProperty ;
+                rdfs:range rdfs:Literal ;
+                dcterms:description "Das Gewicht einer Person."@de ,
+                                    "The weight of a person."@en ;
+                rdfs:label "Person weight"@en ,
+                           "Personengewicht"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#playbackSpeed
+ec:playbackSpeed rdf:type owl:DatatypeProperty ;
+                 rdfs:range xsd:double ;
+                 dcterms:description "Gibt die Rate von Einheiten pro Zeit an, mit der die Ressource zur Nutzung durch Menschen wiedergegeben werden soll. Wenn die Maßeinheit bekannt ist, verwenden Sie die Untereigenschaften framesPerSecond oder inchesPerSecond."@de ,
+                                     "Identifies the rate of units against time at which the resource should be played back for human consumption. If the unit of measure is known, use sub-properties framesPerSecond or inchesPerSecond."@en ;
+                 rdfs:label "Playback speed"@en ,
+                            "Wiedergabegeschwindigkeit"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#playlist
+ec:playlist rdf:type owl:DatatypeProperty ;
+            rdfs:subPropertyOf ec:contentDescription ;
+            rdfs:range rdfs:Literal ;
+            dcterms:description "A playlist associated with the editorial object."@en ,
+                                "Eine Playlist, die mit dem redaktionellen Objekt verbunden ist."@de ;
+            rdfs:label "Playlist"@de ,
+                       "Playlist"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#position
+ec:position rdf:type owl:DatatypeProperty ;
+            rdfs:range rdfs:Literal ;
+            dcterms:description "Die Position eines EditorialObject innerhalb einer geordneten Gruppe."@de ,
+                                "The position of an EditorialObject within an ordered group."@en ;
+            rdfs:label "Position"@de ,
+                       "Position"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#privateEmailAddress
+ec:privateEmailAddress rdf:type owl:DatatypeProperty ;
+                       rdfs:subPropertyOf ec:agentEmailAddress ;
+                       rdfs:range xsd:string ;
+                       dcterms:description "Die private E-Mail-Adresse einer Person."@de ,
+                                           "The private email address of a Person."@en ;
+                       rdfs:label "Privat-E-Mail"@de ,
+                                  "Private email"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#privateHomepage
+ec:privateHomepage rdf:type owl:DatatypeProperty ;
+                   rdfs:subPropertyOf ec:agentWebHomepage ;
+                   rdfs:range xsd:anyURI ;
+                   dcterms:description "Die private Web-Homepage einer Person."@de ,
+                                       "The private web homepage of a Person."@en ;
+                   rdfs:label "Homepage (privat)"@de ,
+                              "Homepage (private)"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#privateMobileTelephoneNumber
+ec:privateMobileTelephoneNumber rdf:type owl:DatatypeProperty ;
+                                rdfs:subPropertyOf ec:agentTelephoneNumber ;
+                                rdfs:range xsd:string ;
+                                dcterms:description "Die private Mobiltelefonnummer einer Person."@de ,
+                                                    "The private mobile telephone number of a Person."@en ;
+                                rdfs:label "Telefon (privat)"@de ,
+                                           "Telephone (private)"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#privateTelephoneNumber
+ec:privateTelephoneNumber rdf:type owl:DatatypeProperty ;
+                          rdfs:subPropertyOf ec:agentTelephoneNumber ;
+                          rdfs:range xsd:string ;
+                          dcterms:description "Die private Telefonnummer, die einer Person zugeordnet ist."@de ,
+                                              "The private telephone number associated with a Person."@en ;
+                          rdfs:label "Telefon (privat)"@de ,
+                                     "Telephone (private)"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#productionSynopsis
+ec:productionSynopsis rdf:type owl:DatatypeProperty ;
+                      rdfs:subPropertyOf ec:contentDescription ;
+                      rdfs:range rdfs:Literal ;
+                      dcterms:description "A synopsis or summary provided by the producer at the time of production."@en ,
+                                          "Eine Zusammenfassung oder ein Überblick, der vom Produzenten zum Zeitpunkt der Produktion bereitgestellt wird."@de ;
+                      rdfs:label "Production synopsis"@en ,
+                                 "Produktionssynopse"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#promotionalInformation
+ec:promotionalInformation rdf:type owl:DatatypeProperty ;
+                          rdfs:subPropertyOf ec:contentDescription ;
+                          rdfs:range rdfs:Literal ;
+                          dcterms:description "Textual promotional information associated with the content."@en ,
+                                              "Textuelle werbliche Informationen, die mit dem Inhalt verknüpft sind."@de ;
+                          rdfs:label "Promotional information"@en ,
+                                     "Werbeinformationen"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#pubStatus
+ec:pubStatus rdf:type owl:DatatypeProperty ;
+             rdfs:subPropertyOf ec:contentDescription ;
+             rdfs:range rdfs:Literal ;
+             dcterms:description "Der mit dem redaktionellen Objekt verbundene Publikationsstatus."@de ,
+                                 "The publication status associated with the editorial object."@en ;
+             rdfs:label "Publication status"@en ,
+                        "Veröffentlichungsstatus"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#publicationPlanTitle
+ec:publicationPlanTitle rdf:type owl:DatatypeProperty ;
+                        dcterms:description "A title associated with a publication plan. It is a literal value used to name or identify the publication plan."@en ,
+                                            "Ein Titel, der mit einem Veröffentlichungsplan verbunden ist. Es handelt sich um einen Literalwert, der verwendet wird, um den Veröffentlichungsplan zu benennen oder zu identifizieren."@de ;
+                        rdfs:label "Publication plan title"@en ,
+                                   "Titel des Veröffentlichungsplans"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#publishingEventsLeft
+ec:publishingEventsLeft rdf:type owl:DatatypeProperty ;
+                        dcterms:description "Die Anzahl der verbleibenden Veröffentlichungsereignisse."@de ,
+                                            "The number of publishing events remaining."@en ;
+                        rdfs:label "Publishing events left"@en ,
+                                   "Verbleibende Publikationsereignisse"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#radioTuner
+ec:radioTuner rdf:type owl:DatatypeProperty ,
+                       owl:FunctionalProperty ;
+              dcterms:description "Ob der Dienst einen Radioempfänger benötigt."@de ,
+                                  "Whether the service requires a radio tuner."@en ;
+              rdfs:label "Radio tuner"@en ,
+                         "Radiotuner"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ratingScaleMax
+ec:ratingScaleMax rdf:type owl:DatatypeProperty ;
+                  rdfs:range rdfs:Literal ;
+                  dcterms:description "Der Maximalwert der für die Bewertung verwendeten Skala."@de ,
+                                      "The maximum value of the scale used for the Rating."@en ;
+                  rdfs:label "Bewertungsskala (oberster Wert)"@de ,
+                             "Rating scale (top value)"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ratingScaleMin
+ec:ratingScaleMin rdf:type owl:DatatypeProperty ;
+                  rdfs:range rdfs:Literal ;
+                  dcterms:description "Der Mindestwert der Skala, die zur Bewertung einer MediaResource verwendet wird."@de ,
+                                      "The minimum value of the scale used for rating a MediaResource."@en ;
+                  rdfs:label "Bewertungsskala (Mindestwert)"@de ,
+                             "Rating scale (min. value)"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ratingSystemEnvironment
+ec:ratingSystemEnvironment rdf:type owl:DatatypeProperty ;
+                           rdfs:range rdfs:Literal ;
+                           dcterms:description "Die Umgebung, in der die Bewertung gilt."@de ,
+                                               "The environment in which the rating applies."@en ;
+                           rdfs:label "Bewertungsumfeld"@de ,
+                                      "Rating environment"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ratingSystemName
+ec:ratingSystemName rdf:type owl:DatatypeProperty ;
+                    rdfs:range rdfs:Literal ;
+                    dcterms:description "Der Name des Bewertungssystems."@de ,
+                                        "The name of the rating system."@en ;
+                    rdfs:label "Bewertungssystem"@de ,
+                               "Rating system"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ratingValue
+ec:ratingValue rdf:type owl:DatatypeProperty ;
+               rdfs:range rdfs:Literal ;
+               dcterms:description "Der Freitextwert einer Bewertung, die in einem Bewertungsklassifizierungsschema definiert ist."@de ,
+                                   "The free-text value of a rating defined in a rating classification scheme."@en ;
+               rdfs:label "Bewertung"@de ,
+                          "Rating"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#readyForPublication
+ec:readyForPublication rdf:type owl:DatatypeProperty ;
+                       rdfs:range xsd:boolean ;
+                       dcterms:description "A flag to indicate that the resource/essence is ready for publication."@en ,
+                                           "Ein Kennzeichen, das anzeigt, dass die Ressource/das Essence-Objekt zur Veröffentlichung bereit ist."@de ;
+                       rdfs:label "Bereit zur Veröffentlichung"@de ,
+                                  "Ready for publication"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#reason
+ec:reason rdf:type owl:DatatypeProperty ;
+          rdfs:range rdfs:Literal ;
+          dcterms:description "A reason given for a rating."@en ,
+                              "Ein Grund, der für eine Bewertung angegeben wird."@de ;
+          rdfs:label "Grund"@de ,
+                     "Reason"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#regionDelimX
+ec:regionDelimX rdf:type owl:DatatypeProperty ;
+                rdfs:range xsd:integer ;
+                dcterms:description "Die x-Koordinate der linken oberen Ecke einer Zone. Falls zusammen mit regionDelimy vorhanden, wird die Zonendefinition durch die zugehörigen Werte für Höhe und Breite ergänzt."@de ,
+                                    "The x-axis coordinate of the top-left corner of a zone. If present with regionDelimy, the zone definition is complemented by the associated values of the height and width."@en ;
+                rdfs:label "Region delimiter (x-axis)"@en ,
+                           "Regionstrenner (x-Achse)"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#regionDelimY
+ec:regionDelimY rdf:type owl:DatatypeProperty ;
+                rdfs:range xsd:integer ;
+                dcterms:description "Die y-Achsenkoordinate der rechten unteren Ecke einer Zone. Wenn sie zusammen mit regionDelimX vorhanden ist, wird die Zonendefinition durch die zugehörigen Werte für Höhe und Breite ergänzt."@de ,
+                                    "The y-axis coordinate of the bottom right corner of a zone. If present with regionDelimX, the zone definition is complemented by the associated values of the height and width."@en ;
+                rdfs:label "Region delimiter (y-axis)"@en ,
+                           "Regionsbegrenzung (y-Achse)"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#relationOrderedGroupFlag
+ec:relationOrderedGroupFlag rdf:type owl:DatatypeProperty ;
+                            rdfs:range xsd:boolean ;
+                            dcterms:description "A boolean to define if a Relation is defined within and ordered group."@en ,
+                                                "Ein boolescher Wert, der festlegt, ob eine Relation innerhalb einer geordneten Gruppe definiert ist."@de ;
+                            rdfs:label "Kennzeichen für geordnete Relationsgruppe"@de ,
+                                       "Relation ordered group flag"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#relationRunningOrderNumber
+ec:relationRunningOrderNumber rdf:type owl:DatatypeProperty ;
+                              rdfs:range xsd:integer ;
+                              dcterms:description "Die Ordnungsnummer in einer Liste."@de ,
+                                                  "The order number in a list."@en ;
+                              rdfs:label "Relation running order number"@en ,
+                                         "Relation-Laufnummer"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#relationTotalNumberOfGroupMembers
+ec:relationTotalNumberOfGroupMembers rdf:type owl:DatatypeProperty ;
+                                     rdfs:range xsd:integer ;
+                                     dcterms:description "Gesamtzahl der Gruppenmitglieder in einer Relation."@de ,
+                                                         "Total number of group members in a Relation."@en ;
+                                     rdfs:label "Gesamtzahl der Gruppenmitglieder"@de ,
+                                                "Total number of group members"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#resolution
+ec:resolution rdf:type owl:DatatypeProperty ;
+              rdfs:range rdfs:Literal ;
+              dcterms:description "Die Auflösung eines redaktionellen Objekts, wie etwa eines Videos oder eines Bildes."@de ,
+                                  "The resolution of an editorial object, such as a video or image."@en ;
+              rdfs:label "Auflösung"@de ,
+                         "Resolution"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#rightsClearanceFlag
+ec:rightsClearanceFlag rdf:type owl:DatatypeProperty ,
+                                owl:FunctionalProperty ;
+                       rdfs:range xsd:boolean ;
+                       dcterms:description "A flag to indicate that rights have been cleared."@en ,
+                                           "Ein Flag, das anzeigt, dass die Rechte geklärt wurden."@de ;
+                       rdfs:label "Rechtefreigabe-Flag"@de ,
+                                  "Rights clearance flag"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#rightsExpression
+ec:rightsExpression rdf:type owl:DatatypeProperty ;
+                    rdfs:range rdfs:Literal ;
+                    dcterms:description "Der Ausdruck der mit der Ressource verbundenen Rechte."@de ,
+                                        "The expression of rights associated with the resource."@en ;
+                    rdfs:label "Rechte"@de ,
+                               "Rights"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#rightsLink
+ec:rightsLink rdf:type owl:DatatypeProperty ;
+              rdfs:range xsd:anyURI ;
+              dcterms:description "A link to e.g. a webpage where an expression of the rights can be found and consulted."@en ,
+                                  "Ein Link, z. B. zu einer Webseite, auf der eine Ausprägung der Rechte gefunden und eingesehen werden kann."@de ;
+              rdfs:label "Rechts-Webressource"@de ,
+                         "Rights web resource"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#rightsUsageRestrictions
+ec:rightsUsageRestrictions rdf:type owl:DatatypeProperty ;
+                           dcterms:description "Legt einen Satz von Nutzungsbeschränkungen fest."@de ,
+                                               "Specifies a set of usage restrictions."@en ;
+                           rdfs:label "Nutzungsbeschränkungen"@de ,
+                                      "Usage restrictions"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ruleStatement
+ec:ruleStatement rdf:type owl:DatatypeProperty ;
+                 dcterms:description "A statement associated with a Rule."@en ,
+                                     "Eine Aussage, die mit einer Regel verbunden ist."@de ;
+                 rdfs:label "Regelaussage"@de ,
+                            "Rule statement"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#salutationTitle
+ec:salutationTitle rdf:type owl:DatatypeProperty ;
+                   rdfs:range rdfs:Literal ;
+                   dcterms:description "A salutation title such as Mr, Ms, Dr, or Prof."@en ,
+                                       "Eine Anrede wie Herr, Frau, Dr. oder Prof."@de ;
+                   rdfs:label "Anrede"@de ,
+                              "Salutation title"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#sampleRate
+ec:sampleRate rdf:type owl:DatatypeProperty ;
+              rdfs:range xsd:integer ;
+              dcterms:description "Die Frequenz, mit der Audio pro Sekunde abgetastet wird. Wird auch als Abtastrate bezeichnet."@de ,
+                                  "The frequency at which audio is sampled per second. Also called sampling rate."@en ;
+              rdfs:label "Abtastrate"@de ,
+                         "Sample rate"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#sampleSize
+ec:sampleSize rdf:type owl:DatatypeProperty ;
+              rdfs:range xsd:integer ;
+              dcterms:description "Die Größe einer Audiosample in Bits. Auch Bit-Tiefe genannt."@de ,
+                                  "The size of an audio sample in bits. Also called bit depth."@en ;
+              rdfs:label "Abtastrate"@de ,
+                         "Sample size"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#sampleType
+ec:sampleType rdf:type owl:DatatypeProperty ;
+              rdfs:range rdfs:Literal ;
+              dcterms:description "Der Typ des Audiosamples."@de ,
+                                  "The type of audio sample."@en ;
+              rdfs:label "Beispieltyp"@de ,
+                         "Sample type"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#scanningFormat
+ec:scanningFormat rdf:type owl:DatatypeProperty ;
+                  rdfs:range rdfs:Literal ;
+                  dcterms:description "Das Abtastformat einer Medienressource. Bei Video sind die beiden Hauptwerte \"interlaced\" oder \"progressive\"."@de ,
+                                      "The scanning format of a media resource. For video, the two main values are \"interlaced\" or \"progressive\"."@en ;
+                  rdfs:label "Scanning format"@en ,
+                             "Scannungsformat"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#script
+ec:script rdf:type owl:DatatypeProperty ;
+          rdfs:subPropertyOf ec:contentDescription ;
+          rdfs:range rdfs:Literal ;
+          dcterms:description "Der mit einem redaktionellen Objekt verknüpfte Skriptinhalt."@de ,
+                              "The script content associated with an editorial object."@en ;
+          rdfs:label "Script"@en ,
+                     "Skript"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#seasonNumber
+ec:seasonNumber rdf:type owl:DatatypeProperty ;
+                rdfs:range xsd:integer ;
+                dcterms:description "Die mit dem Werk verknüpfte Staffelnummer."@de ,
+                                    "The season number associated with the work."@en ;
+                rdfs:label "Season number"@en ,
+                           "Staffelnummer"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#segmentNumber
+ec:segmentNumber rdf:type owl:DatatypeProperty ;
+                 rdfs:range xsd:integer ;
+                 dcterms:description "Die einem Segment als eines von vielen zugeordnete Nummer."@de ,
+                                     "The number associated with a segment as one among many."@en ;
+                 rdfs:label "Segment number"@en ,
+                            "Segmentnummer"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#shotLog
+ec:shotLog rdf:type owl:DatatypeProperty ;
+           rdfs:subPropertyOf ec:contentDescription ;
+           rdfs:range rdfs:Literal ;
+           dcterms:description "Bietet eine shot-by-shot-Beschreibung einer MediaResource."@de ,
+                               "Provides a shot-by-shot description of a MediaResource."@en ;
+           rdfs:label "Schussprotokoll"@de ,
+                      "Shot log"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#soundOutput
+ec:soundOutput rdf:type owl:DatatypeProperty ,
+                        owl:FunctionalProperty ;
+               dcterms:description "A flag to indicate if the Service requires a sound output."@en ,
+                                   "Ein Kennzeichen, das angibt, ob der Dienst eine Tonausgabe benötigt."@de ;
+               rdfs:label "Sound output"@en ,
+                          "Tonausgabe"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#suffix
+ec:suffix rdf:type owl:DatatypeProperty ;
+          rdfs:range rdfs:Literal ;
+          dcterms:description "Der mit dem Namen einer Person verbundene Namenszusatz, wie z. B. Jr."@de ,
+                              "The suffix associated with a person's name, such as Jr."@en ;
+          rdfs:label "Suffix"@de ,
+                     "Suffix"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#summary
+ec:summary rdf:type owl:DatatypeProperty ;
+           rdfs:subPropertyOf ec:contentDescription ;
+           rdfs:range rdfs:Literal ;
+           dcterms:description "A summary of the content."@en ,
+                               "Eine Zusammenfassung des Inhalts."@de ;
+           rdfs:label "Summary"@en ,
+                      "Zusammenfassung"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#synopsis
+ec:synopsis rdf:type owl:DatatypeProperty ;
+            rdfs:subPropertyOf ec:contentDescription ;
+            rdfs:range rdfs:Literal ;
+            dcterms:description "A summary of the content."@en ,
+                                "Eine Zusammenfassung des Inhalts."@de ;
+            rdfs:label "Synopsis"@de ,
+                       "Synopsis"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#tableOfContent
+ec:tableOfContent rdf:type owl:DatatypeProperty ;
+                  rdfs:subPropertyOf ec:contentDescription ;
+                  rdfs:range rdfs:Literal ;
+                  dcterms:description "Die Tabelle des Inhalts für das redaktionelle Objekt."@de ,
+                                      "The table of content for the editorial object."@en ;
+                  rdfs:label "Inhaltsverzeichnis"@de ,
+                             "Table of content"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#tag
+ec:tag rdf:type owl:DatatypeProperty ;
+       rdfs:subPropertyOf ec:contentDescription ;
+       rdfs:range rdfs:Literal ;
+       dcterms:description "A tag value associated with an editorial object."@en ,
+                           "Ein Tag-Wert, der mit einem redaktionellen Objekt verbunden ist."@de ;
+       rdfs:label "Tag"@de ,
+                  "Tag"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#targetAudienceSystem
+ec:targetAudienceSystem rdf:type owl:DatatypeProperty ;
+                        rdfs:range rdfs:Literal ;
+                        dcterms:description "Das System, das verwendet wird, um eine Zielgruppe anzugeben."@de ,
+                                            "The system used to provide a target audience."@en ;
+                        rdfs:label "Target audience system"@en ,
+                                   "Zielgruppensystem"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#textInput
+ec:textInput rdf:type owl:DatatypeProperty ,
+                      owl:FunctionalProperty ;
+             dcterms:description "Gibt an, ob ein Verbrauchsgeräteprofil eine Textingabefähigkeit erfordert."@de ,
+                                 "Indicates whether a consumption device profile requires text input capability."@en ;
+             rdfs:label "Text input capability"@en ,
+                        "Texteingabefähigkeit"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#textLineBoxHeight
+ec:textLineBoxHeight rdf:type owl:DatatypeProperty ;
+                     rdfs:range xsd:nonNegativeInteger ;
+                     dcterms:description "Die Höhe des Textfelds, das die TextLine enthält."@de ,
+                                         "The height of the text box containing the TextLine."@en ;
+                     rdfs:label "Höhe der Textzeilebox"@de ,
+                                "Text line box height"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#textLineBoxTopLeftCornerLineNumber
+ec:textLineBoxTopLeftCornerLineNumber rdf:type owl:DatatypeProperty ;
+                                      rdfs:range xsd:nonNegativeInteger ;
+                                      dcterms:description "Die Koordinaten auf einer vertikalen Achse der Position der linken oberen Ecke des Textfelds, das die TextLine enthält."@de ,
+                                                          "The coordinates on a vertical axis of the position of the top left corner of the text box containing the TextLine."@en ;
+                                      rdfs:label "Text line box top left corner Y position"@en ,
+                                                 "Y-Position der oberen linken Ecke des Textfelds"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#textLineBoxTopLeftCornerPixelNumber
+ec:textLineBoxTopLeftCornerPixelNumber rdf:type owl:DatatypeProperty ;
+                                       rdfs:range xsd:nonNegativeInteger ;
+                                       dcterms:description "Die Koordinaten auf einer horizontalen Achse der Position der linken oberen Ecke des Textfeldes, das die TextLine enthält."@de ,
+                                                           "The coordinates on an horizontal axis of the position of the top left corner of the text box containing the TextLine."@en ;
+                                       rdfs:label "Text line box top left corner X position"@en ,
+                                                  "X-Position der oberen linken Ecke des Textlinienkastens"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#textLineBoxWidth
+ec:textLineBoxWidth rdf:type owl:DatatypeProperty ;
+                    rdfs:range xsd:nonNegativeInteger ;
+                    dcterms:description "Die Breite des Textfelds, das die TextLine enthält."@de ,
+                                        "The width of the text box containing the TextLine."@en ;
+                    rdfs:label "Text line box width"@en ,
+                               "Textlinien-Boxbreite"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#textLineContent
+ec:textLineContent rdf:type owl:DatatypeProperty ;
+                   rdfs:range rdfs:Literal ;
+                   dcterms:description "Der Inhalt einer Textzeile."@de ,
+                                       "The content of a text line."@en ;
+                   rdfs:label "Text line"@en ,
+                              "Textzeile"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#textLineOrder
+ec:textLineOrder rdf:type owl:DatatypeProperty ;
+                 rdfs:range rdfs:Literal ;
+                 dcterms:description "Die Reihenfolge, in der eine Textzeile gefunden werden kann, z. B. in einer Szene."@de ,
+                                     "The order in which a text line can be found e.g. in a scene."@en ;
+                 rdfs:label "Text line order"@en ,
+                            "Textzeilenreihenfolge"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#timeOfDay
+ec:timeOfDay rdf:type owl:DatatypeProperty ;
+             rdfs:range xsd:time ;
+             dcterms:description "A time expressed as a normal time of day."@en ,
+                                 "Eine Zeit, die als normale Tageszeit ausgedrückt wird."@de ;
+             rdfs:label "Tageszeit"@de ,
+                        "Time of day"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#timecodeExpression
+ec:timecodeExpression rdf:type owl:DatatypeProperty ;
+                      rdfs:range xsd:string ;
+                      dcterms:description "A time expressed as timecode."@en ,
+                                          "Eine Zeit, ausgedrückt als Timecode."@de ;
+                      rdfs:label "Timecode expression"@en ,
+                                 "Timecode-Ausdruck"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#timeshift
+ec:timeshift rdf:type owl:DatatypeProperty ,
+                      owl:FunctionalProperty ;
+             dcterms:description "A flag to indicate if the Service requires timeshift support."@en ,
+                                 "Ein Flag, das anzeigt, ob der Dienst Timeshift-Unterstützung benötigt."@de ;
+             rdfs:label "Timeshift support"@en ,
+                        "Timeshift-Unterstützung"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#title
+ec:title rdf:type owl:DatatypeProperty ;
+         rdfs:range rdfs:Literal ;
+         dcterms:description "Gibt den Titel oder Namen an, der der Ressource zugewiesen wurde. Ein Ausgangspunkt für die Definition von Untereigenschaften, die ebucore-Titel unterschiedlicher Typen definieren. Der ebucore-Titeltyp kann verwendet werden, um Untereigenschaften zu definieren, die die Kategorie des Titels optional näher bestimmen. Alle Werte des EBU title status classification scheme (https://github.com/ebu/ebu_cs/blob/main/metadata/cs/ebu_TitleStatusCodeCS.xml) sind potenzielle Untereigenschaften der title-Eigenschaft, wie zum Beispiel bei alternativeTitle umgesetzt."@de ,
+                             "Specifies the title or name given to the resource. A root for the definition of sub-properties defining ebucore titles of different types. The ebucore title type can be used to define sub-properties to optionally refine the category of the title. All values of the EBU title status classification scheme (https://github.com/ebu/ebu_cs/blob/main/metadata/cs/ebu_TitleStatusCodeCS.xml) are candidate sub-properties of the title property as implemented for an example with alternativeTitle."@en ;
+         rdfs:label "Titel"@de ,
+                    "Title"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#totalNumberOfAudioChannels
+ec:totalNumberOfAudioChannels rdf:type owl:DatatypeProperty ;
+                              rdfs:range xsd:nonNegativeInteger ;
+                              dcterms:description "Die Gesamtzahl der Audio-Kanäle, die in der MediaResource enthalten sind."@de ,
+                                                  "The total number of audio channels contained in the MediaResource."@en ;
+                              rdfs:label "Anzahl der Audiokanäle"@de ,
+                                         "Number of audio channel"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#totalNumberOfAudioTracks
+ec:totalNumberOfAudioTracks rdf:type owl:DatatypeProperty ;
+                            rdfs:range xsd:integer ;
+                            dcterms:description "Die Gesamtzahl der Audiotracks in einer Medienressource."@de ,
+                                                "The total number of audio tracks in a media resource."@en ;
+                            rdfs:label "Anzahl der Audiotitel"@de ,
+                                       "Number of audio tracks"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#totalNumberOfEpisodes
+ec:totalNumberOfEpisodes rdf:type owl:DatatypeProperty ;
+                         rdfs:range xsd:integer ;
+                         dcterms:description "Die Gesamtzahl der mit einer Serie oder Staffel verbundenen Episoden."@de ,
+                                             "The total number of episodes associated with a series or season."@en ;
+                         rdfs:label "Gesamtzahl der Episoden"@de ,
+                                    "Total number of episodes"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#totalNumberOfGroupMembers
+ec:totalNumberOfGroupMembers rdf:type owl:DatatypeProperty ;
+                             rdfs:range xsd:integer ;
+                             dcterms:description "Die Gesamtzahl der Mitglieder in einer Gruppe."@de ,
+                                                 "The total number of members in a group."@en ;
+                             rdfs:label "Gesamtzahl der Gruppenmitglieder"@de ,
+                                        "Total number of group members"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#totalNumberOfVideoTracks
+ec:totalNumberOfVideoTracks rdf:type owl:DatatypeProperty ;
+                            rdfs:range xsd:integer ;
+                            dcterms:description "Die Gesamtzahl der Videospuren in der Medienressource."@de ,
+                                                "The total number of video tracks in the media resource."@en ;
+                            rdfs:label "Anzahl der Videospuren"@de ,
+                                       "Number of video tracks"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#username
+ec:username rdf:type owl:DatatypeProperty ;
+            rdfs:range rdfs:Literal ;
+            dcterms:description "Der Benutzername, unter dem eine Person bekannt ist, z. B. wenn ein Bewertungswert zugeordnet wird."@de ,
+                                "The username by which a Person is known e.g. when attributing a rating value."@en ;
+            rdfs:label "Benutzername"@de ,
+                       "Username"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#version
+ec:version rdf:type owl:DatatypeProperty ;
+           rdfs:range rdfs:Literal ;
+           dcterms:description "Die aktuelle Version eines EditorialObject."@de ,
+                               "The current version of an EditorialObject."@en ;
+           rdfs:label "Version"@de ,
+                      "Version"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#videoBitRate
+ec:videoBitRate rdf:type owl:DatatypeProperty ;
+                rdfs:range xsd:nonNegativeInteger ;
+                dcterms:description "Die Videobitrate. Sie gibt die Bitrate an, mit der die MediaResource in Bits/Sekunde wiedergegeben werden kann. Bei konstanter Bitrate ist die aktuelle Bitrate anzugeben, bei variabler Bitrate die durchschnittliche Bitrate."@de ,
+                                    "The video bitrate. To provide the bitrate at which the MediaResource can be played in bits/second. Current bitrate if constant, and average bitrate if variable."@en ;
+                rdfs:label "Video bitrate"@en ,
+                           "Videobitrate"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#videoBitRateMax
+ec:videoBitRateMax rdf:type owl:DatatypeProperty ;
+                   rdfs:range xsd:nonNegativeInteger ;
+                   dcterms:description "Die maximale Videobitrate."@de ,
+                                       "The maximum video bitrate."@en ;
+                   rdfs:label "Maximale Video-Bitrate"@de ,
+                              "Video bitrate max"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#videoBitRateMode
+ec:videoBitRateMode rdf:type owl:DatatypeProperty ;
+                    rdfs:range rdfs:Literal ;
+                    dcterms:description "Der Videobitrate-Modus."@de ,
+                                        "The video bitrate mode."@en ;
+                    rdfs:label "Video bitrate mode"@en ,
+                               "Videobitrate-Modus"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#videoDisplay
+ec:videoDisplay rdf:type owl:DatatypeProperty ,
+                         owl:FunctionalProperty ;
+                dcterms:description "A flag to indicate if the Service requires a video display."@en ,
+                                    "Ein Kennzeichen, das angibt, ob der Dienst eine Videoanzeige benötigt."@de ;
+                rdfs:label "Video display"@en ,
+                           "Videowiedergabe"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#videoEncodingLevel
+ec:videoEncodingLevel rdf:type owl:DatatypeProperty ;
+                      rdfs:subPropertyOf ec:encodingLevel ;
+                      rdfs:range rdfs:Literal ;
+                      dcterms:description "Die Kodierungsebene, wie sie in Spezifikationen definiert ist."@de ,
+                                          "The encoding level as defined in specifications."@en ;
+                      rdfs:label "Video encoding level"@en ,
+                                 "Video-Encodierungsstufe"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#videoEncodingProfile
+ec:videoEncodingProfile rdf:type owl:DatatypeProperty ;
+                        rdfs:subPropertyOf ec:encodingProfile ;
+                        rdfs:range rdfs:Literal ;
+                        dcterms:description "Die Encoding-Ebene, wie sie in den Spezifikationen definiert ist."@de ,
+                                            "The encoding level as defined in specifications."@en ;
+                        rdfs:label "Video encoding profile"@en ,
+                                   "Video-Encoding-Profil"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#videoTrackNumber
+ec:videoTrackNumber rdf:type owl:DatatypeProperty ;
+                    rdfs:range xsd:nonNegativeInteger ;
+                    dcterms:description "Die Nummer, die zur Identifizierung eines Videotracks unter mehreren Tracks in einer Medienressource verwendet wird."@de ,
+                                        "The number used to identify a video track among multiple tracks in a media resource."@en ;
+                    rdfs:label "Video track number"@en ,
+                               "Videospurnummer"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#webcam
+ec:webcam rdf:type owl:DatatypeProperty ,
+                   owl:FunctionalProperty ;
+          dcterms:description "A flag to indicate if the Service requires a webcam."@en ,
+                              "Ein Flag, das angibt, ob der Service eine Webcam benötigt."@de ;
+          rdfs:label "Webcam"@de ,
+                     "Webcam"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#width
+ec:width rdf:type owl:DatatypeProperty ;
+         rdfs:range xsd:integer ;
+         dcterms:description "Die Breite z. B. eines Videobildes, die typischerweise als Anzahl von Pixeln oder bei Bildern in Millimetern angegeben wird."@de ,
+                             "The width of e.g. a video frame typically expressed as a number of pixels, or picture/image in millimeters."@en ;
+         rdfs:label "Breite"@de ,
+                    "Width"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#widthUnit
+ec:widthUnit rdf:type owl:DatatypeProperty ;
+             rdfs:range rdfs:Literal ;
+             dcterms:description "Die Einheit, mit der eine Breite gemessen wird, z. B. in Pixeln, als Anzahl von Zeilen oder in Millimetern oder Ähnlichem."@de ,
+                                 "The unit used to measure a width e.g. in pixels or number of lines or millimeters or else."@en ;
+             rdfs:label "Breiteneinheit"@de ,
+                        "Width unit"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#wordCount
+ec:wordCount rdf:type owl:DatatypeProperty ;
+             rdfs:range xsd:integer ;
+             dcterms:description "Die Anzahl der in einem Dokument enthaltenen Wörter."@de ,
+                                 "The number of words contained in a document."@en ;
+             rdfs:label "Word count"@en ,
+                        "Wortanzahl"@de .
+
+
+###  http://www.w3.org/2006/time#day
+time:day rdf:type owl:DatatypeProperty ;
+         rdfs:range xsd:gDay ;
+         rdfs:label "day"@en .
+
+
+###  http://www.w3.org/2006/time#inXSDDateTimeStamp
+time:inXSDDateTimeStamp rdf:type owl:DatatypeProperty ;
+                        rdfs:range xsd:dateTimeStamp .
+
+
+###  http://www.w3.org/2006/time#month
+time:month rdf:type owl:DatatypeProperty ;
+           rdfs:range xsd:gMonth ;
+           rdfs:label "month"@en .
+
+
+###  http://www.w3.org/2006/time#year
+time:year rdf:type owl:DatatypeProperty ;
+          rdfs:range xsd:gYear ;
+          rdfs:label "year"@en .
+
+
+#################################################################
+#    Classes
+#################################################################
+
+###  http://purl.org/dc/elements/1.1/Agent
+dc:Agent rdf:type owl:Class ;
+         dcterms:description "A resource that acts or has the power to act."@en ;
+         rdfs:label "Agent"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AccessConditions
+ec:AccessConditions rdf:type owl:Class ;
+                    rdfs:subClassOf ec:Rights ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasGeoBlockingBlacklist ;
+                                      owl:allValuesFrom skos:Concept
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasGeoBlockingWhitelist ;
+                                      owl:allValuesFrom skos:Concept
+                                    ] ;
+                    dcterms:description "Die Anforderungen, unter denen der Zugriff auf Inhalte oder deren Veröffentlichung gewährt wird."@de ,
+                                        "The requirements under which access to content or its publication is granted."@en ;
+                    rdfs:label "Access conditions"@en ,
+                               "Zugangsbedingungen"@de ;
+                    skos:definition "a ec:Rights that define the requirements under which access to an ec:Asset or a ec:PublicationEvent is granted"@en ,
+                                    "eine ec:Rights, die die Anforderungen festlegen, unter denen der Zugang zu einer ec:Asset oder einer ec:PublicationEvent gewährt wird"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Account
+ec:Account rdf:type owl:Class ;
+           rdfs:subClassOf [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:hasConsumptionContract ;
+                             owl:allValuesFrom ec:Contract
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:hasIdentifier ;
+                             owl:allValuesFrom ec:Identifier
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:hasObjectType ;
+                             owl:allValuesFrom skos:Concept
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:hasRelatedAccount ;
+                             owl:allValuesFrom ec:Account
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:holdsLicence ;
+                             owl:allValuesFrom ec:ConsumptionLicence
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:description ;
+                             owl:allValuesFrom rdfs:Literal
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:name ;
+                             owl:allValuesFrom rdfs:Literal
+                           ] ;
+           dcterms:description "A registration Account to a Service. Account information can vary from one Service to another. Such information covers e.g. a (nick)name, a login, an age, sex, domains of interest or more."@en ,
+                               "Ein Registrierungs-Konto für einen Dienst. Die Kontoinformationen können von Dienst zu Dienst variieren. Solche Informationen umfassen z. B. einen (Spitz-)Namen, einen Login, ein Alter, das Geschlecht, Interessensgebiete oder mehr."@de ;
+           rdfs:label "Account"@en ,
+                      "Konto"@de ;
+           skos:definition "a registration identity for a media service"@en ,
+                           "eine Registrierungsidentität für einen Mediendienst"@de ;
+           skos:example """- a registered user to access netflix
+- a registered family with nicknames and devices to access a VOD service"""@en ,
+                        """- ein registrierter Nutzer, um auf Netflix zuzugreifen
+- eine registrierte Familie mit Spitznamen und Geräten, um auf einen VOD-Dienst zuzugreifen"""@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Action
+ec:Action rdf:type owl:Class ;
+          rdfs:subClassOf [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasIdentifier ;
+                            owl:allValuesFrom ec:Identifier
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasObjectType ;
+                            owl:allValuesFrom skos:Concept
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasRelatedAgent ;
+                            owl:allValuesFrom ec:Agent
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasRelatedScene ;
+                            owl:allValuesFrom ec:Scene
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasStart ;
+                            owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                            owl:onClass ec:TimelinePoint
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasEnd ;
+                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                            owl:onClass ec:TimelinePoint
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:description ;
+                            owl:allValuesFrom rdfs:Literal
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:name ;
+                            owl:allValuesFrom rdfs:Literal
+                          ] ;
+          dcterms:description "An entry from a list of actions, often used to create log entries about something happening along the timeline of content, eg. a goal scored in a football game."@en ,
+                              "Ein Eintrag aus einer Liste von Aktionen, der häufig verwendet wird, um Protokolleinträge über etwas zu erstellen, das sich entlang der Zeitlinie von Inhalten ereignet, z. B. ein im Fußball erzieltes Tor."@de ;
+          rdfs:label "Action"@en ,
+                     "Aktion"@de ;
+          skos:definition "a skos:Concept classifying an action that happens in the course of an event or some content"@en ,
+                          "ein skos:Concept, der eine Handlung klassifiziert, die im Verlauf eines Ereignisses oder eines Inhalts stattfindet"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ActionType
+ec:ActionType rdf:type owl:Class ;
+              rdfs:subClassOf skos:Concept ;
+              dcterms:description "An entry from a list of actions, often used to create log entries about something happening along the timeline of content, eg. a goal scored in a football game."@en ,
+                                  "Ein Eintrag aus einer Liste von Aktionen, der oft verwendet wird, um Protokolleinträge über ein Ereignis entlang der Zeitachse von Inhalten zu erstellen, z. B. ein Tor in einem Fußballspiel."@de ;
+              rdfs:label "Action type"@en ,
+                         "Aktionsart"@de ;
+              skos:definition "a skos:Concept classifying an action that happens in the course of an event or some content"@en ,
+                              "ein skos:Concept, der eine Handlung klassifiziert, die im Verlauf eines Ereignisses oder eines Inhalts stattfindet"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ActiveFormatDescriptorCode
+ec:ActiveFormatDescriptorCode rdf:type owl:Class ;
+                              rdfs:subClassOf ec:Format ;
+                              dcterms:description "An entry from the classification of aspect ratios of a media resource on display."@en ,
+                                                  "Ein Eintrag aus der Klassifikation der Seitenverhältnisse einer im Anzeigemodus befindlichen Medienressource."@de ;
+                              rdfs:label "Active format descriptor code"@en ,
+                                         "Code für aktiven Formatdeskriptor"@de ;
+                              skos:definition "a ec:Format classifying the aspect ratio of a ec:MediaResource when displayed"@en ,
+                                              "eine ec:Format, die das Seitenverhältnis einer ec:MediaResource bei der Anzeige klassifiziert"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Affiliation
+ec:Affiliation rdf:type owl:Class ;
+               rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                 owl:onProperty ec:hasIdentifier ;
+                                 owl:allValuesFrom ec:Identifier
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty ec:hasObjectType ;
+                                 owl:allValuesFrom skos:Concept
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty ec:isAffiliatedTo ;
+                                 owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                 owl:onClass ec:Organisation
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty ec:hasEndDateTime ;
+                                 owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                 owl:onClass time:Instant
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty ec:hasStartDateTime ;
+                                 owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                 owl:onClass time:Instant
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty ec:description ;
+                                 owl:allValuesFrom rdfs:Literal
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty ec:name ;
+                                 owl:allValuesFrom rdfs:Literal
+                               ] ;
+               dcterms:description "An Organisation to which a Contact is affiliated (with period of validity)."@en ,
+                                   "Eine Organisation, mit der ein Kontakt verbunden ist (mit Gültigkeitszeitraum)."@de ;
+               rdfs:label "Affiliation"@en ,
+                          "Zugehörigkeit"@de ;
+               skos:definition "an association of a Person to an Organisation for a period of time"@en ,
+                               "eine Zuordnung einer Person zu einer Organisation für einen Zeitraum"@de ;
+               skos:example """- a person's employment with the BBC from hiring to retirement
+- the hosting of a BBC weekly radio show on a radio channel over 8 years"""@en ,
+                            """- die Anstellung einer Person bei der BBC von der Einstellung bis zum Ruhestand
+- die Moderation einer wöchentlichen BBC-Radiosendung auf einem Radiosender über 8 Jahre hinweg"""@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Agent
+ec:Agent rdf:type owl:Class ;
+         rdfs:subClassOf dc:Agent ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasAgentBiography ;
+                           owl:allValuesFrom ec:Biography
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasAgentCountryOfResidence ;
+                           owl:allValuesFrom ec:CountryCode
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasAgentLanguage ;
+                           owl:allValuesFrom ec:Language
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasAgentMember ;
+                           owl:allValuesFrom ec:Agent
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasAgentNationality ;
+                           owl:allValuesFrom ec:CountryCode
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasAgentPlaceOfResidence ;
+                           owl:allValuesFrom ec:Location
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasAssociatedArtefact ;
+                           owl:allValuesFrom ec:Artefact
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasCharacter ;
+                           owl:allValuesFrom ec:Character
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasContact ;
+                           owl:allValuesFrom ec:Contact
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasGroupMember ;
+                           owl:allValuesFrom ec:Agent
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasIdentifier ;
+                           owl:allValuesFrom ec:Identifier
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasObjectType ;
+                           owl:allValuesFrom skos:Concept
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasRelatedAgent ;
+                           owl:allValuesFrom ec:Agent
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasRelatedPicture ;
+                           owl:allValuesFrom ec:Picture
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:holdsAward ;
+                           owl:allValuesFrom ec:Award
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:agentDbpedia ;
+                           owl:allValuesFrom xsd:anyURI
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:agentEmailAddress ;
+                           owl:allValuesFrom xsd:string
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:agentFacebook ;
+                           owl:allValuesFrom xsd:anyURI
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:agentFee ;
+                           owl:allValuesFrom rdfs:Literal
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:agentFlickr ;
+                           owl:allValuesFrom xsd:anyURI
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:agentImdb ;
+                           owl:allValuesFrom xsd:anyURI
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:agentInstagram ;
+                           owl:allValuesFrom xsd:anyURI
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:agentLinkedData ;
+                           owl:allValuesFrom xsd:anyURI
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:agentLinkedIn ;
+                           owl:allValuesFrom xsd:anyURI
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:agentMobileTelephoneNumber ;
+                           owl:allValuesFrom xsd:string
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:agentPreviousName ;
+                           owl:allValuesFrom rdfs:Literal
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:agentRelatedInformationLink ;
+                           owl:allValuesFrom xsd:anyURI
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:agentRelatedLink ;
+                           owl:allValuesFrom xsd:anyURI
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:agentRelatedPressLink ;
+                           owl:allValuesFrom xsd:anyURI
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:agentSocialMedia ;
+                           owl:allValuesFrom xsd:anyURI
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:agentTelephoneNumber ;
+                           owl:allValuesFrom xsd:string
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:agentTwitter ;
+                           owl:allValuesFrom xsd:anyURI
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:agentWebHomepage ;
+                           owl:allValuesFrom xsd:anyURI
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:agentWikidata ;
+                           owl:allValuesFrom xsd:anyURI
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:agentWikipedia ;
+                           owl:allValuesFrom xsd:anyURI
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:description ;
+                           owl:allValuesFrom rdfs:Literal
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:name ;
+                           owl:allValuesFrom rdfs:Literal
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:nickName ;
+                           owl:allValuesFrom rdfs:Literal
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:displayOrder ;
+                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                         ] ;
+         dcterms:description "An «Agent» is either a Contact/Person or Organisation to which is associated a Role corresponding to the contribution the «Agent» brings to the realisation of a MediaResource or EditorialObject."@en ,
+                             "Ein «Agent» ist entweder eine Kontaktperson/Person oder eine Organisation, der eine Rolle zugeordnet ist, die dem Beitrag entspricht, den der «Agent» zur Realisierung einer MediaResource oder eines EditorialObject leistet."@de ;
+         rdfs:label "Agent"@de ,
+                    "Agent"@en ;
+         skos:definition "an entity performing an activity in the media business"@en ,
+                         "eine Entität, die eine Aktivität im Mediengeschäft ausübt"@de ;
+         skos:example """- a film director
+- a camera woman
+- a sound engineer
+- an actress
+- an author
+- a publishing media enterprise
+- a content providing enterprise
+- a distribution network enterprise
+- a consumption device manufacturing enterprise"""@en ,
+                      """- ein Filmregisseur
+- eine Kamerafrau
+- ein Toningenieur
+- eine Schauspielerin
+- ein Autor
+- ein Medienunternehmen im Verlagsbereich
+- ein Unternehmen zur Bereitstellung von Inhalten
+- ein Vertriebsnetzwerk-Unternehmen
+- ein Unternehmen zur Herstellung von Endgeräten für den Konsum"""@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AlternativeTitle
+ec:AlternativeTitle rdf:type owl:Class ;
+                    rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasIdentifier ;
+                                      owl:allValuesFrom ec:Identifier
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasObjectType ;
+                                      owl:allValuesFrom skos:Concept
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasEndDateTime ;
+                                      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                      owl:onClass time:Instant
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasStartDateTime ;
+                                      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                      owl:onClass time:Instant
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:title ;
+                                      owl:someValuesFrom rdfs:Literal
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:description ;
+                                      owl:allValuesFrom rdfs:Literal
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:name ;
+                                      owl:allValuesFrom rdfs:Literal
+                                    ] ;
+                    dcterms:description "A title is a name for a piece or a group of content."@en ,
+                                        "Ein Titel ist ein Name für ein Werk oder eine Gruppe von Inhalten."@de ;
+                    rdfs:label "Alternative title"@en ,
+                               "Alternativer Titel"@de ;
+                    skos:definition "a name of a certain type given to an ec:EditorialObject"@en ,
+                                    "eine Bezeichnung einer bestimmten Art, die einem ec:EditorialObject gegeben wird"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AncillaryData
+ec:AncillaryData rdf:type owl:Class ;
+                 rdfs:subClassOf ec:DataTrack ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasWrappingType ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass ec:WrappingType
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:DID ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onDataRange xsd:integer
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:SDID ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onDataRange xsd:integer
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:lineNumber ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onDataRange xsd:integer
+                                 ] ;
+                 dcterms:description "A track containing supplemental data that accompanies video or audio content."@en ,
+                                     "Ein Track mit ergänzenden Daten, die Video- oder Audioinhalte begleiten."@de ;
+                 rdfs:label "Ancillary data"@en ,
+                            "Zusatzdaten"@de ;
+                 skos:definition "a ec:DataTrack of data of a supplemental nature"@en ,
+                                 "ein ec:DataTrack von Daten ergänzender Art"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AncillaryDataFormat
+ec:AncillaryDataFormat rdf:type owl:Class ;
+                       rdfs:subClassOf ec:DataFormat ;
+                       dcterms:description "An entry from the classification of structure schemes for data that supplement audio, video, or images, e.g., legacy data that used to be carried in vertical blanking intervals of video broadcast signals."@en ,
+                                           "Ein Eintrag aus der Klassifikation von Struktur-Schemata für Daten, die Audio, Video oder Bilder ergänzen, z. B. Altdaten, die früher in den vertikalen Austastintervallen von Fernsehsendesignalen übertragen wurden."@de ;
+                       rdfs:label "Ancillary data format"@en ,
+                                  "Sekundärdatenformat"@de ;
+                       skos:definition "a ec:DataFormat classifying the structure of supplemental data"@en ,
+                                       "eine ec:DataFormat, die die Struktur ergänzender Daten klassifiziert"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Animal
+ec:Animal rdf:type owl:Class ;
+          rdfs:subClassOf [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasAnimalBreedCode ;
+                            owl:allValuesFrom ec:AnimalBreedCode
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasAnimalColourCode ;
+                            owl:allValuesFrom ec:AnimalColourCode
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasAnimalGroom ;
+                            owl:allValuesFrom ec:Agent
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasAnimalRole ;
+                            owl:allValuesFrom ec:Involvement
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasIdentifier ;
+                            owl:allValuesFrom ec:Identifier
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasObjectType ;
+                            owl:allValuesFrom skos:Concept
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasOwner ;
+                            owl:allValuesFrom ec:Agent
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:portrays ;
+                            owl:allValuesFrom ec:Character
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasDateOfBirth ;
+                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                            owl:onClass time:Instant
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasDateOfDeath ;
+                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                            owl:onClass time:Instant
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:description ;
+                            owl:allValuesFrom rdfs:Literal
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:name ;
+                            owl:allValuesFrom rdfs:Literal
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:animalCharacterName ;
+                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:animalCode ;
+                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:animalPassport ;
+                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:gender ;
+                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                          ] ;
+          dcterms:description "An animal that is related to or depicted in a piece of work."@en ,
+                              "Ein Tier, das mit einem Werk in Verbindung steht oder in einem Werk dargestellt wird."@de ;
+          rdfs:label "Animal"@en ,
+                     "Tier"@de ;
+          skos:definition "an animal with a role in ec:Involvement"@en ,
+                          "ein Tier mit einer Rolle in ec:Involvement"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AnimalBreedCode
+ec:AnimalBreedCode rdf:type owl:Class ;
+                   rdfs:subClassOf skos:Concept ;
+                   dcterms:description "An entry from the breed classification of animals."@en ,
+                                       "Ein Eintrag aus der Rassenklassifikation von Tieren."@de ;
+                   rdfs:label "Animal breed code"@en ,
+                              "Tierzuchtcode"@de ;
+                   skos:definition "a skos:Concept classifying an ec:Animal by their breed"@en ,
+                                   "ein skos:Concept zur Klassifizierung eines ec:Animal nach ihrer Rasse"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AnimalColourCode
+ec:AnimalColourCode rdf:type owl:Class ;
+                    rdfs:subClassOf skos:Concept ;
+                    dcterms:description "An entry from the colour classification of animals."@en ,
+                                        "Ein Eintrag aus der Farbkategorisierung von Tieren."@de ;
+                    rdfs:label "Animal colour code"@en ,
+                               "Tierfarbcode"@de ;
+                    skos:definition "a skos:Concept classifying an ec:Animal by their colour"@en ,
+                                    "ein skos:Concept, der ein ec:Animal nach seiner Farbe klassifiziert"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Annotation
+ec:Annotation rdf:type owl:Class ;
+              rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:hasAnnotationAgent ;
+                                owl:allValuesFrom ec:Agent
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:hasAnnotationTarget ;
+                                owl:allValuesFrom owl:Thing
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:hasIdentifier ;
+                                owl:allValuesFrom ec:Identifier
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:hasObjectType ;
+                                owl:allValuesFrom skos:Concept
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:hasRelatedAgent ;
+                                owl:allValuesFrom ec:Agent
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:hasRelatedArtefact ;
+                                owl:allValuesFrom ec:Artefact
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:hasRelatedEvent ;
+                                owl:allValuesFrom ec:Event
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:hasAnnotationCurationDateTime ;
+                                owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                owl:onClass time:Instant
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:hasAuthor ;
+                                owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                owl:onClass ec:Agent
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:hasLocation ;
+                                owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                owl:onClass ec:Location
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:isAnnotatedMediaResource ;
+                                owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                owl:onClass ec:MediaResource
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:description ;
+                                owl:allValuesFrom rdfs:Literal
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:name ;
+                                owl:allValuesFrom rdfs:Literal
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:annotationConfidence ;
+                                owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:annotationPurpose ;
+                                owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:annotationSaliency ;
+                                owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                              ] ;
+              dcterms:description "Annotationen sind bedeutungsvolle Begriffe, die mit Dingen verknüpft sind. Dinge, die mit denselben Begriffen annotiert sind, sind implizit miteinander verknüpft."@de ,
+                                  "Annotations are meaningful terms that are associated with things. Things that are annotated with the same terms are implicitly associated."@en ;
+              rdfs:label "Annotation"@de ,
+                         "Annotation"@en ;
+              skos:definition "a string that is assigned to owl:Thing for implicit association amongst them"@en ,
+                              "ein String, der owl:Thing für eine implizite Assoziation zwischen ihnen zugewiesen wird"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AnnotationType
+ec:AnnotationType rdf:type owl:Class ;
+                  rdfs:subClassOf skos:Concept ;
+                  dcterms:description "An entry from the classification of annotations."@en ,
+                                      "Ein Eintrag aus der Klassifikation von Annotationen."@de ;
+                  rdfs:label "Anmerkungstyp"@de ,
+                             "Annotation type"@en ;
+                  skos:definition "a skos:Concept classifying an ec:Annotation"@en ,
+                                  "ein skos:Concept, der ein ec:Annotation klassifiziert"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Artefact
+ec:Artefact rdf:type owl:Class ;
+            rdfs:subClassOf [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasArtefactBuyer ;
+                              owl:allValuesFrom ec:Agent
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasArtefactOwner ;
+                              owl:allValuesFrom ec:Agent
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasArtefactRelatedLocation ;
+                              owl:allValuesFrom ec:Location
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasArtefactRelatedPhysicalResource ;
+                              owl:allValuesFrom ec:PhysicalResource
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasArtefactRetailer ;
+                              owl:allValuesFrom ec:Agent
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasArtefactSupplier ;
+                              owl:allValuesFrom ec:Agent
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasCreator ;
+                              owl:allValuesFrom ec:Involvement
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasIdentifier ;
+                              owl:allValuesFrom ec:Identifier
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasObjectType ;
+                              owl:allValuesFrom skos:Concept
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasRelatedAgent ;
+                              owl:allValuesFrom ec:Agent
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasRelatedEditorialObject ;
+                              owl:allValuesFrom ec:EditorialObject
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasRelatedResource ;
+                              owl:allValuesFrom ec:Resource
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasArtefactDateOfPurchase ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onClass time:Instant
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasArtefactDateOfSale ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onClass time:Instant
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasArtefactPriceCurrency ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onClass ec:CurrencyCode
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasLocation ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onClass ec:Location
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:artefactAvailability ;
+                              owl:allValuesFrom rdfs:Literal
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:artefactBrand ;
+                              owl:allValuesFrom rdfs:Literal
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:artefactColour ;
+                              owl:allValuesFrom rdfs:Literal
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:artefactComment ;
+                              owl:allValuesFrom rdfs:Literal
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:artefactModel ;
+                              owl:allValuesFrom rdfs:Literal
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:artefactPeriod ;
+                              owl:allValuesFrom rdfs:Literal
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:artefactPriceAmount ;
+                              owl:allValuesFrom rdfs:Literal
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:artefactReference ;
+                              owl:allValuesFrom xsd:anyURI
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:artefactStyle ;
+                              owl:allValuesFrom rdfs:Literal
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:artefactUsageHistory ;
+                              owl:allValuesFrom rdfs:Literal
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:artefactWebsite ;
+                              owl:allValuesFrom xsd:anyURI
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:description ;
+                              owl:allValuesFrom rdfs:Literal
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:name ;
+                              owl:allValuesFrom rdfs:Literal
+                            ] ;
+            dcterms:description "Etwas, das während einer Produktion verwendet wird, oft sichtbar oder hörbar und bewusst wegen seines Werts für den resultierenden Inhalt ausgewählt, wie Kostüme, Gegenstände oder Produkte."@de ,
+                                "Something used during a production, often visible or audible and deliberately chosen for its value to the resulting content, such as costumes, objects, or products."@en ;
+            rdfs:label "Artefact"@en ,
+                       "Artefakt"@de ;
+            skos:definition "an object made or modified by a human being, typically one of cultural or historical interest; used in a ec:ProductionJob, often visible or audible, and deliberately chosen for its value to the resulting ec:EditorialObject"@en ,
+                            "ein von einem Menschen hergestellter oder veränderter Gegenstand, typischerweise von kulturellem oder historischem Interesse; verwendet in einem ec:ProductionJob, oft sichtbar oder hörbar und bewusst aufgrund seines Werts für das resultierende ec:EditorialObject ausgewählt"@de ;
+            skos:example """- die Kostüme und Requisiten in einem Film
+- der nicht-dynamische Hintergrund, Stühle, Tisch in einer Talkshow"""@de ,
+                         """- the costumes and props in a movie
+- the non-dynamic backdrop, chairs, table in a talk show"""@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ArtefactType
+ec:ArtefactType rdf:type owl:Class ;
+                rdfs:subClassOf skos:Concept ;
+                dcterms:description "An entry from the classification of media production artefacts."@en ,
+                                    "Ein Eintrag aus der Klassifikation von Artefakten der Medienproduktion."@de ;
+                rdfs:label "Artefact type"@en ,
+                           "Artefakttyp"@de ;
+                skos:definition "a skos:Concept classifying an ec:Artefact"@en ,
+                                "ein skos:Concept zur Klassifizierung eines ec:Artefact"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Article
+ec:Article rdf:type owl:Class ;
+           rdfs:subClassOf ec:EditorialWork ;
+           dcterms:description "A work consisting of text, graphics, sometimes video or audio, and created for publication on websites, blogs, etc., or other platforms similar to the more traditional paper-based publications."@en ,
+                               "Ein Werk, das aus Text, Grafiken, manchmal Video oder Audio besteht und für die Veröffentlichung auf Websites, Blogs usw. oder anderen Plattformen erstellt wurde, die den traditionelleren papierbasierten Veröffentlichungen ähneln."@de ;
+           rdfs:label "Article"@en ,
+                      "Artikel"@de ;
+           skos:definition "an ec:EditorialWork consisting of text, graphics, sometimes video or audio, created for publication on websites, blogs, et al., or other platforms similar to the more traditional paper-based publications"@en ,
+                           "ein ec:EditorialWork, bestehend aus Text, Grafiken, manchmal Video oder Audio, erstellt zur Veröffentlichung auf Websites, Blogs, et al. oder anderen Plattformen, die den traditionelleren papierbasierten Veröffentlichungen ähneln"@de ;
+           skos:example "- a news article on BBC's website"@en ,
+                        "- ein Nachrichtenartikel auf der BBC-Website"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Asset
+ec:Asset rdf:type owl:Class ;
+         rdfs:subClassOf [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:derivedTo ;
+                           owl:allValuesFrom ec:Asset
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasAccessConditions ;
+                           owl:allValuesFrom ec:AccessConditions
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasAssetValue ;
+                           owl:allValuesFrom ec:AssetValue
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasChild ;
+                           owl:allValuesFrom ec:Asset
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasContact ;
+                           owl:allValuesFrom ec:Contact
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasCopyright ;
+                           owl:allValuesFrom ec:Copyright
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasCoverageRestrictions ;
+                           owl:allValuesFrom ec:CoverageRestrictions
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasCreativeCommons ;
+                           owl:allValuesFrom ec:CreativeCommons
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasDisclaimer ;
+                           owl:allValuesFrom ec:Disclaimer
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasExploitationIssues ;
+                           owl:allValuesFrom ec:ExploitationIssues
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasIPRRestrictions ;
+                           owl:allValuesFrom ec:IPRRestrictions
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasIdentifier ;
+                           owl:allValuesFrom ec:Identifier
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasLicensing ;
+                           owl:allValuesFrom ec:Licensing
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasParticipatingAgent ;
+                           owl:allValuesFrom ec:Agent
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasRelatedArtefact ;
+                           owl:allValuesFrom ec:Artefact
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasRelatedAsset ;
+                           owl:allValuesFrom ec:Asset
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasRelatedAuditReport ;
+                           owl:allValuesFrom ec:AuditReport
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasRelatedEditorialObject ;
+                           owl:allValuesFrom ec:EditorialObject
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasRelatedPicture ;
+                           owl:allValuesFrom ec:Picture
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasRelatedRecord ;
+                           owl:allValuesFrom ec:Record
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasRelatedResource ;
+                           owl:allValuesFrom ec:Resource
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasRights ;
+                           owl:allValuesFrom ec:Rights
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasRightsClearance ;
+                           owl:allValuesFrom ec:RightsClearance
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasUsageRestrictions ;
+                           owl:allValuesFrom ec:UsageRestrictions
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasUsageRights ;
+                           owl:allValuesFrom ec:UsageRights
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:isDerivedFrom ;
+                           owl:allValuesFrom ec:Asset
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:isReplacedBy ;
+                           owl:allValuesFrom ec:Asset
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:replaces ;
+                           owl:allValuesFrom ec:Asset
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasDateArchived ;
+                           owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                           owl:onClass time:Instant
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasDateCreated ;
+                           owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                           owl:onClass time:Instant
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasDateDeleted ;
+                           owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                           owl:onClass time:Instant
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasDateDistributed ;
+                           owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                           owl:onClass time:Instant
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasDateLicenseEnd ;
+                           owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                           owl:onClass time:Instant
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasDateLicensedStart ;
+                           owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                           owl:onClass time:Instant
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasDateModified ;
+                           owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                           owl:onClass time:Instant
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasDateProduced ;
+                           owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                           owl:onClass time:Instant
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasDateReleased ;
+                           owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                           owl:onClass time:Instant
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasObjectType ;
+                           owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                           owl:onClass skos:Concept
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:isChildOf ;
+                           owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                           owl:onClass ec:Asset
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:description ;
+                           owl:allValuesFrom rdfs:Literal
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:name ;
+                           owl:allValuesFrom rdfs:Literal
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:orderedFlag ;
+                           owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                           owl:onDataRange xsd:boolean
+                         ] ;
+         owl:disjointWith ec:Rating ;
+         dcterms:description "Assets are abstractions of audio, audiovisual, or bibliographical media objects. They serve to describe the value and the associated rights of the media object."@en ,
+                             "Assets sind Abstraktionen von audiovisuellen oder bibliografischen Medienobjekten. Sie dienen dazu, den Wert und die damit verbundenen Rechte des Medienobjekts zu beschreiben."@de ;
+         rdfs:label "Asset"@en ,
+                    "Bestand"@de ;
+         skos:definition "a piece of content that represents an ec:AssetValue in the context of the owner's business and may carry ec:Rights"@en ,
+                         "ein Inhaltsteil, der im Kontext des Geschäfts des Eigentümers einen ec:AssetValue repräsentiert und ec:Rights tragen kann"@de ;
+         skos:example """- a film on tape in the archive
+- a digital audio recording with associated author's right and copyright
+- a book
+- a collection of books"""@en ,
+                      """- ein Film auf Band im Archiv
+- eine digitale Tonaufnahme mit zugehörigem Urheberrecht und Copyright
+- ein Buch
+- eine Sammlung von Büchern"""@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AssetType
+ec:AssetType rdf:type owl:Class ;
+             rdfs:subClassOf skos:Concept ;
+             dcterms:description "An entry from the classification of media assets."@en ,
+                                 "Ein Eintrag aus der Klassifizierung von Medienobjekten."@de ;
+             rdfs:label "Asset type"@en ,
+                        "Assettyp"@de ;
+             skos:definition "a skos:Concept classifying an ec:Asset"@en ,
+                             "ein skos:Concept zur Klassifizierung eines ec:Asset"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AssetValue
+ec:AssetValue rdf:type owl:Class ;
+              rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:hasAssetValueCurrency ;
+                                owl:allValuesFrom skos:Concept
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:hasIdentifier ;
+                                owl:allValuesFrom ec:Identifier
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:hasObjectType ;
+                                owl:allValuesFrom skos:Concept
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:assetValue ;
+                                owl:allValuesFrom xsd:decimal
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:description ;
+                                owl:allValuesFrom rdfs:Literal
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:name ;
+                                owl:allValuesFrom rdfs:Literal
+                              ] ;
+              dcterms:description "Der Wert eines Vermögenswerts, ausgedrückt als Geldbetrag, als Beschreibung des Werts oder als nichtfinanzieller Ausdruck oder Typ."@de ,
+                                  "The value of an asset expressed as an amount of money, a description of the value or a non-financial expression or type."@en ;
+              rdfs:label "Asset value"@en ,
+                         "Vermögenswert"@de ;
+              skos:definition "a financial or intrinsic value of an ec:Asset"@en ,
+                              "ein finanzieller oder intrinsischer Wert eines ec:Asset"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Atmosphere
+ec:Atmosphere rdf:type owl:Class ;
+              rdfs:subClassOf ec:Type ;
+              dcterms:description "A list of entries to classify the atmosphere represented in some content."@en ,
+                                  "Eine Liste von Einträgen zur Klassifizierung der Atmosphäre, die in einem Inhalt dargestellt wird."@de ;
+              rdfs:label "Atmosphere"@en ,
+                         "Atmosphäre"@de ;
+              skos:definition "a ec:Type that lists classifications of the atmosphere of the content"@en ,
+                              "eine ec:Type, die Klassifikationen der Atmosphäre des Inhalts auflistet"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Audience
+ec:Audience rdf:type owl:Class ;
+            rdfs:subClassOf [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:excludesAudience ;
+                              owl:allValuesFrom ec:Audience
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasIdentifier ;
+                              owl:allValuesFrom ec:Identifier
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasObjectType ;
+                              owl:allValuesFrom skos:Concept
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:includesAudience ;
+                              owl:allValuesFrom ec:Audience
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:audienceAgeHigh ;
+                              owl:allValuesFrom xsd:integer
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:audienceAgeLow ;
+                              owl:allValuesFrom xsd:integer
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:audienceCount ;
+                              owl:allValuesFrom rdfs:Literal
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:audienceInterest ;
+                              owl:allValuesFrom rdfs:Literal
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:description ;
+                              owl:allValuesFrom rdfs:Literal
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:name ;
+                              owl:allValuesFrom rdfs:Literal
+                            ] ;
+            dcterms:description "A group of potential media consumers clustered by age, interest, social categories, or similar. Audience descriptions are used to characterize the intended or observed population for editorial or service analysis."@en ,
+                                "Eine Gruppe potenzieller Mediennutzer, die nach Alter, Interessen, sozialen Kategorien oder Ähnlichem zusammengefasst ist. Beschreibungen von Zielgruppen werden verwendet, um die beabsichtigte oder beobachtete Population für redaktionelle oder Dienstanalyse zu charakterisieren."@de ;
+            rdfs:label "Audience"@en ,
+                       "Publikum"@de ;
+            skos:definition "a group of potential media consumers clustered by age, interest, social categories, or similar"@en ,
+                            "eine Gruppe potenzieller Medienkonsumenten, gruppiert nach Alter, Interessen, sozialen Kategorien oder Ähnlichem"@de ;
+            skos:example """- 14 bis 29 Jahre
+- Jugendliche im ländlichen Raum
+- Männer über 70
+- kulturorientierte Menschen
+- freizeitorientierte Menschen
+- Eltern schulpflichtiger Kinder
+- gering gebildete Männer unter 25
+- junge progressive Menschen"""@de ,
+                         """- age 14 to 29
+- rural youth
+- males over 70
+- culture oriented people
+- fun oriented people
+- school kid's parents
+- low educated males under 25
+- young progressive people"""@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AudienceLevel
+ec:AudienceLevel rdf:type owl:Class ;
+                 rdfs:subClassOf ec:Rating ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:targetAudienceSystem ;
+                                   owl:allValuesFrom rdfs:Literal
+                                 ] ;
+                 dcterms:description "Die Bewertung der Übereinstimmung von Inhalten mit einer beabsichtigten Zielgruppe, die von einem Zielgruppensystem definiert wird."@de ,
+                                     "The rating of the conformity of some content to an intended audience defined by a target audience system."@en ;
+                 rdfs:label "Target audience"@en ,
+                            "Zielgruppe"@de ;
+                 skos:definition "a ec:Rating for the conformity of the ec:EditorialObject to an intended ec:Audience"@en ,
+                                 "eine ec:Rating für die Konformität des ec:EditorialObject mit einem beabsichtigten ec:Audience"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AudienceRating
+ec:AudienceRating rdf:type owl:Class ;
+                  rdfs:subClassOf ec:Rating ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:hasAudienceScoreRecordingTechnique ;
+                                    owl:allValuesFrom skos:Concept
+                                  ] ;
+                  dcterms:description "Der Grad der Angemessenheit für ein definiertes Publikum gemäß einem Standard, z. B. wie http://en.wikipedia.org/wiki/Motion_picture_rating_system."@de ,
+                                      "The level of appropriateness for a defined audience according to a standard, e.g. like http://en.wikipedia.org/wiki/Motion_picture_rating_system."@en ;
+                  rdfs:label "Audience rating"@en ,
+                             "Publikumsbewertung"@de ;
+                  skos:definition "a ec:Rating expressing the appropriateness for a defined ec:Audience"@en ,
+                                  "eine ec:Rating, die die Eignung für ein definiertes ec:Audience ausdrückt"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AudienceScoreRecordingTechnique
+ec:AudienceScoreRecordingTechnique rdf:type owl:Class ;
+                                   rdfs:subClassOf skos:Concept ;
+                                   dcterms:description "An entry from the classification of techniques used to measure audience score."@en ,
+                                                       "Ein Eintrag aus der Klassifikation der Techniken zur Messung der Zuschauerwertung."@de ;
+                                   rdfs:label "Audience score recording technique"@en ,
+                                              "Technik zur Aufzeichnung der Zuschauerbewertung"@de ;
+                                   skos:definition "a skos:Concept classifying the technique used to measure an audience score"@en ,
+                                                   "ein skos:Concept, das die zur Messung eines Publikumswerts verwendete Technik klassifiziert"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AudioChannelFunction
+ec:AudioChannelFunction rdf:type owl:Class ;
+                        rdfs:subClassOf skos:Concept ;
+                        dcterms:description "An entry from the classification of functions of an audio channel."@en ,
+                                            "Ein Eintrag aus der Klassifikation der Funktionen eines Audiokanals."@de ;
+                        rdfs:label "Audio channel function"@en ,
+                                   "Audiokanal-Funktion"@de ;
+                        skos:definition "a skos:Concept classifying the function of audio channel"@en ,
+                                        "eine skos:Concept, das die Funktion eines Audiokanals klassifiziert"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AudioChannelPurpose
+ec:AudioChannelPurpose rdf:type owl:Class ;
+                       rdfs:subClassOf skos:Concept ;
+                       dcterms:description "An entry from the classification of purposes of an audio channel."@en ,
+                                           "Ein Eintrag aus der Klassifikation der Zwecke eines Audiokanals."@de ;
+                       rdfs:label "Audio channel purpose"@en ,
+                                  "Zweck des Audiokanals"@de ;
+                       skos:definition "a skos:Concept classifying the purpose of an audio channel"@en ,
+                                       "ein skos:Concept zur Klassifizierung des Zwecks eines Audiokanals"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AudioCodec
+ec:AudioCodec rdf:type owl:Class ;
+              rdfs:subClassOf ec:Codec ;
+              dcterms:description "Der bei der Produktion von Audioinhalten verwendete Codec."@de ,
+                                  "The codec used in the production of audio content."@en ;
+              rdfs:label "Audio codec"@en ,
+                         "Audiocodec"@de ;
+              skos:definition "a ec:Codec used in the production of an audio stream, file or track"@en ,
+                              "ein ec:Codec, das bei der Produktion eines Audio-Streams, einer Datei oder eines Tracks verwendet wird"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AudioContent
+ec:AudioContent rdf:type owl:Class ;
+                rdfs:subClassOf ec:EditorialSegment ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty ec:loudnessIntegratedLoudness ;
+                                  owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                  owl:onDataRange xsd:float
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty ec:loudnessMaxMomentary ;
+                                  owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                  owl:onDataRange xsd:float
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty ec:loudnessMaxShortTerm ;
+                                  owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                  owl:onDataRange xsd:float
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty ec:loudnessMaxTruepeak ;
+                                  owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                  owl:onDataRange xsd:float
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty ec:loudnessRange ;
+                                  owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                  owl:onDataRange xsd:float
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty ec:loudnessMethod ;
+                                  owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                ] ;
+                dcterms:description "A segment of a programme with its descriptive metadata according to the EBU R128 loudness standard and its set of loudness parameters. This notion of a segment will often, but not always, encompass the entire timeline."@en ,
+                                    "Ein Segment eines Programms mit seinen beschreibenden Metadaten gemäß dem EBU-R128-Lautheitsstandard sowie seinem Satz von Lautheitsparametern. Dieser Begriff eines Segments umfasst oft, aber nicht immer, die gesamte Zeitleiste."@de ;
+                rdfs:label "Audio content"@en ,
+                           "Audioinhalt"@de ;
+                skos:definition "a ec:EditorialSegment of audio signals that are described according to the EBU R128 loudness standard"@en ,
+                                "ein ec:EditorialSegment von Audiosignalen, die gemäß dem Lautheitsstandard EBU R128 beschrieben werden"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AudioContentType
+ec:AudioContentType rdf:type owl:Class ;
+                    rdfs:subClassOf skos:Concept ;
+                    dcterms:description "An entry from the classification of types of audio content according to the loudness standard."@en ,
+                                        "Ein Eintrag aus der Klassifizierung von Arten von Audioinhalten gemäß dem Lautheitsstandard."@de ;
+                    rdfs:label "Audio content type"@en ,
+                               "Audiocontenttyp"@de ;
+                    skos:definition "a skos:Concept classifying the type of ec:AudioContent"@en ,
+                                    "ein skos:Concept zur Klassifizierung der Art von ec:AudioContent"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AudioDescription
+ec:AudioDescription rdf:type owl:Class ;
+                    rdfs:subClassOf ec:AudioTrack ;
+                    dcterms:description "An audio track describing the visible scenes for visually impaired viewers."@en ,
+                                        "Eine Tonspur, die die sichtbaren Szenen für sehbehinderte Zuschauer beschreibt."@de ;
+                    rdfs:label "Audio description"@en ,
+                               "Audiodeskription"@de ;
+                    skos:definition "a ec:AudioTrack describing the visible scenes on the screen for the visually impaired"@en ,
+                                    "eine ec:AudioTrack, die die sichtbaren Szenen auf dem Bildschirm für Sehbehinderte beschreibt"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AudioEncodingFormat
+ec:AudioEncodingFormat rdf:type owl:Class ;
+                       rdfs:subClassOf ec:EncodingFormat ;
+                       dcterms:description "An entry from the classification of transformations that produce digital audio resources from audio signals."@en ,
+                                           "Ein Eintrag aus der Klassifikation von Transformationen, die digitale Audioressourcen aus Audiosignalen erzeugen."@de ;
+                       rdfs:label "Audio encoding format"@en ,
+                                  "Audio-Codierungsformat"@de ;
+                       skos:definition "a ec:EncodingFormat classifying the transformation from an audio signal to audio data in a ec;MediaResource"@en ,
+                                       "eine ec:EncodingFormat-Klasse, die die Transformation von einem Audiosignal zu Audiodaten in einer ec;MediaResource klassifiziert"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AudioFormat
+ec:AudioFormat rdf:type owl:Class ;
+               rdfs:subClassOf ec:Format ;
+               dcterms:description "An entry from the classification of audio formats."@en ,
+                                   "Ein Eintrag aus der Klassifikation von Audioformaten."@de ;
+               rdfs:label "Audio format"@en ,
+                          "Audioformat"@de ;
+               skos:definition "a ec:Format classifying the encoding format used for audio information"@en ,
+                               "eine ec:Format, die das Kodierungsformat klassifiziert, das für Audioinformationen verwendet wird"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AudioObject
+ec:AudioObject rdf:type owl:Class ;
+               rdfs:subClassOf ec:MediaResource ;
+               dcterms:description "A media resource in the form of an object in reference to the Audio Definition Model (ADM)."@en ,
+                                   "Eine Medienressource in Form eines Objekts in Bezug auf das Audio Definition Model (ADM)."@de ;
+               rdfs:label "Audio object"@en ,
+                          "Audioobjekt"@de ;
+               skos:definition "a ec:MediaResource in the form of an object in reference to the Audio Definition Model (ADM)"@en ,
+                               "eine ec:MediaResource in Form eines Objekts in Bezug auf das Audio Definition Model (ADM)"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AudioProgramme
+ec:AudioProgramme rdf:type owl:Class ;
+                  rdfs:subClassOf ec:EditorialWork ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:loudnessIntegratedLoudness ;
+                                    owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                    owl:onDataRange xsd:float
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:loudnessMaxMomentary ;
+                                    owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                    owl:onDataRange xsd:float
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:loudnessMaxShortTerm ;
+                                    owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                    owl:onDataRange xsd:float
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:loudnessMaxTruepeak ;
+                                    owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                    owl:onDataRange xsd:float
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:loudnessRange ;
+                                    owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                    owl:onDataRange xsd:float
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:loudnessMethod ;
+                                    owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                  ] ;
+                  dcterms:description "A whole programme with its descriptive metadata according to the EBU R128 loudness standard and its set of loudness parameters."@en ,
+                                      "Ein vollständiges Programm mit seinen beschreibenden Metadaten gemäß dem Lautheitsstandard EBU R128 und seinem Satz von Lautheitsparametern."@de ;
+                  rdfs:isDefinedBy <https://tech.ebu.ch/docs/r/r128.pdf> ;
+                  rdfs:label "Audio programme"@en ,
+                             "Audioprogramm"@de ;
+                  skos:definition "an ec:EditorialWork of audio signals that are described according to the EBU R128 loudness standard"@en ,
+                                  "eine ec:EditorialWork von Audiosignalen, die gemäß dem EBU R128-Lautheitsstandard beschrieben sind"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AudioProgrammeType
+ec:AudioProgrammeType rdf:type owl:Class ;
+                      rdfs:subClassOf skos:Concept ;
+                      dcterms:description "An entry from the classification of types of audio programmes as used for measuring loudness in a finished production."@en ,
+                                          "Ein Eintrag aus der Klassifikation von Arten von Audio-Programmen, wie sie zur Messung der Lautheit in einer fertigen Produktion verwendet werden."@de ;
+                      rdfs:label "Audio programme type"@en ,
+                                 "Audio-Programmtyp"@de ;
+                      skos:definition "a skos:Concept classifying the type of ec:AudioProgrammet"@en ,
+                                      "ein skos:Concept zur Klassifizierung des Typs von ec:AudioProgrammet"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AudioStream
+ec:AudioStream rdf:type owl:Class ;
+               rdfs:subClassOf ec:Stream ;
+               dcterms:description "A data stream containing a decidable audio signal, e.g. PCM, Dolby E. It is composed of one or more AudioTracks."@en ,
+                                   "Ein Datenstrom, der ein dekodierbares Audiosignal enthält, z. B. PCM, Dolby E. Er besteht aus einem oder mehreren AudioTracks."@de ;
+               rdfs:label "Audio stream"@en ,
+                          "Audiostream"@de ;
+               skos:definition "a ec:Stream with encoded audio"@en ,
+                               "ein ec:Stream mit kodiertem Audio"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AudioTrack
+ec:AudioTrack rdf:type owl:Class ;
+              rdfs:subClassOf ec:Track ;
+              dcterms:description "A track that contains encoded audio signals and defines a component of an audio stream."@en ,
+                                  "Ein Track, der codierte Audiosignale enthält und eine Komponente eines Audiostreams definiert."@de ;
+              rdfs:label "Audio track"@en ,
+                         "Audiospur"@de ;
+              skos:definition "a ec:Track containing encoded audio signal and forming part of an ech:AudioStream"@en ,
+                              "ein ec:Track, der ein codiertes Audiosignal enthält und Teil eines ech:AudioStream ist"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AudioTrackPurpose
+ec:AudioTrackPurpose rdf:type owl:Class ;
+                     rdfs:subClassOf skos:Concept ;
+                     dcterms:description "An entry from the classification of purposes of an audio track."@en ,
+                                         "Ein Eintrag aus der Klassifikation der Zwecke eines Audiotracks."@de ;
+                     rdfs:label "Audio track purpose"@en ,
+                                "Zweck des Audiotracks"@de ;
+                     skos:definition "a skos:Concept classifying the purpose of an ec:AudioTrack"@en ,
+                                     "ein skos:Concept, das den Zweck eines ec:AudioTrack klassifiziert"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AuditJob
+ec:AuditJob rdf:type owl:Class ;
+            rdfs:subClassOf ec:ProductionJob ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasAuditJobRelatedAuditReport ;
+                              owl:allValuesFrom ec:AuditReport
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:usesMeasure ;
+                              owl:allValuesFrom ec:Measure
+                            ] ;
+            dcterms:description "Die Bewertung der Konformität wird anhand einer mit einer Regel über einen AuditJob verknüpften Measure vorgenommen."@de ,
+                                "The assessment of compliance is made against a Measure associated with a Rule via an AuditJob."@en ;
+            rdfs:label "Audit job"@en ,
+                       "Auditauftrag"@de ;
+            skos:definition "an assessment of compliance against a Measure"@en ,
+                            "eine Bewertung der Konformität gegenüber einer Measure"@de ;
+            skos:example """- Messung des maximalen Lautstärkepegels in der Tonspur einer Videodatei
+- Messung des Anteils der Sprechzeit in einer Debatte der Kandidaten vor einer Wahl
+- Messung des Anteils männlicher/weiblicher Expertinnen und Experten über alle Programme eines Publikationsdienstes"""@de ,
+                         """- measuring the maximum volume level in the audio track of a video file
+- measuring the share of speaker time in a debate of the candidates before an election
+- measuring the share of male/females experts across all programmes of a publication service"""@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AuditReport
+ec:AuditReport rdf:type owl:Class ;
+               rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                 owl:onProperty ec:hasApprover ;
+                                 owl:allValuesFrom ec:Agent
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty ec:hasAuditReportDate ;
+                                 owl:allValuesFrom time:Instant
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty ec:hasIdentifier ;
+                                 owl:allValuesFrom ec:Identifier
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty ec:hasObjectType ;
+                                 owl:allValuesFrom skos:Concept
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty ec:hasRelatedAuditJob ;
+                                 owl:allValuesFrom ec:AuditJob
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty ec:hasRelatedResource ;
+                                 owl:allValuesFrom ec:Resource
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty ec:referencesRule ;
+                                 owl:allValuesFrom ec:Rule
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty ec:auditReportResults ;
+                                 owl:allValuesFrom rdfs:Literal
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty ec:description ;
+                                 owl:allValuesFrom rdfs:Literal
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty ec:name ;
+                                 owl:allValuesFrom rdfs:Literal
+                               ] ;
+               dcterms:description "An AuditReport aggregates results from related AuditJob."@en ,
+                                   "Ein AuditReport aggregiert die Ergebnisse der zugehörigen AuditJob."@de ;
+               rdfs:label "Audit report"@en ,
+                          "Auditbericht"@de ;
+               skos:definition "a report on aggregated results from auditing"@en ,
+                               "ein Bericht über aggregierte Ergebnisse aus der Prüfung"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Award
+ec:Award rdf:type owl:Class ;
+         rdfs:subClassOf [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasIdentifier ;
+                           owl:allValuesFrom ec:Identifier
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasLogo ;
+                           owl:allValuesFrom ec:Logo
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasObjectType ;
+                           owl:allValuesFrom skos:Concept
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasRelatedAgent ;
+                           owl:allValuesFrom ec:Agent
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasRelatedEvent ;
+                           owl:allValuesFrom ec:Event
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:isAwardedTo ;
+                           owl:allValuesFrom ec:Agent
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasAwardDate ;
+                           owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                           owl:onClass time:Instant
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:description ;
+                           owl:allValuesFrom rdfs:Literal
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:name ;
+                           owl:allValuesFrom rdfs:Literal
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:awardCeremony ;
+                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                         ] ;
+         dcterms:description "A prize, such as money, or something else, for something that somebody has done."@en ,
+                             "Ein Preis, wie Geld oder etwas anderes, für etwas, das jemand getan hat."@de ;
+         rdfs:label "Auszeichnung"@de ,
+                    "Award"@en ;
+         skos:definition "a financial or symbolic prize given to an ec:Agent to honor an outstanding performance, achievement or contribution"@en ,
+                         "eine finanzielle oder symbolische Auszeichnung, die einem ec:Agent verliehen wird, um eine herausragende Leistung, einen herausragenden Erfolg oder einen Beitrag zu würdigen"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AwardType
+ec:AwardType rdf:type owl:Class ;
+             rdfs:subClassOf skos:Concept ;
+             dcterms:description "An entry from the classification of award types."@en ,
+                                 "Ein Eintrag aus der Klassifizierung von Auszeichnungstypen."@de ;
+             rdfs:label "Auszeichnungstyp"@de ,
+                        "Award type"@en ;
+             skos:definition "a skos:Concept classifying the type of ec:Award"@en ,
+                             "ein skos:Concept, der den Typ von ec:Award klassifiziert"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#BibliographicalObject
+ec:BibliographicalObject rdf:type owl:Class ;
+                         rdfs:subClassOf ec:Asset ,
+                                         [ rdf:type owl:Restriction ;
+                                           owl:onProperty ec:references ;
+                                           owl:allValuesFrom ec:BibliographicalObject
+                                         ] ,
+                                         [ rdf:type owl:Restriction ;
+                                           owl:onProperty ec:references ;
+                                           owl:allValuesFrom ec:EditorialObject
+                                         ] ;
+                         dcterms:description "A written piece of work."@en ,
+                                             "Ein schriftliches Werk."@de ;
+                         rdfs:label "Bibliografisches Objekt"@de ,
+                                    "Bibliographical object"@en ;
+                         skos:definition "a ec:Asset consisting of text"@en ,
+                                         "ein ec:Asset, das aus Text besteht"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Biography
+ec:Biography rdf:type owl:Class ;
+             rdfs:subClassOf ec:BibliographicalObject ;
+             dcterms:description "A book about the life of a person."@en ,
+                                 "Ein Buch über das Leben einer Person."@de ;
+             rdfs:label "Biografie"@de ,
+                        "Biography"@en ;
+             skos:definition "a ec:BibliographicalObject about the life of a ec:Person"@en ,
+                             "eine ec:BibliographicalObject über das Leben einer ec:Person"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Campaign
+ec:Campaign rdf:type owl:Class ;
+            rdfs:subClassOf [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasConsumptionCount ;
+                              owl:allValuesFrom ec:Audience
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasIdentifier ;
+                              owl:allValuesFrom ec:Identifier
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasInputResonance ;
+                              owl:allValuesFrom ec:ResonanceCount
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasObjectType ;
+                              owl:allValuesFrom skos:Concept
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasPublicationPlan ;
+                              owl:allValuesFrom ec:PublicationPlan
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasTargetAudience ;
+                              owl:allValuesFrom ec:Audience
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:description ;
+                              owl:allValuesFrom rdfs:Literal
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:title ;
+                              owl:allValuesFrom rdfs:Literal
+                            ] ;
+            dcterms:description "A Campaign defines a strategy for publishing content (EditorialObjects and related Resources/MediaResources/Essences) to a targeted Audience according to a PublicationPlan. Campaign strategies can be adapted taking into account the analysis of the Resonance of related ConsumptionEvents (e.g. likes, downloads, etc.). Campaigns can apply to a variety of broadcasting strategies e.g. advertising campaigns, promotional campaigns or else."@en ,
+                                "Eine Campaign definiert eine Strategie zur Veröffentlichung von Inhalten (EditorialObjects und zugehörigen Resources/MediaResources/Essences) für ein zielgerichtetes Audience gemäß einem PublicationPlan. Campaign-Strategien können unter Berücksichtigung der Analyse der Resonanz zugehöriger ConsumptionEvents (z. B. Likes, Downloads usw.) angepasst werden. Campaigns können für verschiedene Broadcasting-Strategien gelten, z. B. Werbekampagnen, Promotionskampagnen oder andere."@de ;
+            rdfs:label "Campaign"@en ,
+                       "Kampagne"@de ;
+            skos:definition "a strategy for coordinated publishing effort towards a target audience"@en ,
+                            "eine Strategie für eine koordinierte Veröffentlichung für eine Zielgruppe"@de ;
+            skos:example """- an advertisement effort for a product, by publishing a set of videos at a time and on a channel, when and where the target audience can be effectively reached
+- an announcement of the journalistic coverage of an upcoming government election from many different perspectives and for a variety of target audiences published on several channels of linear TV, linear radio, social media, podcast portals, etc."""@en ,
+                         """- eine Werbemaßnahme für ein Produkt, bei der zu einem bestimmten Zeitpunkt und auf einem Kanal eine Reihe von Videos veröffentlicht wird, wenn und wo die Zielgruppe wirksam erreicht werden kann
+- eine Ankündigung der journalistischen Berichterstattung über eine bevorstehende Regierungswahl aus vielen verschiedenen Perspektiven und für eine Vielzahl von Zielgruppen, veröffentlicht auf mehreren Kanälen wie linearem Fernsehen, linearem Radio, sozialen Medien, Podcast-Portalen usw."""@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#CampaignPackage
+ec:CampaignPackage rdf:type owl:Class ;
+                   rdfs:subClassOf ec:EditorialGroup ;
+                   dcterms:description "A package of promotional content to advertise a product, a service, an event or similar in various ways but in a coordinated effort."@en ,
+                                       "Ein Paket aus Werbeinhalten, um ein Produkt, eine Dienstleistung, eine Veranstaltung oder Ähnliches auf verschiedene Weise, aber im Rahmen einer koordinierten Aktion zu bewerben."@de ;
+                   rdfs:label "Campaign package"@en ,
+                              "Kampagnenpaket"@de ;
+                   skos:definition "an ec:EditorialGroup whose members are brought together to advertise a product, a service, an event, or similar in various ways but in a coordinated effort"@en ,
+                                   "eine ec:EditorialGroup, deren Mitglieder zusammengebracht werden, um ein Produkt, eine Dienstleistung, eine Veranstaltung oder Ähnliches auf verschiedene Weise, aber in koordinierter Weise zu bewerben"@de ;
+                   skos:example """- a set of different ads for one product
+- a set of different trailers for a film"""@en ,
+                                """- eine Reihe verschiedener Anzeigen für ein Produkt
+- eine Reihe verschiedener Trailer für einen Film"""@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Captioning
+ec:Captioning rdf:type owl:Class ;
+              rdfs:subClassOf ec:Track ;
+              dcterms:description "A track containing text from transcribed dialogues or a description of the audio for the hard of hearing."@en ,
+                                  "Eine Spur, die Text aus transkribierten Dialogen oder eine Beschreibung des Audios für Hörgeschädigte enthält."@de ;
+              rdfs:label "Captioning"@en ,
+                         "Untertitelung"@de ;
+              skos:definition "a ec:Track containing text from transcribed dialogues or description of the audio for the hard of hearing"@en ,
+                              "ein ec:Track mit Text aus transkribierten Dialogen oder einer Beschreibung des Tons für Schwerhörige"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#CaptioningFormat
+ec:CaptioningFormat rdf:type owl:Class ;
+                    rdfs:subClassOf ec:DataFormat ;
+                    dcterms:description "An entry from the classification of structure schemes for captioning data, mainly used for transcription."@en ,
+                                        "Ein Eintrag aus der Klassifikation von Strukturschemata für Untertitelungsdaten, hauptsächlich für Transkriptionen verwendet."@de ;
+                    rdfs:label "Beschriftungsformat"@de ,
+                               "Captioning format"@en ;
+                    skos:definition "a ec:DataFormat classifying the structure of captioning data from transcriptions"@en ,
+                                    "eine ec:DataFormat-Klasse, die die Struktur von Untertitelungsdaten aus Transkriptionen klassifiziert"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#CastMember
+ec:CastMember rdf:type owl:Class ;
+              rdfs:subClassOf ec:Person ;
+              dcterms:description "A cast member performs a role or acts as a character in a screenplay."@en ,
+                                  "Ein Darsteller übernimmt eine Rolle oder verkörpert eine Figur in einem Drehbuch."@de ;
+              rdfs:label "Besetzungsmitglied"@de ,
+                         "Cast member"@en ;
+              skos:definition "a ec:Person that is a member of the cast of a fictional piece of work"@en ,
+                              "eine ec:Person, die Mitglied der Besetzung eines fiktionalen Werks ist"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Character
+ec:Character rdf:type owl:Class ;
+             rdfs:subClassOf ec:Person ,
+                             [ rdf:type owl:Restriction ;
+                               owl:onProperty ec:hasEmbodyingArtefact ;
+                               owl:allValuesFrom ec:Artefact
+                             ] ,
+                             [ rdf:type owl:Restriction ;
+                               owl:onProperty ec:isAnimatedBy ;
+                               owl:allValuesFrom ec:Person
+                             ] ,
+                             [ rdf:type owl:Restriction ;
+                               owl:onProperty ec:isPlayedBy ;
+                               owl:allValuesFrom ec:Involvement
+                             ] ,
+                             [ rdf:type owl:Restriction ;
+                               owl:onProperty ec:isPortrayedBy ;
+                               owl:allValuesFrom ec:Animal
+                             ] ,
+                             [ rdf:type owl:Restriction ;
+                               owl:onProperty ec:hasFictitiousPerson ;
+                               owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                               owl:onClass ec:Person
+                             ] ;
+             dcterms:description "A character is played by an actor in a screenplay or drama."@en ,
+                                 "Eine Figur wird von einem Schauspieler in einem Drehbuch oder Drama dargestellt."@de ;
+             rdfs:label "Character"@en ,
+                        "Figur"@de ;
+             skos:definition "a fictitious ec:Person in a screenplay or drama"@en ,
+                             "eine fiktive ec:Person in einem Drehbuch oder Drama"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#CityCode
+ec:CityCode rdf:type owl:Class ;
+            rdfs:subClassOf skos:Concept ;
+            dcterms:description "An entry from the postal codes of cities."@en ,
+                                "Ein Eintrag aus den Postleitzahlen von Städten."@de ;
+            rdfs:label "City code"@en ,
+                       "Stadtkode"@de ;
+            skos:definition "a skos:Concept classifying cities by their postal codes"@en ,
+                            "ein skos:Concept zur Klassifizierung von Städten nach ihren Postleitzahlen"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ClosedCaptions
+ec:ClosedCaptions rdf:type owl:Class ;
+                  rdfs:subClassOf ec:Captioning ;
+                  dcterms:description "A captioning that exists in a media resource of its own, outside of video, i.e. it can be turned on or off at any time."@en ,
+                                      "Eine Untertitelung, die in einer eigenen Medienressource außerhalb des Videos vorliegt, d. h. sie kann jederzeit ein- oder ausgeschaltet werden."@de ;
+                  rdfs:label "Closed caption"@en ,
+                             "Untertitel"@de ;
+                  skos:definition "a ec:Captioning that exists in a ec:MediaResource of its own, outside of video"@en ,
+                                  "eine ec:Captioning, die in einer eigenen ec:MediaResource außerhalb des Videos existiert"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ClosedSigning
+ec:ClosedSigning rdf:type owl:Class ;
+                 rdfs:subClassOf ec:Signing ;
+                 dcterms:description "A signing that is provided as a separate media resource, separate from the video or audio content, i.e., it can be turned on or off at any time."@en ,
+                                     "Eine Gebärdensprachdarstellung, die als separate Medienressource bereitgestellt wird, getrennt vom Video- oder Audiostream, also jederzeit ein- oder ausgeschaltet werden kann."@de ;
+                 rdfs:label "Closed signing"@en ,
+                            "Geschlossenes Gebärden"@de ;
+                 skos:definition "a ec:Signing that exists in a ec:MediaResource of its own, outside of video"@en ,
+                                 "eine ec:Signing, die in einer eigenen ec:MediaResource außerhalb von Video existiert"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ClosedSubtitling
+ec:ClosedSubtitling rdf:type owl:Class ;
+                    rdfs:subClassOf ec:Subtitling ;
+                    dcterms:description "A subtitling that is carried in its own media resource, besides media resources for audio and/or video. Subtitling can be turned on or off."@en ,
+                                        "Eine Untertitelung, die in einer eigenen Medienressource übertragen wird, zusätzlich zu Medienressourcen für Audio und/oder Video. Die Untertitelung kann ein- oder ausgeschaltet werden."@de ;
+                    rdfs:label "Closed subtitling"@en ,
+                               "Geschlossene Untertitelung"@de ;
+                    skos:definition "a ec:Subtitling that exists in a ec:MediaResource of its own, outside of video"@en ,
+                                    "eine ec:Subtitling, die in einer eigenen ec:MediaResource außerhalb des Videos existiert"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Codec
+ec:Codec rdf:type owl:Class ;
+         rdfs:subClassOf [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasCodecVendor ;
+                           owl:allValuesFrom ec:Agent
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasIdentifier ;
+                           owl:allValuesFrom ec:Identifier
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasObjectType ;
+                           owl:allValuesFrom skos:Concept
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:codecFamily ;
+                           owl:allValuesFrom rdfs:Literal
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:codecVersion ;
+                           owl:allValuesFrom rdfs:Literal
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:description ;
+                           owl:allValuesFrom rdfs:Literal
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:name ;
+                           owl:allValuesFrom rdfs:Literal
+                         ] ;
+         dcterms:description "Die Technik, mit der Foto-, Video- oder Audioinformationen in Dateien oder Streams kodiert und dekodiert werden."@de ,
+                             "The technique used to encode and decode photo, video, or audio information into files or streams."@en ;
+         rdfs:label "Codec"@de ,
+                    "Codec"@en ;
+         skos:definition "a coding/decoding technique used in the production of a ec:MediaResource"@en ,
+                         "eine Kodier-/Dekodiertechnik, die bei der Produktion einer ec:MediaResource verwendet wird"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Collection
+ec:Collection rdf:type owl:Class ;
+              rdfs:subClassOf ec:EditorialGroup ;
+              dcterms:description "A group of content of many types. Grouping is done according to a concept or intention. In the world of archives, a collection corresponds to all items belonging to an individual/collector."@en ,
+                                  "Eine Gruppe von Inhalten unterschiedlicher Art. Die Gruppierung erfolgt nach einem Konzept oder einer Absicht. In der Welt der Archive entspricht eine Sammlung allen Objekten, die zu einer Person oder einem Sammler gehören."@de ;
+              rdfs:label "Collection"@en ,
+                         "Sammlung"@de ;
+              skos:definition "an ec:EditorialGroup that can group content of any type"@en ,
+                              "eine ec:EditorialGroup, die Inhalte beliebiger Art gruppieren kann"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ColourSpace
+ec:ColourSpace rdf:type owl:Class ;
+               rdfs:subClassOf ec:Format ;
+               dcterms:description "An entry from the classification of colour spaces for videos."@en ,
+                                   "Ein Eintrag aus der Klassifikation der Farbräume für Videos."@de ;
+               rdfs:label "Colour space"@en ,
+                          "Farbraum"@de ;
+               skos:definition "a ec:Format classifying the colour space of a video"@en ,
+                               "eine ec:Format, die den Farbraum eines Videos klassifiziert"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#CommercialCode
+ec:CommercialCode rdf:type owl:Class ;
+                  rdfs:subClassOf ec:Type ;
+                  dcterms:description "A list of entries to classify commercial content, e.g. EBU's classification scheme on Commerciality Type."@en ,
+                                      "Eine Liste von Einträgen zur Klassifizierung kommerzieller Inhalte, z. B. das Klassifizierungsschema der EBU zum Commerciality Type."@de ;
+                  rdfs:label "Commercial code"@en ,
+                             "Kommerzieller Code"@de ;
+                  skos:definition "a ec:Type that lists types of commercial content"@en ,
+                                  "eine ec:Type, die Arten von kommerziellen Inhalten auflistet"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Component
+ec:Component rdf:type owl:Class ;
+             rdfs:subClassOf ec:MediaResource ;
+             dcterms:description "A media resource that is an ingredient of another media resource e.g. audio track, data track or similar."@en ,
+                                 "Eine Medienressource, die Bestandteil einer anderen Medienressource ist, z. B. eine Audiospur, Datenspur oder Ähnliches."@de ;
+             rdfs:label "Component"@en ,
+                        "Komponente"@de ;
+             skos:definition "a ec:MediaResource that is an ingredient of another ec:MediaResource"@en ,
+                             "eine ec:MediaResource, die eine Zutat einer anderen ec:MediaResource ist"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Consumer
+ec:Consumer rdf:type owl:Class ;
+            rdfs:subClassOf ec:Person ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:belongsToAudience ;
+                              owl:allValuesFrom ec:Audience
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasAssociatedConsumptionEvent ;
+                              owl:allValuesFrom ec:ConsumptionEvent
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasRegistration ;
+                              owl:allValuesFrom ec:Account
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:usesConsumptionDevice ;
+                              owl:allValuesFrom ec:ConsumptionDevice
+                            ] ;
+            dcterms:description "A person consuming a media service."@en ,
+                                "Eine Person, die einen Mediendienst nutzt."@de ;
+            rdfs:label "Consumer"@en ,
+                       "Verbraucher"@de ;
+            skos:definition "a ec:Person consuming a media service"@en ,
+                            "eine ec:Person, die einen Mediendienst konsumiert"@de ;
+            skos:example """- a radio listener
+- a video stream viewer"""@en ,
+                         """- ein Radiohörer
+- ein Zuschauer eines Videostreams"""@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ConsumptionCount
+ec:ConsumptionCount rdf:type owl:Class ;
+                    rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasAudience ;
+                                      owl:allValuesFrom ec:Audience
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasConsumptionEvent ;
+                                      owl:allValuesFrom ec:ConsumptionEvent
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasIdentifier ;
+                                      owl:allValuesFrom ec:Identifier
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasObjectType ;
+                                      owl:allValuesFrom skos:Concept
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasEnd ;
+                                      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                      owl:onClass ec:TimelinePoint
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasEndDateTime ;
+                                      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                      owl:onClass time:Instant
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasStart ;
+                                      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                      owl:onClass ec:TimelinePoint
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasStartDateTime ;
+                                      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                      owl:onClass time:Instant
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:audienceCount ;
+                                      owl:allValuesFrom rdfs:Literal
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:description ;
+                                      owl:allValuesFrom rdfs:Literal
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:name ;
+                                      owl:allValuesFrom rdfs:Literal
+                                    ] ;
+                    dcterms:description "A count of consumption events aggregated by one or more attributed properties, e.g. start time, end time, duration, publication event, service, platform, channel, device, account, consumer, resonance event, essence (stream or file), content, content genre, serial/series/season, and so on. Consumption counts are used to answer analytical questions and to compare answers over periods of time. Standardized counts (\"consumptions on our platform in July\") can be defined as subclasses and be stored and reused for comparison."@en ,
+                                        "Eine Zählung von Konsumereignissen, aggregiert nach einem oder mehreren zugeordneten Eigenschaften, z. B. Startzeit, Endzeit, Dauer, Veröffentlichungsereignis, Dienst, Plattform, Kanal, Gerät, Konto, Konsument, Resonanzereignis, Essenz (Stream oder Datei), Inhalt, Inhaltsgenre, Serie/Staffel und so weiter. Verbrauchszählungen werden verwendet, um analytische Fragen zu beantworten und Antworten über Zeiträume hinweg zu vergleichen. Standardisierte Zählungen („Verbrauch auf unserer Plattform im Juli“) können als Unterklassen definiert und zur Vergleichszwecken gespeichert und wiederverwendet werden."@de ;
+                    rdfs:label "Consumption count"@en ,
+                               "Verbrauchszählung"@de ;
+                    skos:definition "a count of ec:ConsumptionEvents aggregated by one or more attributed properties"@en ,
+                                    "eine Zählung von ec:ConsumptionEvents, aggregiert nach einem oder mehreren zugeordneten Eigenschaften"@de ;
+                    skos:example """- a 46% market share of French viewers for the football world cup final 2022
+- a 72% market share of French viewers aged 14 to 29 for the football world cup final 2022
+- 18.7 million live stream views of the funeral of former pope Benedict in Europe
+- 36973 views of the youtube-video \"Tom Hanks had an ICONIC chat with the Queen\" from BBC's \"The One Show\" 6 months after publishing
+- 2080 attendees at Stuttgart Liederhalle for a live concert of SWR's symphonic orchestra on April 8, 2022"""@en ,
+                                 """- ein Marktanteil von 46 % unter französischen Zuschauern für das Fußball-WM-Finale 2022
+- ein Marktanteil von 72 % unter französischen Zuschauern im Alter von 14 bis 29 Jahren für das Fußball-WM-Finale 2022
+- 18,7 Millionen Live-Stream-Aufrufe der Beerdigung des ehemaligen Papstes Benedikt in Europa
+- 36.973 Aufrufe des YouTube-Videos „Tom Hanks hatte ein IKONISCHES Gespräch mit der Queen“ aus der BBC-Sendung „The One Show“ 6 Monate nach der Veröffentlichung
+- 2080 Besucher in der Stuttgarter Liederhalle bei einem Live-Konzert des Sinfonieorchesters des SWR am 8. April 2022"""@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ConsumptionDevice
+ec:ConsumptionDevice rdf:type owl:Class ;
+                     rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                       owl:onProperty ec:compliesWith ;
+                                       owl:allValuesFrom ec:ConsumptionDeviceProfile
+                                     ] ,
+                                     [ rdf:type owl:Restriction ;
+                                       owl:onProperty ec:hasConsumptionDeviceManufacturer ;
+                                       owl:allValuesFrom ec:Agent
+                                     ] ,
+                                     [ rdf:type owl:Restriction ;
+                                       owl:onProperty ec:hasIdentifier ;
+                                       owl:allValuesFrom ec:Identifier
+                                     ] ,
+                                     [ rdf:type owl:Restriction ;
+                                       owl:onProperty ec:hasObjectType ;
+                                       owl:allValuesFrom skos:Concept
+                                     ] ,
+                                     [ rdf:type owl:Restriction ;
+                                       owl:onProperty ec:renders ;
+                                       owl:allValuesFrom ec:Essence
+                                     ] ,
+                                     [ rdf:type owl:Restriction ;
+                                       owl:onProperty ec:consumptionDeviceBrand ;
+                                       owl:allValuesFrom xsd:string
+                                     ] ,
+                                     [ rdf:type owl:Restriction ;
+                                       owl:onProperty ec:consumptionDeviceBrowser ;
+                                       owl:allValuesFrom xsd:string
+                                     ] ,
+                                     [ rdf:type owl:Restriction ;
+                                       owl:onProperty ec:consumptionDeviceModel ;
+                                       owl:allValuesFrom xsd:string
+                                     ] ,
+                                     [ rdf:type owl:Restriction ;
+                                       owl:onProperty ec:consumptionDeviceOS ;
+                                       owl:allValuesFrom xsd:string
+                                     ] ,
+                                     [ rdf:type owl:Restriction ;
+                                       owl:onProperty ec:description ;
+                                       owl:allValuesFrom rdfs:Literal
+                                     ] ,
+                                     [ rdf:type owl:Restriction ;
+                                       owl:onProperty ec:name ;
+                                       owl:allValuesFrom rdfs:Literal
+                                     ] ;
+                     dcterms:description "A device for consuming a media service, such as a television, set-top box, or other playback endpoint used to access media content."@en ,
+                                         "Ein Gerät zum Konsumieren eines Mediendienstes, wie etwa ein Fernseher, eine Set-Top-Box oder ein anderes Wiedergabe-Endgerät zum Zugriff auf Medieninhalte."@de ;
+                     rdfs:label "Consumption device"@en ,
+                                "Verbrauchsgerät"@de ;
+                     skos:definition "a device for consuming a media service"@en ,
+                                     "ein Gerät zum Konsumieren eines Mediendienstes"@de ;
+                     skos:example """- a smartphone
+- a smart TV
+- a fm radio set
+- a beamer fed with a media signal and projecting onto a screen"""@en ,
+                                  """- ein Smartphone
+- ein Smart-TV
+- ein UKW-Radiogerät
+- ein Beamer, der mit einem Mediensignal gespeist wird und auf eine Leinwand projiziert"""@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ConsumptionDeviceProfile
+ec:ConsumptionDeviceProfile rdf:type owl:Class ;
+                            rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                              owl:onProperty ec:canAccessPublicationChannel ;
+                                              owl:allValuesFrom ec:PublicationChannel
+                                            ] ,
+                                            [ rdf:type owl:Restriction ;
+                                              owl:onProperty ec:canAccessPublicationPlatform ;
+                                              owl:allValuesFrom ec:PublicationPlatform
+                                            ] ,
+                                            [ rdf:type owl:Restriction ;
+                                              owl:onProperty ec:hasGeoLocation ;
+                                              owl:allValuesFrom ec:Location
+                                            ] ,
+                                            [ rdf:type owl:Restriction ;
+                                              owl:onProperty ec:hasIdentifier ;
+                                              owl:allValuesFrom ec:Identifier
+                                            ] ,
+                                            [ rdf:type owl:Restriction ;
+                                              owl:onProperty ec:hasObjectType ;
+                                              owl:allValuesFrom skos:Concept
+                                            ] ,
+                                            [ rdf:type owl:Restriction ;
+                                              owl:onProperty ec:description ;
+                                              owl:allValuesFrom rdfs:Literal
+                                            ] ,
+                                            [ rdf:type owl:Restriction ;
+                                              owl:onProperty ec:name ;
+                                              owl:allValuesFrom rdfs:Literal
+                                            ] ,
+                                            [ rdf:type owl:Restriction ;
+                                              owl:onProperty ec:internetConnectivity ;
+                                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                              owl:onDataRange xsd:boolean
+                                            ] ,
+                                            [ rdf:type owl:Restriction ;
+                                              owl:onProperty ec:microphone ;
+                                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                              owl:onDataRange xsd:boolean
+                                            ] ,
+                                            [ rdf:type owl:Restriction ;
+                                              owl:onProperty ec:radioTuner ;
+                                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                              owl:onDataRange xsd:boolean
+                                            ] ,
+                                            [ rdf:type owl:Restriction ;
+                                              owl:onProperty ec:soundOutput ;
+                                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                              owl:onDataRange xsd:boolean
+                                            ] ,
+                                            [ rdf:type owl:Restriction ;
+                                              owl:onProperty ec:textInput ;
+                                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                              owl:onDataRange xsd:boolean
+                                            ] ,
+                                            [ rdf:type owl:Restriction ;
+                                              owl:onProperty ec:timeshift ;
+                                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                              owl:onDataRange xsd:boolean
+                                            ] ,
+                                            [ rdf:type owl:Restriction ;
+                                              owl:onProperty ec:videoDisplay ;
+                                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                              owl:onDataRange xsd:boolean
+                                            ] ,
+                                            [ rdf:type owl:Restriction ;
+                                              owl:onProperty ec:webcam ;
+                                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                              owl:onDataRange xsd:boolean
+                                            ] ;
+                            dcterms:description "A set of characteristic properties to classify a consumption device, for example manufacturer, model, operating system, screen size, etc."@en ,
+                                                "Eine Menge charakteristischer Eigenschaften zur Klassifizierung eines Wiedergabegeräts, zum Beispiel Hersteller, Modell, Betriebssystem, Bildschirmgröße usw."@de ;
+                            rdfs:label "Consumption device profile"@en ,
+                                       "Verbrauchsgerätprofil"@de ;
+                            skos:definition "a set of properties that allow classification of a ec:ConsumptionDevice"@en ,
+                                            "eine Menge von Eigenschaften, die die Klassifizierung eines ec:ConsumptionDevice ermöglichen"@de ;
+                            skos:example """- an Apple smartphone with iOS version > 16
+- a smart TV with screen 50' to 60' and HDR support
+- a VR headset"""@en ,
+                                         """- ein Apple-Smartphone mit iOS-Version > 16
+- ein Smart-TV mit Bildschirmdiagonale 50' bis 60' und HDR-Unterstützung
+- ein VR-Headset"""@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ConsumptionEvent
+ec:ConsumptionEvent rdf:type owl:Class ;
+                    rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:consumesEssence ;
+                                      owl:allValuesFrom ec:Essence
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasConsumer ;
+                                      owl:allValuesFrom ec:Consumer
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasConsumptionEventResumePoint ;
+                                      owl:allValuesFrom ec:TimelinePoint
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasDevice ;
+                                      owl:allValuesFrom ec:ConsumptionDevice
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasIdentifier ;
+                                      owl:allValuesFrom ec:Identifier
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasObjectType ;
+                                      owl:allValuesFrom skos:Concept
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasRelatedConsumptionEvent ;
+                                      owl:allValuesFrom ec:ConsumptionEvent
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasRelatedPublicationEvent ;
+                                      owl:allValuesFrom ec:PublicationEvent
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:occursIn ;
+                                      owl:allValuesFrom ec:PublicationChannel
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:occursIn ;
+                                      owl:allValuesFrom ec:PublicationService
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:occursOn ;
+                                      owl:allValuesFrom ec:PublicationPlatform
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:requiresLicence ;
+                                      owl:allValuesFrom ec:ConsumptionLicence
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:resultsIn ;
+                                      owl:allValuesFrom ec:ResonanceEvent
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:accountingTo ;
+                                      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                      owl:onClass ec:Account
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasEnd ;
+                                      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                      owl:onClass ec:TimelinePoint
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasEndDateTime ;
+                                      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                      owl:onClass time:Instant
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasStart ;
+                                      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                      owl:onClass ec:TimelinePoint
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasStartDateTime ;
+                                      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                      owl:onClass time:Instant
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:description ;
+                                      owl:allValuesFrom rdfs:Literal
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:name ;
+                                      owl:allValuesFrom rdfs:Literal
+                                    ] ;
+                    dcterms:description "A location and time span during which consumers of a media service use a device to read, watch or listen to some content that was published within that media service. E.g. a woman watching the latest video of BBC News on YouTube on her smartphone or a family watching a skiing competition during the winter Olympics live on their big screen at home."@en ,
+                                        "Ein Ort und ein Zeitraum, während dessen Nutzer eines Mediendienstes ein Gerät verwenden, um Inhalte zu lesen, anzusehen oder anzuhören, die innerhalb dieses Mediendienstes veröffentlicht wurden. Z. B. eine Frau, die auf ihrem Smartphone das neueste Video von BBC News auf YouTube ansieht, oder eine Familie, die zu Hause auf ihrem großen Bildschirm live einen Skilanglaufwettbewerb während der Winterspiele verfolgt."@de ;
+                    rdfs:label "Consumption event"@en ,
+                               "Verbrauchsereignis"@de ;
+                    skos:definition "an event of a ec:Consumer using a ec:Device to consume an ec:EditorialObject that was published in a ec:PublicationEvent within a ec:MediaService"@en ,
+                                    "ein Ereignis eines ec:Consumer, der ein ec:Device verwendet, um ein ec:EditorialObject zu konsumieren, das in einem ec:PublicationEvent innerhalb eines ec:MediaService veröffentlicht wurde"@de ;
+                    skos:example """- a person watching a news show on linear tv
+- a family listening to linear radio while having breakfast at home
+- a couple on their living room couch streaming a movie from a VoD service"""@en ,
+                                 """- eine Person, die eine Nachrichtensendung im linearen Fernsehen schaut
+- eine Familie, die beim Frühstück zu Hause lineares Radio hört
+- ein Paar, das auf dem Sofa im Wohnzimmer einen Film von einem VoD-Dienst streamt"""@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ConsumptionLicence
+ec:ConsumptionLicence rdf:type owl:Class ;
+                      rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:coversConsumptionDevice ;
+                                        owl:allValuesFrom ec:ConsumptionDevice
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:hasIdentifier ;
+                                        owl:allValuesFrom ec:Identifier
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:hasObjectType ;
+                                        owl:allValuesFrom skos:Concept
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:hasConsumptionLicenceLink ;
+                                        owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                        owl:onClass ec:Contract
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:description ;
+                                        owl:allValuesFrom rdfs:Literal
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:name ;
+                                        owl:allValuesFrom rdfs:Literal
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:consumptionLicenceText ;
+                                        owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                      ] ;
+                      dcterms:description "A permit attributed to a consumer defines the terms of content consumption within a media service. E.g., the licence is verified by a mechanism often located in the device, referred to as DRM (Digital Rights Management). Age-restricted content can be consumed only after the consumer verifies their age."@en ,
+                                          "Eine einem Verbraucher zugewiesene Erlaubnis legt die Bedingungen für den Konsum von Inhalten innerhalb eines Mediendienstes fest. Z. B. wird die Lizenz durch einen Mechanismus überprüft, der sich oft im Gerät befindet und als DRM (Digital Rights Management) bezeichnet wird. Altersbeschränkte Inhalte dürfen erst konsumiert werden, nachdem der Verbraucher sein Alter verifiziert hat."@de ;
+                      rdfs:label "Consumption licence"@en ,
+                                 "Verbrauchslizenz"@de ;
+                      skos:definition "a permit attributed to a ec:Consumer that defines the terms of use for a ec:PublicationService or a ec:PublicationEvent of an ec:EditorialObject"@en ,
+                                      "eine Genehmigung, die einem ec:Consumer zugeordnet ist und die Nutzungsbedingungen für einen ec:PublicationService oder ein ec:PublicationEvent eines ec:EditorialObject festlegt"@de ;
+                      skos:example """- a subscription to unlimited streaming from spotify, encompassing 3 devices
+- a 3 month test subscription to a VoD service
+- the entitlement to consume free-to-air broadcast services as the resident of a country"""@en ,
+                                   """- ein Abonnement für unbegrenztes Streaming von Spotify, einschließlich 3 Geräten
+- ein 3-monatiges Testabonnement für einen VoD-Dienst
+- das Recht, frei empfangbare Rundfunkdienste als Einwohner eines Landes zu nutzen"""@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Contact
+ec:Contact rdf:type owl:Class ;
+           rdfs:subClassOf ec:Person ;
+           dcterms:description "A person's name and address details through which a connection can be established, often to an organisation or a business the person belongs to."@en ,
+                               "Name und Adressdaten einer Person, über die eine Verbindung hergestellt werden kann, oft zu einer Organisation oder einem Unternehmen, dem die Person angehört."@de ;
+           rdfs:label "Contact"@en ,
+                      "Kontakt"@de ;
+           skos:definition "a ec:Person that is fully described by its address details"@en ,
+                           "eine ec:Person, die durch ihre Adressdetails vollständig beschrieben wird"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ContainerCodec
+ec:ContainerCodec rdf:type owl:Class ;
+                  rdfs:subClassOf ec:Codec ;
+                  dcterms:description "Der bei der Produktion eines Inhaltscontainers verwendete Codec."@de ,
+                                      "The codec used in the production of a content container."@en ;
+                  rdfs:label "Container codec"@en ,
+                             "Container-Codec"@de ;
+                  skos:definition "a ec:Codec used in the production of a container of ec:MediaResources"@en ,
+                                  "ein ec:Codec, der bei der Produktion eines ec:MediaResources-Containers verwendet wird"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ContainerEncodingFormat
+ec:ContainerEncodingFormat rdf:type owl:Class ;
+                           rdfs:subClassOf ec:EncodingFormat ;
+                           dcterms:description "An entry from the classification of transformations that produce digital audio resources from audio signals."@en ,
+                                               "Ein Eintrag aus der Klassifikation von Transformationen, die digitale Audiomedien aus Audiosignalen erzeugen."@de ;
+                           rdfs:label "Container encoding format"@en ,
+                                      "Container-Kodierungsformat"@de ;
+                           skos:definition "a ec:EncodingFormat classifying the transformation from source data into a container that is a ec;MediaResource"@en ,
+                                           "eine ec:EncodingFormat-Klasse, die die Transformation von Quelldaten in einen Container klassifiziert, der eine ec;MediaResource ist"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ContainerFormat
+ec:ContainerFormat rdf:type owl:Class ;
+                   rdfs:subClassOf ec:Format ;
+                   dcterms:description "An entry from the classification of packing schemes for a collection of files or streams with encoded audio, video, image or data information packed in a single file that serves as a container."@en ,
+                                       "Ein Eintrag aus der Klassifizierung von Verpackungsschemata für eine Sammlung von Dateien oder Streams mit codierten Audio-, Video-, Bild- oder Dateninformationen, die in einer einzelnen Datei als Container zusammengefasst sind."@de ;
+                   rdfs:label "Container format"@en ,
+                              "Containerformat"@de ;
+                   skos:definition "a ec:Format classifying the packing scheme of a file containing a set of encoded audio, video, image and/or data streams"@en ,
+                                   "eine ec:Format-Klasse, die das Verpackungsschema einer Datei klassifiziert, die einen Satz codierter Audio-, Video-, Bild- und/oder Datenströme enthält"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ContainerMimeType
+ec:ContainerMimeType rdf:type owl:Class ;
+                     rdfs:subClassOf ec:Format ;
+                     dcterms:description "An entry from the classification of Internet media types. See also: http://www.iana.org/assignments/media-types/application/index.html."@en ,
+                                         "Ein Eintrag aus der Klassifikation von Internet-Medientypen. Siehe auch: http://www.iana.org/assignments/media-types/application/index.html."@de ;
+                     rdfs:label "Container mime type"@en ,
+                                "Container-MIME-Typ"@de ;
+                     skos:definition "a ec:Format classifying the structure of a file as its Internet media type"@en ,
+                                     "eine ec:Format-Klasse, die die Struktur einer Datei als ihren Internet-Medientyp klassifiziert"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ContentAlert
+ec:ContentAlert rdf:type owl:Class ;
+                rdfs:subClassOf ec:Type ;
+                dcterms:description "A list of entries to classify the type of alerting for some content."@en ,
+                                    "Eine Liste von Einträgen zur Klassifizierung der Art der Warnung für bestimmte Inhalte."@de ;
+                rdfs:label "Content alert"@en ,
+                           "Inhaltswarnung"@de ;
+                skos:definition "a ec:Type that list types of alerting for some content"@en ,
+                                "eine ec:Type, die Typen von Warnmeldungen für bestimmte Inhalte auflistet"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ContentEditorialCode
+ec:ContentEditorialCode rdf:type owl:Class ;
+                        rdfs:subClassOf ec:Type ;
+                        dcterms:description "A list of entries to classify some content by an editorial format code, e.g. EBU's classification scheme on Editorial Format Codes."@en ,
+                                            "Eine Liste von Einträgen, um bestimmte Inhalte anhand eines Editorial-Format-Codes zu klassifizieren, z. B. das Klassifizierungsschema von EBU für Editorial Format Codes."@de ;
+                        rdfs:label "Editorial code"@en ,
+                                   "Redaktionscode"@de ;
+                        skos:definition "a ec:Type that lists editorial format codes for some content"@en ,
+                                        "ein ec:Type, das redaktionelle Formatcodes für einige Inhalte auflistet"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ContentEditorialFormat
+ec:ContentEditorialFormat rdf:type owl:Class ;
+                          rdfs:subClassOf ec:Type ;
+                          dcterms:description "A list of entries to classify some content by an editorial format."@en ,
+                                              "Eine Liste von Einträgen, um bestimmte Inhalte nach einem redaktionellen Format zu klassifizieren."@de ;
+                          rdfs:label "Editorial format"@en ,
+                                     "Redaktionelles Format"@de ;
+                          skos:definition "a ec:Type that lists editorial formats for some content"@en ,
+                                          "ein ec:Type, der redaktionelle Formate für bestimmte Inhalte auflistet"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Contract
+ec:Contract rdf:type owl:Class ;
+            rdfs:subClassOf [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasContractLink ;
+                              owl:allValuesFrom ec:Resource
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasContractRelatedCost ;
+                              owl:allValuesFrom ec:ContractCost
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasContractTemplate ;
+                              owl:allValuesFrom ec:Contract
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasContractualParty ;
+                              owl:allValuesFrom ec:Agent
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasIdentifier ;
+                              owl:allValuesFrom ec:Identifier
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasObjectType ;
+                              owl:allValuesFrom skos:Concept
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:description ;
+                              owl:allValuesFrom rdfs:Literal
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:name ;
+                              owl:allValuesFrom rdfs:Literal
+                            ] ;
+            dcterms:description "An agreement between parties or a law concerning the rights and duties in the creation or publication of content. More specific contracts for activities like licensing, buying, ordering, etc., can be defined as subclasses."@en ,
+                                "Eine Vereinbarung zwischen Parteien oder ein Gesetz betreffend die Rechte und Pflichten bei der Erstellung oder Veröffentlichung von Inhalten. Spezifischere Verträge für Aktivitäten wie Lizenzierung, Kauf, Bestellung usw. können als Unterklassen definiert werden."@de ;
+            rdfs:label "Contract"@en ,
+                       "Vertrag"@de ;
+            skos:definition "an agreement between ec:Agents or a law concerning the rights and duties in the creation or publication of ec:Assets"@en ,
+                            "eine Vereinbarung zwischen ec:Agents oder ein Gesetz betreffend die Rechte und Pflichten bei der Erstellung oder Veröffentlichung von ec:Assets"@de ;
+            skos:example """- a contract between a PSM and a production company for the delivery of a series
+- a law about copyrights of news articles"""@en ,
+                         """- ein Vertrag zwischen einem PSM und einer Produktionsfirma über die Lieferung einer Serie
+- ein Gesetz über Urheberrechte an Nachrichtenartikeln"""@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ContractCost
+ec:ContractCost rdf:type owl:Class ;
+                rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                  owl:onProperty ec:hasContractCostAmountCurrency ;
+                                  owl:allValuesFrom skos:Concept
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty ec:hasIdentifier ;
+                                  owl:allValuesFrom ec:Identifier
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty ec:hasObjectType ;
+                                  owl:allValuesFrom skos:Concept
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty ec:contractCostAmount ;
+                                  owl:allValuesFrom xsd:decimal
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty ec:description ;
+                                  owl:allValuesFrom rdfs:Literal
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty ec:name ;
+                                  owl:allValuesFrom rdfs:Literal
+                                ] ;
+                dcterms:description "Die finanziellen Kosten, die mit einem Vertrag verbunden sind."@de ,
+                                    "The financial costs associated to a contract."@en ;
+                rdfs:label "Contract cost"@en ,
+                           "Vertragskosten"@de ;
+                skos:definition "a costs associated to an ec:Contract"@en ,
+                                "eine mit ec:Contract verbundene Kosten"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ContractType
+ec:ContractType rdf:type owl:Class ;
+                rdfs:subClassOf skos:Concept ;
+                dcterms:description "An entry from the classification of types of contracts."@en ,
+                                    "Ein Eintrag aus der Klassifikation der Vertragstypen."@de ;
+                rdfs:label "Contract type"@en ,
+                           "Vertragstyp"@de ;
+                skos:definition "a skos:Concept classifying the type of a ec:Contract"@en ,
+                                "ein skos:Concept zur Klassifizierung des Typs eines ec:Contract"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Copyright
+ec:Copyright rdf:type owl:Class ;
+             rdfs:subClassOf ec:Rights ;
+             dcterms:description "Die Bedingungen, unter denen Inhalte kopiert werden können."@de ,
+                                 "The conditions under which content can be copied."@en ;
+             rdfs:label "Copyright"@en ,
+                        "Urheberrecht"@de ;
+             skos:definition "a ec:Rights that define the conditions for copying a ec:MediaResource"@en ,
+                             "eine ec:Rights, die die Bedingungen für das Kopieren einer ec:MediaResource festlegen"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Costume
+ec:Costume rdf:type owl:Class ;
+           rdfs:subClassOf ec:Artefact ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:hasLogo ;
+                             owl:allValuesFrom ec:Logo
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:hasSticker ;
+                             owl:allValuesFrom ec:Sticker
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:costumeSizeInformation ;
+                             owl:allValuesFrom rdfs:Literal
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:costumeTexture ;
+                             owl:allValuesFrom rdfs:Literal
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:gender ;
+                             owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                           ] ;
+           dcterms:description "A piece of clothing that an actress or actor wears while acting."@en ,
+                               "Ein Kleidungsstück, das eine Schauspielerin oder ein Schauspieler beim Spielen trägt."@de ;
+           rdfs:label "Costume"@en ,
+                      "Kostüm"@de ;
+           skos:definition "an ec:Artefact in the form of a garment that an actress or actor wears while acting"@en ,
+                           "ein ec:Artefakt in Form eines Kleidungsstücks, das eine Schauspielerin oder ein Schauspieler beim Spielen trägt"@de ;
+           skos:example "- die Uniformen, die von der Star-Trek-Besatzung getragen werden"@de ,
+                        "- the uniforms worn by the Star Trek crew"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#CostumeType
+ec:CostumeType rdf:type owl:Class ;
+               rdfs:subClassOf skos:Concept ;
+               dcterms:description "An entry from the classification of types of costumes."@en ,
+                                   "Ein Eintrag aus der Klassifikation von Kostümarten."@de ;
+               rdfs:label "Costume type"@en ,
+                          "Kostümtyp"@de ;
+               skos:definition "a skos:Concept classifying the type of a ec:Costume"@en ,
+                               "ein skos:Concept zur Klassifizierung der Art eines ec:Costume"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#CountryCode
+ec:CountryCode rdf:type owl:Class ;
+               rdfs:subClassOf skos:Concept ;
+               dcterms:description "An entry from the ISO codes of countries."@en ,
+                                   "Ein Eintrag aus den ISO-Codes der Länder."@de ;
+               rdfs:label "Country code"@en ,
+                          "Ländercode"@de ;
+               skos:definition "a skos:Concept classifying countries by their ISO codes"@en ,
+                               "ein skos:Concept zur Klassifizierung von Ländern nach ihren ISO-Codes"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#CoverageRestrictions
+ec:CoverageRestrictions rdf:type owl:Class ;
+                        rdfs:subClassOf ec:Rights ;
+                        dcterms:description "Die Einschränkungen für die Veröffentlichung von Inhalten, z. B. hinsichtlich Zeit oder räumlicher Abdeckung."@de ,
+                                            "The limitations for publishing content, e.g. in terms of time or spatial coverage."@en ;
+                        rdfs:label "Coverage restrictions"@en ,
+                                   "Nutzungsbeschränkungen"@de ;
+                        skos:definition "a ec:Rights that define the limitations for publishing an ec:Asset"@en ,
+                                        "eine ec:Rights, die die Einschränkungen für die Veröffentlichung eines ec:Asset definieren"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#CreativeCommons
+ec:CreativeCommons rdf:type owl:Class ;
+                   rdfs:subClassOf ec:Rights ;
+                   dcterms:description "A standardized set of licensing conditions edited by a non-profit organisation that authors can choose from to limit the use of their works by others."@en ,
+                                       "Ein standardisiertes Set von Lizenzbedingungen, das von einer gemeinnützigen Organisation herausgegeben wird und aus dem Autoren wählen können, um die Nutzung ihrer Werke durch andere einzuschränken."@de ;
+                   rdfs:label "Creative Commons"@de ,
+                              "Creative commons"@en ;
+                   skos:definition "a ec:Rights that is a standardized set of licencing conditions selectable for authors (as ec:RightsHolder) to protect their work"@en ,
+                                   "eine ec:Rights, die ein standardisierter Satz von Lizenzbedingungen ist, aus dem Autoren (als ec:RightsHolder) wählen können, um ihre Werke zu schützen"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#CrewMember
+ec:CrewMember rdf:type owl:Class ;
+              rdfs:subClassOf ec:Person ;
+              dcterms:description "Crew members work in the production of media resources."@en ,
+                                  "Crewmitglieder arbeiten bei der Produktion von Medienressourcen."@de ;
+              rdfs:label "Besatzung"@de ,
+                         "Crew"@en ;
+              skos:definition "a ec:Person who is a member of the workforce in the production of a media resource"@en ,
+                              "eine ec:Person, die Mitglied der Belegschaft bei der Produktion einer Medienressource ist"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#CuisineStyle
+ec:CuisineStyle rdf:type owl:Class ;
+                rdfs:subClassOf skos:Concept ;
+                dcterms:description "An entry from the classification of cuisine styles to describe food."@en ,
+                                    "Ein Eintrag aus der Klassifikation von Küchenstilen zur Beschreibung von Speisen."@de ;
+                rdfs:label "Cuisine style"@en ,
+                           "Küchenstil"@de ;
+                skos:definition "a skos:Concept classifying the style of a cuisine to describe ec:Food"@en ,
+                                "ein skos:Concept zur Klassifizierung des Stils einer Küche zur Beschreibung von ec:Food"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#CurrencyCode
+ec:CurrencyCode rdf:type owl:Class ;
+                rdfs:subClassOf skos:Concept ;
+                dcterms:description "An entry from the ISO codes of currencies."@en ,
+                                    "Ein Eintrag aus den ISO-Währungscodes."@de ;
+                rdfs:label "Currency code"@en ,
+                           "Währungscode"@de ;
+                skos:definition "a skos:Concept classifying currencies by their ISO codes"@en ,
+                                "ein skos:Concept zur Klassifizierung von Währungen anhand ihrer ISO-Codes"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#DataFormat
+ec:DataFormat rdf:type owl:Class ;
+              rdfs:subClassOf ec:Format ;
+              dcterms:description "An entry from the classification of structure schemes for data."@en ,
+                                  "Ein Eintrag aus der Klassifikation von Struktur-Schemata für Daten."@de ;
+              rdfs:label "Data format"@en ,
+                         "Datenformat"@de ;
+              skos:definition "a ec:Format classifying the structure of data"@en ,
+                              "eine ec:Format, die die Struktur von Daten klassifiziert"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#DataTrack
+ec:DataTrack rdf:type owl:Class ;
+             rdfs:subClassOf ec:Track ,
+                             [ rdf:type owl:Restriction ;
+                               owl:onProperty ec:hasDataFormat ;
+                               owl:allValuesFrom ec:DataFormat
+                             ] ;
+             dcterms:description "A track containing data that accompanies video or audio content."@en ,
+                                 "Ein Track, der Daten enthält, die Video- oder Audioinhalte begleiten."@de ;
+             rdfs:label "Data track"@en ,
+                        "Datentrack"@de ;
+             skos:definition "a ec:Track containing data accompanying video or audio"@en ,
+                             "ein ec:Track, der Daten enthält, die Video oder Audio begleiten"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Department
+ec:Department rdf:type owl:Class ;
+              rdfs:subClassOf ec:Organisation ;
+              dcterms:description "A section in a large organisation, typically built around a business task, like an archive department in a media enterprise."@en ,
+                                  "Ein Bereich in einer großen Organisation, typischerweise um eine betriebliche Aufgabe herum aufgebaut, wie etwa eine Archivabteilung in einem Medienunternehmen."@de ;
+              rdfs:label "Abteilung"@de ,
+                         "Department"@en ;
+              skos:definition "a ec:Organisation that is a substructure within an ec:Organisation"@en ,
+                              "eine ec:Organisation, die eine Unterstruktur innerhalb einer ec:Organisation ist"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#DepictedEvent
+ec:DepictedEvent rdf:type owl:Class ;
+                 rdfs:subClassOf ec:Event ;
+                 dcterms:description "A DepictedEVent is fictitious or historical or other sort of Event that the content of the EditorialObject or resource relates to."@en ,
+                                     "Ein DepictedEVent ist ein fiktives, historisches oder sonstiges Event, auf das sich der Inhalt des EditorialObject oder der Ressource bezieht."@de ;
+                 rdfs:label "Dargestelltes Ereignis"@de ,
+                            "Depicted event"@en ;
+                 skos:definition "a ec:Event"@en ,
+                                 "eine ec:Event"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Disclaimer
+ec:Disclaimer rdf:type owl:Class ;
+              rdfs:subClassOf ec:Rights ;
+              dcterms:description "A declaration of an intentional giving up of an entitlement, claim, or privilege."@en ,
+                                  "Eine Erklärung des absichtlichen Verzichts auf einen Anspruch, ein Recht oder ein Privileg."@de ;
+              rdfs:label "Disclaimer"@en ,
+                         "Haftungsausschluss"@de ;
+              skos:definition "a ec:Rights that declares the intentional giving up of an entitlement, claim, or privilege"@en ,
+                              "eine ec:Rights, die das absichtliche Aufgeben eines Anspruchs, einer Forderung oder eines Privilegs erklärt"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Document
+ec:Document rdf:type owl:Class ;
+            rdfs:subClassOf ec:Resource ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasDocumentFormat ;
+                              owl:allValuesFrom ec:DocumentFormat
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasEncodingFormat ;
+                              owl:allValuesFrom ec:EncodingFormat
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:wordCount ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onDataRange xsd:integer
+                            ] ;
+            dcterms:description "A resource in the form of encoded text and/or graphics, e.g. a HTML webpage with news items; a screenplay as a PDF document."@en ,
+                                "Eine Ressource in Form von codiertem Text und/oder Grafiken, z. B. eine HTML-Webseite mit Nachrichtenartikeln; ein Drehbuch als PDF-Dokument."@de ;
+            rdfs:label "Document"@en ,
+                       "Dokument"@de ;
+            skos:definition "a ec:Resource in the form of encoded text and/or graphics"@en ,
+                            "ein ec:Resource in Form von codiertem Text und/oder Grafiken"@de ;
+            skos:example """- a text file
+- a paper book
+- a web page or a reusable block thereof"""@en ,
+                         """- eine Textdatei
+- ein gedrucktes Buch
+- eine Webseite oder ein wiederverwendbarer Ausschnitt davon"""@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#DocumentFormat
+ec:DocumentFormat rdf:type owl:Class ;
+                  rdfs:subClassOf ec:Format ;
+                  dcterms:description "An entry from the classification of structure schemes for digital documents."@en ,
+                                      "Ein Eintrag aus der Klassifikation von Struktur-Schemata für digitale Dokumente."@de ;
+                  rdfs:label "Document format"@en ,
+                             "Dokumentenformat"@de ;
+                  skos:definition "a ec:Format classifying the structure of a ec:Document"@en ,
+                                  "eine ec:Format, die die Struktur eines ec:Document klassifiziert"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Dopesheet
+ec:Dopesheet rdf:type owl:Class ;
+             rdfs:subClassOf ec:Document ;
+             dcterms:description "A document containing additional information about a news item."@en ,
+                                 "Ein Dokument mit zusätzlichen Informationen zu einem Nachrichtenbeitrag."@de ;
+             rdfs:label "Dopblatt"@de ,
+                        "Dopesheet"@en ;
+             skos:definition "a ec:Document containing additional information about a news item"@en ,
+                             "ein ec:Document mit zusätzlichen Informationen über einen Nachrichtenbeitrag"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#EditUnitCount
+ec:EditUnitCount rdf:type owl:Class ;
+                 rdfs:subClassOf ec:TimelinePoint ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:editUnit ;
+                                   owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onDataRange xsd:long
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:editUnitNumbering ;
+                                   owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onDataRange xsd:long
+                                 ] ;
+                 dcterms:description "A point in time within the timeline of a content that is expressed in units of frames, samples or time."@en ,
+                                     "Ein Zeitpunkt innerhalb der Zeitleiste eines Inhalts, der in Einheiten von Bildern, Samples oder Zeit ausgedrückt wird."@de ;
+                 rdfs:label "Edit unit count"@en ,
+                            "Schnittpunktanzahl"@de ;
+                 skos:definition "a ec:TimelinePoint expressed in units of frames, samples or times"@en ,
+                                 "eine ec:TimelinePoint, ausgedrückt in Einheiten von Frames, Samples oder Zeiten"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#EditorialExtra
+ec:EditorialExtra rdf:type owl:Class ;
+                  rdfs:subClassOf ec:EditorialWork ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:hasProgramme ;
+                                    owl:allValuesFrom ec:Programme
+                                  ] ;
+                  dcterms:description "An optional addition to a main work, created to explain, entertain, advertise, or similar, e.g., a trailer or behind-the-scenes."@en ,
+                                      "Eine optionale Ergänzung zu einem Hauptwerk, die dazu erstellt wurde, zu erklären, zu unterhalten, zu werben oder Ähnliches, z. B. ein Trailer oder ein Blick hinter die Kulissen."@de ;
+                  rdfs:label "Editorial extra"@en ,
+                             "Editorial-Zusatz"@de ;
+                  skos:definition "an ec:EditorialWork serving as an optional addition to a main ec:EditorialWork created to explain, entertain, advertise or similar"@en ,
+                                  "eine ec:EditorialWork, die als optionale Ergänzung zu einer Haupt-ec:EditorialWork dient und erstellt wurde, um zu erklären, zu unterhalten, zu bewerben oder Ähnliches"@de ;
+                  skos:example """Extra content for a movie: trailer, making of, bonus material, outtakes ...
+
+Behind the scenes:
+- an editorial extra that provides a story about scenes of the EditorialWork
+- short film with explanations on the stunt scenes in an action movie
+
+Bonus:
+- an Editorial Extra intended as an enhancing content of a main EditorialWork.
+- Additional content for a movie to be consumed separately as an enhancement
+
+Making of:
+- an EditorialExtra about the making of a film or a Programme
+- A documentary film about the shooting or production of a film or audiovisual work (TV film, TV series, etc.), or even another artistic production (e.g. comic strip).
+
+Outtakes:
+- an Editorial Extra collecting Shots or Scenes that were sorted out during post-production, but still appeal to consumers for fun, curiosity, etc
+- a clip with a collection of outtakes on a bonus DVD of a film
+
+Trailer:
+-an Editorial Extra with typical promotion length of up to 2 minutes, promoting a Programme, a Serial or a Series to be published in the future
+- An AV sequence promoting a film, series or television programme.
+- a 1-minute-preview for next Sunday's episode of German Series \"Tatort\"
+- a promo-clip for a sports-cup-final later tonight"""@en ,
+                               """Zusatzinhalt für einen Film: Trailer, Making-of, Bonusmaterial, Outtakes ...
+
+Hinter den Kulissen:
+- ein redaktioneller Zusatz, der eine Geschichte über Szenen des EditorialWork liefert
+- Kurzfilm mit Erklärungen zu den Stuntszenen in einem Actionfilm
+
+Bonus:
+- ein Editorial Extra, das als ergänzender Inhalt zu einem Haupt-EditorialWork gedacht ist.
+- zusätzlicher Inhalt für einen Film, der separat als Ergänzung konsumiert werden kann
+
+Making-of:
+- ein EditorialExtra über die Entstehung eines Films oder eines Programms
+- ein Dokumentarfilm über die Dreharbeiten oder die Produktion eines Films oder audiovisuellen Werks (TV-Film, TV-Serie usw.) oder sogar einer anderen künstlerischen Produktion (z. B. Comicstrip).
+
+Outtakes:
+- ein Editorial Extra, das Shots oder Scenes sammelt, die in der Postproduktion aussortiert wurden, aber dennoch aus Spaß, Neugier usw. für Konsumenten interessant sind
+- ein Clip mit einer Sammlung von Outtakes auf einer Bonus-DVD eines Films
+
+Trailer:
+-ein Editorial Extra mit typischer Werbelänge von bis zu 2 Minuten, das ein in der Zukunft zu veröffentlichendes Programme, eine Serial oder eine Series bewirbt
+- Eine AV-Sequenz, die einen Film, eine Serie oder ein Fernsehprogramm bewirbt.
+- eine 1-Minuten-Vorschau auf die Folge der deutschen Serie „Tatort“ vom nächsten Sonntag
+- ein Promo-Clip für ein Sportpokal-Finale noch heute Abend"""@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#EditorialFormat
+ec:EditorialFormat rdf:type owl:Class ;
+                   rdfs:subClassOf ec:EditorialGroup ;
+                   dcterms:description "A set of content with a specific editorial style, content layout, anchor host, etc., to address a target audience. Most often used in the assessment of current offerings or in the development of new offerings."@en ,
+                                       "Eine Menge von Inhalten mit einem spezifischen redaktionellen Stil, einem bestimmten Content-Layout, einem Anchor Host usw., um eine Zielgruppe anzusprechen. Wird meist bei der Bewertung aktueller Angebote oder bei der Entwicklung neuer Angebote verwendet."@de ;
+                   rdfs:label "Format"@de ,
+                              "Format"@en ;
+                   skos:definition "an ec:EditorialGroup of members with a specific editorial style, content layout, anchor-host, e.g., to address a target audience"@en ,
+                                   "eine ec:EditorialGroup von Mitgliedern mit einem spezifischen redaktionellen Stil, Inhaltslayout, Anchor-Host, z. B. zur Ansprache einer Zielgruppe"@de ;
+                   skos:example """- A game show with a specific host: \"Rudis Raterunde\"
+- A journal show on Asian topics: \"Asia Report\"
+- An evening news program: \"Tagesschau Main Edition at 8:00 PM\"
+- An online-streamed discussion show for young people with live audience members and a commentary feature: \"MixTalk\""""@en ,
+                                """- Eine Spielshow mit einem bestimmten Moderator: „Rudis Raterunde“
+- Eine Magazinsendung zu asiatischen Themen: „Asia Report“
+- Eine Abendnachrichtensendung: „Tagesschau Main Edition um 20:00 Uhr“
+- Eine online gestreamte Diskussionssendung für junge Leute mit Publikum vor Ort und einer Kommentarfunktion: „MixTalk\""""@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#EditorialGroup
+ec:EditorialGroup rdf:type owl:Class ;
+                  rdfs:subClassOf ec:EditorialObject ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:hasEditorialGroup ;
+                                    owl:allValuesFrom ec:EditorialGroup
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:hasMember ;
+                                    owl:allValuesFrom ec:EditorialObject
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:totalNumberOfEpisodes ;
+                                    owl:allValuesFrom xsd:integer
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:totalNumberOfGroupMembers ;
+                                    owl:allValuesFrom xsd:integer
+                                  ] ;
+                  dcterms:description "A set of works aligned by either story continuity, format similarity, a common motto, or similar."@en ,
+                                      "Eine Gruppe von Werken, die durch Handlungszusammenhang, ähnliche Formate, ein gemeinsames Motto oder Ähnliches miteinander verbunden sind."@de ;
+                  rdfs:label "Editorial group"@en ,
+                             "Redaktionsgruppe"@de ;
+                  skos:definition "a ec:EditorialObject that is a group of ec:EditorialWorks and/or ec:EditorialSegments"@en ,
+                                  "eine ec:EditorialObject, die eine Gruppe von ec:EditorialWorks und/oder ec:EditorialSegments ist"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#EditorialObject
+ec:EditorialObject rdf:type owl:Class ;
+                   rdfs:subClassOf ec:Asset ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:approvedBy ;
+                                     owl:allValuesFrom ec:Agent
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:coversEvent ;
+                                     owl:allValuesFrom ec:Event
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:coversLocation ;
+                                     owl:allValuesFrom ec:Location
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:existsAs ;
+                                     owl:allValuesFrom ec:EditorialObject
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasAlternativeTitle ;
+                                     owl:allValuesFrom ec:AlternativeTitle
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasAssociatedProductionJob ;
+                                     owl:allValuesFrom ec:ProductionJob
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasAudioDescription ;
+                                     owl:allValuesFrom ec:AudioDescription
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasBrand ;
+                                     owl:allValuesFrom ec:MarketingBrand
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasCaptioning ;
+                                     owl:allValuesFrom ec:Captioning
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasCastMember ;
+                                     owl:allValuesFrom ec:CastMember
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasCharacter ;
+                                     owl:allValuesFrom ec:Character
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasCommissioningContract ;
+                                     owl:allValuesFrom ec:Contract
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasContentEditorialFormat ;
+                                     owl:allValuesFrom ec:ContentEditorialFormat
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasContributor ;
+                                     owl:allValuesFrom ec:Involvement
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasCoverage ;
+                                     owl:allValuesFrom owl:Thing
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasCreator ;
+                                     owl:allValuesFrom ec:Involvement
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasCrewMember ;
+                                     owl:allValuesFrom ec:CrewMember
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasDubbedLanguage ;
+                                     owl:allValuesFrom ec:Language
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasEditorialFormat ;
+                                     owl:allValuesFrom ec:EditorialFormat
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasEditorialFormatOf ;
+                                     owl:allValuesFrom ec:EditorialObject
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasGenre ;
+                                     owl:allValuesFrom skos:Concept
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasKeyword ;
+                                     owl:allValuesFrom ec:Keyword
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasLanguage ;
+                                     owl:allValuesFrom ec:Language
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasManifestation ;
+                                     owl:allValuesFrom ec:Resource
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasOriginalLanguage ;
+                                     owl:allValuesFrom ec:Language
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasParentEditorialObject ;
+                                     owl:allValuesFrom ec:EditorialObject
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasPart ;
+                                     owl:allValuesFrom ec:EditorialSegment
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasProducer ;
+                                     owl:allValuesFrom ec:Agent
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasPublication ;
+                                     owl:allValuesFrom ec:PublicationEvent
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasPublicationHistory ;
+                                     owl:allValuesFrom ec:PublicationHistory
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasPublisher ;
+                                     owl:allValuesFrom ec:Involvement
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasRating ;
+                                     owl:allValuesFrom ec:Rating
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasRelatedAnimal ;
+                                     owl:allValuesFrom ec:Animal
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasRelatedAudioContent ;
+                                     owl:allValuesFrom ec:AudioContent
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasRelatedAudioProgramme ;
+                                     owl:allValuesFrom ec:AudioProgramme
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasRelatedAward ;
+                                     owl:allValuesFrom ec:Award
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasRelatedEditorialObject ;
+                                     owl:allValuesFrom ec:EditorialObject
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasRelatedEvent ;
+                                     owl:allValuesFrom ec:Event
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasRelatedMediaResource ;
+                                     owl:allValuesFrom ec:MediaResource
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasRelatedTextLine ;
+                                     owl:allValuesFrom ec:TextLine
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasReview ;
+                                     owl:allValuesFrom ec:Review
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasSigning ;
+                                     owl:allValuesFrom ec:Signing
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasSubject ;
+                                     owl:allValuesFrom ec:Subject
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasSubtitling ;
+                                     owl:allValuesFrom ec:Subtitling
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasTargetAudience ;
+                                     owl:allValuesFrom ec:Audience
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasTargetChannel ;
+                                     owl:allValuesFrom ec:PublicationChannel
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasTargetPlatform ;
+                                     owl:allValuesFrom ec:PublicationPlatform
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasTargetService ;
+                                     owl:allValuesFrom ec:PublicationService
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasTheme ;
+                                     owl:allValuesFrom ec:Theme
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasTimelineTrack ;
+                                     owl:allValuesFrom ec:TimelineTrack
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasTopic ;
+                                     owl:allValuesFrom ec:Topic
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasVersion ;
+                                     owl:allValuesFrom ec:EditorialObject
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasVersionType ;
+                                     owl:allValuesFrom skos:Concept
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:isAbout ;
+                                     owl:allValuesFrom ec:Asset
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:isDistributedOn ;
+                                     owl:allValuesFrom ec:PublicationService
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:isExtractOf ;
+                                     owl:allValuesFrom ec:EditorialObject
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:isInstantiatedBy ;
+                                     owl:allValuesFrom ec:MediaResource
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:isMemberOf ;
+                                     owl:allValuesFrom ec:EditorialGroup
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:isRequiredBy ;
+                                     owl:allValuesFrom ec:EditorialObject
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:isTimelineTrackPartOf ;
+                                     owl:allValuesFrom ec:TimelineTrack
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:isVersionOf ;
+                                     owl:allValuesFrom ec:EditorialObject
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:references ;
+                                     owl:allValuesFrom ec:BibliographicalObject
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:references ;
+                                     owl:allValuesFrom ec:EditorialObject
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:represents ;
+                                     owl:allValuesFrom ec:Asset
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:requires ;
+                                     owl:allValuesFrom ec:EditorialObject
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasDateBroadcast ;
+                                     owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                     owl:onClass time:Instant
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasDateIssued ;
+                                     owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                     owl:onClass time:Instant
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasDuration ;
+                                     owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                     owl:onClass ec:TimelinePoint
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasEnd ;
+                                     owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                     owl:onClass ec:TimelinePoint
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasLocation ;
+                                     owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                     owl:onClass ec:Location
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasResourceOffset ;
+                                     owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                     owl:onClass ec:TimelinePoint
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasStart ;
+                                     owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                     owl:onClass ec:TimelinePoint
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:isNextInSequence ;
+                                     owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                     owl:onClass ec:EditorialObject
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:isPreviousInSequence ;
+                                     owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                     owl:onClass ec:EditorialObject
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:title ;
+                                     owl:someValuesFrom rdfs:Literal
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:abstract ;
+                                     owl:allValuesFrom rdfs:Literal
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:bookmark ;
+                                     owl:allValuesFrom rdfs:Literal
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:comments ;
+                                     owl:allValuesFrom rdfs:Literal
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:contentDescription ;
+                                     owl:allValuesFrom rdfs:Literal
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:folksonomy ;
+                                     owl:allValuesFrom rdfs:Literal
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:highlights ;
+                                     owl:allValuesFrom rdfs:Literal
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:log ;
+                                     owl:allValuesFrom rdfs:Literal
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:playlist ;
+                                     owl:allValuesFrom rdfs:Literal
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:productionSynopsis ;
+                                     owl:allValuesFrom rdfs:Literal
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:promotionalInformation ;
+                                     owl:allValuesFrom rdfs:Literal
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:pubStatus ;
+                                     owl:allValuesFrom rdfs:Literal
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:script ;
+                                     owl:allValuesFrom rdfs:Literal
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:shotLog ;
+                                     owl:allValuesFrom rdfs:Literal
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:summary ;
+                                     owl:allValuesFrom rdfs:Literal
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:synopsis ;
+                                     owl:allValuesFrom rdfs:Literal
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:tableOfContent ;
+                                     owl:allValuesFrom rdfs:Literal
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:tag ;
+                                     owl:allValuesFrom rdfs:Literal
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:midRollAdAllowed ;
+                                     owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                     owl:onDataRange xsd:boolean
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:orientation ;
+                                     owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:partTotalNumber ;
+                                     owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                     owl:onDataRange xsd:integer
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:position ;
+                                     owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:resolution ;
+                                     owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                     owl:onDataRange xsd:string
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:rightsClearanceFlag ;
+                                     owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                     owl:onDataRange xsd:boolean
+                                   ] ;
+                   dcterms:description "An EditorialObject collects all the descriptive information about an object to be realised as a single MediaResource or a collection thereof. An «EditorialObject» describes any idea, any story and will be used to transform a concept into an editorial definition of a MediaResource before fabrication (Production Domain) and Distribution (Distribution Domain). An «EditorialObject» is a set of descriptive metadata summarising e.g. editing decisions. An «EditorialObject» can be a group of EditorialObjects. An «EditorialObject» can also be a part of another «EditorialObject», which is defined by its start time and duration. EditorialObjects can be ordered either as groups or as items on a timeline. Examples of simple EditorialObjects: Programme, Item, Shot, Part, etc. Examples of Groups: Brand, Series, Serial, Collection, etc. A simplified use-case: A news broadcast consists of two news items. One news item contains the last ten seconds of a one minute long interview taken from another source (i.e. 50\">60\" ). This could be modelled as follows: • The NewsBroadcast is linked to a MediaResource using the instantiates-property • The NewsItems are linked to the NewsBroadcast using a TimelineTrack. Tech 3351 EBU CCDM 13 • The InterviewPart is linked to the NewsItem using the hasMember-property. Start and Duration are properties within the InterviewPart indicating its appearance within the NewsItem2. • The InterviewPart is linked to its original source using the existsAs-property • The Interview instantiates a MediaResource, which in turn is linked from the MediaResource of the NewsBroadcast using the hasSource-property • Representation of segmentation: TimelineTracks are preferred over hasPart-properties, when a rundown is needed, e.g. for playout."@en ,
+                                       "Ein EditorialObject sammelt alle beschreibenden Informationen über ein Objekt, das als einzelne MediaResource oder als Sammlung davon realisiert werden soll. Ein «EditorialObject» beschreibt jede Idee, jede Geschichte und wird verwendet, um ein Konzept vor der Produktion (Production Domain) und Distribution (Distribution Domain) in eine redaktionelle Definition einer MediaResource zu überführen. Ein «EditorialObject» ist eine Menge beschreibender Metadaten, die z. B. Schnittentscheidungen zusammenfassen. Ein «EditorialObject» kann eine Gruppe von EditorialObjects sein. Ein «EditorialObject» kann auch Teil eines anderen «EditorialObject» sein, das durch seine Startzeit und Dauer definiert ist. EditorialObjects können entweder als Gruppen oder als Elemente auf einer Zeitleiste angeordnet werden. Beispiele für einfache EditorialObjects: Programme, Item, Shot, Part usw. Beispiele für Gruppen: Brand, Series, Serial, Collection usw. Ein vereinfachter Anwendungsfall: Eine Nachrichtensendung besteht aus zwei Nachrichtenbeiträgen. Ein Nachrichtenbeitrag enthält die letzten zehn Sekunden eines einminütigen Interviews, das aus einer anderen Quelle stammt (d. h. 50\">60\" ). Dies könnte wie folgt modelliert werden: • Die NewsBroadcast ist über die instantiates-Property mit einer MediaResource verknüpft • Die NewsItems sind über einen TimelineTrack mit der NewsBroadcast verknüpft. Tech 3351 EBU CCDM 13 • Das InterviewPart ist über die hasMember-Property mit dem NewsItem verknüpft. Start und Duration sind Eigenschaften innerhalb des InterviewPart und geben dessen Auftreten innerhalb des NewsItem2 an. • Das InterviewPart ist über die existsAs-Property mit seiner ursprünglichen Quelle verknüpft • Das Interview instanziiert eine MediaResource, die wiederum über die hasSource-Property von der MediaResource der NewsBroadcast aus verknüpft ist • Darstellung der Segmentierung: TimelineTracks werden gegenüber hasPart-Properties bevorzugt, wenn eine Rundown benötigt wird, z. B. für den Playout."@de ;
+                   rdfs:label "Editorial object"@en ,
+                              "Redaktionelles Objekt"@de ;
+                   skos:definition "an Asset in the form of content related information about a MediaResource that may or may not exist"@en ,
+                                   "ein Asset in Form von inhaltlich bezogenen Informationen über eine MediaResource, die existieren kann oder auch nicht"@de ;
+                   skos:example """- a group of EditorialObjects
+- a single \"work of the mind\", a piece
+- a segment of a \"work of the mind\""""@en ,
+                                """- eine Gruppe von EditorialObjects
+- ein einzelnes „Werk des Geistes“, ein Stück
+- ein Segment eines „Werks des Geistes\""""@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#EditorialObjectType
+ec:EditorialObjectType rdf:type owl:Class ;
+                       rdfs:subClassOf skos:Concept ;
+                       dcterms:description "An entry from the classification of types of editorial objects."@en ,
+                                           "Ein Eintrag aus der Klassifikation von Arten redaktioneller Objekte."@de ;
+                       rdfs:label "Editorial object type"@en ,
+                                  "Redaktioneller Objekttyp"@de ;
+                       skos:definition "a skos:Concept classifying the type of a ec:EditorialObject"@en ,
+                                       "ein skos:Concept, das den Typ eines ec:EditorialObject klassifiziert"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#EditorialSegment
+ec:EditorialSegment rdf:type owl:Class ;
+                    rdfs:subClassOf ec:EditorialObject ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:isPartOf ;
+                                      owl:someValuesFrom ec:EditorialObject
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasEditorialGroup ;
+                                      owl:allValuesFrom ec:EditorialGroup
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasEditorialWork ;
+                                      owl:allValuesFrom ec:EditorialWork
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:segmentNumber ;
+                                      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                      owl:onDataRange xsd:integer
+                                    ] ;
+                    dcterms:description "A fraction of a work."@en ,
+                                        "Ein Bruchteil eines Werks."@de ;
+                    rdfs:label "Editorial segment"@en ,
+                               "Redaktionelles Segment"@de ;
+                    skos:definition "an ec:EditorialObject representing a fraction of an ec:EditorialWork"@en ,
+                                    "ein ec:EditorialObject, das einen Bruchteil eines ec:EditorialWork darstellt"@de ;
+                    skos:example """- a scene in a movie
+- a section of an interview
+- an intro of a song
+- a paragraph of a text"""@en ,
+                                 """- eine Szene in einem Film
+- ein Abschnitt eines Interviews
+- eine Einleitung eines Liedes
+- ein Absatz eines Textes"""@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#EditorialWork
+ec:EditorialWork rdf:type owl:Class ;
+                 rdfs:subClassOf ec:EditorialObject ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasEditorialGroup ;
+                                   owl:allValuesFrom ec:EditorialGroup
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasEditorialWork ;
+                                   owl:allValuesFrom ec:EditorialWork
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:promotes ;
+                                   owl:allValuesFrom ec:EditorialGroup
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:promotes ;
+                                   owl:allValuesFrom ec:EditorialWork
+                                 ] ;
+                 dcterms:description "Inhalte, die zur Veröffentlichung und Nutzung erstellt werden, z. B. ein Film, eine Episode einer Serie, ein Beitrag in einer Nachrichtensendung, ein Webartikel, ein Social-Media-Beitrag usw."@de ,
+                                     "Some content that is created for publication and consumption, e.g. a film, an episode of a series, an item in a news show, a web article, a social media post, etc."@en ;
+                 rdfs:label "Editorial work"@en ,
+                            "Redaktionelle Arbeit"@de ;
+                 skos:definition "an ec:EditorialObject representing a \"work of the mind\", a piece"@en ,
+                                 "eine ec:EditorialObject, das ein „Werk des Geistes“ darstellt, ein Werk"@de ;
+                 skos:example """- a film based on a playbook
+- a radio drama based on a playbook
+- a news programme with several items
+- an item in a news programme
+- an episode of a series"""@en ,
+                              """- ein auf einem Drehbuch basierender Film
+- ein auf einem Drehbuch basiertes Hörspiel
+- eine Nachrichtensendung mit mehreren Beiträgen
+- ein Beitrag in einer Nachrichtensendung
+- eine Folge einer Serie"""@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Emotion
+ec:Emotion rdf:type owl:Class ;
+           rdfs:subClassOf [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:hasIdentifier ;
+                             owl:allValuesFrom ec:Identifier
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:hasObjectType ;
+                             owl:allValuesFrom skos:Concept
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:hasRelatedAgent ;
+                             owl:allValuesFrom ec:Agent
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:hasRelatedScene ;
+                             owl:allValuesFrom ec:Scene
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:hasStart ;
+                             owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                             owl:onClass ec:TimelinePoint
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:hasEnd ;
+                             owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                             owl:onClass ec:TimelinePoint
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:description ;
+                             owl:allValuesFrom rdfs:Literal
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:name ;
+                             owl:allValuesFrom rdfs:Literal
+                           ] ;
+           dcterms:description "A feeling related to an agent or a sequence in some content."@en ,
+                               "Ein Gefühl, das mit einem Agenten oder einer Sequenz in einem Inhalt verbunden ist."@de ;
+           rdfs:label "Emotion"@de ,
+                      "Emotion"@en ;
+           skos:definition "a feeling related to a ec:Agent or a ec:Scene or a period of time in some content"@en ,
+                           "ein Gefühl, das sich auf einen ec:Agent oder eine ec:Scene oder einen Zeitraum in einem Inhalt bezieht"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#EmotionType
+ec:EmotionType rdf:type owl:Class ;
+               rdfs:subClassOf skos:Concept ;
+               dcterms:description "An entry from the classification of types of emotions."@en ,
+                                   "Ein Eintrag aus der Klassifikation von Emotionstypen."@de ;
+               rdfs:label "Emotion type"@en ,
+                          "Emotionstyp"@de ;
+               skos:definition "a skos:Concept classifying the type of an emotion"@en ,
+                               "ein skos:Concept zur Klassifizierung der Art einer Emotion"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#EncodingFormat
+ec:EncodingFormat rdf:type owl:Class ;
+                  rdfs:subClassOf ec:Format ;
+                  dcterms:description "An entry from the classification of transformations that produce digital resources such as video, audio, images or documents from source signals or data streams."@en ,
+                                      "Ein Eintrag aus der Klassifikation von Transformationen, die aus Ausgangssignalen oder Datenströmen digitale Ressourcen wie Video, Audio, Bilder oder Dokumente erzeugen."@de ;
+                  rdfs:label "Encoding"@en ,
+                             "Kodierung"@de ;
+                  skos:definition "a ec:Format classifying the transformation from a source signal or data to a ec:MediaResource, ec:Picture or ec:Document"@en ,
+                                  "eine ec:Format-Klasse, die die Transformation von einem Quellsignal oder Daten zu einer ec:MediaResource, ec:Picture oder ec:Document klassifiziert"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Essence
+ec:Essence rdf:type owl:Class ;
+           rdfs:subClassOf ec:MediaResource ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:hasRelatedPublicationEvent ;
+                             owl:allValuesFrom ec:PublicationEvent
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:isComposedOf ;
+                             owl:allValuesFrom ec:MediaResource
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:readyForPublication ;
+                             owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                             owl:onDataRange xsd:boolean
+                           ] ;
+           dcterms:description "A media resource in the form of a single file or a file package for play-out or publishing, e.g. an audio file for playout on an audio on demand platform; a MXF container for playout; a video file together with additional language tracks and a subtitle file."@en ,
+                               "Eine Medienressource in Form einer einzelnen Datei oder eines Dateipakets für die Ausspielung oder Veröffentlichung, z. B. eine Audiodatei für die Ausspielung auf einer Audio-on-Demand-Plattform; ein MXF-Container für die Ausspielung; eine Videodatei zusammen mit zusätzlichen Sprachspuren und einer Untertiteldatei."@de ;
+           rdfs:label "Essence"@en ,
+                      "Essenz"@de ;
+           skos:definition "a ec:MediaResource in the form of a single file or a file package for play-out or publishing"@en ,
+                           "eine ec:MediaResource in Form einer einzelnen Datei oder eines Dateipakets für Playout oder Veröffentlichung"@de ;
+           skos:example """- a mxf file
+- a file package delivered by a camera of a specific brand"""@en ,
+                        """- eine MXF-Datei
+- ein von einer Kamera einer bestimmten Marke geliefertes Dateipaket"""@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Event
+ec:Event rdf:type owl:Class ;
+         rdfs:subClassOf [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasIdentifier ;
+                           owl:allValuesFrom ec:Identifier
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasObjectType ;
+                           owl:allValuesFrom skos:Concept
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasRelatedAgent ;
+                           owl:allValuesFrom ec:Agent
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasRelatedArtefact ;
+                           owl:allValuesFrom ec:Artefact
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasRelatedEvent ;
+                           owl:allValuesFrom ec:Event
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasRelatedResource ;
+                           owl:allValuesFrom ec:Resource
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasEndDateTime ;
+                           owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                           owl:onClass time:Instant
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasLocation ;
+                           owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                           owl:onClass ec:Location
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasStartDateTime ;
+                           owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                           owl:onClass time:Instant
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:description ;
+                           owl:allValuesFrom rdfs:Literal
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:name ;
+                           owl:allValuesFrom rdfs:Literal
+                         ] ;
+         dcterms:description "A real or fictional happening that is covered in some content."@en ,
+                             "Ein reales oder fiktives Geschehen, das in einem Inhalt behandelt wird."@de ;
+         rdfs:label "Ereignis"@de ,
+                    "Event"@en ;
+         skos:definition "a real or fictional happening covered in some content"@en ,
+                         "ein tatsächliches oder fiktives Ereignis, das in einem Inhalt behandelt wird"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#EventType
+ec:EventType rdf:type owl:Class ;
+             rdfs:subClassOf skos:Concept ;
+             dcterms:description "An entry from the classification of types of events."@en ,
+                                 "Ein Eintrag aus der Klassifikation der Ereignistypen."@de ;
+             rdfs:label "Ereignistyp"@de ,
+                        "Event type"@en ;
+             skos:definition "a skos:Concept classifying the type of a ec:Event"@en ,
+                             "ein skos:Concept, der den Typ eines ec:Event klassifiziert"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ExclusivityType
+ec:ExclusivityType rdf:type owl:Class ;
+                   rdfs:subClassOf skos:Concept ;
+                   dcterms:description "An entry from a list of types of particularity of rights."@en ,
+                                       "Ein Eintrag aus einer Liste von Arten der Besonderheit von Rechten."@de ;
+                   rdfs:label "Exclusivity type"@en ,
+                              "Exklusivitätstyp"@de ;
+                   skos:definition "a skos:Concept identifying the type of particularity of rights"@en ,
+                                   "ein skos:Concept zur Identifizierung der Art der Besonderheit von Rechten"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ExploitationIssues
+ec:ExploitationIssues rdf:type owl:Class ;
+                      rdfs:subClassOf ec:Rights ;
+                      dcterms:description "A potential problem arising from the use of someone else's work."@en ,
+                                          "Ein potenzielles Problem, das sich aus der Nutzung der Arbeit einer anderen Person ergibt."@de ;
+                      rdfs:label "Exploitation issues"@en ,
+                                 "Verwertungsprobleme"@de ;
+                      skos:definition "a ec:Rights that highlight potential problems in the use of someone else's work"@en ,
+                                      "eine ec:Rights, die potenzielle Probleme bei der Nutzung der Arbeit eines anderen hervorheben"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#FictionalEvent
+ec:FictionalEvent rdf:type owl:Class ;
+                  rdfs:subClassOf ec:Event ;
+                  dcterms:description "An event that is not real."@en ,
+                                      "Ein Ereignis, das nicht real ist."@de ;
+                  rdfs:label "Fictional event"@en ,
+                             "Fiktives Ereignis"@de ;
+                  skos:definition "a ec:Event that is not real"@en ,
+                                  "ein ec:Event, das nicht real ist"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#FictionalLocation
+ec:FictionalLocation rdf:type owl:Class ;
+                     rdfs:subClassOf ec:Location ;
+                     dcterms:description "A location that is not real."@en ,
+                                         "Ein Ort, der nicht real ist."@de ;
+                     rdfs:label "Fictional location"@en ,
+                                "Fiktiver Ort"@de ;
+                     skos:definition "a ec:Location that is not real"@en ,
+                                     "eine ec:Location, die nicht real ist"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#FictionalOrganisation
+ec:FictionalOrganisation rdf:type owl:Class ;
+                         rdfs:subClassOf ec:Organisation ;
+                         dcterms:description "A non-existent organisation mentioned in a fictional story."@en ,
+                                             "Eine nicht existierende Organisation, die in einer fiktiven Geschichte erwähnt wird."@de ;
+                         rdfs:label "Fictional organisation"@en ,
+                                    "Fiktive Organisation"@de ;
+                         skos:definition "an ec:Organisation that does not exist in reality, but as part of a fiction"@en ,
+                                         "eine ec:Organisation, die in der Realität nicht existiert, sondern Teil einer Fiktion ist"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#FileFormat
+ec:FileFormat rdf:type owl:Class ;
+              rdfs:subClassOf ec:Format ;
+              dcterms:description "An entry from the classification of file formats for files with non-audiovisual content."@en ,
+                                  "Ein Eintrag aus der Klassifikation von Dateiformaten für Dateien mit nicht-audiovisuellem Inhalt."@de ;
+              rdfs:label "Dateiformat"@de ,
+                         "File format"@en ;
+              skos:definition "a ec:Format for non-audiovisual resources"@en ,
+                              "ein ec:Format für nicht-audiovisuelle Ressourcen"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Food
+ec:Food rdf:type owl:Class ;
+        rdfs:subClassOf ec:Artefact ,
+                        [ rdf:type owl:Restriction ;
+                          owl:onProperty ec:hasCuisineOrigin ;
+                          owl:allValuesFrom ec:CountryCode
+                        ] ,
+                        [ rdf:type owl:Restriction ;
+                          owl:onProperty ec:hasCuisineStyle ;
+                          owl:allValuesFrom ec:CuisineStyle
+                        ] ,
+                        [ rdf:type owl:Restriction ;
+                          owl:onProperty ec:hasFoodStyle ;
+                          owl:allValuesFrom ec:FoodStyle
+                        ] ,
+                        [ rdf:type owl:Restriction ;
+                          owl:onProperty ec:foodCategory ;
+                          owl:allValuesFrom rdfs:Literal
+                        ] ,
+                        [ rdf:type owl:Restriction ;
+                          owl:onProperty ec:foodIngredient ;
+                          owl:allValuesFrom rdfs:Literal
+                        ] ;
+        dcterms:description "Provisions that are shown or consumed in a scene, such as an apple, a bottle of beer, etc."@en ,
+                            "Vorräte, die in einer Szene gezeigt oder verzehrt werden, wie etwa ein Apfel, eine Flasche Bier usw."@de ;
+        rdfs:label "Food"@en ,
+                   "Lebensmittel"@de ;
+        skos:definition "an edible item shown or consumed in a scene of the ec:EditorialObject"@en ,
+                        "ein essbares Objekt, das in einer Szene des ec:EditorialObject gezeigt oder konsumiert wird"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#FoodStyle
+ec:FoodStyle rdf:type owl:Class ;
+             rdfs:subClassOf skos:Concept ;
+             dcterms:description "An entry from the classification of food styles."@en ,
+                                 "Ein Eintrag aus der Klassifikation von Nahrungsmittelarten."@de ;
+             rdfs:label "Food style"@en ,
+                        "Lebensmittelsorte"@de ;
+             skos:definition "a skos:Concept classifying the style of ec:Food"@en ,
+                             "ein skos:Concept, der den Stil von ec:Food klassifiziert"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Format
+ec:Format rdf:type owl:Class ;
+          rdfs:subClassOf skos:Concept ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasFormatId ;
+                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                            owl:onClass ec:Identifier
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasFormatVersionId ;
+                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                            owl:onClass ec:Identifier
+                          ] ;
+          dcterms:description "An entry from the classification of types of formats, that can also be more specific like audio / video / image / document / data and container formats. A format can be globally associated with a resource but more specific formats can also be distinctly associated with a more specific resource."@en ,
+                              "Ein Eintrag aus der Klassifikation von Formattypen, die auch spezifischer sein können, etwa Audio-/Video-/Bild-/Dokument-/Daten- und Containerformate. Ein Format kann global mit einer Ressource verknüpft sein, spezifischere Formate können jedoch auch getrennt einer spezifischeren Ressource zugeordnet werden."@de ;
+          rdfs:label "Format"@de ,
+                     "Format"@en ;
+          skos:definition "a skos:Concept classifying the technical format of a ec:Resource"@en ,
+                          "ein skos:Concept, das das technische Format einer ec:Resource klassifiziert"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Generation
+ec:Generation rdf:type owl:Class ;
+              rdfs:subClassOf ec:Format ;
+              dcterms:description "An entry from the classification of versions of media resources, e.g. \"master\", \"edit master\" or \"distribution copy\"."@en ,
+                                  "Ein Eintrag aus der Klassifikation von Versionen von Medienressourcen, z. B. „master“, „edit master“ oder „distribution copy“."@de ;
+              rdfs:label "Generation"@de ,
+                         "Generation"@en ;
+              skos:definition "a ec:Format classifying the version of a ec:MediaResource"@en ,
+                              "eine ec:Format-Klasse, die die Version einer ec:MediaResource klassifiziert"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Genre
+ec:Genre rdf:type owl:Class ;
+         rdfs:subClassOf ec:Type ;
+         dcterms:description "A list of entries to classify some content by genre, e.g. EBU's classification scheme on ContentGenre."@en ,
+                             "Eine Liste von Einträgen, um bestimmte Inhalte nach Genre zu klassifizieren, z. B. EBUs Klassifikationsschema für ContentGenre."@de ;
+         rdfs:label "Genre"@de ,
+                    "Genre"@en ;
+         skos:definition "a ec:Type that lists editorial genres for some content"@en ,
+                         "eine ec:Type, die redaktionelle Genres für bestimmte Inhalte auflistet"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#IPRRestrictions
+ec:IPRRestrictions rdf:type owl:Class ;
+                   rdfs:subClassOf ec:Rights ;
+                   dcterms:description "A limitation of the use of a work referring to intellectual property legislation or contracts."@en ,
+                                       "Eine Einschränkung der Nutzung eines Werkes, die sich auf Rechtsvorschriften zum geistigen Eigentum oder auf Verträge bezieht."@de ;
+                   rdfs:label "IPR restrictions"@en ,
+                              "IPR-Beschränkungen"@de ;
+                   skos:definition "a ec:Rights that limits the use of a work referring to intellectual property legislation or contracts"@en ,
+                                   "eine ec:Rights, die die Nutzung eines Werks einschränkt und auf Gesetze oder Verträge zum geistigen Eigentum Bezug nimmt"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Identifier
+ec:Identifier rdf:type owl:Class ;
+              rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:hasIssuer ;
+                                owl:allValuesFrom ec:Agent
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:hasObjectType ;
+                                owl:allValuesFrom skos:Concept
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:hasDateCreated ;
+                                owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                owl:onClass time:Instant
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:description ;
+                                owl:allValuesFrom rdfs:Literal
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:name ;
+                                owl:allValuesFrom rdfs:Literal
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:identifierValue ;
+                                owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                owl:onDataRange xsd:string
+                              ] ;
+              dcterms:description "To support the use of structured identifiers."@en ,
+                                  "Zur Unterstützung der Verwendung strukturierter Identifikatoren."@de ;
+              rdfs:label "Identifier"@en ,
+                         "Kennung"@de ;
+              skos:definition "a unique string associated with an entity"@en ,
+                              "eine eindeutige Zeichenfolge, die einer Entität zugeordnet ist"@de ;
+              skos:example """- \"ISAN 0000-0001-8947-0000-8-0000-0000-D\" is an ISAN Identifier
+- \"10.5240/EA73-79D7-1B2B-B378-3A73-M\" is an EIDR Identifier for the movie \"Blade Runner\""""@en ,
+                           """- \"ISAN 0000-0001-8947-0000-8-0000-0000-D\" ist ein ISAN-იდენტifikator
+- \"10.5240/EA73-79D7-1B2B-B378-3A73-M\" ist ein EIDR-იდენტifikator für den Film \"Blade Runner\""""@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#IdentifierType
+ec:IdentifierType rdf:type owl:Class ;
+                  rdfs:subClassOf skos:Concept ;
+                  dcterms:description "An entry from the classification of types of identifiers."@en ,
+                                      "Ein Eintrag aus der Klassifikation von Identifikatortypen."@de ;
+                  rdfs:label "Identifier type"@en ,
+                             "Identifikatortyp"@de ;
+                  skos:definition "a skos:Concept classifying the type of a ec:Identifier"@en ,
+                                  "ein skos:Concept zur Klassifizierung des Typs eines ec:Identifier"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ImageCodec
+ec:ImageCodec rdf:type owl:Class ;
+              rdfs:subClassOf ec:Codec ;
+              dcterms:description "Der Codec, der bei der Erstellung digitaler Bilder verwendet wird."@de ,
+                                  "The codec used in the production of digital images."@en ;
+              rdfs:label "Bildcodec"@de ,
+                         "Image codec"@en ;
+              skos:definition "a ec:Codec used in the production of a file for a photo"@en ,
+                              "ein ec:Codec, der bei der Produktion einer Datei für ein Foto verwendet wird"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ImageFormat
+ec:ImageFormat rdf:type owl:Class ;
+               rdfs:subClassOf ec:Format ;
+               dcterms:description "An entry from the classification of formats of pictures or media resources, e.g. \"3x4\", \"4x3\" or \"16x9\"."@en ,
+                                   "Ein Eintrag aus der Klassifikation von Formaten für Bilder oder Medienressourcen, z. B. „3x4“, „4x3“ oder „16x9“."@de ;
+               rdfs:label "Bildformat"@de ,
+                          "Image format"@en ;
+               skos:definition "a ec:Format classifying the relation of length vs. height of a ec:Picture or a ec:MediaResource"@en ,
+                               "eine ec:Format, die das Verhältnis von Länge zu Höhe einer ec:Picture oder einer ec:MediaResource klassifiziert"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#IntentionCode
+ec:IntentionCode rdf:type owl:Class ;
+                 rdfs:subClassOf ec:Type ;
+                 dcterms:description "A list of entries to classify the intention for the creation of some content, e.g. EBU's classification scheme of Intention Codes."@en ,
+                                     "Eine Liste von Einträgen zur Klassifizierung der Absicht bei der Erstellung bestimmter Inhalte, z. B. EBUs Klassifizierungsschema für Intention Codes."@de ;
+                 rdfs:label "Intention code"@en ,
+                            "Intentionscode"@de ;
+                 skos:definition "a ec:Type that lists intentions for which some content was created"@en ,
+                                 "ein ec:Type, der die Intentionen auflistet, für die ein Inhalt erstellt wurde"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Involvement
+ec:Involvement rdf:type owl:Class ;
+               rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                 owl:onProperty ec:bringsRights ;
+                                 owl:allValuesFrom ec:Rights
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty ec:hasAgent ;
+                                 owl:allValuesFrom ec:Agent
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty ec:hasAgentOnStagePosition ;
+                                 owl:allValuesFrom ec:OnStagePosition
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty ec:hasAssociatedArtefact ;
+                                 owl:allValuesFrom ec:Artefact
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty ec:hasIdentifier ;
+                                 owl:allValuesFrom ec:Identifier
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty ec:hasObjectType ;
+                                 owl:allValuesFrom skos:Concept
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty ec:hasRelatedArtefact ;
+                                 owl:allValuesFrom ec:Artefact
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty ec:playsCharacter ;
+                                 owl:allValuesFrom ec:Character
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty ec:usesProductionDevice ;
+                                 owl:allValuesFrom ec:ProductionDevice
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty ec:description ;
+                                 owl:allValuesFrom rdfs:Literal
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty ec:name ;
+                                 owl:allValuesFrom rdfs:Literal
+                               ] ;
+               dcterms:description "An agent's participation in the content, e.g., an actress playing a character, a screenwriter, a production company, or a broadcaster holding the publishing rights."@en ,
+                                   "Die Beteiligung eines Akteurs am Inhalt, z. B. eine Schauspielerin, die eine Figur spielt, ein Drehbuchautor, eine Produktionsfirma oder ein Sender, der die Veröffentlichungsrechte innehat."@de ;
+               rdfs:label "Einbindung"@de ,
+                          "Involvement"@en ;
+               skos:definition "an ec:Agent's participation in an ec:EditorialObject or the creation or publication thereof"@en ,
+                               "die Beteiligung eines ec:Agent an einem ec:EditorialObject oder dessen Erstellung oder Veröffentlichung"@de ;
+               skos:example """- Verfassen eines Drehbuchs für eine Filmproduktion
+- Regie bei einem Film führen
+- Toningenieurarbeit bei einer Talkshow
+- Erstellung von Spezialeffekten für einen Film"""@de ,
+                            """- authoring a screenplay for a film production
+- directing a movie
+- sound engineering of a talk show
+- creation special effects for a movie"""@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Item
+ec:Item rdf:type owl:Class ;
+        rdfs:subClassOf ec:EditorialWork ,
+                        [ rdf:type owl:Restriction ;
+                          owl:onProperty ec:hasArticle ;
+                          owl:allValuesFrom ec:Article
+                        ] ,
+                        [ rdf:type owl:Restriction ;
+                          owl:onProperty ec:hasDopesheet ;
+                          owl:allValuesFrom ec:Dopesheet
+                        ] ,
+                        [ rdf:type owl:Restriction ;
+                          owl:onProperty ec:hasPost ;
+                          owl:allValuesFrom ec:Post
+                        ] ,
+                        [ rdf:type owl:Restriction ;
+                          owl:onProperty ec:hasProgramme ;
+                          owl:allValuesFrom ec:Programme
+                        ] ;
+        dcterms:description "Content created to be incorporated into a programme, an article, or a post, e.g., a news item or a short video for social media."@en ,
+                            "Inhalt, der dazu erstellt wurde, in ein Programm, einen Artikel oder einen Beitrag integriert zu werden, z. B. eine Nachricht oder ein kurzes Video für soziale Medien."@de ;
+        rdfs:label "Item"@en ,
+                   "Objekt"@de ;
+        skos:definition "an ec:EditorialWork to be incorporated into a Programme, an Article or a Post"@en ,
+                        "ein ec:EditorialWork, das in ein Programm, einen Artikel oder einen Post aufgenommen werden soll"@de ;
+        skos:example """- a news item to be incorporated in a news programme
+- a survey-clip to be incorporated in a debate"""@en ,
+                     """- ein Nachrichtenbeitrag, der in ein Nachrichtenprogramm aufgenommen werden soll
+- ein Beitrag aus einer Umfrage, der in eine Debatte aufgenommen werden soll"""@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#KeyCareerEvent
+ec:KeyCareerEvent rdf:type owl:Class ;
+                  rdfs:subClassOf ec:KeyEvent ;
+                  dcterms:description "A significant event for the career of a real or fictional person."@en ,
+                                      "Ein bedeutendes Ereignis für die Karriere einer realen oder fiktiven Person."@de ;
+                  rdfs:label "Key career event"@en ,
+                             "Wichtiges Karrierereignis"@de ;
+                  skos:definition "a ec:KeyEvent for the career of a ec:Person"@en ,
+                                  "ein ec:KeyEvent für die Karriere einer ec:Person"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#KeyEvent
+ec:KeyEvent rdf:type owl:Class ;
+            rdfs:subClassOf ec:Event ;
+            dcterms:description "A significant event in a person’s career or personal life, or another notable happening covered in content."@en ,
+                                "Ein bedeutsames Ereignis im Berufsleben oder Privatleben einer Person oder ein anderes bemerkenswertes Ereignis, das in Inhalten behandelt wird."@de ;
+            rdfs:label "Key event"@en ,
+                       "Schlüsselereignis"@de ;
+            skos:definition "a ec:Event that is significant"@en ,
+                            "ein ec:Event, das bedeutend ist"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#KeyPersonalEvent
+ec:KeyPersonalEvent rdf:type owl:Class ;
+                    rdfs:subClassOf ec:KeyEvent ;
+                    dcterms:description "A significant event in the personal life of a real or fictional person."@en ,
+                                        "Ein bedeutendes Ereignis im persönlichen Leben einer realen oder fiktiven Person."@de ;
+                    rdfs:label "Key personal event"@en ,
+                               "Wichtiges persönliches Ereignis"@de ;
+                    skos:definition "a ec:KeyEvent in the personal life a ec:Person"@en ,
+                                    "ein ec:KeyEvent im persönlichen Leben einer ec:Person"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Keyframe
+ec:Keyframe rdf:type owl:Class ;
+            rdfs:subClassOf ec:Picture ;
+            dcterms:description "A picture extracted at some point in time from a video, often called a \"frame\", used to represent the surrounding video sequence for easy navigation back and forth along the video timeline."@en ,
+                                "Ein zu einem bestimmten Zeitpunkt aus einem Video extrahiertes Bild, oft als „Frame“ bezeichnet, das verwendet wird, um die umgebende Videosequenz darzustellen und eine einfache Navigation vor und zurück entlang der Videotimeline zu ermöglichen."@de ;
+            rdfs:label "Key frame"@en ,
+                       "Schlüsselframe"@de ;
+            skos:definition "a ec:Picture that is extracted at a point in time from a video and used to visually reference that same point in time"@en ,
+                            "ein ec:Picture, das zu einem Zeitpunkt aus einem Video extrahiert wird und dazu verwendet wird, diesen selben Zeitpunkt visuell zu referenzieren"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Keyword
+ec:Keyword rdf:type owl:Class ;
+           rdfs:subClassOf skos:Concept ;
+           dcterms:description "An entry from the list of keywords to classify the content of a piece of work."@en ,
+                               "Ein Eintrag aus der Liste der Schlagwörter zur Klassifizierung des Inhalts eines Werkes."@de ;
+           rdfs:label "Keyword"@en ,
+                      "Schlüsselwort"@de ;
+           skos:definition "a skos:Concept classifying the content of a ec:EditorialObject"@en ,
+                           "ein skos:Concept zur Klassifizierung des Inhalts eines ec:EditorialObject"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Language
+ec:Language rdf:type owl:Class ;
+            rdfs:subClassOf skos:Concept ;
+            dcterms:description "An entry from the list of languages related to, e.g. a piece of work, a person or an organisation."@en ,
+                                "Ein Eintrag aus der Liste der Sprachen, die sich z. B. auf ein Werk, eine Person oder eine Organisation beziehen."@de ;
+            rdfs:label "Language"@en ,
+                       "Sprache"@de ;
+            skos:definition "a skos:Concept classifying the language of a ec:EditorialObject or ec:Agent"@en ,
+                            "ein skos:Concept zur Klassifizierung der Sprache eines ec:EditorialObject oder ec:Agent"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Licensing
+ec:Licensing rdf:type owl:Class ;
+             rdfs:subClassOf ec:Rights ;
+             dcterms:description "A set of conditions under which the use of a work is granted."@en ,
+                                 "Eine Menge von Bedingungen, unter denen die Nutzung eines Werks gewährt wird."@de ;
+             rdfs:label "Licensing"@en ,
+                        "Lizenzierung"@de ;
+             skos:definition "a ec:Rights that defines the conditions under which the use of a work is granted"@en ,
+                             "eine ec:Rights, die die Bedingungen festlegt, unter denen die Nutzung eines Werks gewährt wird"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Location
+ec:Location rdf:type owl:Class ;
+            rdfs:subClassOf [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasIdentifier ;
+                              owl:allValuesFrom ec:Identifier
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasLocationCode ;
+                              owl:allValuesFrom ec:LocationCode
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasLocationPicture ;
+                              owl:allValuesFrom ec:Picture
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasObjectType ;
+                              owl:allValuesFrom skos:Concept
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasRelatedArtefact ;
+                              owl:allValuesFrom ec:Artefact
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasRelatedEvent ;
+                              owl:allValuesFrom ec:Event
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasRelatedResource ;
+                              owl:allValuesFrom ec:Resource
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasRegionCode ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onClass ec:RegionCode
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:description ;
+                              owl:allValuesFrom rdfs:Literal
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:locationAddressMunicipality ;
+                              owl:allValuesFrom rdfs:Literal
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:locationAddressPostalCode ;
+                              owl:allValuesFrom rdfs:Literal
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:locationAddressStreetName ;
+                              owl:allValuesFrom rdfs:Literal
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:name ;
+                              owl:allValuesFrom rdfs:Literal
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:locationAddressApartmentNumber ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onDataRange xsd:string
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:locationAddressArea ;
+                              owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:locationAddressCountry ;
+                              owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:locationAddressHouseNumber ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onDataRange xsd:string
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:locationAltitude ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onDataRange xsd:float
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:locationCoordinateSystemName ;
+                              owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:locationLatitude ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onDataRange xsd:float
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:locationLongitude ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onDataRange xsd:float
+                            ] ;
+            dcterms:description "A location related to the media resource, e.g. depicted in the resource (possibly fictional) or where the resource was created (shooting location), e.g. A «Location» is used to define the spatial coverage of the story or recording locations like studios or in the field, associated with the EditorialObjects (or Part of EditorialObjects). Note: a type of location shall be defined as a sub-class of Location."@en ,
+                                "Ein Ort im Zusammenhang mit der Medienressource, z. B. in der Ressource dargestellt (möglicherweise fiktiv) oder der Ort, an dem die Ressource erstellt wurde (Drehort), z. B. wird ein «Location» verwendet, um die räumliche Abdeckung der Handlung oder Aufzeichnungsorte wie Studios oder Aufnahmen im Feld zu definieren, die mit den EditorialObjects (oder Teilen von EditorialObjects) verbunden sind. Hinweis: Ein Typ von Ort muss als Unterklasse von Location definiert werden."@de ;
+            rdfs:label "Location"@en ,
+                       "Ort"@de ;
+            skos:definition "a spatial assignment to a media related locatable Thing"@en ,
+                            "eine räumliche Zuordnung zu einem medienbezogenen lokalisierbaren Ding"@de ;
+            skos:example """- London als Ort, an dem die BBC Nachrichtensendungen produziert
+- London als Ort für ein Drehbuch
+- London als Ort für die öffentliche Ankündigung des Premierministers, die in einer BBC-Nachrichtensendung berichtet wird"""@de ,
+                         """- London as a place where BBC produces news shows
+- London as a place for a screenplay
+- London as a place for the prime minister's public announcement covered in a BBC news show"""@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#LocationCode
+ec:LocationCode rdf:type owl:Class ;
+                rdfs:subClassOf skos:Concept ;
+                dcterms:description "An entry from a list of codes identifying a location."@en ,
+                                    "Ein Eintrag aus einer Liste von Codes zur Identifizierung eines Ortes."@de ;
+                rdfs:label "Location code"@en ,
+                           "Ortscode"@de ;
+                skos:definition "a skos:Concept identifying a ec:Location"@en ,
+                                "ein skos:Concept, der eine ec:Location identifiziert"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#LocationType
+ec:LocationType rdf:type owl:Class ;
+                rdfs:subClassOf skos:Concept ;
+                dcterms:description "An entry from a list of types to classify locations."@en ,
+                                    "Ein Eintrag aus einer Liste von Typen zur Klassifizierung von Orten."@de ;
+                rdfs:label "Location type"@en ,
+                           "Ortstyp"@de ;
+                skos:definition "a skos:Concept classifying the type of a ec:Location"@en ,
+                                "ein skos:Concept, das den Typ eines ec:Location klassifiziert"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Locator
+ec:Locator rdf:type owl:Class ;
+           rdfs:subClassOf [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:hasIdentifier ;
+                             owl:allValuesFrom ec:Identifier
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:hasObjectType ;
+                             owl:allValuesFrom skos:Concept
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:description ;
+                             owl:allValuesFrom rdfs:Literal
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:locatorTargetInformation ;
+                             owl:allValuesFrom rdfs:Literal
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:name ;
+                             owl:allValuesFrom rdfs:Literal
+                           ] ;
+           dcterms:description "A place within a location, e.g. a hall name and number in a large concert building."@en ,
+                               "Ein Ort innerhalb eines Ortes, z. B. die Bezeichnung und Nummer eines Saals in einem großen Konzertgebäude."@de ;
+           rdfs:label "Locator"@en ,
+                      "Ortungsmarke"@de ;
+           skos:definition "an additional specification of a place subordinate to a ec:Locator"@en ,
+                           "eine zusätzliche Spezifikation eines Ortes, der einem ec:Locator untergeordnet ist"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Logo
+ec:Logo rdf:type owl:Class ;
+        rdfs:subClassOf ec:Picture ;
+        dcterms:description "A picture representing an organisation, an award, a brand, a publication platform, a publication channel, a publication service or a rating. This list may be extended in the future."@en ,
+                            "Ein Bild, das eine Organisation, eine Auszeichnung, eine Marke, eine Veröffentlichungsplattform, einen Veröffentlichungskanal, einen Veröffentlichungsdienst oder eine Bewertung repräsentiert. Diese Liste kann in Zukunft erweitert werden."@de ;
+        rdfs:label "Logo"@de ,
+                   "Logo"@en ;
+        skos:definition "a ec:Picture to represent an ec: Organization, a ec:Award, a ec:MarketingBrand, a ec:PublicationPlatform, a ec:PublicationChannel, a ec:PublicationService, or a ec:Rating"@en ,
+                        "ein ec:Picture zur Darstellung einer ec: Organization, einer ec:Award, einer ec:MarketingBrand, einer ec:PublicationPlatform, eines ec:PublicationChannel, eines ec:PublicationService oder einer ec:Rating"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#MarketingBrand
+ec:MarketingBrand rdf:type owl:Class ;
+                  rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:hasIdentifier ;
+                                    owl:allValuesFrom ec:Identifier
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:hasLogo ;
+                                    owl:allValuesFrom ec:Logo
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:isOwnedBy ;
+                                    owl:allValuesFrom ec:Agent
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:description ;
+                                    owl:allValuesFrom rdfs:Literal
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:name ;
+                                    owl:allValuesFrom rdfs:Literal
+                                  ] ;
+                  dcterms:description "A name, often accompanied by a logo, and given to an asset or a publication service or a group thereof to distinguish them from those provided by other manufacturers or merchants."@en ,
+                                      "Ein Name, oft begleitet von einem Logo, der einem Asset, einem Publikationsdienst oder einer Gruppe davon gegeben wird, um sie von denen anderer Hersteller oder Händler zu unterscheiden."@de ;
+                  rdfs:label "Brand"@en ,
+                             "Marke"@de ;
+                  skos:definition "a name, often accompanied by a logo, and given to an ec:Asset or an ec:PublicationService or a group thereof to distinguish them from those provided by other manufacturers or merchants"@en ,
+                                  "ein Name, oft begleitet von einem Logo, der einem ec:Asset oder einem ec:PublicationService oder einer Gruppe davon gegeben wird, um sie von denen anderer Hersteller oder Händler zu unterscheiden"@de ;
+                  skos:example """- der Name einer PSM-Organisation: \"BBC\"
+- der Name eines Medienkanals: \"BBC4\"
+- der Name einer Serie: \"Downton Abbey\"
+- der Name einer Reihe: \"BBC News\""""@de ,
+                               """- the name of a PSM organization: \"BBC\"
+- the name of a media channel: \"BBC4\"
+- the name of a series: \"Downton Abbey\"
+- the name of a serial: \"BBC News\""""@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Measure
+ec:Measure rdf:type owl:Class ;
+           rdfs:subClassOf [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:hasIdentifier ;
+                             owl:allValuesFrom ec:Identifier
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:hasObjectType ;
+                             owl:allValuesFrom skos:Concept
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:hasUnit ;
+                             owl:allValuesFrom skos:Concept
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:measures ;
+                             owl:allValuesFrom ec:Rule
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:description ;
+                             owl:allValuesFrom rdfs:Literal
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:measureValue ;
+                             owl:allValuesFrom rdfs:Literal
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:measureValueMax ;
+                             owl:allValuesFrom rdfs:Literal
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:measureValueMin ;
+                             owl:allValuesFrom rdfs:Literal
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:name ;
+                             owl:allValuesFrom rdfs:Literal
+                           ] ;
+           dcterms:description "A Measure associated with a Rule to assess compliance through AuditJobs."@en ,
+                               "Eine Measure, die mit einer Rule verbunden ist, um die Einhaltung durch AuditJobs zu bewerten."@de ;
+           rdfs:label "Measure"@en ,
+                      "Messung"@de ;
+           skos:definition "a act of determining a number and a unit to answer a given question, by counting, comparing, aggregating or calculating"@en ,
+                           "ein Akt des Bestimmens einer Zahl und einer Einheit, um eine gegebene Frage durch Zählen, Vergleichen, Aggregieren oder Berechnen zu beantworten"@de ;
+           skos:example """- Bestimmung des Lautstärkepegels einer Audiospur
+- Zählen der Minuten, die ein Sprecher während einer Debatte zur Verfügung hat
+- Zählen der Anzahl weiblicher Expertinnen in allen Sendungen von BBC One"""@de ,
+                        """- determining the volume level of audio track
+- counting the minutes that a speaker has during a debate
+- counting the number of female experts in all programmes of BBC One"""@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#MediaFragment
+ec:MediaFragment rdf:type owl:Class ;
+                 rdfs:subClassOf ec:MediaResource ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:isMediaFragmentOf ;
+                                   owl:allValuesFrom ec:MediaResource
+                                 ] ;
+                 dcterms:description "A media resource that is a temporal or spatial segment of a resource as defined by the Media Fragment URI (http://www.w3.org/2008/WebVideo/Fragments/WD-media-fragments-spec/)."@en ,
+                                     "Eine Medienressource, die ein zeitlicher oder räumlicher Ausschnitt einer Ressource ist, wie durch den Media Fragment URI (http://www.w3.org/2008/WebVideo/Fragments/WD-media-fragments-spec/) definiert."@de ;
+                 rdfs:label "Media fragment"@en ,
+                            "Medienfragment"@de ;
+                 skos:definition "a ec:MediaResource that is a temporal or spatial segment of a ec:Resource as defined by the Media Fragment URI (http://www.w3.org/2008/WebVideo/Fragments/WD-media-fragments-spec/)"@en ,
+                                 "ein ec:MediaResource, das ein zeitlicher oder räumlicher Abschnitt einer ec:Resource ist, wie durch die Media Fragment URI (http://www.w3.org/2008/WebVideo/Fragments/WD-media-fragments-spec/) definiert"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#MediaResource
+ec:MediaResource rdf:type owl:Class ;
+                 rdfs:subClassOf ec:Resource ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasAudioTrack ;
+                                   owl:allValuesFrom ec:AudioTrack
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasCaptioningSource ;
+                                   owl:allValuesFrom ec:Agent
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasClone ;
+                                   owl:allValuesFrom ec:MediaResource
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasCodec ;
+                                   owl:allValuesFrom ec:Codec
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasDataTrack ;
+                                   owl:allValuesFrom ec:DataTrack
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasDub ;
+                                   owl:allValuesFrom ec:MediaResource
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasEncodingFormat ;
+                                   owl:allValuesFrom ec:EncodingFormat
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasGeneration ;
+                                   owl:allValuesFrom ec:MediaResource
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasMediaFragment ;
+                                   owl:allValuesFrom ec:MediaFragment
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasMedium ;
+                                   owl:allValuesFrom ec:Medium
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasMetadataTrack ;
+                                   owl:allValuesFrom ec:MetadataTrack
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasProductionDevice ;
+                                   owl:allValuesFrom ec:ProductionDevice
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasRelatedAudioObject ;
+                                   owl:allValuesFrom ec:AudioObject
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasRelatedAudioTrack ;
+                                   owl:allValuesFrom ec:AudioTrack
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasRelatedEssence ;
+                                   owl:allValuesFrom ec:Essence
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasStandard ;
+                                   owl:allValuesFrom ec:Standard
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasStorageType ;
+                                   owl:allValuesFrom ec:StorageType
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasSubtitlingFormat ;
+                                   owl:allValuesFrom ec:SubtitlingFormat
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasTimecodeTrack ;
+                                   owl:allValuesFrom ec:TimecodeTrack
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasTrack ;
+                                   owl:allValuesFrom ec:Track
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasVideoTrack ;
+                                   owl:allValuesFrom ec:VideoTrack
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:isMasterOf ;
+                                   owl:allValuesFrom ec:MediaResource
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:isRequiredBy ;
+                                   owl:allValuesFrom ec:MediaResource
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:requires ;
+                                   owl:allValuesFrom ec:MediaResource
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasAncillaryDataFormat ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass ec:AncillaryDataFormat
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasAudioCodec ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass ec:AudioCodec
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasAudioEncodingFormat ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass ec:AudioEncodingFormat
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasCaptioningFormat ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass ec:CaptioningFormat
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasColourSpace ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass ec:ColourSpace
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasContainerCodec ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass ec:ContainerCodec
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasContainerEncodingFormat ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass ec:ContainerEncodingFormat
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasContainerMimeType ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass ec:MimeType
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasDateDigitised ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass time:Instant
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasDateIngested ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass time:Instant
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasDateMigrated ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass time:Instant
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasDateNormalized ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass time:Instant
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasDateTransferred ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass time:Instant
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasDisplayAspectRatio ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass ec:ActiveFormatDescriptorCode
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasFileFormat ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass ec:FileFormat
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasImageCodec ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass ec:ImageCodec
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasImageFormat ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass ec:ImageFormat
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasLocation ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass ec:Location
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasMaster ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass ec:MediaResource
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasMimeType ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass ec:MimeType
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasParentMediaResource ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass ec:MediaResource
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasSource ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass ec:MediaResource
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasVideoCodec ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass ec:VideoCodec
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasVideoEncodingFormat ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass ec:VideoEncodingFormat
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:instantiates ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass ec:EditorialObject
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:isCloneOf ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass ec:MediaResource
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:isDubOf ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass ec:MediaResource
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:isTrackPartOf ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass ec:Track
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:encodingLevel ;
+                                   owl:allValuesFrom rdfs:Literal
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:encodingProfile ;
+                                   owl:allValuesFrom rdfs:Literal
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty dc:source ;
+                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:aspectRatio ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onDataRange xsd:string
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:audioBitRate ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onDataRange xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:audioBitRateMax ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onDataRange xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:audioBitRateMode ;
+                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:audioEncodingLevel ;
+                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:audioEncodingProfile ;
+                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:audioTrackConfiguration ;
+                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:audioTrackNumber ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onDataRange xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:bitDepth ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onDataRange xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:bitRate ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onDataRange xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:bitRateMax ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onDataRange xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:bitRateMode ;
+                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:bitRateOverall ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onDataRange xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:dimensions ;
+                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:frameHeight ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onDataRange xsd:integer
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:frameHeightUnit ;
+                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:frameRate ;
+                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:frameSizeUnit ;
+                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:frameWidth ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onDataRange xsd:integer
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:frameWidthUnit ;
+                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hashValue ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onDataRange xsd:string
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:iFrameSize ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onDataRange xsd:integer
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:inchesPerSecond ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onDataRange xsd:double
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:noiseFilter ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onDataRange xsd:boolean
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:packageByteSize ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onDataRange xsd:long
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:packageName ;
+                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:playbackSpeed ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onDataRange xsd:double
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:regionDelimX ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onDataRange xsd:integer
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:regionDelimY ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onDataRange xsd:integer
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:sampleRate ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onDataRange xsd:integer
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:sampleSize ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onDataRange xsd:integer
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:sampleType ;
+                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:scanningFormat ;
+                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:totalNumberOfAudioChannels ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onDataRange xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:totalNumberOfAudioTracks ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onDataRange xsd:integer
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:totalNumberOfVideoTracks ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onDataRange xsd:integer
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:videoBitRate ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onDataRange xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:videoBitRateMax ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onDataRange xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:videoBitRateMode ;
+                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:videoEncodingLevel ;
+                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:videoEncodingProfile ;
+                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                 ] ;
+                 owl:disjointWith ec:Rating ;
+                 dcterms:description "A resource that comprises encoded audio, video, graphics, data or text."@en ,
+                                     "Eine Ressource, die kodierte Audio-, Video-, Grafik-, Daten- oder Textinhalte umfasst."@de ;
+                 rdfs:label "Media resource"@en ,
+                            "Medienressource"@de ;
+                 skos:definition "a ec:Resource that comprises encoded audio, video, graphics, data or text"@en ,
+                                 "eine ec:Resource, die kodierte Audio-, Video-, Grafik-, Daten- oder Textinhalte umfasst"@de ;
+                 skos:example """- an audio CD
+- an audio track on a CD
+- an audio file
+- a video file
+- a video DVD"""@en ,
+                              """- eine Audio-CD
+- ein Audiotitel auf einer CD
+- eine Audiodatei
+- eine Videodatei
+- eine Video-DVD"""@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#MediaResourceType
+ec:MediaResourceType rdf:type owl:Class ;
+                     rdfs:subClassOf skos:Concept ;
+                     dcterms:description "An entry from a list of types to classify media resources."@en ,
+                                         "Ein Eintrag aus einer Liste von Typen zur Klassifizierung von Medienressourcen."@de ;
+                     rdfs:label "Media resource type"@en ,
+                                "Medienressourcentyp"@de ;
+                     skos:definition "a skos:Concept classifying the type of a ec:MediaResource"@en ,
+                                     "ein skos:Concept, das den Typ einer ec:MediaResource klassifiziert"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#MediaType
+ec:MediaType rdf:type owl:Class ;
+             rdfs:subClassOf ec:Format ;
+             dcterms:description "An entry from the classification of types of media resources, often historic, like phonograph cylinder."@en ,
+                                 "Ein Eintrag aus der Klassifikation von Arten von Medienressourcen, oft historischen, wie einer Grammophonwalze."@de ;
+             rdfs:label "Media type"@en ,
+                        "Medientyp"@de ;
+             skos:definition "a ec:Format classifying additional type information about a ec:MediaResource"@en ,
+                             "eine ec:Format, die zusätzliche Typinformationen über eine ec:MediaResource klassifiziert"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Medium
+ec:Medium rdf:type owl:Class ;
+          rdfs:subClassOf ec:Format ;
+          dcterms:description "An entry from the classification of media that carry media resources, e.g. \"Betamax\", \"DVD\", \"LP\"."@en ,
+                              "Ein Eintrag aus der Klassifikation von Medien, die Medienressourcen tragen, z. B. \"Betamax\", \"DVD\", \"LP\"."@de ;
+          rdfs:label "Medium"@de ,
+                     "Medium"@en ;
+          skos:definition "a ec:Format classifying the medium carrying a ec:MediaResource"@en ,
+                          "eine ec:Format, die das Medium klassifiziert, das eine ec:MediaResource trägt"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#MetadataTrack
+ec:MetadataTrack rdf:type owl:Class ;
+                 rdfs:subClassOf ec:Track ;
+                 dcterms:description "A track containing metadata about the content that it accompanies, e.g. in MXF containers."@en ,
+                                     "Ein Track, der Metadaten über den Inhalt enthält, den er begleitet, z. B. in MXF-Containern."@de ;
+                 rdfs:label "Metadata track"@en ,
+                            "Metadaten-Track"@de ;
+                 skos:definition "a ec:Track containing metadata about the content that it accompanies"@en ,
+                                 "ein ec:Track, der Metadaten über den Inhalt enthält, den er begleitet"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#MimeType
+ec:MimeType rdf:type owl:Class ;
+            rdfs:subClassOf ec:Format ;
+            dcterms:description "An entry from the classification of Internet media types. See also: http://www.iana.org/assignments/media-types/application/index.html."@en ,
+                                "Ein Eintrag aus der Klassifizierung von Internet-Medientypen. Siehe auch: http://www.iana.org/assignments/media-types/application/index.html."@de ;
+            rdfs:label "MIME-Typ"@de ,
+                       "Mime type"@en ;
+            skos:definition "a ec:Format classifying the structure of a file as its Internet media type"@en ,
+                            "eine ec:Format, die die Struktur einer Datei als ihren Internet-Medientyp klassifiziert"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#NormalPlayTime
+ec:NormalPlayTime rdf:type owl:Class ;
+                  rdfs:subClassOf ec:TimelinePoint ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:isoDuration ;
+                                    owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                    owl:onDataRange xsd:string
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:timeOfDay ;
+                                    owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                    owl:onDataRange xsd:time
+                                  ] ;
+                  dcterms:description "Die Dauer eines Inhalts wird als Zeitpunkt im ISO-Format ausgedrückt."@de ,
+                                      "The duration of a content is expressed as a point in time in ISO format."@en ;
+                  rdfs:label "Normal play time"@en ,
+                             "Normale Wiedergabezeit"@de ;
+                  skos:definition "a ec:TimelinePoint representing the duration of a content expressed in ISO Format"@en ,
+                                  "ein ec:TimelinePoint, das die Dauer eines Inhalts darstellt, ausgedrückt im ISO-Format"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#OnStagePosition
+ec:OnStagePosition rdf:type owl:Class ;
+                   rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasIdentifier ;
+                                     owl:allValuesFrom ec:Identifier
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasObjectType ;
+                                     owl:allValuesFrom skos:Concept
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasRelatedStage ;
+                                     owl:allValuesFrom ec:Stage
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:description ;
+                                     owl:allValuesFrom rdfs:Literal
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:name ;
+                                     owl:allValuesFrom rdfs:Literal
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:onStagePositionCoordinateX ;
+                                     owl:allValuesFrom xsd:float
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:onStagePositionCoordinateY ;
+                                     owl:allValuesFrom xsd:float
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:onStagePositionCoordinateZ ;
+                                     owl:allValuesFrom xsd:float
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:onStagePositionCoordinatesReferencePoint ;
+                                     owl:allValuesFrom rdfs:Literal
+                                   ] ;
+                   dcterms:description "A position on a specific stage given in coordinates."@en ,
+                                       "Eine Position auf einer bestimmten Bühne, angegeben in Koordinaten."@de ;
+                   rdfs:label "Bühnenposition"@de ,
+                              "On stage position"@en ;
+                   skos:definition "a coordinate-based location on a ec:Stage"@en ,
+                                   "eine koordinatenbasierte Position auf einer ec:Stage"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#OpenCaptions
+ec:OpenCaptions rdf:type owl:Class ;
+                rdfs:subClassOf ec:Captioning ;
+                dcterms:description "A caption that is burnt into the images of a media resource. i.e. it cannot be turned off."@en ,
+                                    "Eine Einblendung, die in die Bilder einer Medienressource eingebrannt ist, d. h. sie kann nicht abgeschaltet werden."@de ;
+                rdfs:label "Offene Untertitel"@de ,
+                           "Open captions"@en ;
+                skos:definition "a ec:Captioning that is burned in the images of a ec:MediaResource"@en ,
+                                "eine ec:Captioning, die in die Bilder einer ec:MediaResource eingebrannt ist"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#OpenSigning
+ec:OpenSigning rdf:type owl:Class ;
+               rdfs:subClassOf ec:Signing ;
+               dcterms:description "A signing that is burned in the images of a media resource."@en ,
+                                   "Eine Einblendung, die in die Bilder einer Medienressource eingebrannt ist."@de ;
+               rdfs:label "Offenes Signing"@de ,
+                          "Open signing"@en ;
+               skos:definition "a ec:Signing that is burned in the images of a ec:MediaResource and cannot be turned off"@en ,
+                               "eine ec:Signing, die in die Bilder einer ec:MediaResource eingebrannt ist und nicht abgeschaltet werden kann"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#OpenSubtitling
+ec:OpenSubtitling rdf:type owl:Class ;
+                  rdfs:subClassOf ec:Subtitling ;
+                  dcterms:description "A subtitling that is carried in the same media resource as audio and/or video. Subtitling cannot be turned on or off."@en ,
+                                      "Eine Untertitelung, die im selben Medienobjekt wie Audio und/oder Video mitgeführt wird. Die Untertitelung kann nicht ein- oder ausgeschaltet werden."@de ;
+                  rdfs:label "Offene Untertitelung"@de ,
+                             "Open subtitling"@en ;
+                  skos:definition "a ec:Subtitling that is burned in the images of a ec:MediaResource"@en ,
+                                  "eine ec:Subtitling, die in den Bildern einer ec:MediaResource eingebrannt ist"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Organisation
+ec:Organisation rdf:type owl:Class ;
+                rdfs:subClassOf ec:Agent ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty ec:hasDepartment ;
+                                  owl:allValuesFrom ec:Department
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty ec:hasLogo ;
+                                  owl:allValuesFrom ec:Logo
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty ec:hasOrganisationStaff ;
+                                  owl:allValuesFrom ec:StaffMember
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty ec:hasStaffMember ;
+                                  owl:allValuesFrom ec:StaffMember
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty ec:hasEndDateTime ;
+                                  owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                  owl:onClass time:Instant
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty ec:hasStartDateTime ;
+                                  owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                  owl:onClass time:Instant
+                                ] ;
+                dcterms:description "An organisation (business, corporation, federation, etc.) or moral agent (government body)."@en ,
+                                    "Eine Organisation (Unternehmen, Konzern, Verband usw.) oder ein moralischer Akteur (staatliche Stelle)."@de ;
+                rdfs:label "Organisation"@de ,
+                           "Organisation"@en ;
+                skos:definition "an Agent in the form of an administrative and functional structure participating in media related activities"@en ,
+                                "eine Agentin in Form einer administrativen und funktionalen Struktur, die an medienbezogenen Aktivitäten teilnimmt"@de ;
+                skos:example """- PSM organisations
+- EBU
+- collecting society
+- film studios
+- cinemas
+- authors' union"""@en ,
+                             """- PSM-Organisationen
+- EBU
+- Verwertungsgesellschaft
+- Filmstudios
+- Kinos
+- Autorenverband"""@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#PartType
+ec:PartType rdf:type owl:Class ;
+            rdfs:subClassOf skos:Concept ;
+            dcterms:description "An entry from a list of types to classify media resources."@en ,
+                                "Ein Eintrag aus einer Liste von Typen zur Klassifizierung von Medienressourcen."@de ;
+            rdfs:label "Part type"@en ,
+                       "Teiltyp"@de ;
+            skos:definition "a skos:Concept classifying the type of a ec:MediaResource"@en ,
+                            "ein skos:Concept zur Klassifizierung des Typs einer ec:MediaResource"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Person
+ec:Person rdf:type owl:Class ;
+          rdfs:subClassOf ec:Agent ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasAffiliation ;
+                            owl:allValuesFrom ec:Affiliation
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasIdPicture ;
+                            owl:allValuesFrom ec:Picture
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasKeyCareerEvent ;
+                            owl:allValuesFrom ec:KeyCareerEvent
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasKeyPersonalEvent ;
+                            owl:allValuesFrom ec:KeyPersonalEvent
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasCountryOfBirth ;
+                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                            owl:onClass ec:CountryCode
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasCountryOfDeath ;
+                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                            owl:onClass ec:CountryCode
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasDateOfBirth ;
+                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                            owl:onClass time:Instant
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasDateOfDeath ;
+                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                            owl:onClass time:Instant
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasDateOfRetirement ;
+                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                            owl:onClass time:Instant
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasPlaceOfBirth ;
+                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                            owl:onClass ec:Location
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasPlaceOfDeath ;
+                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                            owl:onClass ec:Location
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:education ;
+                            owl:allValuesFrom rdfs:Literal
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:familyInformation ;
+                            owl:allValuesFrom rdfs:Literal
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:familyName ;
+                            owl:allValuesFrom rdfs:Literal
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:givenName ;
+                            owl:allValuesFrom rdfs:Literal
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hobbies ;
+                            owl:allValuesFrom rdfs:Literal
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:middleName ;
+                            owl:allValuesFrom rdfs:Literal
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:occupation ;
+                            owl:allValuesFrom rdfs:Literal
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:officeEmailAddress ;
+                            owl:allValuesFrom xsd:string
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:officeMobileTelephoneNumber ;
+                            owl:allValuesFrom xsd:string
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:officeTelephoneNumber ;
+                            owl:allValuesFrom xsd:string
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:personWeight ;
+                            owl:allValuesFrom rdfs:Literal
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:privateEmailAddress ;
+                            owl:allValuesFrom xsd:string
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:privateHomepage ;
+                            owl:allValuesFrom xsd:anyURI
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:privateMobileTelephoneNumber ;
+                            owl:allValuesFrom xsd:string
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:privateTelephoneNumber ;
+                            owl:allValuesFrom xsd:string
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:salutationTitle ;
+                            owl:allValuesFrom rdfs:Literal
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:suffix ;
+                            owl:allValuesFrom rdfs:Literal
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:username ;
+                            owl:allValuesFrom rdfs:Literal
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:age ;
+                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                            owl:onDataRange xsd:integer
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:gender ;
+                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:maritalStatus ;
+                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:personHeight ;
+                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                          ] ;
+          dcterms:description "A person who is an individual agent in the media domain."@en ,
+                              "Eine Person, die im Medienbereich ein individueller Akteur ist."@de ;
+          rdfs:label "Person"@de ,
+                     "Person"@en ;
+          skos:definition "an individual Agent"@en ,
+                          "ein individueller Agent"@de ;
+          skos:example """- Alfred Hitchcock (Regisseur)
+- James Bond (Figur)
+- Sean Connery (Schauspieler)
+- John Ford (Pseudonym, das vom Regisseur John Martin Feeney verwendet wurde)"""@de ,
+                       """- Alfred Hitchcock (director)
+- James Bond (character)
+- Sean Connery (actor)
+- John Ford (pseudonym used by the director John Martin Feeney)"""@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#PhysicalResource
+ec:PhysicalResource rdf:type owl:Class ;
+                    rdfs:subClassOf ec:Resource ;
+                    dcterms:description "A tangible resource for the storage and transportation of media content, e.g. a tape."@en ,
+                                        "Eine greifbare Ressource für die Speicherung und den Transport von Medieninhalten, z. B. ein Band."@de ;
+                    rdfs:label "Physical resource"@en ,
+                               "Physische Ressource"@de ;
+                    skos:definition "a tangible ec:Resource for the storage and transportation of media content"@en ,
+                                    "ein greifbarer ec:Resource für die Speicherung und den Transport von Medieninhalten"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Pictogram
+ec:Pictogram rdf:type owl:Class ;
+             rdfs:subClassOf ec:Picture ;
+             dcterms:description "A picture, often abstracted, simplified or graphical, that represents a concept and aids non-verbal communication."@en ,
+                                 "Ein Bild, oft abstrahiert, vereinfacht oder grafisch gestaltet, das ein Konzept darstellt und die nonverbale Kommunikation unterstützt."@de ;
+             rdfs:label "Pictogram"@en ,
+                        "Piktogramm"@de ;
+             skos:definition "a ec:Picture, often abstracted, that represents or symbolizes a concept to aid non-verbal communication"@en ,
+                             "ein ec:Picture, oft abstrahiert, das ein Konzept darstellt oder symbolisiert, um nichtverbale Kommunikation zu unterstützen"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Picture
+ec:Picture rdf:type owl:Class ;
+           rdfs:subClassOf ec:Resource ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:hasEncodingFormat ;
+                             owl:allValuesFrom ec:EncodingFormat
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:hasImageCodec ;
+                             owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                             owl:onClass ec:ImageCodec
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:hasImageFormat ;
+                             owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                             owl:onClass ec:ImageFormat
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:aspectRatio ;
+                             owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                             owl:onDataRange xsd:string
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:frameHeight ;
+                             owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                             owl:onDataRange xsd:integer
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:frameHeightUnit ;
+                             owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:frameWidth ;
+                             owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                             owl:onDataRange xsd:integer
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:frameWidthUnit ;
+                             owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                           ] ;
+           dcterms:description "A photography, a logo, and a pictogram."@en ,
+                               "Ein Foto, ein Logo und ein Piktogramm."@de ;
+           rdfs:label "Bild"@de ,
+                      "Picture"@en ;
+           skos:definition "a Resource in the form of an encoded picture"@en ,
+                           "eine Ressource in Form eines kodierten Bildes"@de ;
+           skos:example """- a JPEG file of a photo, a logo, a graphic, ...
+- a PNG file of a photo, a logo, a graphic, ..."""@en ,
+                        """- eine JPEG-Datei eines Fotos, eines Logos, einer Grafik, ...
+- eine PNG-Datei eines Fotos, eines Logos, einer Grafik, ..."""@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#PictureDisplayFormat
+ec:PictureDisplayFormat rdf:type owl:Class ;
+                        rdfs:subClassOf ec:Format ;
+                        dcterms:description "An entry from the classification of formats that a display can have."@en ,
+                                            "Ein Eintrag aus der Klassifikation der Formate, die eine Anzeige haben kann."@de ;
+                        rdfs:label "Bildanzeigeformat-Code"@de ,
+                                   "Picture display format code"@en ;
+                        skos:definition "a ec:Format classifying the format of a display"@en ,
+                                        "eine ec:Format-Klasse zur Klassifizierung des Formats einer Anzeige"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Post
+ec:Post rdf:type owl:Class ;
+        rdfs:subClassOf ec:EditorialWork ;
+        dcterms:description "A combination of text, graphics, sometimes video or audio, created to be published on a social media platform or similar."@en ,
+                            "Eine Kombination aus Text, Grafiken, manchmal auch Video oder Audio, die zur Veröffentlichung auf einer Social-Media-Plattform oder einer ähnlichen Plattform erstellt wurde."@de ;
+        rdfs:label "Beitrag"@de ,
+                   "Post"@en ;
+        skos:definition "an ec:EditorialWork consisting of text, graphics, sometimes video or audio, created for publication on social media platforms or similar"@en ,
+                        "eine ec:EditorialWork bestehend aus Text, Grafiken, manchmal Video oder Audio, erstellt zur Veröffentlichung auf Social-Media-Plattformen oder Ähnlichem"@de ;
+        skos:example """- a tweet on twitter
+- a post on Facebook
+- a post on Instagram
+- a video-post on Youtube"""@en ,
+                     """- ein Tweet auf Twitter
+- ein Beitrag auf Facebook
+- ein Beitrag auf Instagram
+- ein Video-Beitrag auf YouTube"""@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ProductionDevice
+ec:ProductionDevice rdf:type owl:Class ;
+                    rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasIdentifier ;
+                                      owl:allValuesFrom ec:Identifier
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasObjectType ;
+                                      owl:allValuesFrom skos:Concept
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasProductionDeviceOnStagePosition ;
+                                      owl:allValuesFrom ec:OnStagePosition
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasUsageContract ;
+                                      owl:allValuesFrom ec:Contract
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:description ;
+                                      owl:allValuesFrom rdfs:Literal
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:name ;
+                                      owl:allValuesFrom rdfs:Literal
+                                    ] ;
+                    dcterms:description "A Device used for creating/processing a MediaResource."@en ,
+                                        "Ein Gerät zum Erstellen und Verarbeiten einer MediaResource."@de ;
+                    rdfs:label "Production device"@en ,
+                               "Produktionsgerät"@de ;
+                    skos:definition "a tool to facilitate activities in a ProductionJob"@en ,
+                                    "ein Werkzeug zur Unterstützung von Aktivitäten in einem ProductionJob"@de ;
+                    skos:example """- a camera
+- a microphone
+- a video or sound mixer
+- a video or sound editor
+- spot lights
+- a LED wall"""@en ,
+                                 """- eine Kamera
+- ein Mikrofon
+- ein Video- oder Tonmischpult
+- ein Video- oder Tonschnittsystem
+- Scheinwerfer
+- eine LED-Wand"""@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ProductionJob
+ec:ProductionJob rdf:type owl:Class ;
+                 rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:basedOn ;
+                                   owl:allValuesFrom ec:EditorialObject
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:createsMetadata ;
+                                   owl:allValuesFrom ec:EditorialObject
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasContributor ;
+                                   owl:allValuesFrom ec:Involvement
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasIdentifier ;
+                                   owl:allValuesFrom ec:Identifier
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasInputMediaResource ;
+                                   owl:allValuesFrom ec:MediaResource
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasInputResource ;
+                                   owl:allValuesFrom ec:Resource
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasObjectType ;
+                                   owl:allValuesFrom skos:Concept
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasOutputEssence ;
+                                   owl:allValuesFrom ec:Essence
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasOutputMediaResource ;
+                                   owl:allValuesFrom ec:MediaResource
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasOutputResource ;
+                                   owl:allValuesFrom ec:Resource
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasPreviousRelated ;
+                                   owl:allValuesFrom ec:ProductionJob
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasProductionJobEvent ;
+                                   owl:allValuesFrom ec:Event
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasProductionJobLocation ;
+                                   owl:allValuesFrom ec:Location
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasSubJob ;
+                                   owl:allValuesFrom ec:ProductionJob
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:isOrderedBy ;
+                                   owl:allValuesFrom ec:Contract
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:usesProductionDevice ;
+                                   owl:allValuesFrom ec:ProductionDevice
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasEndDateTime ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass time:Instant
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasStartDateTime ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass time:Instant
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:description ;
+                                   owl:allValuesFrom rdfs:Literal
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:name ;
+                                   owl:allValuesFrom rdfs:Literal
+                                 ] ;
+                 dcterms:description "A job / process to be performed to manipulate/create/modify/store, etc., MediaResources and Essences as defined in an associated EditorialObject. It is ordered by Contract."@en ,
+                                     "Ein Job-/Prozess, der zur Manipulation/Erstellung/Änderung/Speicherung usw. von MediaResources und Essences, wie sie in einem zugehörigen EditorialObject definiert sind, auszuführen ist. Er wird durch Contract geordnet."@de ;
+                 rdfs:label "Production job"@en ,
+                            "Produktionsauftrag"@de ;
+                 skos:definition "a task or set of tasks to create, modify, manipulate, store, or otherwise process a MediaResource"@en ,
+                                 "eine Aufgabe oder eine Aufgabengruppe zum Erstellen, Ändern, Manipulieren, Speichern oder anderweitigen Verarbeiten einer MediaResource"@de ;
+                 skos:example """- a live show production for broadcasting
+- filming and editing a news clip
+- an outsourced production of a complete movie"""@en ,
+                              """- eine Live-Show-Produktion für die Ausstrahlung
+- das Filmen und Schneiden eines Nachrichtenbeitrags
+- eine ausgelagerte Produktion eines vollständigen Films"""@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ProductionOrder
+ec:ProductionOrder rdf:type owl:Class ;
+                   rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasIdentifier ;
+                                     owl:allValuesFrom ec:Identifier
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasObjectType ;
+                                     owl:allValuesFrom skos:Concept
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasProductionContract ;
+                                     owl:allValuesFrom ec:Contract
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:description ;
+                                     owl:allValuesFrom rdfs:Literal
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:name ;
+                                     owl:allValuesFrom rdfs:Literal
+                                   ] ;
+                   dcterms:description "A formal request for the creation, production, purchase or reuse of media resources, often resulting from a contract with a third party."@en ,
+                                       "Eine formale Anfrage zur Erstellung, Produktion, zum Kauf oder zur Wiederverwendung von Medienressourcen, die oft aus einem Vertrag mit einem Dritten resultiert."@de ;
+                   rdfs:label "Production order"@en ,
+                              "Produktionsauftrag"@de ;
+                   skos:definition "a formal request for the creation, production, purchase or reuse of ec:MediaResources often resulting from a ec:Contract"@en ,
+                                   "ein formeller Antrag auf die Erstellung, Produktion, den Kauf oder die Wiederverwendung von ec:MediaResources, oft als Ergebnis eines ec:Contract"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Programme
+ec:Programme rdf:type owl:Class ;
+             rdfs:subClassOf ec:EditorialWork ,
+                             [ rdf:type owl:Restriction ;
+                               owl:onProperty ec:isEpisodeOfSeason ;
+                               owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                               owl:onClass ec:Season
+                             ] ,
+                             [ rdf:type owl:Restriction ;
+                               owl:onProperty ec:isEpisodeOfSerial ;
+                               owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                               owl:onClass ec:Serial
+                             ] ,
+                             [ rdf:type owl:Restriction ;
+                               owl:onProperty ec:isEpisodeOfSeries ;
+                               owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                               owl:onClass ec:Series
+                             ] ,
+                             [ rdf:type owl:Restriction ;
+                               owl:onProperty ec:episodeNumber ;
+                               owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                               owl:onDataRange xsd:integer
+                             ] ,
+                             [ rdf:type owl:Restriction ;
+                               owl:onProperty ec:episodeNumberInSeason ;
+                               owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                               owl:onDataRange xsd:integer
+                             ] ,
+                             [ rdf:type owl:Restriction ;
+                               owl:onProperty ec:episodeNumberInSerial ;
+                               owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                               owl:onDataRange xsd:integer
+                             ] ,
+                             [ rdf:type owl:Restriction ;
+                               owl:onProperty ec:episodeNumberInSeries ;
+                               owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                               owl:onDataRange xsd:integer
+                             ] ;
+             dcterms:description "A stand-alone work or an episode of a serial or a series, created to be published and consumed as a whole."@en ,
+                                 "Ein eigenständiges Werk oder eine Episode einer Serie oder Reihenfolge, die als Ganzes veröffentlicht und konsumiert werden soll."@de ;
+             rdfs:label "Programm"@de ,
+                        "Programme"@en ;
+             skos:definition "an ec:EditorialWork as a stand-alone content or an episode of a ec:Serial or ec:Series and created to be published and consumed as a whole"@en ,
+                             "ein ec:EditorialWork als eigenständiger Inhalt oder eine Episode einer ec:Serial oder ec:Series und zur Veröffentlichung und Nutzung als Ganzes erstellt"@de ;
+             skos:example """- der Film „Titanic“
+- die Folge 2 „The Blind Banker“ der Serie „Sherlock“, einer Detektivserie
+- die heutige Folge von „BBC News“, der täglichen Nachrichtensendung
+- die Folge 2 „Frozen Worlds“ der Serie „Our Planet“, einer Naturdokumentationsserie
+- die Folge des BBC-Serienformats „Panorama“ vom nächsten Montag, ein politischer Bericht"""@de ,
+                          """- the movie \"Titanic\"
+- the episode 2 \"The Blind Banker\" of the series \"Sherlock\", a detective series
+- today's episode of \"BBC News\", the daily news show serial
+- the episode 2 \"Frozen Worlds\" of the series \"Our Planet\", a nature documentary series
+- next Monday's episode of the BBC serial \"Panorama\", a political report"""@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Promotion
+ec:Promotion rdf:type owl:Class ;
+             rdfs:subClassOf ec:EditorialWork ,
+                             [ rdf:type owl:Restriction ;
+                               owl:onProperty ec:isMemberOf ;
+                               owl:allValuesFrom ec:CampaignPackage
+                             ] ;
+             dcterms:description "An advertisement, e.g. for a car model, an event, a programme, a travel offer or similar."@en ,
+                                 "Eine Werbung, z. B. für ein Automodell, eine Veranstaltung, ein Programm, ein Reiseangebot oder Ähnliches."@de ;
+             rdfs:label "Promotion"@en ,
+                        "Werbung"@de ;
+             skos:definition "an ec:EditorialWork for advertising purposes"@en ,
+                             "eine ec:EditorialWork für Werbezwecke"@de ;
+             skos:example """- an ad for an insurance company
+- a promotion-clip for a PSM, one of its channels, its brands"""@en ,
+                          """- eine Anzeige für ein Versicherungsunternehmen
+- ein Promotion-Clip für einen PSM, einen seiner Kanäle oder seine Marken"""@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Props
+ec:Props rdf:type owl:Class ;
+         rdfs:subClassOf ec:Artefact ;
+         dcterms:description "Ein Objekt, das in einer Szene sichtbar oder hörbar ist und absichtlich wegen seines Werts für den entstehenden Inhalt ausgewählt wurde, wie etwa ein Stein, eine Waffe, eine Tasche usw."@de ,
+                             "Some object that is visible or audible in a scene and deliberately chosen for its value to the resulting content, such as a stone, a weapon, a bag, etc."@en ;
+         rdfs:label "Props"@en ,
+                    "Requisiten"@de ;
+         skos:definition "an object deliberately chosen to appear in a scene of the ec:EditorialObject"@en ,
+                         "ein Objekt, das absichtlich ausgewählt wurde, um in einer Szene des ec:EditorialObject aufzutauchen"@de ;
+         skos:example """- a car in a movie
+- furniture in a movie
+- a buzzer in a quiz show"""@en ,
+                      """- ein Auto in einem Film
+- Möbel in einem Film
+- ein Summer in einer Quizshow"""@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Provenance
+ec:Provenance rdf:type owl:Class ;
+              rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:hasIdentifier ;
+                                owl:allValuesFrom ec:Identifier
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:hasObjectType ;
+                                owl:allValuesFrom skos:Concept
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:hasProvenanceTarget ;
+                                owl:allValuesFrom owl:Thing
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:isAttributedTo ;
+                                owl:allValuesFrom ec:Agent
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:hasDateCreated ;
+                                owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                owl:onClass time:DateTimeDescription
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:hasDateModified ;
+                                owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                owl:onClass time:DateTimeDescription
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:description ;
+                                owl:allValuesFrom rdfs:Literal
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:name ;
+                                owl:allValuesFrom rdfs:Literal
+                              ] ;
+              dcterms:description "Provenance records can identify the data object whose history is described, the agent to which it is attributed, and relevant creation or modification dates."@en ,
+                                  "Provenienzdatensätze können das Datenobjekt identifizieren, dessen Verlauf beschrieben wird, den Agenten, dem es zugeschrieben wird, sowie relevante Erstellungs- oder Änderungsdaten."@de ;
+              rdfs:label "Provenance"@en ,
+                         "Provenienz"@de ;
+              skos:definition "a set of properties describing the origin and life cycle of a data object"@en ,
+                              "eine Menge von Eigenschaften, die den Ursprung und den Lebenszyklus eines Datenobjekts beschreiben"@de ;
+              skos:example """- das creationDate eines Datenobjekts
+- das System, aus dem das Datenobjekt ursprünglich abgerufen wurde"""@de ,
+                           """- the creationDate of a data object
+- the system from which the data object was originally retrieved"""@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Pseudonym
+ec:Pseudonym rdf:type owl:Class ;
+             rdfs:subClassOf ec:Person ;
+             dcterms:description "A pseudonym is a fictitious name used by an author, an actor or others, invented to hide the real name, to sound better, to foster associations or similar."@en ,
+                                 "Ein Pseudonym ist ein erfundener Name, der von einem Autor, einem Schauspieler oder anderen verwendet wird und dazu dient, den wirklichen Namen zu verbergen, besser zu klingen, Assoziationen hervorzurufen oder Ähnliches."@de ;
+             rdfs:label "Pseudonym"@de ,
+                        "Pseudonym"@en ;
+             skos:definition "a fictitious ec:Person mainly described by its name that is used to hide the name of the real ec:Person"@en ,
+                             "eine fiktive ec:Person, die hauptsächlich durch ihren Namen beschrieben wird und dazu verwendet wird, den Namen der echten ec:Person zu verbergen"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#PublicationChannel
+ec:PublicationChannel rdf:type owl:Class ;
+                      rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:accountingTo ;
+                                        owl:allValuesFrom ec:Account
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:hasConsumptionCount ;
+                                        owl:allValuesFrom ec:Audience
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:hasIdentifier ;
+                                        owl:allValuesFrom ec:Identifier
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:hasLogo ;
+                                        owl:allValuesFrom ec:Logo
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:hasObjectType ;
+                                        owl:allValuesFrom skos:Concept
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:hasRelatedPublicationChannel ;
+                                        owl:allValuesFrom ec:PublicationChannel
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:hasTargetAudience ;
+                                        owl:allValuesFrom ec:Audience
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:isOperatedBy ;
+                                        owl:allValuesFrom ec:PublicationService
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:isOwnedBy ;
+                                        owl:allValuesFrom ec:Agent
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:transports ;
+                                        owl:allValuesFrom ec:PublicationService
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:hasEndDateTime ;
+                                        owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                        owl:onClass time:Instant
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:hasStartDateTime ;
+                                        owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                        owl:onClass time:Instant
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:description ;
+                                        owl:allValuesFrom rdfs:Literal
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:name ;
+                                        owl:allValuesFrom rdfs:Literal
+                                      ] ;
+                      dcterms:description "A connection through which a consumption device can consume a service, e.g. a cable receiver for linear services on a cable network, an FM receiver for linear audio services, the YouTube.com webpage or the YouTube application on Android for the VoD service YouTube, the BBC iPlayer App on LG Smart-TVs for BBC's VoD, event streaming and live streaming services."@en ,
+                                          "Eine Verbindung, über die ein Endgerät einen Dienst empfangen kann, z. B. ein Kabelreceiver für lineare Dienste in einem Kabelnetz, ein FM-Empfänger für lineare Audiodienste, die Webseite YouTube.com oder die YouTube-Anwendung auf Android für den VoD-Dienst YouTube, die BBC-iPlayer-App auf LG-Smart-TVs für die VoD-, Event-Streaming- und Live-Streaming-Dienste der BBC."@de ;
+                      rdfs:label "Publication channel"@en ,
+                                 "Publikationskanal"@de ;
+                      skos:definition "a connection through which a ec:ConsumptionDevice can consume ec:PublicationServices"@en ,
+                                      "eine Verbindung, über die ein ec:ConsumptionDevice ec:PublicationServices empfangen kann"@de ;
+                      skos:example """- der DVB-S-Kanal bei 10714 MHz H auf dem Satelliten Astra 2E für den linearen Videodienst „BBC One HD\"
+- der DVB-T-Kanal E23 in London/Chrystal Palace für den linearen Videodienst „BBC One London\"
+- der Live-Videostream „BBC One“ innerhalb von BBC iPlayer
+- der Kanal @bbcradio1 auf youtube für den On-Demand-Videodienst „BBC Radio 1 visual radio\"
+- der Kanal @elonmusk auf twitter für einen sozialen Textdienst „Elon Musk's Tweets\""""@de ,
+                                   """- the DVB-S channel at 10714 MHz H on the Astra 2E satellite for the linear video service \"BBC One HD\"
+- the DVB-T channel E23 in London/Chrystal Palace for the linear video service \"BBC One London\"
+- the live video stream \"BBC One\" within the BBC iPlayer
+- the channel @bbcradio1 on youtube for the on demand video service \"BBC Radio 1 visual radio\"
+- the channel @elonmusk on twitter for a social text service \"Elon Musk's Tweets\""""@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#PublicationChannelType
+ec:PublicationChannelType rdf:type owl:Class ;
+                          rdfs:subClassOf skos:Concept ;
+                          dcterms:description "An entry from a list of types to classify publication channels."@en ,
+                                              "Ein Eintrag aus einer Liste von Typen zur Klassifizierung von Veröffentlichungskanälen."@de ;
+                          rdfs:label "Publication channel type"@en ,
+                                     "Publikationskanaltyp"@de ;
+                          skos:definition "a skos:Concept classifying the type of a ec:PublicationChannel"@en ,
+                                          "ein skos:Concept zur Klassifizierung des Typs einer ec:PublicationChannel"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#PublicationEvent
+ec:PublicationEvent rdf:type owl:Class ;
+                    rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasAccessConditions ;
+                                      owl:allValuesFrom ec:AccessConditions
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasAlternativeTitle ;
+                                      owl:allValuesFrom ec:AlternativeTitle
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasConsumptionCount ;
+                                      owl:allValuesFrom ec:ConsumptionCount
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasCoverageRestrictions ;
+                                      owl:allValuesFrom ec:CoverageRestrictions
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasIdentifier ;
+                                      owl:allValuesFrom ec:Identifier
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasObjectType ;
+                                      owl:allValuesFrom skos:Concept
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasPublicationChannel ;
+                                      owl:allValuesFrom ec:PublicationChannel
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasPublicationEvent ;
+                                      owl:allValuesFrom ec:PublicationEvent
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasPublicationMedium ;
+                                      owl:allValuesFrom ec:PublicationMedium
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasPublicationRegion ;
+                                      owl:allValuesFrom ec:Location
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasRestrictedAudience ;
+                                      owl:allValuesFrom ec:Audience
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasRights ;
+                                      owl:allValuesFrom ec:Rights
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasTargetAudience ;
+                                      owl:allValuesFrom ec:Audience
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasUsageRestrictions ;
+                                      owl:allValuesFrom ec:UsageRestrictions
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:isOfferedBy ;
+                                      owl:allValuesFrom ec:PublicationService
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:playsOut ;
+                                      owl:allValuesFrom ec:Essence
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:publishes ;
+                                      owl:allValuesFrom ec:EditorialObject
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasStartDateTime ;
+                                      owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                      owl:onClass time:Instant
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasDuration ;
+                                      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                      owl:onClass ec:TimelinePoint
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasEndDateTime ;
+                                      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                      owl:onClass time:DateTimeDescription
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasScheduleDate ;
+                                      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                      owl:onClass time:Instant
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:title ;
+                                      owl:someValuesFrom rdfs:Literal
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:abstract ;
+                                      owl:allValuesFrom rdfs:Literal
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:description ;
+                                      owl:allValuesFrom rdfs:Literal
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:name ;
+                                      owl:allValuesFrom rdfs:Literal
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:firstShowing ;
+                                      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                      owl:onDataRange xsd:boolean
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:firstShowingThisService ;
+                                      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                      owl:onDataRange xsd:boolean
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:free ;
+                                      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                      owl:onDataRange xsd:boolean
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:live ;
+                                      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                      owl:onDataRange xsd:boolean
+                                    ] ;
+                    owl:disjointWith ec:Rating ;
+                    dcterms:description "Die Zeit oder der Zeitraum und der Mediendienst, innerhalb derer bzw. innerhalb dessen der Inhalt für Geräte von Verbrauchern technisch zugänglich gemacht wird, z. B. die Ausstrahlung einer geplanten Nachrichtensendung, das Hochladen einer Dokumentation auf eine VoD-Plattform oder das Posten eines Memes auf Instagram."@de ,
+                                        "The time or time span and the media service within which the content is made technically accessible for devices of consumers, e.g. broadcasting a scheduled news show, uploading a documentary to a VoD platform, posting a meme on Instagram."@en ;
+                    rdfs:label "Publication event"@en ,
+                               "Veröffentlichungsereignis"@de ;
+                    skos:definition "a time or time span and the ec:PublicationService within which an ec:Essence is made technically accessible for ec:ConsumptionDevices of ec:Consumers"@en ,
+                                    "eine Zeit oder Zeitspanne und der ec:PublicationService, innerhalb der ec:Essence technisch zugänglich gemacht wird für ec:ConsumptionDevices von ec:Consumers"@de ;
+                    skos:example """- die Ausstrahlung des Fußball-Weltmeisterschaftsfinales 2022 in einem Live-Video-Dienst über Satellit durch die BBC in Großbritannien
+- das Posting von Elon Musks Text „Als Nächstes kaufe ich Coca Cola, um das Kokain wieder hineinzulegen“ auf Twitter, am 27. April 2022, in seinem Kanal @elonmusk"""@de ,
+                                 """- the broadcasting of the football world cup final 2022 in a live video service over satellite by the BBC in Great Britain
+- the posting of Elon Musk's text \"Next I'm buying Coca Cola to put the cocaine back in\" on twitter, April 27, 2022, in his channel @elonmusk"""@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#PublicationEventType
+ec:PublicationEventType rdf:type owl:Class ;
+                        rdfs:subClassOf skos:Concept ;
+                        dcterms:description "An entry from a list of types to classify publication events."@en ,
+                                            "Ein Eintrag aus einer Liste von Typen zur Klassifizierung von Veröffentlichungsereignissen."@de ;
+                        rdfs:label "Publication event type"@en ,
+                                   "Publikationsereignistyp"@de ;
+                        skos:definition "a skos:Concept classifying the type of a ec:PublicationEvent"@en ,
+                                        "ein skos:Concept zur Klassifizierung des Typs eines ec:PublicationEvent"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#PublicationHistory
+ec:PublicationHistory rdf:type owl:Class ;
+                      rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:hasPublicationEvent ;
+                                        owl:someValuesFrom ec:PublicationEvent
+                                      ] ;
+                      dcterms:description "A collection of publication events of the content."@en ,
+                                          "Eine Sammlung von Veröffentlichungsereignissen des Inhalts."@de ;
+                      rdfs:label "Publication history"@en ,
+                                 "Publikationsverlauf"@de ;
+                      skos:definition "a collection of ec:PublicationEvents of an ec:EditorialObject"@en ,
+                                      "eine Sammlung von ec:PublicationEvents eines ec:EditorialObject"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#PublicationLog
+ec:PublicationLog rdf:type owl:Class ;
+                  rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:hasResourceOffset ;
+                                    owl:someValuesFrom ec:TimelinePoint
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:hasStartDateTime ;
+                                    owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                    owl:onClass time:Instant
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:logs ;
+                                    owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                    owl:onClass ec:PublicationEvent
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:hasEndDateTime ;
+                                    owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                    owl:onClass time:Instant
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:hasObjectType ;
+                                    owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                    owl:onClass skos:Concept
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:description ;
+                                    owl:allValuesFrom rdfs:Literal
+                                  ] ;
+                  dcterms:description "A collection of consecutive publication events of a service."@en ,
+                                      "Eine Sammlung aufeinanderfolgender Veröffentlichungsereignisse eines Dienstes."@de ;
+                  rdfs:label "Publication log"@en ,
+                             "Publikationsprotokoll"@de ;
+                  skos:definition "a collection of consecutive ec:PublicationEvents of a ec:PublicationService"@en ,
+                                  "eine Sammlung aufeinanderfolgender ec:PublicationEvents eines ec:PublicationService"@de ;
+                  skos:example """- das „as run log“ eines linearen TV-Playout-Systems für einen ganzen Tag
+- das „as run log“ eines linearen Radio-Playout-Systems für den Morgen"""@de ,
+                               """- the \"as run log\" of a linear TV playout system for a full day
+- the \"as run log\" of a linear radio playout system for the morning"""@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#PublicationMedium
+ec:PublicationMedium rdf:type owl:Class ;
+                     rdfs:subClassOf skos:Concept ;
+                     dcterms:description "An entry from a list of types to classify the publication medium, e.g. radio, tv, internet, online, streaming."@en ,
+                                         "Ein Eintrag aus einer Liste von Typen zur Klassifizierung des Veröffentlichungsmediums, z. B. Radio, Fernsehen, Internet, Online, Streaming."@de ;
+                     rdfs:label "Publication medium"@en ,
+                                "Veröffentlichungsmedium"@de ;
+                     skos:definition "a skos:Concept classifying the type of a ec:PublicationMedium"@en ,
+                                     "ein skos:Concept, der den Typ von ec:PublicationMedium klassifiziert"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#PublicationPlan
+ec:PublicationPlan rdf:type owl:Class ;
+                   rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasPublicationEvent ;
+                                     owl:someValuesFrom ec:PublicationEvent
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasAsset ;
+                                     owl:allValuesFrom ec:Asset
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasAssociatedProductionOrder ;
+                                     owl:allValuesFrom ec:ProductionOrder
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasBusinessContract ;
+                                     owl:allValuesFrom ec:Contract
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasIdentifier ;
+                                     owl:allValuesFrom ec:Identifier
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasObjectType ;
+                                     owl:allValuesFrom skos:Concept
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasPublicationPlanMember ;
+                                     owl:allValuesFrom ec:PublicationPlan
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasStakeholder ;
+                                     owl:allValuesFrom ec:Agent
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:isMemberOf ;
+                                     owl:allValuesFrom ec:PublicationPlan
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasEndDateTime ;
+                                     owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                     owl:onClass time:Instant
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasPublicationPlanStatus ;
+                                     owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                     owl:onClass skos:Collection
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasStartDateTime ;
+                                     owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                     owl:onClass time:Instant
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:description ;
+                                     owl:allValuesFrom rdfs:Literal
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:name ;
+                                     owl:allValuesFrom rdfs:Literal
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:publicationPlanTitle ;
+                                     owl:allValuesFrom rdfs:Literal
+                                   ] ;
+                   dcterms:description "A collection of scheduled publication events related to a targeted audience (e.g. a list of publications for sports lovers), promotion material for a content (e.g. a campaign of several commercials for a product), a time span in a media service (e.g. a full day's programme in a linear service), or other useful criteria."@en ,
+                                       "Eine Sammlung geplanter Veröffentlichungsereignisse in Bezug auf eine Zielgruppe (z. B. eine Liste von Veröffentlichungen für Sportliebhaber), Werbematerial für einen Inhalt (z. B. eine Kampagne mehrerer Werbespots für ein Produkt), ein Zeitabschnitt in einem Mediendienst (z. B. das Tagesprogramm eines linearen Dienstes) oder andere nützliche Kriterien."@de ;
+                   rdfs:label "Publication plan"@en ,
+                              "Veröffentlichungsplan"@de ;
+                   skos:definition "a collection of scheduled ec:PublicationEvents related to a targeted ec:Audience, promotion material for an ec:EditorialObject, a time span in a ec:PublicationService or other useful criteria"@en ,
+                                   "eine Sammlung geplanter ec:PublicationEvents, die sich auf eine zielgerichtete ec:Audience beziehen, Werbematerial für ein ec:EditorialObject, ein Zeitabschnitt in einem ec:PublicationService oder andere nützliche Kriterien"@de ;
+                   skos:example """- das geplante Datum, die geplante Uhrzeit und der geplante Übertragungskanal für die Veröffentlichung eines Films
+- die geplanten Daten, Uhrzeiten und Übertragungskanäle für die Veröffentlichung der Episoden einer Serie
+- der geplante Sendeplan für einen Kanal während eines Tages
+- die geplanten Daten, Uhrzeiten und Übertragungskanäle für eine Sammlung von Inhalten zu einem gemeinsamen Thema"""@de ,
+                                """- the planned date, time and channel for the publication of a movie
+- the planned dates, times and channels for the publication of the episodes of a serial
+- the planned schedule for a channel during one day
+- the planned dates, times and channels for a collection of content about a common theme"""@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#PublicationPlanType
+ec:PublicationPlanType rdf:type owl:Class ;
+                       rdfs:subClassOf skos:Concept ;
+                       dcterms:description "An entry from a list of types to classify the publication plan, like daily, monthly, yearly."@en ,
+                                           "Ein Eintrag aus einer Liste von Typen zur Klassifizierung des Veröffentlichungsplans, z. B. täglich, monatlich, jährlich."@de ;
+                       rdfs:label "Art des Veröffentlichungsplans"@de ,
+                                  "Publication plan type"@en ;
+                       skos:definition "a skos:Concept classifying the type of a ec:PublicationPlan"@en ,
+                                       "ein skos:Concept, der den Typ eines ec:PublicationPlan klassifiziert"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#PublicationPlatform
+ec:PublicationPlatform rdf:type owl:Class ;
+                       rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                         owl:onProperty ec:accountingTo ;
+                                         owl:allValuesFrom ec:Account
+                                       ] ,
+                                       [ rdf:type owl:Restriction ;
+                                         owl:onProperty ec:hasConsumptionCount ;
+                                         owl:allValuesFrom ec:Audience
+                                       ] ,
+                                       [ rdf:type owl:Restriction ;
+                                         owl:onProperty ec:hasIdentifier ;
+                                         owl:allValuesFrom ec:Identifier
+                                       ] ,
+                                       [ rdf:type owl:Restriction ;
+                                         owl:onProperty ec:hasLogo ;
+                                         owl:allValuesFrom ec:Logo
+                                       ] ,
+                                       [ rdf:type owl:Restriction ;
+                                         owl:onProperty ec:hasObjectType ;
+                                         owl:allValuesFrom skos:Concept
+                                       ] ,
+                                       [ rdf:type owl:Restriction ;
+                                         owl:onProperty ec:hasPublicationChannel ;
+                                         owl:allValuesFrom ec:PublicationChannel
+                                       ] ,
+                                       [ rdf:type owl:Restriction ;
+                                         owl:onProperty ec:hasRelatedPublicationService ;
+                                         owl:allValuesFrom ec:PublicationService
+                                       ] ,
+                                       [ rdf:type owl:Restriction ;
+                                         owl:onProperty ec:hasTargetAudience ;
+                                         owl:allValuesFrom ec:Audience
+                                       ] ,
+                                       [ rdf:type owl:Restriction ;
+                                         owl:onProperty ec:isOwnedBy ;
+                                         owl:allValuesFrom ec:Agent
+                                       ] ,
+                                       [ rdf:type owl:Restriction ;
+                                         owl:onProperty ec:offers ;
+                                         owl:allValuesFrom ec:PublicationService
+                                       ] ,
+                                       [ rdf:type owl:Restriction ;
+                                         owl:onProperty ec:supportsConsumptionDeviceProfile ;
+                                         owl:allValuesFrom ec:ConsumptionDeviceProfile
+                                       ] ,
+                                       [ rdf:type owl:Restriction ;
+                                         owl:onProperty ec:hasEndDateTime ;
+                                         owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                         owl:onClass time:Instant
+                                       ] ,
+                                       [ rdf:type owl:Restriction ;
+                                         owl:onProperty ec:hasStartDateTime ;
+                                         owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                         owl:onClass time:Instant
+                                       ] ,
+                                       [ rdf:type owl:Restriction ;
+                                         owl:onProperty ec:description ;
+                                         owl:allValuesFrom rdfs:Literal
+                                       ] ,
+                                       [ rdf:type owl:Restriction ;
+                                         owl:onProperty ec:name ;
+                                         owl:allValuesFrom rdfs:Literal
+                                       ] ;
+                       dcterms:description "A facility that distributes media services so that devices can access them through a channel, e.g. a satellite network distributes a video broadcast service so that a TV-set can access it through a satellite receiver; a VoD platform distributes a non-linear service so that a tablet can access it through an application. Platforms can be uni- or bidirectional. Platforms support a range of services and channels. The choices are limited by technology or by negotiation between the media service provider and the platform provider."@en ,
+                                           "Eine Einrichtung, die Mediendienste verbreitet, damit Geräte über einen Kanal darauf zugreifen können; so verbreitet beispielsweise ein Satellitennetz einen Fernsehausstrahlungsdienst, damit ein Fernsehgerät ihn über einen Satellitenempfänger empfangen kann; eine VoD-Plattform verbreitet einen nichtlinearen Dienst, damit ein Tablet über eine Anwendung darauf zugreifen kann. Plattformen können ein- oder bidirektional sein. Plattformen unterstützen eine Reihe von Diensten und Kanälen. Die Auswahl wird durch die Technologie oder durch Verhandlungen zwischen dem Anbieter des Mediendienstes und dem Plattformanbieter begrenzt."@de ;
+                       rdfs:label "Publication platform"@en ,
+                                  "Publikationsplattform"@de ;
+                       skos:definition "a facility that distributes ec:PublicationServices so that ec:ConsumptionDevices can access them through ec:PublicationChannels"@en ,
+                                       "eine Einrichtung, die ec:PublicationServices so verteilt, dass ec:ConsumptionDevices über ec:PublicationChannels auf sie zugreifen können"@de ;
+                       skos:example """- die Eutelsat-DVB-S-Sendeplattform
+- die YouTube-Video-on-Demand-Plattform
+- alle über Internetprotokolle erreichbaren Server, die Inhalte in HTML oder ähnlichen Formaten anbieten oder empfangen
+- Fortnite, Decentraland oder Roblox als Metaversen"""@de ,
+                                    """- the Eutelsat DVB-S broadcasting platform
+- the youtube video on demand platform
+- all servers accessible via internet protocols and offering / taking content encoded in HTML or similar
+- Fortnite, Decentraland or Roblox as metaverses"""@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#PublicationService
+ec:PublicationService rdf:type owl:Class ;
+                      rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:accountingTo ;
+                                        owl:allValuesFrom ec:Account
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:hasBrand ;
+                                        owl:allValuesFrom ec:MarketingBrand
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:hasConsumptionCount ;
+                                        owl:allValuesFrom ec:Audience
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:hasIdentifier ;
+                                        owl:allValuesFrom ec:Identifier
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:hasLogo ;
+                                        owl:allValuesFrom ec:Logo
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:hasObjectType ;
+                                        owl:allValuesFrom skos:Concept
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:hasRelatedPublicationService ;
+                                        owl:allValuesFrom ec:PublicationService
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:hasServiceGenre ;
+                                        owl:allValuesFrom skos:Concept
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:hasTargetAudience ;
+                                        owl:allValuesFrom ec:Audience
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:isOwnedBy ;
+                                        owl:allValuesFrom ec:Agent
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:hasEndDateTime ;
+                                        owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                        owl:onClass time:Instant
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:hasStartDateTime ;
+                                        owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                        owl:onClass time:Instant
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:description ;
+                                        owl:allValuesFrom rdfs:Literal
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:name ;
+                                        owl:allValuesFrom rdfs:Literal
+                                      ] ;
+                      dcterms:description "A named media offering provided by a publisher, distributed by a platform and made accessible through a channel for devices to allow people to consume the service, e.g. a linear audio service distributed via FM; a non-linear video streaming service distributed via a PSM's own VoD platform; a YouTube channel distributed via the YouTube platform."@en ,
+                                          "Ein benanntes Medienangebot, das von einem Verlag bereitgestellt, von einer Plattform verbreitet und über einen Kanal für Geräte zugänglich gemacht wird, damit Menschen den Dienst nutzen können, z. B. ein linearer Audiodienst, der über FM verbreitet wird; ein nichtlinearer Video-Streaming-Dienst, der über die eigene VoD-Plattform eines PSM verbreitet wird; ein YouTube-Kanal, der über die YouTube-Plattform verbreitet wird."@de ;
+                      rdfs:label "Publication service"@en ,
+                                 "Veröffentlichungsdienst"@de ;
+                      skos:definition "a named media offering provided by a publishing ec:Agent, distributed by a ec:PublicationPlatform and made accessible through ec:PublicationChannels for ec:ConsumptionDevices to allow ec:Consumers to consume the service"@en ,
+                                      "ein benanntes Medienangebot, bereitgestellt von einem publizierenden ec:Agent, verteilt über eine ec:PublicationPlatform und zugänglich gemacht über ec:PublicationChannels für ec:ConsumptionDevices, damit ec:Consumers den Dienst nutzen können"@de ;
+                      skos:example """- der lineare Videodienst namens „BBC One“
+- der Video-on-Demand-Dienst von Netflix"""@de ,
+                                   """- the linear video service named \"BBC One\"
+- the video on demand service of Netflix"""@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Rating
+ec:Rating rdf:type owl:Class ;
+          rdfs:subClassOf [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasIdentifier ;
+                            owl:allValuesFrom ec:Identifier
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasLogo ;
+                            owl:allValuesFrom ec:Logo
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasObjectType ;
+                            owl:allValuesFrom skos:Concept
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasPictogram ;
+                            owl:allValuesFrom ec:Picture
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasTerritoryExcludes ;
+                            owl:allValuesFrom ec:CountryCode
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasTerritoryIncludes ;
+                            owl:allValuesFrom ec:CountryCode
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasRatingProvider ;
+                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                            owl:onClass ec:Agent
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:description ;
+                            owl:allValuesFrom rdfs:Literal
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:name ;
+                            owl:allValuesFrom rdfs:Literal
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:reason ;
+                            owl:allValuesFrom rdfs:Literal
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:ratingValue ;
+                            owl:cardinality "1"^^xsd:nonNegativeInteger
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:notRated ;
+                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                            owl:onDataRange xsd:boolean
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:ratingScaleMax ;
+                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:ratingScaleMin ;
+                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:ratingSystemEnvironment ;
+                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:ratingSystemName ;
+                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                          ] ;
+          dcterms:description "An evaluation of some content to judge the level of conformity with the applied criteria."@en ,
+                              "Eine Bewertung von Inhalten, um den Grad der Übereinstimmung mit den angewendeten Kriterien zu beurteilen."@de ;
+          rdfs:label "Bewertung"@de ,
+                     "Rating"@en ;
+          skos:definition "an evaluation of a ec:EditorialObject based on explainable criteria to judge the level of conformity"@en ,
+                          "eine Bewertung eines ec:EditorialObject basierend auf erklärbaren Kriterien zur Beurteilung des Konformitätsgrads"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Record
+ec:Record rdf:type owl:Class ;
+          rdfs:subClassOf ec:BibliographicalObject ;
+          dcterms:description "A written account of something that is kept for future reading or use."@en ,
+                              "Ein schriftlicher Bericht über etwas, der für späteres Lesen oder zur späteren Verwendung aufbewahrt wird."@de ;
+          rdfs:label "Aufzeichnung"@de ,
+                     "Record"@en ;
+          skos:definition "a ec:BibliographicalObject about something happening that is kept for later use"@en ,
+                          "ein ec:BibliographicalObject über etwas, das geschieht und für die spätere Verwendung aufbewahrt wird"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#RegionCode
+ec:RegionCode rdf:type owl:Class ;
+              rdfs:subClassOf skos:Concept ;
+              dcterms:description "An entry from a list of codes identifying regions of locations."@en ,
+                                  "Ein Eintrag aus einer Liste von Codes zur Identifizierung von Regionen von Orten."@de ;
+              rdfs:label "Region code"@en ,
+                         "Regionscode"@de ;
+              skos:definition "a skos:Concept identifying the region of a ec:Location"@en ,
+                              "ein skos:Concept, der die Region eines ec:Location identifiziert"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Relation
+ec:Relation rdf:type owl:Class ;
+            rdfs:subClassOf [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasIdentifier ;
+                              owl:allValuesFrom ec:Identifier
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasObjectType ;
+                              owl:allValuesFrom skos:Concept
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasRelationLink ;
+                              owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasRelationSource ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onClass ec:Agent
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:description ;
+                              owl:allValuesFrom rdfs:Literal
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:name ;
+                              owl:allValuesFrom rdfs:Literal
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:relationOrderedGroupFlag ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onDataRange xsd:boolean
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:relationRunningOrderNumber ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onDataRange xsd:integer
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:relationTotalNumberOfGroupMembers ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onDataRange xsd:integer
+                            ] ;
+            dcterms:description "A link between a person or organisation and a thing. The link can be classified, named, grouped and numbered."@en ,
+                                "Eine Verknüpfung zwischen einer Person oder Organisation und einer Sache. Die Verknüpfung kann klassifiziert, benannt, gruppiert und nummeriert werden."@de ;
+            rdfs:label "Relation"@de ,
+                       "Relation"@en ;
+            skos:definition "a link between a ec:Agent and a owl:Thing"@en ,
+                            "eine Verbindung zwischen einem ec:Agent und einem owl:Thing"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#RelationType
+ec:RelationType rdf:type owl:Class ;
+                rdfs:subClassOf skos:Concept ;
+                dcterms:description "An entry from a list of types to classify a relation."@en ,
+                                    "Ein Eintrag aus einer Liste von Typen zur Klassifizierung einer Relation."@de ;
+                rdfs:label "Relation type"@en ,
+                           "Relationstyp"@de ;
+                skos:definition "a skos:Concept identifying the type of a ec:Relation"@en ,
+                                "ein skos:Concept zur Identifizierung des Typs einer ec:Relation"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Reminder
+ec:Reminder rdf:type owl:Class ;
+            rdfs:subClassOf ec:EditorialWork ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasPromotion ;
+                              owl:allValuesFrom ec:Promotion
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:isMemberOf ;
+                              owl:allValuesFrom ec:CampaignPackage
+                            ] ;
+            dcterms:description "A content that refers to previous promotion created to remind the consumer of the advertised object."@en ,
+                                "Ein Inhalt, der sich auf eine frühere Promotion bezieht und dazu erstellt wurde, den Verbraucher an das beworbene Objekt zu erinnern."@de ;
+            rdfs:label "Erinnerung"@de ,
+                       "Reminder"@en ;
+            skos:definition "an ec:EditorialWork that reminds a consumer of previous ec:Promotion"@en ,
+                            "eine ec:EditorialWork, die einen Verbraucher an eine frühere ec:Promotion erinnert"@de ;
+            skos:example "- a 4 second repetition of the logo and the jingle of an insurance company, minutes after a 15 second advertisement"@en ,
+                         "- eine 4-sekündige Wiederholung des Logos und des Jingles eines Versicherungsunternehmens, wenige Minuten nach einer 15-sekündigen Werbung"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ResonanceCount
+ec:ResonanceCount rdf:type owl:Class ;
+                  rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:compilesResonanceEvents ;
+                                    owl:allValuesFrom ec:ResonanceEvent
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:hasIdentifier ;
+                                    owl:allValuesFrom ec:Identifier
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:hasLocator ;
+                                    owl:allValuesFrom ec:Locator
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:hasMeasurementAgent ;
+                                    owl:allValuesFrom ec:Agent
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:hasObjectType ;
+                                    owl:allValuesFrom skos:Concept
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:description ;
+                                    owl:allValuesFrom rdfs:Literal
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:name ;
+                                    owl:allValuesFrom rdfs:Literal
+                                  ] ;
+                  dcterms:description "Die Aggregation von Resonanzereignissen, oft innerhalb eines Zeitraums, um die Leistung eines Publikationsereignisses, eines Dienstes oder von Inhalten anzuzeigen, z. B. Marktanteil für das Live-Event \"UEFA Champions League Final 2025\", das auf DVB-Plattformen im Vergleich zu einem Live-Stream auf einer Breitband-Vertriebsplattform ausgestrahlt wird; die Anzahl positiver gegenüber negativen Kommentaren zu einem Instagram-Post innerhalb des ersten Tages nach der Veröffentlichung."@de ,
+                                      "The aggregation of resonance events, often within a time span, to indicate performance of a publication event, a service or content, e.g. market share for he live event \"UEFA Champions League Final 2025\" broadcast on DVB platforms compared to live stream on broadband distribution platform; the number of positive vs. negative comments on an instagram post within the first day of the publication."@en ;
+                  rdfs:label "Resonance"@en ,
+                             "Resonanz"@de ;
+                  skos:definition "an aggregation of ec:ResonanceEvents, often within a time span, to indicate performance of a ec:PublicationEvent, a ec:PublicationService or an ec:EditorialObject"@en ,
+                                  "eine Aggregation von ec:ResonanceEvents, oft innerhalb eines Zeitraums, zur Anzeige der Ausführung eines ec:PublicationEvent, eines ec:PublicationService oder eines ec:EditorialObject"@de ;
+                  skos:example """- Marktanteil der Zuschauer bei einer Sport-Liveübertragung
+- wöchentliche Seitenaufrufe einer Nachrichtenwebsite
+- Anzahl der täglichen eindeutigen Nutzer auf einer Nachrichtenwebsite
+- Anzahl der Likes auf einem Instagram-Post
+- Anzahl der Aufrufe eines Films von einem VOD-Portal"""@de ,
+                               """- market share of viewers on a sports live broadcast
+- weekly page impressions of a news website
+- number of daily unique users on a news website
+- number of likes on an instagram post
+- number of views of a movie from a VOD portal"""@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ResonanceEvent
+ec:ResonanceEvent rdf:type owl:Class ;
+                  rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:references ;
+                                    owl:someValuesFrom ec:ConsumptionEvent
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:references ;
+                                    owl:someValuesFrom ec:EditorialObject
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:references ;
+                                    owl:someValuesFrom ec:PublicationChannel
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:references ;
+                                    owl:someValuesFrom ec:PublicationEvent
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:references ;
+                                    owl:someValuesFrom ec:PublicationPlatform
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:references ;
+                                    owl:someValuesFrom ec:PublicationService
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:hasAssociatedConsumer ;
+                                    owl:allValuesFrom ec:Consumer
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:hasIdentifier ;
+                                    owl:allValuesFrom ec:Identifier
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:hasLocator ;
+                                    owl:allValuesFrom ec:Locator
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:description ;
+                                    owl:allValuesFrom rdfs:Literal
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:name ;
+                                    owl:allValuesFrom rdfs:Literal
+                                  ] ;
+                  dcterms:description "A countable or noticeable consumption-related action by a consumer during or after a consumption, e.g. a click on \"play\" or on \"pause\", likes, comments, votes, tweets, preferences, downloads. Resonance events are linked by content consumption. They represent raw data that need to be aggregated (e.g., summed)."@en ,
+                                      "Eine zählbare oder wahrnehmbare verbrauchsbezogene Handlung eines Konsumenten während oder nach einem Konsum, z. B. ein Klick auf „Play“ oder „Pause“, Likes, Kommentare, Stimmen, Tweets, Präferenzen, Downloads. Resonanzereignisse sind durch den Inhaltskonsum verknüpft. Sie stellen Rohdaten dar, die aggregiert werden müssen (z. B. durch Summieren)."@de ;
+                  rdfs:label "Resonance event"@en ,
+                             "Resonanzereignis"@de ;
+                  skos:definition "a countable or noticeable consumption-related action by a ec:Consumer during or after a ec:ConsumptionEvent"@en ,
+                                  "eine zählbare oder wahrnehmbare konsumbezogene Handlung eines ec:Consumer während oder nach einem ec:ConsumptionEvent"@de ;
+                  skos:example """- Fernseher ausschalten
+- auf einen anderen Radiosender umschalten
+- die Wiedergabe eines Videos in einem VOD-Portal pausieren
+- auf einem VOD-Portal nach Inhalten suchen
+- einen Twitter-Beitrag liken, teilen oder kommentieren
+- ein Video auf YouTube kommentieren
+- die Programmhörerservicenummer des PSM per Telefon anrufen, um sich zu beschweren
+- eine Radiosendung in der App des Radiosenders bewerten"""@de ,
+                               """- turning off the TV set
+- switching to another radio channel
+- pausing the playback of a video from a VOD portal
+- searching for content on a VOD portal
+- liking, sharing or commenting a twitter post
+- commenting a video on youtube
+- calling the PSM's program hotline by phone to complain
+- rating a radio show in the radio station's app"""@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Resource
+ec:Resource rdf:type owl:Class ;
+            rdfs:subClassOf [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasAncillaryData ;
+                              owl:allValuesFrom ec:AncillaryData
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasFormat ;
+                              owl:allValuesFrom ec:Format
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasIdentifier ;
+                              owl:allValuesFrom ec:Identifier
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasLocator ;
+                              owl:allValuesFrom ec:Locator
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasObjectType ;
+                              owl:allValuesFrom skos:Concept
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasRelatedMediaFragment ;
+                              owl:allValuesFrom ec:MediaFragment
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasStorageId ;
+                              owl:allValuesFrom ec:Identifier
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasStorageType ;
+                              owl:allValuesFrom skos:Concept
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:isCommissionedBy ;
+                              owl:allValuesFrom ec:Contract
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasDateDeleted ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onClass time:Instant
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasDateValidated ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onClass time:Instant
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:description ;
+                              owl:allValuesFrom rdfs:Literal
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:name ;
+                              owl:allValuesFrom rdfs:Literal
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:fileName ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onDataRange xsd:string
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:fileSize ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onDataRange xsd:double
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:resolution ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onDataRange xsd:string
+                            ] ;
+            dcterms:description "A tangible or digital thing that is used or referred to in a media-related workflow, e.g. a document, an image, or similar. It often has a locator indicating from where it can be retrieved."@en ,
+                                "Ein materielles oder digitales Objekt, das in einem medienbezogenen Workflow verwendet oder darauf bezogen wird, z. B. ein Dokument, ein Bild oder Ähnliches. Es hat oft einen Locator, der angibt, von wo es abgerufen werden kann."@de ;
+            rdfs:label "Resource"@en ,
+                       "Ressource"@de ;
+            skos:definition "a tangible or digital ec:Thing that is used or referred to in a media-related workflow"@en ,
+                            "ein materielles oder digitales ec:Thing, das in einem medienbezogenen Workflow verwendet oder darauf verwiesen wird"@de ;
+            skos:example """- a paper document
+- a digital document
+- a digital picture
+- a vinyl record
+- an audio CD
+- an audio tape
+- a video tape
+- a film dvd"""@en ,
+                         """- ein Papierdokument
+- ein digitales Dokument
+- ein digitales Bild
+- eine Schallplatte
+- eine Audio-CD
+- ein Audioband
+- ein Videoband
+- eine Film-DVD"""@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ResourceType
+ec:ResourceType rdf:type owl:Class ;
+                rdfs:subClassOf skos:Concept ;
+                dcterms:description "An entry from a list of types to classify a relation."@en ,
+                                    "Ein Eintrag aus einer Liste von Typen zur Klassifizierung einer Beziehung."@de ;
+                rdfs:label "Resource type"@en ,
+                           "Ressourcentyp"@de ;
+                skos:definition "a skos:Concept identifying the type of a ec:Resource"@en ,
+                                "ein skos:Concept zur Identifizierung des Typs einer ec:Resource"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Review
+ec:Review rdf:type owl:Class ;
+          rdfs:subClassOf ec:Item ;
+          dcterms:description "An audio or audio-visual report, in which somebody gives their opinion of a play, film, etc."@en ,
+                              "Ein Audio- oder audiovisueller Bericht, in dem jemand seine Meinung zu einem Theaterstück, Film usw. äußert."@de ;
+          rdfs:label "Review"@en ,
+                     "Rezension"@de ;
+          skos:definition "a ec:Item in which somebody gives their opinion about an ec:EditorialObject"@en ,
+                          "eine ec:Item, in dem jemand seine Meinung über ein ec:EditorialObject äußert"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Rights
+ec:Rights rdf:type owl:Class ;
+          rdfs:subClassOf [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:applyTo ;
+                            owl:allValuesFrom ec:Asset
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasContact ;
+                            owl:allValuesFrom ec:Contact
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasIdentifier ;
+                            owl:allValuesFrom ec:Identifier
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasObjectType ;
+                            owl:allValuesFrom skos:Concept
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasRightsHolder ;
+                            owl:allValuesFrom ec:Agent
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasRightsTargetService ;
+                            owl:allValuesFrom ec:PublicationService
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasRightsTerritoryExcludes ;
+                            owl:allValuesFrom ec:CountryCode
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasRightsTerritoryIncludes ;
+                            owl:allValuesFrom ec:CountryCode
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:originatesFrom ;
+                            owl:allValuesFrom ec:Contract
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasDuration ;
+                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                            owl:onClass ec:TimelinePoint
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasEndDateTime ;
+                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                            owl:onClass time:Instant
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasStartDateTime ;
+                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                            owl:onClass time:Instant
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:description ;
+                            owl:allValuesFrom rdfs:Literal
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:name ;
+                            owl:allValuesFrom rdfs:Literal
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:publishingEventsLeft ;
+                            owl:allValuesFrom xsd:integer
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:rightsExpression ;
+                            owl:allValuesFrom rdfs:Literal
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:rightsLink ;
+                            owl:allValuesFrom xsd:anyURI
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:rightsUsageRestrictions ;
+                            owl:allValuesFrom rdfs:Literal
+                          ] ;
+          dcterms:description "Die Berechtigung von Rechteinhabern, Werke gemäß den Bestimmungen des Immaterialgüterrechts oder aufgrund von Verträgen zu nutzen oder zu veröffentlichen."@de ,
+                              "The entitlement of rights holders to use or publish works as defined by intellectual property legislation or by contracts."@en ;
+          rdfs:label "Rechte"@de ,
+                     "Rights"@en ;
+          skos:definition "an entitlement of a ec:RightsHolder to use or publish an ec:Asset according to a ec:Contract"@en ,
+                          "ein Anspruch eines ec:RightsHolder, ein ec:Asset gemäß einem ec:Contract zu nutzen oder zu veröffentlichen"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#RightsClearance
+ec:RightsClearance rdf:type owl:Class ;
+                   rdfs:subClassOf ec:Rights ;
+                   dcterms:description "A grant to use the work in any way, issued by the organisation that checked all possible limitations and concluded that there are none."@en ,
+                                       "Eine Erlaubnis, das Werk in beliebiger Weise zu nutzen, ausgestellt von der Organisation, die alle möglichen Einschränkungen geprüft und festgestellt hat, dass es keine gibt."@de ;
+                   rdfs:label "Rechtefreigabe"@de ,
+                              "Rights clearance"@en ;
+                   skos:definition "a ec:Rights that allows all uses of the work to the organisation that has checked all possible limitations"@en ,
+                                   "eine ec:Rights, die alle Nutzungen des Werks für die Organisation erlaubt, die alle möglichen Einschränkungen geprüft hat"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#RightsType
+ec:RightsType rdf:type owl:Class ;
+              rdfs:subClassOf skos:Concept ;
+              dcterms:description "An entry from a list of types to classify rights."@en ,
+                                  "Ein Eintrag aus einer Liste von Typen zur Klassifizierung von Rechten."@de ;
+              rdfs:label "Rechtstyp"@de ,
+                         "Rights type"@en ;
+              skos:definition "a skos:Concept identifying the type of a ec:Rights"@en ,
+                              "ein skos:Concept zur Identifizierung des Typs einer ec:Rights"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Rule
+ec:Rule rdf:type owl:Class ;
+        rdfs:subClassOf [ rdf:type owl:Restriction ;
+                          owl:onProperty ec:hasIdentifier ;
+                          owl:allValuesFrom ec:Identifier
+                        ] ,
+                        [ rdf:type owl:Restriction ;
+                          owl:onProperty ec:hasObjectType ;
+                          owl:allValuesFrom skos:Concept
+                        ] ,
+                        [ rdf:type owl:Restriction ;
+                          owl:onProperty ec:hasPriority ;
+                          owl:allValuesFrom skos:Concept
+                        ] ,
+                        [ rdf:type owl:Restriction ;
+                          owl:onProperty ec:hasRelatedRule ;
+                          owl:allValuesFrom ec:Rule
+                        ] ,
+                        [ rdf:type owl:Restriction ;
+                          owl:onProperty ec:isDefinedBy ;
+                          owl:allValuesFrom ec:Contract
+                        ] ,
+                        [ rdf:type owl:Restriction ;
+                          owl:onProperty ec:description ;
+                          owl:allValuesFrom rdfs:Literal
+                        ] ,
+                        [ rdf:type owl:Restriction ;
+                          owl:onProperty ec:name ;
+                          owl:allValuesFrom rdfs:Literal
+                        ] ,
+                        [ rdf:type owl:Restriction ;
+                          owl:onProperty ec:ruleStatement ;
+                          owl:allValuesFrom rdfs:Literal
+                        ] ;
+        dcterms:description "A Rule defined from legal, technical or editorial, or regulatory requirements."@en ,
+                            "Eine Regel, die aus rechtlichen, technischen, redaktionellen oder regulatorischen Anforderungen abgeleitet ist."@de ;
+        rdfs:label "Regel"@de ,
+                   "Rule"@en ;
+        skos:definition "a legal, regulatory, technical or editorial guideline"@en ,
+                        "eine rechtliche, regulatorische, technische oder redaktionelle Richtlinie"@de ;
+        skos:example """- Die Lautstärke der Audiospur muss unter 0 dB liegen
+- die Sprechzeit in einer Debatte zwischen zwei Kandidaten muss gleich sein
+- der Anteil männlicher/weiblicher Expertinnen und Experten in allen Programmen von BBC One sollte jeweils 50 % betragen"""@de ,
+                     """- audio track volume level must be below 0dB
+- speaker time in a debate between two candidates must be equal
+- the share of male/female experts in all programmes of BBC One should be 50% each"""@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Scene
+ec:Scene rdf:type owl:Class ;
+         rdfs:subClassOf ec:EditorialSegment ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasProgramme ;
+                           owl:allValuesFrom ec:Programme
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasShot ;
+                           owl:allValuesFrom ec:Shot
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasTake ;
+                           owl:allValuesFrom ec:Take
+                         ] ;
+         owl:disjointWith ec:Shot ,
+                          ec:Take ;
+         dcterms:description "A (usually small) part of a story that is filmed or recorded without a leap in time or location to represent a continuous action."@en ,
+                             "Ein (meist kleiner) Teil einer Geschichte, der ohne Zeitsprung oder Ortswechsel gefilmt oder aufgenommen wird, um eine zusammenhängende Handlung darzustellen."@de ;
+         rdfs:label "Scene"@en ,
+                    "Szene"@de ;
+         skos:definition "an ec:EditorialSegment that contains a small part of a story without leaps in time or location"@en ,
+                         "ein ec:EditorialSegment, das einen kleinen Teil einer Geschichte ohne Sprünge in Zeit oder Ort enthält"@de ;
+         skos:example "- the final goodbye of Humphrey Bogart and Ingrid Bergman at the airport of Casablanca in the equally named film."@en ,
+                      "– der letzte Abschied von Humphrey Bogart und Ingrid Bergman am Flughafen von Casablanca in dem gleichnamigen Film."@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Season
+ec:Season rdf:type owl:Class ;
+          rdfs:subClassOf ec:EditorialGroup ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasEpisode ;
+                            owl:someValuesFrom ec:Programme
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasSerial ;
+                            owl:allValuesFrom ec:Serial
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:isSeasonOf ;
+                            owl:allValuesFrom ec:Series
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:seasonNumber ;
+                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                            owl:onDataRange xsd:integer
+                          ] ;
+          dcterms:description "A group of works that is produced within one production effort, like episodes 1 to 6 for a new fictional series. Alternatively, grouping can be done by time span, such as all comedy shows by a host in one fiscal year."@en ,
+                              "Eine Gruppe von Werken, die im Rahmen eines Produktionsvorhabens produziert wird, etwa die Folgen 1 bis 6 einer neuen fiktionalen Serie. Alternativ kann die Gruppierung nach einem Zeitabschnitt erfolgen, etwa alle Comedy-Sendungen eines Moderators in einem Geschäftsjahr."@de ;
+          rdfs:label "Season"@en ,
+                     "Staffel"@de ;
+          skos:definition "an ec:EditorialGroup that contains episodes of ec:Series or ec:Serial, usually due to a common production effort or a common production time"@en ,
+                          "eine ec:EditorialGroup, die Episoden von ec:Series oder ec:Serial enthält, gewöhnlich aufgrund einer gemeinsamen Produktionsleistung oder einer gemeinsamen Produktionszeit"@de ;
+          skos:example """- die 216 Episoden der BBC-Serie „EastEnders“ aus dem Jahr 2018
+- Staffel 1 mit 8 Episoden der deutschen Serie „Babylon Berlin\""""@de ,
+                       """- the 216 episodes of 2018 of BBC series \"EastEnder\"
+- season 1 with 8 episodes of German serial \"Babylon Berlin\""""@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Serial
+ec:Serial rdf:type owl:Class ;
+          rdfs:subClassOf ec:EditorialGroup ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasEpisode ;
+                            owl:someValuesFrom ec:Programme
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasSeason ;
+                            owl:allValuesFrom ec:Season
+                          ] ;
+          dcterms:description "A group of works that usually sum up sequentially to a common story, like chapters in a novel."@en ,
+                              "Eine Gruppe von Werken, die sich gewöhnlich nacheinander zu einer gemeinsamen Geschichte ergänzen, wie Kapitel in einem Roman."@de ;
+          rdfs:label "Serial"@en ,
+                     "Serie"@de ;
+          skos:definition "an ec:EditorialGroup telling a whole story in parts, each continuing the preceding part"@en ,
+                          "eine ec:EditorialGroup, die eine ganze Geschichte in Teilen erzählt, wobei jeder Teil den vorhergehenden fortsetzt"@de ;
+          skos:example "- Deutsche Serie „Babylon Berlin“ mit mehreren Staffeln"@de ,
+                       "- German serial \"Babylon Berlin\" with several seasons"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Series
+ec:Series rdf:type owl:Class ;
+          rdfs:subClassOf ec:EditorialGroup ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasEpisode ;
+                            owl:someValuesFrom ec:Programme
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasSeason ;
+                            owl:allValuesFrom ec:Season
+                          ] ;
+          dcterms:description "A group of works that are usually grouped by characters (e.g. talk show host) or topics (e.g. sports, news, ...) or publication scheme (weekly), but not by a sequential story."@en ,
+                              "Eine Gruppe von Werken, die üblicherweise nach Figuren (z. B. Talkshow-Moderator) oder Themen (z. B. Sport, Nachrichten, ...) oder nach dem Erscheinungsrhythmus (wöchentlich) zusammengefasst werden, aber nicht nach einer fortlaufenden Handlung."@de ;
+          rdfs:label "Serie"@de ,
+                     "Series"@en ;
+          skos:definition "an ec:EditorialGroup of Programmes, that are grouped by characters or topics or publication scheme, but not by a sequential story"@en ,
+                          "eine ec:EditorialGroup von Programmen, die nach Figuren, Themen oder Publikationsschema gruppiert sind, aber nicht nach einer sequenziellen Handlung"@de ;
+          skos:example """- ABC serial \"Friends\"
+- BBC's daily news programme \"BBC News\"
+- ARD's Sunday night drama \"Tatort\""""@en ,
+                       """- ABC-Serien „Friends“
+- das tägliche Nachrichtenprogramm „BBC News“ von BBC
+- das Sonntagsabend-Drama „Tatort“ von ARD"""@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ServiceType
+ec:ServiceType rdf:type owl:Class ;
+               rdfs:subClassOf skos:Concept ;
+               dcterms:description "An entry from a list of types to classify a publication service."@en ,
+                                   "Ein Eintrag aus einer Liste von Typen zur Klassifizierung eines Veröffentlichungsdienstes."@de ;
+               rdfs:label "Diensttyp"@de ,
+                          "Service type"@en ;
+               skos:definition "a skos:Concept identifying the type of a ec:PublicationService"@en ,
+                               "ein skos:Concept, der den Typ eines ec:PublicationService identifiziert"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Shot
+ec:Shot rdf:type owl:Class ;
+        rdfs:subClassOf ec:EditorialSegment ,
+                        [ rdf:type owl:Restriction ;
+                          owl:onProperty ec:hasScene ;
+                          owl:allValuesFrom ec:Scene
+                        ] ,
+                        [ rdf:type owl:Restriction ;
+                          owl:onProperty ec:hasTake ;
+                          owl:allValuesFrom ec:Take
+                        ] ;
+        owl:disjointWith ec:Take ;
+        dcterms:description "A video sequence filmed continuously by one camera."@en ,
+                            "Eine Videosequenz, die von einer Kamera kontinuierlich aufgezeichnet wurde."@de ;
+        rdfs:label "Einstellung"@de ,
+                   "Shot"@en ;
+        skos:definition "an ec:EditorialSegment filmed with one camera without interruption"@en ,
+                        "ein ec:EditorialSegment, der mit einer Kamera ohne Unterbrechung gefilmt wurde"@de ;
+        skos:example "- a part of the final Scene of \"Casablanca\" showing Humphrey Bogart from behind while watching Ingrid Bergman and Paul Henreid walking to the plane, filmed from one camera without interruption"@en ,
+                     "- ein Teil der letzten Szene von „Casablanca“, der Humphrey Bogart von hinten zeigt, während er Ingrid Bergman und Paul Henreid auf dem Weg zum Flugzeug beobachtet, gefilmt mit einer Kamera ohne Unterbrechung"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#SignLanguageCode
+ec:SignLanguageCode rdf:type owl:Class ;
+                    rdfs:subClassOf skos:Concept ;
+                    dcterms:description "An entry from a list of codes to identify a sign language."@en ,
+                                        "Ein Eintrag aus einer Liste von Codes zur Identifizierung einer Gebärdensprache."@de ;
+                    rdfs:label "Gebärdensprachcode"@de ,
+                               "Sign language code"@en ;
+                    skos:definition "a skos:Concept identifying the code of a sign language"@en ,
+                                    "ein skos:Concept zur Identifizierung des Codes einer Gebärdensprache"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Signing
+ec:Signing rdf:type owl:Class ;
+           rdfs:subClassOf ec:Track ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:hasSigningFormat ;
+                             owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                             owl:onClass ec:SigningFormat
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:hasSigningSource ;
+                             owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                             owl:onClass ec:Agent
+                           ] ;
+           dcterms:description "A track containing sign language."@en ,
+                               "Eine Spur mit Gebärdensprache."@de ;
+           rdfs:label "Gebärdensprache"@de ,
+                      "Signing"@en ;
+           skos:definition "a ec:Track containing sign language for deaf and hard of hearing"@en ,
+                           "ein ec:Track mit Gebärdensprache für Gehörlose und Schwerhörige"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#SigningFormat
+ec:SigningFormat rdf:type owl:Class ;
+                 rdfs:subClassOf skos:Concept ;
+                 dcterms:description "An entry from a list of formats to identify the sign language interpretation in audiovisual media, e.g. in-vision/inset, full-screen, overlay, avatar."@en ,
+                                     "Ein Eintrag aus einer Liste von Formaten zur Kennzeichnung der Gebärdensprachdolmetschung in audiovisuellen Medien, z. B. In-Vision/Inset, Vollbild, Overlay, Avatar."@de ;
+                 rdfs:label "Gebärdensprachformat"@de ,
+                            "Signing format"@en ;
+                 skos:definition "a skos:Concept identifying the format of sign language interpretation"@en ,
+                                 "ein skos:Concept zur Identifizierung des Formats der Gebärdensprachverdolmetschung"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#StaffMember
+ec:StaffMember rdf:type owl:Class ;
+               rdfs:subClassOf ec:Person ;
+               dcterms:description "A member of staff is a person in a company's workforce."@en ,
+                                   "Ein Mitarbeiter ist eine Person in der Belegschaft eines Unternehmens."@de ;
+               rdfs:label "Mitarbeiter"@de ,
+                          "Staff member"@en ;
+               skos:definition "a ec:Person who is a member of the workforce in a company"@en ,
+                               "eine ec:Person, die Mitglied der Belegschaft eines Unternehmens ist"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Stage
+ec:Stage rdf:type owl:Class ;
+         rdfs:subClassOf [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasLocator ;
+                           owl:allValuesFrom ec:Locator
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasObjectType ;
+                           owl:allValuesFrom skos:Concept
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasStageLocation ;
+                           owl:allValuesFrom ec:Location
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:description ;
+                           owl:allValuesFrom rdfs:Literal
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:name ;
+                           owl:allValuesFrom rdfs:Literal
+                         ] ;
+         dcterms:description "A space for the performing arts, such as a theatre, a concert hall or a film studio."@en ,
+                             "Ein Raum für die darstellenden Künste, wie etwa ein Theater, ein Konzertsaal oder ein Filmstudio."@de ;
+         rdfs:label "Bühne"@de ,
+                    "Stage"@en ;
+         skos:definition "a space for the performing arts"@en ,
+                         "ein Raum für die darstellenden Künste"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Standard
+ec:Standard rdf:type owl:Class ;
+            rdfs:subClassOf ec:Format ;
+            dcterms:description "An entry from the classification of video standards for media resources, i.e. NTSC or PAL."@en ,
+                                "Ein Eintrag aus der Klassifizierung von Videostandards für Medienressourcen, z. B. NTSC oder PAL."@de ;
+            rdfs:label "Standard"@de ,
+                       "Standard"@en ;
+            skos:definition "a ec:Format classifying the video standard of a ec:MediaResource"@en ,
+                            "eine ec:Format, das den Videostandard einer ec:MediaResource klassifiziert"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Sticker
+ec:Sticker rdf:type owl:Class ;
+           rdfs:subClassOf ec:Picture ;
+           dcterms:description "A picture that is attached to a piece of clothing worn by an actor."@en ,
+                               "Ein Bild, das an einem von einem Schauspieler getragenen Kleidungsstück befestigt ist."@de ;
+           rdfs:label "Aufkleber"@de ,
+                      "Sticker"@en ;
+           skos:definition "a ec:Picture that is attached to a ec:Costume"@en ,
+                           "eine ec:Picture, die an ein ec:Costume angebracht ist"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#StorageType
+ec:StorageType rdf:type owl:Class ;
+               rdfs:subClassOf skos:Concept ;
+               dcterms:description "An entry from a list of types to classify a storage."@en ,
+                                   "Ein Eintrag aus einer Typenliste zur Klassifizierung eines Speichers."@de ;
+               rdfs:label "Speichertyp"@de ,
+                          "Storage type"@en ;
+               skos:definition "a skos:Concept identifying the type of storage"@en ,
+                               "ein skos:Concept zur Identifizierung der Art der Speicherung"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Stream
+ec:Stream rdf:type owl:Class ;
+          rdfs:subClassOf ec:Component ;
+          dcterms:description "A component of a media resource in the form of a continuous flow of bits."@en ,
+                              "Eine Komponente einer Medienressource in Form eines kontinuierlichen Bitstroms."@de ;
+          rdfs:label "Stream"@de ,
+                     "Stream"@en ;
+          skos:definition "a ec:Component in the form of a continuous flow of bits"@en ,
+                          "ein ec:Component in Form eines kontinuierlichen Bitstroms"@de ;
+          skos:example """- an audio stream from an audio on demand service
+- a video stream from a video on demand service"""@en ,
+                       """- ein Audiostream von einem Audio-on-Demand-Dienst
+- ein Videostream von einem Video-on-Demand-Dienst"""@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Subject
+ec:Subject rdf:type owl:Class ;
+           rdfs:subClassOf skos:Concept ;
+           dcterms:description "An entry from the list of subjects to classify the content of a piece of work."@en ,
+                               "Ein Eintrag aus der Liste der Schlagwörter zur Klassifizierung des Inhalts eines Werkes."@de ;
+           rdfs:label "Subject"@en ,
+                      "Thema"@de ;
+           skos:definition "a skos:Concept classifying the topic covered by a ec:EditorialObject"@en ,
+                           "ein skos:Concept, der das von einem ec:EditorialObject behandelte Thema klassifiziert"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Subtitling
+ec:Subtitling rdf:type owl:Class ;
+              rdfs:subClassOf ec:Track ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:hasSubtitlingSource ;
+                                owl:allValuesFrom ec:Agent
+                              ] ;
+              dcterms:description "A track containing subtitles in some languages."@en ,
+                                  "Eine Spur, die Untertitel in einigen Sprachen enthält."@de ;
+              rdfs:label "Subtitling"@en ,
+                         "Untertitelung"@de ;
+              skos:definition "a ec:Track containing subtitles in some language"@en ,
+                              "ein ec:Track, das Untertitel in einer Sprache enthält"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#SubtitlingFormat
+ec:SubtitlingFormat rdf:type owl:Class ;
+                    rdfs:subClassOf ec:DataFormat ;
+                    dcterms:description "An entry from the classification of structure schemes for subtitling data, mainly used for translations."@en ,
+                                        "Ein Eintrag aus der Klassifizierung von Struktur-Schemata für Untertitelungsdaten, hauptsächlich für Übersetzungen verwendet."@de ;
+                    rdfs:label "Subtitling format"@en ,
+                               "Untertitelungsformat"@de ;
+                    skos:definition "a ec:DataFormat classifying the structure of subtitling data"@en ,
+                                    "eine ec:DataFormat-Klasse zur Klassifizierung der Struktur von Untertitelungsdaten"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Take
+ec:Take rdf:type owl:Class ;
+        rdfs:subClassOf ec:EditorialSegment ,
+                        [ rdf:type owl:Restriction ;
+                          owl:onProperty ec:hasScene ;
+                          owl:allValuesFrom ec:Scene
+                        ] ;
+        dcterms:description "A shot or a scene filmed repeatedly to provide a choice of takes and allow to select the best fit during post-production."@en ,
+                            "Eine Aufnahme oder Szene, die wiederholt gefilmt wurde, um eine Auswahl an Takes bereitzustellen und die Auswahl der am besten geeigneten Aufnahme in der Postproduktion zu ermöglichen."@de ;
+        rdfs:label "Take"@de ,
+                   "Take"@en ;
+        skos:definition "a ec:Shot or a ec:Scene filmed or recorded repeatedly to provide a choice of Takes"@en ,
+                        "ein ec:Shot oder eine ec:Scene, die wiederholt gefilmt oder aufgezeichnet wird, um eine Auswahl an Takes bereitzustellen"@de ;
+        skos:example "- an EditorialWork consists of selected Takes, while discarded Takes sometimes are published as \"outtakes\", for which examples can be easily found in the web"@en ,
+                     "- ein EditorialWork besteht aus ausgewählten Takes, während verworfene Takes manchmal als „Outtakes“ veröffentlicht werden, wofür sich im Web leicht Beispiele finden lassen"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Team
+ec:Team rdf:type owl:Class ;
+        rdfs:subClassOf ec:Organisation ,
+                        [ rdf:type owl:Restriction ;
+                          owl:onProperty ec:hasTeamMember ;
+                          owl:allValuesFrom ec:Person
+                        ] ;
+        dcterms:description "A number of people working together, often in different roles, toward a common goal, such as conducting a project, operating a service, executing a process, or similar."@en ,
+                            "Eine Anzahl von Personen, die zusammenarbeiten, oft in unterschiedlichen Rollen, um ein gemeinsames Ziel zu erreichen, etwa ein Projekt durchzuführen, einen Dienst zu betreiben, einen Prozess auszuführen oder Ähnliches."@de ;
+        rdfs:label "Team"@de ,
+                   "Team"@en ;
+        skos:definition "a ec:Organisation consisting of ec:Persons as members"@en ,
+                        "eine ec:Organisation, die aus ec:Personen als Mitgliedern besteht"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Template
+ec:Template rdf:type owl:Class ;
+            rdfs:subClassOf ec:Essence ;
+            dcterms:description "An essence in the form of a template for essences with all associated technical parameters."@en ,
+                                "Eine Essenz in Form einer Vorlage für Essenzen mit allen zugehörigen technischen Parametern."@de ;
+            rdfs:label "Template"@en ,
+                       "Vorlage"@de ;
+            skos:definition "an ec:Essence in the form of a template for ec:Essences with all associated technical parameters"@en ,
+                            "eine ec:Essence in Form einer Vorlage für ec:Essences mit allen zugehörigen technischen Parametern"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#TerritoryCode
+ec:TerritoryCode rdf:type owl:Class ;
+                 rdfs:subClassOf skos:Concept ;
+                 dcterms:description "An entry from a list of codes identifying territories, e.g. by their UN Code."@en ,
+                                     "Ein Eintrag aus einer Liste von Codes zur Identifizierung von Territorien, z. B. anhand ihres UN-Codes."@de ;
+                 rdfs:label "Gebietscode"@de ,
+                            "Territory code"@en ;
+                 skos:definition "a skos:Concept identifying a territory"@en ,
+                                 "ein skos:Concept, der ein Territorium identifiziert"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#TextAnnotation
+ec:TextAnnotation rdf:type owl:Class ;
+                  rdfs:subClassOf ec:Annotation ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:characterEndIndex ;
+                                    owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                    owl:onDataRange xsd:integer
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:characterStartIndex ;
+                                    owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                    owl:onDataRange xsd:integer
+                                  ] ;
+                  dcterms:description "A text annotation adds description, context, comments, or similar to a thing."@en ,
+                                      "Eine Textannotation fügt einer Sache eine Beschreibung, einen Kontext, Kommentare oder Ähnliches hinzu."@de ;
+                  rdfs:label "Text annotation"@en ,
+                             "Textannotation"@de ;
+                  skos:definition "a ec:Annotation containing text or portions of texts"@en ,
+                                  "eine ec:Annotation, die Text oder Textteile enthält"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#TextLine
+ec:TextLine rdf:type owl:Class ;
+            rdfs:subClassOf [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasIdentifier ;
+                              owl:allValuesFrom ec:Identifier
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasRelatedAgent ;
+                              owl:allValuesFrom ec:Agent
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasRelatedCharacter ;
+                              owl:allValuesFrom ec:Character
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasRelatedScene ;
+                              owl:allValuesFrom ec:Scene
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasEnd ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onClass ec:TimelinePoint
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasObjectType ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onClass skos:Concept
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasStart ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onClass ec:TimelinePoint
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasTextLineSource ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onClass ec:Agent
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:artefactBoxHeight ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onDataRange xsd:nonNegativeInteger
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:artefactBoxTopLeftCornerLineNumber ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onDataRange xsd:nonNegativeInteger
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:artefactBoxTopLeftCornerPixelNumber ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onDataRange xsd:nonNegativeInteger
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:artefactBoxWidth ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onDataRange xsd:nonNegativeInteger
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:textLineBoxHeight ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onDataRange xsd:nonNegativeInteger
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:textLineBoxTopLeftCornerLineNumber ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onDataRange xsd:nonNegativeInteger
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:textLineBoxTopLeftCornerPixelNumber ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onDataRange xsd:nonNegativeInteger
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:textLineBoxWidth ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onDataRange xsd:nonNegativeInteger
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:textLineContent ;
+                              owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:textLineOrder ;
+                              owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                            ] ;
+            dcterms:description "A line of text that appears within some content on a screen, at a given space and time."@en ,
+                                "Eine Textzeile, die innerhalb eines Inhalts auf einem Bildschirm zu einem bestimmten Ort und Zeitpunkt erscheint."@de ;
+            rdfs:label "Text line"@en ,
+                       "Textzeile"@de ;
+            skos:definition "a line of text that is visible in a spatial and timed context together with content"@en ,
+                            "eine Textzeile, die in einem räumlichen und zeitlichen Kontext zusammen mit Inhalt sichtbar ist"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#TextLineType
+ec:TextLineType rdf:type owl:Class ;
+                rdfs:subClassOf skos:Concept ;
+                dcterms:description "An entry from a list of types to classify a text line."@en ,
+                                    "Ein Eintrag aus einer Liste von Typen zur Klassifizierung einer Textzeile."@de ;
+                rdfs:label "Text line type"@en ,
+                           "Textzeilentyp"@de ;
+                skos:definition "a skos:Concept identifying the type of a ec:TextLine"@en ,
+                                "ein skos:Concept, der den Typ einer ec:TextLine identifiziert"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#TextUsageType
+ec:TextUsageType rdf:type owl:Class ;
+                 rdfs:subClassOf skos:Concept ;
+                 dcterms:description "An entry from a list of types to classify the usage of a text."@en ,
+                                     "Ein Eintrag aus einer Liste von Typen zur Klassifizierung der Verwendung eines Textes."@de ;
+                 rdfs:label "Text usage type"@en ,
+                            "Textnutzungstyp"@de ;
+                 skos:definition "a skos:Concept identifying the type of usage of text"@en ,
+                                 "ein skos:Concept zur Identifizierung der Art der Textverwendung"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Theme
+ec:Theme rdf:type owl:Class ;
+         rdfs:subClassOf skos:Concept ;
+         dcterms:description "An entry from the list of themes to associate with of a piece of work."@en ,
+                             "Ein Eintrag aus der Liste der Themen, die einem Werk zugeordnet werden sollen."@de ;
+         rdfs:label "Thema"@de ,
+                    "Theme"@en ;
+         skos:definition "a skos:Concept classifying the theme associated with a ec:Asset"@en ,
+                         "ein skos:Concept, der das Thema klassifiziert, das mit einem ec:Asset verbunden ist"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Thumbnail
+ec:Thumbnail rdf:type owl:Class ;
+             rdfs:subClassOf ec:Picture ;
+             dcterms:description "A low-resolution picture to save computing and storage resources in user interfaces, e.g. on small-screen devices for consumption."@en ,
+                                 "Ein Bild mit niedriger Auflösung, um Rechen- und Speicherressourcen in Benutzeroberflächen zu sparen, z. B. auf Geräten mit kleinem Bildschirm zur Anzeige."@de ;
+             rdfs:label "Miniaturansicht"@de ,
+                        "Thumbnail"@en ;
+             skos:definition "a ec:Picture in a low resolution instantiation to save computing and storage resources in user interfaces"@en ,
+                             "ein ec:Picture in einer niedrig aufgelösten Instanziierung, um Rechen- und Speicherressourcen in Benutzeroberflächen zu sparen"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#TimeCode
+ec:TimeCode rdf:type owl:Class ;
+            rdfs:subClassOf ec:TimelinePoint ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:timecodeExpression ;
+                              owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onDataRange xsd:string
+                            ] ;
+            dcterms:description "A point in time within the timeline of a content that is expressed as a timecode."@en ,
+                                "Ein Zeitpunkt innerhalb der Zeitleiste eines Inhalts, der als Timecode ausgedrückt wird."@de ;
+            rdfs:label "Time code"@en ,
+                       "Zeitcode"@de ;
+            skos:definition "a ec:TimelinePoint expressed in a timecode expression"@en ,
+                            "eine ec:TimelinePoint, ausgedrückt in einer Timecode-Expression"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#TimeCodeDropFrame
+ec:TimeCodeDropFrame rdf:type owl:Class ;
+                     rdfs:subClassOf ec:TimelinePoint ,
+                                     [ rdf:type owl:Restriction ;
+                                       owl:onProperty ec:timecodeExpression ;
+                                       owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                       owl:onDataRange xsd:string
+                                     ] ;
+                     dcterms:description "A point in time within the timeline of a content that is expressed as a timecode with dropframe."@en ,
+                                         "Ein Zeitpunkt innerhalb der Zeitleiste eines Inhalts, der als Timecode mit Drop-Frame ausgedrückt wird."@de ;
+                     rdfs:label "Time code with dropframe"@en ,
+                                "Zeitcode mit Dropframe"@de ;
+                     skos:definition "a ec:TimelinePoint expressed in a timecode expression with dropframe"@en ,
+                                     "ein ec:TimelinePoint, ausgedrückt in einer Timecode-Expression mit Dropframe"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#TimecodeTrack
+ec:TimecodeTrack rdf:type owl:Class ;
+                 rdfs:subClassOf ec:Track ;
+                 dcterms:description "A track containing timecode information."@en ,
+                                     "Ein Track, der Zeitcode-Informationen enthält."@de ;
+                 rdfs:label "Timecode track"@en ,
+                            "Zeitcode-Spur"@de ;
+                 skos:definition "a ec:Track containing timecode information"@en ,
+                                 "ein ec:Track mit Timecode-Informationen"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#TimedTextAuthoringTechnique
+ec:TimedTextAuthoringTechnique rdf:type owl:Class ;
+                               rdfs:subClassOf ec:Format ;
+                               dcterms:description "An entry from the classification of techniques for the representation of timed text for media resources."@en ,
+                                                   "Ein Eintrag aus der Klassifikation von Techniken zur Darstellung zeitbasierter Texte für Medienressourcen."@de ;
+                               rdfs:label "Technik zur Erstellung zeitgesteuerter Texte"@de ,
+                                          "Timed text authoring technique"@en ;
+                               skos:definition "a ec:Format classifying the technique to represent time related text for a ec:MediaResource"@en ,
+                                               "ein ec:Format zur Klassifizierung der Technik zur Darstellung zeitbezogener Texte für eine ec:MediaResource"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#TimedTextContentType
+ec:TimedTextContentType rdf:type owl:Class ;
+                        rdfs:subClassOf ec:Format ;
+                        dcterms:description "An entry from the classification of types of timed text for media resources."@en ,
+                                            "Ein Eintrag aus der Klassifikation von Arten von zeitbasiertem Text für Medienressourcen."@de ;
+                        rdfs:label "Timed text content type"@en ,
+                                   "Zeitgesteuerter Textinhaltstyp"@de ;
+                        skos:definition "a ec:Format classifying the type of timed text for a ec:MediaResource"@en ,
+                                        "eine ec:Format, die den Typ von zeitgesteuertem Text für eine ec:MediaResource klassifiziert"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#TimedTextSubtitleTargetFormat
+ec:TimedTextSubtitleTargetFormat rdf:type owl:Class ;
+                                 rdfs:subClassOf ec:Format ;
+                                 dcterms:description "An entry from the classification of types of timed text subtitles for media resources."@en ,
+                                                     "Ein Eintrag aus der Klassifikation der Arten von zeitgesteuerten Untertiteln für Medienressourcen."@de ;
+                                 rdfs:label "Timed text subtitle target format"@en ,
+                                            "Zeitgesteuertes Text-Untertitel-Zielformat"@de ;
+                                 skos:definition "a ec:Format classifying the format of timed text subtitles for a ec:MediaResource"@en ,
+                                                 "eine ec:Format-Klasse, die das Format von zeitgesteuerten Untertiteln für eine ec:MediaResource klassifiziert"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#TimelinePoint
+ec:TimelinePoint rdf:type owl:Class ;
+                 rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:equivalentTime ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onDataRange xsd:float
+                                 ] ;
+                 dc:description "A precise time point  of a media resource"@en ;
+                 dcterms:description "A point in time within the timeline of a content, typically used to mark a specific event, position, or segment boundary in media timing metadata."@en ,
+                                     "Ein Zeitpunkt innerhalb der Zeitleiste eines Inhalts, der typischerweise verwendet wird, um ein bestimmtes Ereignis, eine Position oder eine Segmentgrenze in Metadaten zur Medienzeitmessung zu markieren."@de ;
+                 rdfs:label "Timeline point"@en ,
+                            "Zeitachsenpunkt"@de ;
+                 skos:definition "a point in time within the timeline of a content"@en ,
+                                 "ein Zeitpunkt innerhalb der Zeitleiste eines Inhalts"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#TimelineTrack
+ec:TimelineTrack rdf:type owl:Class ;
+                 rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasIdentifier ;
+                                   owl:allValuesFrom ec:Identifier
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasTimelineTrackPart ;
+                                   owl:allValuesFrom ec:EditorialObject
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasDuration ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass ec:TimelinePoint
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasObjectType ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass skos:Concept
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:description ;
+                                   owl:allValuesFrom rdfs:Literal
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:name ;
+                                   owl:allValuesFrom rdfs:Literal
+                                 ] ;
+                 dcterms:description "A temporal scale used as a reference to express the sequence in time for a set of content."@en ,
+                                     "Eine zeitliche Skala, die als Referenz dient, um die zeitliche Abfolge für eine Menge von Inhalten auszudrücken."@de ;
+                 rdfs:label "Timeline track"@en ,
+                            "Zeitleiste-Track"@de ;
+                 skos:definition "a temporal scale used as a reference to express the sequence in time of a set of ec:EditorialObjects"@en ,
+                                 "eine zeitliche Skala, die als Referenz verwendet wird, um die zeitliche Abfolge einer Menge von ec:EditorialObjects auszudrücken"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#TimelineTrackType
+ec:TimelineTrackType rdf:type owl:Class ;
+                     rdfs:subClassOf skos:Concept ;
+                     dcterms:description "An entry from a list of types to classify timeline tracks."@en ,
+                                         "Ein Eintrag aus einer Liste von Typen zur Klassifizierung von Timeline-Spuren."@de ;
+                     rdfs:label "Timeline track type"@en ,
+                                "Timeline-Track-Typ"@de ;
+                     skos:definition "a skos:Concept identifying the type of a ec:TimelineTrack"@en ,
+                                     "ein skos:Concept, der den Typ eines ec:TimelineTrack identifiziert"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Topic
+ec:Topic rdf:type owl:Class ;
+         rdfs:subClassOf skos:Concept ;
+         dcterms:description "An entry from the list of topics to classify the content of a piece of work."@en ,
+                             "Ein Eintrag aus der Themenliste zur Klassifizierung des Inhalts eines Werkes."@de ;
+         rdfs:label "Thema"@de ,
+                    "Topic"@en ;
+         skos:definition "a skos:Concept classifying a topic covered in a ec:EditorialObject"@en ,
+                         "ein skos:Concept, das ein in einem ec:EditorialObject behandelte Thema klassifiziert"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Track
+ec:Track rdf:type owl:Class ;
+         rdfs:subClassOf ec:MediaResource ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasTrackPart ;
+                           owl:allValuesFrom ec:MediaResource
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasTrackPurpose ;
+                           owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                           owl:onClass ec:TrackPurpose
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasTrackType ;
+                           owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                           owl:onClass ec:TrackType
+                         ] ;
+         dcterms:description "E.g. audio, video, timecode and/or data Tracks forming the MediaResource."@en ,
+                             "Z. B. Audio-, Video-, Timecode- und/oder Daten-Tracks, die die MediaResource bilden."@de ;
+         rdfs:label "Titel"@de ,
+                    "Track"@en ;
+         skos:definition "a MediaResource in the form of time-based elements for audio, video or data (\"track\") comprised in an \"aggregated\" MediaResource"@en ,
+                         "ein MediaResource in Form von zeitbasierten Elementen für Audio, Video oder Daten (\"track\") in einer \"aggregierten\" MediaResource"@de ;
+         skos:example "- der Ton in einer MPEG4-Videodatei"@de ,
+                      "- the audio in a MPEG4 video file"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#TrackPurpose
+ec:TrackPurpose rdf:type owl:Class ;
+                rdfs:subClassOf skos:Concept ;
+                dcterms:description "An entry from a list of purposes to classify a track."@en ,
+                                    "Ein Eintrag aus einer Liste von Zwecken zur Klassifizierung eines Tracks."@de ;
+                rdfs:label "Track purpose"@en ,
+                           "Zweck des Tracks"@de ;
+                skos:definition "a skos:Concept identifying the purpose of a ec:Track"@en ,
+                                "ein skos:Concept, das den Zweck eines ec:Track bezeichnet"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#TrackType
+ec:TrackType rdf:type owl:Class ;
+             rdfs:subClassOf skos:Concept ;
+             dcterms:description "An entry from a list of types to classify a track, e.g. EBU's classification scheme on Track Type."@en ,
+                                 "Ein Eintrag aus einer Liste von Typen zur Klassifizierung eines Tracks, z. B. EBU's Klassifizierungsschema für Track Type."@de ;
+             rdfs:label "Spurtyp"@de ,
+                        "Track type"@en ;
+             skos:definition "a skos:Concept identifying the type of a ec:Track"@en ,
+                             "ein skos:Concept, der den Typ eines ec:Track identifiziert"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Type
+ec:Type rdf:type owl:Class ;
+        rdfs:subClassOf skos:Concept ;
+        dcterms:description "A superclass for classification types of content."@en ,
+                            "Eine Oberklasse für Klassifikationstypen von Inhalten."@de ;
+        rdfs:label "Typ"@de ,
+                   "Type"@en ;
+        skos:definition "a skos:Concept representing the superclass for classification types of content"@en ,
+                        "ein skos:Concept, der die Oberklasse für Klassifikationstypen von Inhalten darstellt"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#UncertainDate
+ec:UncertainDate rdf:type owl:Class ;
+                 rdfs:subClassOf time:Instant ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasEndDateTime ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass time:Instant
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasObjectType ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass skos:Concept
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasStartDateTime ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass time:Instant
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:description ;
+                                   owl:allValuesFrom rdfs:Literal
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:period ;
+                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                 ] ;
+                 owl:disjointWith time:DateTimeDescription ;
+                 dcterms:description "A time stamp that is lacking exactness can be expressed by the following scheme: omit information from small to large time units: omit seconds, then minutes, then hours, then days, then months, then years. To express a period of time with lacking exactness, define a start and end time stamp using the described uncertainty scheme."@en ,
+                                     "Ein Zeitstempel, dem es an Genauigkeit fehlt, kann nach folgendem Schema ausgedrückt werden: Informationen von kleinen zu großen Zeiteinheiten weglassen: Sekunden weglassen, dann Minuten, dann Stunden, dann Tage, dann Monate, dann Jahre. Um einen Zeitraum mit fehlender Genauigkeit auszudrücken, definiert man einen Start- und einen Endzeitstempel unter Verwendung des beschriebenen Unsicherheits-Schemas."@de ;
+                 rdfs:label "Uncertain date"@en ,
+                            "Ungewisses Datum"@de ;
+                 skos:definition "a time:Instant that can express missing exactness of a time stamp or a period of time"@en ,
+                                 "eine time:Instant, die die fehlende Genauigkeit eines Zeitstempels oder eines Zeitraums ausdrücken kann"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#UsageRestrictions
+ec:UsageRestrictions rdf:type owl:Class ;
+                     rdfs:subClassOf ec:Rights ;
+                     dcterms:description "A set of constraints on the use of a work."@en ,
+                                         "Eine Menge von Beschränkungen für die Nutzung eines Werks."@de ;
+                     rdfs:label "Nutzungsbeschränkungen"@de ,
+                                "Usage restrictions"@en ;
+                     skos:definition "a ec:Rights that define the constraints on the use of a work"@en ,
+                                     "eine ec:Rights, die die Beschränkungen für die Nutzung eines Werks festlegt"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#UsageRights
+ec:UsageRights rdf:type owl:Class ;
+               rdfs:subClassOf ec:Rights ;
+               dcterms:description "A set of entitlements to the use of work."@en ,
+                                   "Eine Menge von Nutzungsrechten für ein Werk."@de ;
+               rdfs:label "Nutzungsrechte"@de ,
+                          "Usage rights"@en ;
+               skos:definition "a ec:Rights that define the entitlements in the use of a work"@en ,
+                               "eine ec:Rights, die die Nutzungsberechtigungen eines Werks definieren"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#VideoCodec
+ec:VideoCodec rdf:type owl:Class ;
+              rdfs:subClassOf ec:Codec ;
+              dcterms:description "Der bei der Produktion von Videoinhalten verwendete Codec."@de ,
+                                  "The codec used in the production of video content."@en ;
+              rdfs:label "Video codec"@en ,
+                         "Videocodec"@de ;
+              skos:definition "a ec:Codec used in the production of a video stream, file or track"@en ,
+                              "ein ec:Codec, der bei der Produktion eines Videostreams, einer Datei oder eines Tracks verwendet wird"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#VideoEncodingFormat
+ec:VideoEncodingFormat rdf:type owl:Class ;
+                       rdfs:subClassOf ec:EncodingFormat ;
+                       dcterms:description "An entry from the classification of transformations that produce digital video resources from audio signals."@en ,
+                                           "Ein Eintrag aus der Klassifikation von Transformationen, die digitale Videoressourcen aus Audiosignalen erzeugen."@de ;
+                       rdfs:label "Video encoding format"@en ,
+                                  "Video-Encoding-Format"@de ;
+                       skos:definition "a ec:EncodingFormat classifying the transformation from a video signal to video data in a ec:MediaResource"@en ,
+                                       "eine ec:EncodingFormat-Klasse, die die Transformation von einem Videosignal zu Videodaten in einer ec:MediaResource klassifiziert"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#VideoFormat
+ec:VideoFormat rdf:type owl:Class ;
+               rdfs:subClassOf ec:Format ;
+               dcterms:description "An entry from the classification of types of video formats for media resources."@en ,
+                                   "Ein Eintrag aus der Klassifikation von Typen von Videoformaten für Medienressourcen."@de ;
+               rdfs:label "Video format"@en ,
+                          "Videoformat"@de ;
+               skos:definition "a ec:Format classifying the format of video in a ec:MediaResource"@en ,
+                               "eine ec:Format-Klasse zur Klassifizierung des Videoformats in einer ec:MediaResource"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#VideoStream
+ec:VideoStream rdf:type owl:Class ;
+               rdfs:subClassOf ec:Stream ;
+               dcterms:description "A data stream containing a decidable video signal."@en ,
+                                   "Ein Datenstrom, der ein decodierbares Videosignal enthält."@de ;
+               rdfs:label "Video stream"@en ,
+                          "Videostream"@de ;
+               skos:definition "a ec:Stream with encoded video"@en ,
+                               "ein ec:Stream mit kodiertem Video"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#VideoTrack
+ec:VideoTrack rdf:type owl:Class ;
+              rdfs:subClassOf ec:Track ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:videoTrackNumber ;
+                                owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                owl:onDataRange xsd:nonNegativeInteger
+                              ] ;
+              dcterms:description "A track containing video."@en ,
+                                  "Ein Track, der Video enthält."@de ;
+              rdfs:label "Video track"@en ,
+                         "Videospur"@de ;
+              skos:definition "a ec:Track containing video"@en ,
+                              "ein ec:Track mit Video"@de .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#WrappingType
+ec:WrappingType rdf:type owl:Class ;
+                rdfs:subClassOf skos:Concept ;
+                dcterms:description "An entry from a list of types for the wrapping, usually of data."@en ,
+                                    "Ein Eintrag aus einer Liste von Typen für die Umhüllung, in der Regel von Daten."@de ;
+                rdfs:label "Verpackungstyp"@de ,
+                           "Wrapping type"@en ;
+                skos:definition "a skos:Concept identifying the type of wrapping"@en ,
+                                "ein skos:Concept, das den Typ der Umhüllung identifiziert"@de .
+
+
+###  http://www.w3.org/2004/02/skos/core#Concept
+skos:Concept rdf:type owl:Class ;
+             dcterms:description "An entry from a list of complementary notions."@en ;
+             rdfs:isDefinedBy <http://www.w3.org/2004/02/skos/core> ;
+             skos:definition "an entity representing a notion or an idea from a knowledge domain"@en .
+
+
+###  http://www.w3.org/2006/time#DateTimeDescription
+time:DateTimeDescription rdf:type owl:Class ;
+                         rdfs:subClassOf time:Instant ,
+                                         [ rdf:type owl:Restriction ;
+                                           owl:onProperty time:day ;
+                                           owl:allValuesFrom xsd:gDay
+                                         ] ,
+                                         [ rdf:type owl:Restriction ;
+                                           owl:onProperty time:month ;
+                                           owl:allValuesFrom xsd:gMonth
+                                         ] ,
+                                         [ rdf:type owl:Restriction ;
+                                           owl:onProperty time:year ;
+                                           owl:allValuesFrom xsd:gYear
+                                         ] ;
+                         dcterms:description "A point in time that is described by year, month, day, hour, minute, second and milliseconds with respect to the Gregorian calendar."@en ;
+                         rdfs:label "Date-time description"@en ;
+                         skos:definition "a time:Instant that can express a date and a time of day with respect ot a time:TRS"@en .
+
+
+###  http://www.w3.org/2006/time#Instant
+time:Instant rdf:type owl:Class ;
+             rdfs:subClassOf [ rdf:type owl:Restriction ;
+                               owl:onProperty time:hasTRS ;
+                               owl:hasValue <http://www.opengis.net/def/uom/ISO-8601/0/Gregorian>
+                             ] ,
+                             [ rdf:type owl:Restriction ;
+                               owl:onProperty time:inXSDDateTimeStamp ;
+                               owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                               owl:onDataRange xsd:dateTimeStamp
+                             ] ;
+             dcterms:description "A point in time."@en ;
+             rdfs:label "Time instant"@en ;
+             skos:definition "a temporal entity with zero extent or duration"@en .
+
+
+###  http://www.w3.org/2006/time#TRS
+time:TRS rdf:type owl:Class ;
+         dcterms:description "A reference system for the specification of points in time with an origin, a direction and a scale, such as a calendar-clock combination, e.g. the Gregorian calendar, or a (possibly hierarchical) ordinal system."@en ;
+         rdfs:label "Temporal reference system"@en ;
+         skos:definition "a reference system for the specification of points in time with an origin, a direction and a scale"@en .
+
+
+#################################################################
+#    Individuals
+#################################################################
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#SOMEPROGRAMME
+ec:SOMEPROGRAMME rdf:type owl:NamedIndividual ,
+                          ec:EditorialObject ;
+                 ec:aspectRatio "16:9" ;
+                 ec:tag "Et merke"@nb ,
+                        "et annet merke (some tag)"@nb .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#abridgedTitle
+ec:abridgedTitle rdf:type owl:NamedIndividual ,
+                          skos:Concept ;
+                 skos:inScheme ec:alternativeTitleTypes ;
+                 skos:prefLabel "Abridged title"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#alternativeTitleTypes
+ec:alternativeTitleTypes rdf:type owl:NamedIndividual ,
+                                  skos:ConceptScheme ;
+                         skos:prefLabel "Alternative title types"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#originalTitle
+ec:originalTitle rdf:type owl:NamedIndividual ,
+                          skos:Concept ;
+                 skos:inScheme ec:alternativeTitleTypes ;
+                 skos:definition "The original title used to identify the work."@en ;
+                 skos:prefLabel "Original title"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#serialTitle
+ec:serialTitle rdf:type owl:NamedIndividual ,
+                        skos:Concept ;
+               skos:inScheme ec:alternativeTitleTypes ;
+               skos:prefLabel "Serial title"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#seriesTitle
+ec:seriesTitle rdf:type owl:NamedIndividual ,
+                        skos:Concept ;
+               skos:inScheme ec:alternativeTitleTypes ;
+               skos:prefLabel "Series title"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#subtitle
+ec:subtitle rdf:type owl:NamedIndividual ,
+                     skos:Concept ;
+            skos:inScheme ec:alternativeTitleTypes ;
+            skos:prefLabel "Subtitle"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#translationTitle
+ec:translationTitle rdf:type owl:NamedIndividual ,
+                             skos:Concept ;
+                    skos:inScheme ec:alternativeTitleTypes ;
+                    skos:prefLabel "Translation title"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#versionTitle
+ec:versionTitle rdf:type owl:NamedIndividual ,
+                         skos:Concept ;
+                skos:inScheme ec:alternativeTitleTypes ;
+                skos:prefLabel "Version title"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#workingTitle
+ec:workingTitle rdf:type owl:NamedIndividual ,
+                         skos:Concept ;
+                skos:inScheme ec:alternativeTitleTypes ;
+                skos:prefLabel "working title"@en .
+
+
+###  http://www.opengis.net/def/uom/ISO-8601/0/Gregorian
+<http://www.opengis.net/def/uom/ISO-8601/0/Gregorian> rdf:type owl:NamedIndividual .
+
+
+[ owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger
+] .
+
+#################################################################
+#    Annotations
+#################################################################
+
+dcterms:contributor dcterms:description "In the context of EBUCore, reserved for the annotation of RDF properties."@en ;
+                     rdfs:label "Contributor"@en .
+
+
+###  Generated by the OWL API (version 4.5.9.2019-02-01T07:24:44Z) https://github.com/owlcs/owlapi

--- a/ontology/EBUCorePlus/ebucoreplus_en_fr.owl
+++ b/ontology/EBUCorePlus/ebucoreplus_en_fr.owl
@@ -1,0 +1,14182 @@
+@prefix : <http://www.ebu.ch/metadata/ontologies/ebucoreplus#> .
+@prefix cc: <http://creativecommons.org/ns#> .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix ec: <http://www.ebu.ch/metadata/ontologies/ebucoreplus#> .
+@prefix vs: <http://www.w3.org/2003/06/sw-vocab-status/ns#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix spin: <http://spinrdf.org/spin#> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix vann: <http://purl.org/vocab/vann/> .
+@prefix xkos: <https://rdf-vocabulary.ddialliance.org/xkos/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@base <http://www.ebu.ch/metadata/ontologies/ebucoreplus> .
+
+<http://www.ebu.ch/metadata/ontologies/ebucoreplus> rdf:type owl:Ontology ;
+                                                     owl:versionIRI <http://www.ebu.ch/metadata/ontologies/ebucoreplus/2.0.0> ;
+                                                     owl:imports <http://www.w3.org/2004/02/skos/core> ;
+                                                     cc:licence "http://creativecommons.org/licenses/by-sa/3.0/" ;
+                                                     dc:contributor "Adam Wead, Penn State University"@en-us ,
+                                                                    "Alexander Schulze, Innotrade"@de ,
+                                                                    "Alexandre Rouxel, EBU"@ch ,
+                                                                    "Are Tverberg, TV2"@no ,
+                                                                    "Casey Davis, WGBH"@en-us ,
+                                                                    "Cedric Klein, Perfect Memory"@fr ,
+                                                                    "Christophe Debruyne, RIA"@ie ,
+                                                                    "Chuck McCallum, WGBH"@en-us ,
+                                                                    "Cliff Ingham, City of Bloomington"@en-us ,
+                                                                    "Dalia R. Levine, HBO"@en-us ,
+                                                                    "Drew Myers, WGBH"@en-us ,
+                                                                    "Glenn Clatworthy, PBS"@en-us ,
+                                                                    "Guillaume Rachez, Perfect Memory"@fr ,
+                                                                    "Hugo Cordier, SetKeeper"@fr ,
+                                                                    "Hugo Manguinhas, Europeana"@nl ,
+                                                                    "Ismail Harrendo, Eurecom"@fr ,
+                                                                    "Jack Brighton, WILL Public Media"@en-us ,
+                                                                    "Julie Hardesty, Indian University Library"@en-us ,
+                                                                    "Jürgen Grupp, SWR"@de ,
+                                                                    "Kara van Malssen, AV Preserve"@en-us ,
+                                                                    "Karen Cariani, WGBH"@en-us ,
+                                                                    "Kim Viljanen, YLE"@fi ,
+                                                                    "Knut-Olav Hoven, NRK"@no ,
+                                                                    "Laurence Cook, metaCirque"@en-us ,
+                                                                    "Marc-Antoine Arnaud, Media-IO"@fr ,
+                                                                    "Mark Guelbahar, IRT"@de ,
+                                                                    "Matthieu Parmentier, francetelevisions"@fr ,
+                                                                    "Michael J. Giarlo, Penn State University"@en-us ,
+                                                                    "Peggy Griesinger, George Mason University Libraries"@en-us ,
+                                                                    "Raphael Troncy, Eurecom"@fr ,
+                                                                    "Rebecca Fraimow, WGBH"@en-us ,
+                                                                    "Rebecca Guenther, Rebecca Guenther Consulting"@en-us ,
+                                                                    "Robert Engels, NRK"@no ,
+                                                                    "Sadie Roosa, WGBH"@en-us ,
+                                                                    "Tormod Vævågen, GluonMedia"@no ,
+                                                                    "Valentine Charles, Europeana"@nl ,
+                                                                    "Valerie J. Miller, PBS"@en-us ,
+                                                                    "Vincent Dabouineau"@fr ;
+                                                     dc:creator "Jean Pierre Evain, EBU"@ch ;
+                                                     dc:description """EBUCorePlus is an ontology for media enterprises, developed as an open source project. It follows-up on two long-standing EBU ontologies: EBUCore and CCDM (Class Conceptual Data Model). The two were merged and thoroughly revisioned. The result is EBUCorePlus, the new standard that can fully replace its predecessors. It inherits both the long-lasting reliability of EBUCore and the end-to-end coverage of the media value chain of CCDM.
+
+EBUCorePlus is strictly semantic. It avoids ambiguities that were introduced when using EBUCore and CCDM classes in one graph. It has its own, new name space therefore it is not backward compatible, but can be mapped to its predecessors. It provides complete documentation of all entities in English, French and German (English being normative).
+
+One major problem of EBUCore and CCDM was the use of ranges: semantically similar object properties needed to be defined in parallel for each class that the property referred to. Another case was the use of multi-range properties, leading to insufficient type safety. EBUCorePlus now uses class restrictions instead, leading to less and more coherent properties.
+
+EBUCorePlus aims to serve as a plug and play framework. It can be used out of the box, either in its entirety or just a subset of its elements. But it may also be adapted and extended to enterprise-specific needs. Especially for system integration tasks and defining requirements, projects benefit from EBUCorePlus as a business – not technology – oriented language.
+
+The ontology is developed by the EBU Metadata Modelling Working Group as an open source project on github. Requests for changes and improvements can be submitted by EBU Members, media organizations or anybody else from the media community. The EBUCorePlus Editorial Committee reviews requests and implements changes.
+
+The EBU Metadata Modelling Working Group provides access, upon request, to a cloud hosted demonstration kit to explore and better understand the whole EBUCorePlus model."""@en ;
+                                                     dc:publisher "European Broadcasting Union (EBU)"@ch ;
+                                                     dc:rights "Copyright 2023 EBU"@en ;
+                                                     vann:preferredNamespaceUri "http://www.ebu.ch/metadata/ontologies/ebucoreplus#" ;
+                                                     owl:versionInfo "Version 2.0.0"@en ;
+                                                     vs:term_status "stable"@en .
+
+#################################################################
+#    Annotation properties
+#################################################################
+
+###  http://creativecommons.org/ns#licence
+cc:licence rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/contributor
+dc:contributor rdf:type owl:AnnotationProperty ;
+               dcterms:description "An Agent who has participated in any phase of management of an Asset."@en ;
+               rdfs:label "Contributor"@en .
+
+
+###  http://purl.org/dc/elements/1.1/creator
+dc:creator rdf:type owl:AnnotationProperty ;
+           dcterms:description "To identify the creator of an Asset."@en ;
+           rdfs:label "Creator"@en .
+
+
+###  http://purl.org/dc/elements/1.1/date
+dc:date rdf:type owl:AnnotationProperty ;
+        dcterms:description "A date associated with a resource."@en ;
+        rdfs:label "Date"@en ;
+        rdfs:range xsd:date .
+
+
+###  http://purl.org/dc/elements/1.1/description
+dc:description rdf:type owl:AnnotationProperty ;
+               dcterms:description "A description of an Asset."@en ;
+               rdfs:label "Description"@en .
+
+
+###  http://purl.org/dc/elements/1.1/format
+dc:format rdf:type owl:AnnotationProperty ;
+          dcterms:description "Information about the Format of a Resource."@en ;
+          rdfs:label "Format"@en .
+
+
+###  http://purl.org/dc/elements/1.1/identifier
+dc:identifier rdf:type owl:AnnotationProperty ;
+              dcterms:description "To provide a simple not strongly structured identifier."@en ;
+              rdfs:label "Identifier"@en .
+
+
+###  http://purl.org/dc/elements/1.1/language
+dc:language rdf:type owl:AnnotationProperty ;
+            dcterms:description "To define languages associated with an Asset."@en ;
+            rdfs:label "Language"@en .
+
+
+###  http://purl.org/dc/elements/1.1/publisher
+dc:publisher rdf:type owl:AnnotationProperty ;
+             dcterms:description "An Agent involved in the distribution of content."@en ;
+             rdfs:label "Publisher"@en .
+
+
+###  http://purl.org/dc/elements/1.1/rights
+dc:rights rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/title
+dc:title rdf:type owl:AnnotationProperty ;
+         dcterms:description "The title by which a EditorialObject is known."@en ;
+         rdfs:label "Title"@en .
+
+
+###  http://purl.org/dc/elements/1.1/type
+dc:type rdf:type owl:AnnotationProperty ;
+        dcterms:description "A concept associated with a resource."@en ;
+        rdfs:label "Type"@en .
+
+
+###  http://purl.org/dc/terms/description
+dcterms:description rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/vocab/vann/preferredNamespaceUri
+vann:preferredNamespaceUri rdf:type owl:AnnotationProperty .
+
+
+###  http://spinrdf.org/spin#imports
+spin:imports rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2000/01/rdf-schema#example
+rdfs:example rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2002/07/owl#maxQualifiedCardinality
+owl:maxQualifiedCardinality rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2003/06/sw-vocab-status/ns#term_status
+vs:term_status rdf:type owl:AnnotationProperty .
+
+
+#################################################################
+#    Datatypes
+#################################################################
+
+###  http://www.w3.org/2001/XMLSchema#date
+xsd:date rdf:type rdfs:Datatype .
+
+
+###  http://www.w3.org/2001/XMLSchema#gDay
+xsd:gDay rdf:type rdfs:Datatype .
+
+
+###  http://www.w3.org/2001/XMLSchema#gMonth
+xsd:gMonth rdf:type rdfs:Datatype .
+
+
+###  http://www.w3.org/2001/XMLSchema#gYear
+xsd:gYear rdf:type rdfs:Datatype .
+
+
+###  http://www.w3.org/2001/XMLSchema#time
+xsd:time rdf:type rdfs:Datatype .
+
+
+#################################################################
+#    Object Properties
+#################################################################
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#accountingTo
+ec:accountingTo rdf:type owl:ObjectProperty ;
+                dcterms:description "A Consumer Account for a particular Service."@en ,
+                                    "Un compte de consommateur pour un service particulier."@fr ;
+                rdfs:label "Account"@en ,
+                           "Compte"@fr ;
+                skos:definition "an owl:ObjectProperty relating an ec:ConsumptionEvent to an ec:Account"@en ,
+                                "une propriété objet owl reliant un ec:ConsumptionEvent à un ec:Account"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#animates
+ec:animates rdf:type owl:ObjectProperty ;
+            owl:inverseOf ec:isAnimatedBy ;
+            dcterms:description "Indicates that a person animates a character through the use of an artefact, such as a puppet or animation rig."@en ,
+                                "Indique qu’une personne anime un personnage au moyen d’un artefact, tel qu’une marionnette ou un banc d’animation."@fr ;
+            rdfs:label "Animates"@en ,
+                       "Anime"@fr ;
+            skos:definition "an owl:ObjectProperty relating an ec:Person to an ec:Character"@en ,
+                            "une propriété objet owl reliant une ec:Person à une ec:Character"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#applyTo
+ec:applyTo rdf:type owl:ObjectProperty ;
+           dcterms:description "L’Asset auquel s’appliquent les droits."@fr ,
+                               "The Asset to which Rights apply."@en ;
+           rdfs:label "Actif"@fr ,
+                      "Asset"@en ;
+           skos:definition "an owl:ObjectProperty relating an ec:Rights to an ec:Asset"@en ,
+                           "une propriété d'objet owl reliant une ec:Rights à un ec:Asset"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#approvedBy
+ec:approvedBy rdf:type owl:ObjectProperty ;
+              dcterms:description "L’Agent qui a approuvé l’EditorialObject pour publication. Lorsqu’elle est présente, la propriété agit comme un déclencheur de publication de l’EditorialObject."@fr ,
+                                  "The Agent who approved the EditorialObject for publishing. When present, the property acts as a trigger for publishing the EditorialObject."@en ;
+              rdfs:label "Agent"@en ,
+                         "Agent"@fr ;
+              skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Agent"@en ,
+                              "une propriété d'objet owl reliant un ec:EditorialObject à un ec:Agent"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#basedOn
+ec:basedOn rdf:type owl:ObjectProperty ;
+           dcterms:description "L'objeto éditorial auquel se rapporte le travail de production."@fr ,
+                               "The EditorialObject that the ProductionJob relates to."@en ;
+           rdfs:label "Objet éditorial associé"@fr ,
+                      "Related editorial object"@en ;
+           skos:definition "an owl:ObjectProperty relating an ec:ProductionJob to an ec:EditorialObject"@en ,
+                           "une propriété objet owl reliant un ec:ProductionJob à un ec:EditorialObject"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#belongsToAudience
+ec:belongsToAudience rdf:type owl:ObjectProperty ;
+                     dcterms:description "Le groupe Audience parent auquel un Consumer appartient."@fr ,
+                                         "The parent Audience group to which a Consumer is a member of."@en ;
+                     rdfs:label "Audience parent"@fr ,
+                                "Parent audience"@en ;
+                     skos:definition "an owl:ObjectProperty relating an ec:Consumer to an ec:Audience"@en ,
+                                     "une propriété d'objet owl:ObjectProperty reliant un ec:Consumer à un ec:Audience"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#bringsRights
+ec:bringsRights rdf:type owl:ObjectProperty ;
+                dcterms:description "Les droits apparaissent comme une conséquence de l’engagement."@fr ,
+                                    "The rights appear as a consequence of the engagement."@en ;
+                rdfs:label "Apporte des droits"@fr ,
+                           "Brings rights"@en ;
+                skos:definition "an owl:ObjectProperty relating an ec:Involvement to ec:Rights"@en ,
+                                "une propriété d’objet owl reliant un ec:Involvement à ec:Rights"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#canAccessPublicationChannel
+ec:canAccessPublicationChannel rdf:type owl:ObjectProperty ;
+                               dcterms:description "A property that indicates whether a consumption device profile can access a publication channel."@en ,
+                                                   "Une propriété qui indique si un profil de dispositif de consommation peut accéder à un canal de publication."@fr ;
+                               rdfs:label "Can access publication channel"@en ,
+                                          "Peut accéder au canal de publication"@fr ;
+                               skos:definition "an owl:ObjectProperty relating an ec:ConsumptionDeviceProfile to an ec:PublicationChannel"@en ,
+                                               "une owl:ObjectProperty reliant un ec:ConsumptionDeviceProfile à un ec:PublicationChannel"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#canAccessPublicationPlatform
+ec:canAccessPublicationPlatform rdf:type owl:ObjectProperty ;
+                                dcterms:description "A property that indicates whether a consumption device profile can access a publication platform."@en ,
+                                                    "Une propriété qui indique si un profil de dispositif de consommation peut accéder à une plateforme de publication."@fr ;
+                                rdfs:label "Can access publication platform"@en ,
+                                           "Peut accéder à la plateforme de publication"@fr ;
+                                skos:definition "an owl:ObjectProperty relating an ec:ConsumptionDeviceProfile to an ec:PublicationPlatform"@en ,
+                                                "une propriété d’objet owl liant une ec:ConsumptionDeviceProfile à une ec:PublicationPlatform"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#commissions
+ec:commissions rdf:type owl:ObjectProperty ;
+               owl:inverseOf ec:hasCommissioningContract ;
+               dcterms:description "Relates an EditorialObject to the Contract through which it is commissioned."@en ,
+                                   "Relie un objet éditorial au contrat par lequel il est commandé."@fr ;
+               rdfs:label "Commissions"@en ,
+                          "Commissions"@fr ;
+               skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Contract"@en ,
+                               "une propriété objet owl reliant un ec:EditorialObject à un ec:Contract"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#compilesResonanceEvents
+ec:compilesResonanceEvents rdf:type owl:ObjectProperty ;
+                           dcterms:description "L’un des ResonanceEvents agrégés en un ensemble significatif de données Resonance."@fr ,
+                                               "One of the ResonanceEvents aggregated into a meaningful set of Resonance data."@en ;
+                           rdfs:label "Resonance"@en ,
+                                      "Résonance"@fr ;
+                           skos:definition "an owl:ObjectProperty relating a ec:ResonanceCount to a ec:ResonanceEvent"@en ,
+                                           "une propriété d’objet owl reliant une ec:ResonanceCount à une ec:ResonanceEvent"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#compliesWith
+ec:compliesWith rdf:type owl:ObjectProperty ;
+                dcterms:description "Le profil auquel une ConsumptionDevice est conforme."@fr ,
+                                    "The profile a ConsumptionDevice complies with."@en ;
+                rdfs:label "Device profile"@en ,
+                           "Profil de l'appareil"@fr ;
+                skos:definition "an owl:ObjectProperty relating an ec:ConsumptionDevice to an ec:ConsumptionDeviceProfile"@en ,
+                                "une propriété d’objet owl reliant un ec:ConsumptionDevice à un ec:ConsumptionDeviceProfile"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#consumesEssence
+ec:consumesEssence rdf:type owl:ObjectProperty ;
+                   dcterms:description "L’essence qui a été consommée pendant un ConsumptionEvent."@fr ,
+                                       "The Essence that has been consumed during a ConsumptionEvent."@en ;
+                   rdfs:label "Essence"@en ,
+                              "Essence"@fr ;
+                   skos:definition "an ec:ConsumptionEvent relating to an ec:Essence"@en ,
+                                   "un ec:ConsumptionEvent relatif à un ec:Essence"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#coversConsumptionDevice
+ec:coversConsumptionDevice rdf:type owl:ObjectProperty ;
+                           dcterms:description "A device compatible with the ConsumptionLicence."@en ,
+                                               "Un appareil compatible avec la ConsumptionLicence."@fr ;
+                           rdfs:label "Compatible consumption device"@en ,
+                                      "Dispositif de consommation compatible"@fr ;
+                           skos:definition "an owl:ObjectProperty relating an ec:ConsumptionLicence to an ec:ConsumptionDevice"@en ,
+                                           "une propriété d’objet owl reliant un ec:ConsumptionLicence à un ec:ConsumptionDevice"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#coversEvent
+ec:coversEvent rdf:type owl:ObjectProperty ;
+               rdfs:subPropertyOf ec:hasCoverage ;
+               dcterms:description "A property to identify the Events, all real or fictional, covered by the EditorialObject."@en ,
+                                   "Une propriété permettant d’identifier les événements, réels ou fictifs, couverts par l’objet éditorial."@fr ;
+               rdfs:label "Couvre événement"@fr ,
+                          "Covers event"@en ;
+               skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Event"@en ,
+                               "une propriété d'objet owl reliant un ec:EditorialObject à un ec:Event"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#coversLocation
+ec:coversLocation rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf ec:hasCoverage ;
+                  dcterms:description "A property to identify the Locations, all real or fictional, covered by the EditorialObject."@en ,
+                                      "Une propriété permettant d’identifier les lieux, réels ou fictifs, couverts par l’EditorialObject."@fr ;
+                  rdfs:label "Couvre le lieu"@fr ,
+                             "Covers location"@en ;
+                  skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Location"@en ,
+                                  "une propriété objet owl reliant un ec:EditorialObject à un ec:Location"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#createsMetadata
+ec:createsMetadata rdf:type owl:ObjectProperty ;
+                   dcterms:description "Used where a production job, e.g. a face recognition service, yields information that can be described using the EditorialObject class."@en ,
+                                       "Utilisé lorsqu’un job de production, par exemple un service de reconnaissance faciale, produit des informations pouvant être décrites à l’aide de la classe EditorialObject."@fr ;
+                   rdfs:label "Creates metadata"@en ,
+                              "Crée des métadonnées"@fr ;
+                   skos:definition "an owl:ObjectProperty relating an ec:ProductionJob to an ec:EditorialObject"@en ,
+                                   "une propriété d’objet owl reliant un ec:ProductionJob à un ec:EditorialObject"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#defines
+ec:defines rdf:type owl:ObjectProperty ;
+           owl:inverseOf ec:isDefinedBy ;
+           dcterms:description "Identifie le contrat, l’accord ou la loi qui définit une règle."@fr ,
+                               "Identifies the contract, agreement, or law that defines a rule."@en ;
+           rdfs:label "Defines"@en ,
+                      "Définit"@fr ;
+           skos:definition "an owl:ObjectProperty relating an ec:Rule to an ec:Contract"@en ,
+                           "une propriété d’objet owl reliant un ec:Rule à un ec:Contract"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#derivedTo
+ec:derivedTo rdf:type owl:ObjectProperty ;
+             owl:inverseOf ec:isDerivedFrom ;
+             dcterms:description "A new version derived from the original asset."@en ,
+                                 "Une nouvelle version dérivée de l’actif d’origine."@fr ;
+             rdfs:label "Cible de dérivation"@fr ,
+                        "Derivation target"@en ;
+             skos:definition "an owl:ObjectProperty relating an ec:Asset to an ec:Asset"@en ,
+                             "une propriété d’objet owl reliant une ec:Asset à une ec:Asset"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#excludesAudience
+ec:excludesAudience rdf:type owl:ObjectProperty ;
+                    dcterms:description "A defined audience group that is excluded from the audience."@en ,
+                                        "Un groupe d’audience défini qui est exclu de l’audience."@fr ;
+                    rdfs:label "Excludes audience"@en ,
+                               "Exclut l’audience"@fr ;
+                    skos:definition "an owl:ObjectProperty relating an ec:Audience to an ec:Audience"@en ,
+                                    "une propriété objet owl reliant un ec:Audience à un ec:Audience"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#existsAs
+ec:existsAs rdf:type owl:ObjectProperty ;
+            dcterms:description "La relation qui lie un EditorialObject à un EditorialObject alternatif dans lequel il peut exister."@fr ,
+                                "The relationship that links an EditorialObject to an alternative EditorialObject in which it may exist."@en ;
+            rdfs:label "Editorial object"@en ,
+                       "Objet éditorial"@fr ;
+            skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:EditorialObject"@en ,
+                            "une propriété d’objet owl reliant un ec:EditorialObject à un ec:EditorialObject"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#grantsApproval
+ec:grantsApproval rdf:type owl:ObjectProperty ;
+                  owl:inverseOf ec:hasApprover ;
+                  dcterms:description "Indicates that an Agent grants approval for an Audit Report."@en ,
+                                      "Indique qu’un Agent accorde une approbation pour un Rapport d’audit."@fr ;
+                  rdfs:label "Accorde l’approbation"@fr ,
+                             "Grants approval"@en ;
+                  skos:definition "an owl:ObjectProperty relating an ec:AuditReport to an ec:Agent"@en ,
+                                  "une propriété d'objet owl reliant un ec:AuditReport à un ec:Agent"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAccessConditions
+ec:hasAccessConditions rdf:type owl:ObjectProperty ;
+                       rdfs:subPropertyOf ec:hasRights ;
+                       dcterms:description "Access conditions or restrictions under which access to content or its publication is granted."@en ,
+                                           "Conditions ou restrictions d’accès selon lesquelles l’accès au contenu ou sa publication est accordé."@fr ;
+                       rdfs:label "Access conditions"@en ,
+                                  "Conditions d'accès"@fr ;
+                       skos:definition "an owl:ObjectProperty relating an ec:Asset or ec:PublicationEvent to ec:AccessConditions"@en ,
+                                       "une propriété d’objet owl:ObjectProperty reliant un ec:Asset ou un ec:PublicationEvent à ec:AccessConditions"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAffiliation
+ec:hasAffiliation rdf:type owl:ObjectProperty ;
+                  owl:inverseOf ec:isAffiliationFor ;
+                  dcterms:description "A property to establish the relation between a Contact/Person and an Organisation."@en ,
+                                      "Une propriété permettant d’établir la relation entre un contact/personne et une organisation."@fr ;
+                  rdfs:label "Affiliation"@en ,
+                             "Affiliation"@fr ;
+                  skos:definition "an owl:ObjectProperty relating an ec:Person to an ec:Affiliation"@en ,
+                                  "une owl:ObjectProperty reliant un ec:Person à un ec:Affiliation"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAgent
+ec:hasAgent rdf:type owl:ObjectProperty ;
+            dcterms:description "Relates an involvement to the agent who participates in it."@en ,
+                                "Relie une implication à l’agent qui y participe."@fr ;
+            rdfs:label "A un agent"@fr ,
+                       "Has agent"@en ;
+            skos:definition "an owl:ObjectProperty relating an ec:Involvement to an ec:Agent"@en ,
+                            "une propriété objet owl reliant un ec:Involvement à un ec:Agent"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAgentBiography
+ec:hasAgentBiography rdf:type owl:ObjectProperty ;
+                     dcterms:description "A biography of an Agent."@en ,
+                                         "Une biographie d'un Agent."@fr ;
+                     rdfs:label "Biographie"@fr ,
+                                "Biography"@en ;
+                     skos:definition "an owl:ObjectProperty relating an ec:Agent to an ec:Biography"@en ,
+                                     "une propriété objet owl reliant un ec:Agent à une ec:Biography"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAgentCountryOfResidence
+ec:hasAgentCountryOfResidence rdf:type owl:ObjectProperty ;
+                              dcterms:description "Le pays de résidence d’un Agent."@fr ,
+                                                  "The country of residence of an Agent."@en ;
+                              rdfs:label "Country of residence"@en ,
+                                         "Pays de résidence"@fr ;
+                              skos:definition "an owl:ObjectProperty relating an ec:Agent to an ec:CountryCode"@en ,
+                                              "une owl:ObjectProperty reliant un ec:Agent à un ec:CountryCode"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAgentLanguage
+ec:hasAgentLanguage rdf:type owl:ObjectProperty ;
+                    dcterms:description "La ou les langues associées à un Agent."@fr ,
+                                        "The language or languages associated with an Agent."@en ;
+                    rdfs:label "Language"@en ,
+                               "Langue"@fr ;
+                    skos:definition "an owl:ObjectProperty relating an ec:Agent to an ec:Language"@en ,
+                                    "une propriété d'objet owl reliant un ec:Agent à un ec:Language"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAgentMember
+ec:hasAgentMember rdf:type owl:ObjectProperty ;
+                  dcterms:description "L’Agent qui est membre d’un autre Agent, comme une équipe."@fr ,
+                                      "The Agent that is a member of another Agent, such as a Team."@en ;
+                  rdfs:label "Agent member"@en ,
+                             "Membre d’agent"@fr ;
+                  skos:definition "an owl:ObjectProperty relating an ec:Agent to an ec:Agent"@en ,
+                                  "une propriété objet owl reliant un ec:Agent à un ec:Agent"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAgentNationality
+ec:hasAgentNationality rdf:type owl:ObjectProperty ;
+                       dcterms:description "La nationalité associée à un Agent."@fr ,
+                                           "The nationality associated with an Agent."@en ;
+                       rdfs:label "Nationality"@en ,
+                                  "Nationalité"@fr ;
+                       skos:definition "an owl:ObjectProperty relating an ec:Agent to an ec:CountryCode"@en ,
+                                       "une propriété objet owl reliant un ec:Agent à un ec:CountryCode"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAgentOnStagePosition
+ec:hasAgentOnStagePosition rdf:type owl:ObjectProperty ;
+                           dcterms:description "La position d’un agent sur scène."@fr ,
+                                               "The position of an agent on stage."@en ;
+                           rdfs:label "On stage position"@en ,
+                                      "Position sur scène"@fr ;
+                           skos:definition "an owl:ObjectProperty relating an ec:Involvement to an ec:OnStagePosition"@en ,
+                                           "une owl:ObjectProperty reliant une ec:Involvement à une ec:OnStagePosition"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAgentPlaceOfResidence
+ec:hasAgentPlaceOfResidence rdf:type owl:ObjectProperty ;
+                            dcterms:description "L’endroit où réside un Agent."@fr ,
+                                                "The place where an Agent resides."@en ;
+                            rdfs:label "Lieu de résidence"@fr ,
+                                       "Place of residence"@en ;
+                            skos:definition "an owl:ObjectProperty relating an ec:Agent to an ec:Location"@en ,
+                                            "une propriété d’objet owl:ObjectProperty reliant un ec:Agent à un ec:Location"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAlternativeTitle
+ec:hasAlternativeTitle rdf:type owl:ObjectProperty ;
+                       dcterms:description "Lie un objet éditorial à l’un de ses titres alternatifs."@fr ,
+                                           "Links an editorial object to one of its alternative titles."@en ;
+                       rdfs:label "A un titre alternatif"@fr ,
+                                  "Has alternative title"@en ;
+                       skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:AlternativeTitle"@en ,
+                                       "une propriété objet owl reliant un ec:EditorialObject à un ec:AlternativeTitle"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAncillaryData
+ec:hasAncillaryData rdf:type owl:ObjectProperty ;
+                    dcterms:description "Les données auxiliaires contenues dans la ressource multimédia."@fr ,
+                                        "The ancillary data contained in the media resource."@en ;
+                    rdfs:label "Ancillary data"@en ,
+                               "Données auxiliaires"@fr ;
+                    skos:definition "an owl:ObjectProperty relating an ec:Resource to an ec:AncillaryData"@en ,
+                                    "une propriété d’objet owl reliant une ec:Resource à une ec:AncillaryData"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAncillaryDataFormat
+ec:hasAncillaryDataFormat rdf:type owl:ObjectProperty ;
+                          rdfs:subPropertyOf ec:hasFormat ;
+                          dcterms:description "Le format des données auxiliaires."@fr ,
+                                              "The format of ancillary data."@en ;
+                          rdfs:label "Ancillary data format"@en ,
+                                     "Format des données auxiliaires"@fr ;
+                          skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:AncillaryDataFormat"@en ,
+                                          "une propriété objet owl reliant un ec:MediaResource à un ec:AncillaryDataFormat"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAnimalBreedCode
+ec:hasAnimalBreedCode rdf:type owl:ObjectProperty ;
+                      dcterms:description "Le code de race associé à un animal."@fr ,
+                                          "The breed code associated with an animal."@en ;
+                      rdfs:label "Animal breed code"@en ,
+                                 "Code de race animale"@fr ;
+                      skos:definition "an owl:ObjectProperty relating an ec:Animal to an ec:AnimalBreedCode"@en ,
+                                      "une propriété objet owl reliant un ec:Animal à un ec:AnimalBreedCode"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAnimalColourCode
+ec:hasAnimalColourCode rdf:type owl:ObjectProperty ;
+                       dcterms:description "Le code de couleur de l’animal associé à un animal."@fr ,
+                                           "The animal colour code associated with an animal."@en ;
+                       rdfs:label "Animal colour code"@en ,
+                                  "Code de couleur de l’animal"@fr ;
+                       skos:definition "an owl:ObjectProperty relating an ec:Animal to an ec:AnimalColourCode"@en ,
+                                       "une propriété d’objet owl liant un ec:Animal à un ec:AnimalColourCode"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAnimalGroom
+ec:hasAnimalGroom rdf:type owl:ObjectProperty ;
+                  owl:inverseOf ec:isAnimalGroomFor ;
+                  dcterms:description "La personne ou l’agent qui toilette et prend soin d’un animal."@fr ,
+                                      "The person or agent who grooms and cares for an animal."@en ;
+                  rdfs:label "Animal groom"@en ,
+                             "Toiletteur d’animaux"@fr ;
+                  skos:definition "an owl:ObjectProperty relating an ec:Animal to an ec:Agent"@en ,
+                                  "une owl:ObjectProperty reliant une ec:Animal à une ec:Agent"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAnimalRole
+ec:hasAnimalRole rdf:type owl:ObjectProperty ;
+                 dcterms:description "Le rôle d’un animal dans une implication."@fr ,
+                                     "The role of an animal in an involvement."@en ;
+                 rdfs:label "Animal role"@en ,
+                            "Rôle d’animal"@fr ;
+                 skos:definition "an owl:ObjectProperty relating an ec:Animal to an ec:Involvement"@en ,
+                                 "une propriété objet owl reliant un ec:Animal à une ec:Involvement"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAnnotationAgent
+ec:hasAnnotationAgent rdf:type owl:ObjectProperty ;
+                      dcterms:description "L’agent associé à l’annotation."@fr ,
+                                          "The Agent associated with the annotation."@en ;
+                      rdfs:label "Agent d'annotation"@fr ,
+                                 "Annotation agent"@en ;
+                      skos:definition "an owl:ObjectProperty relating an ec:Annotation to an ec:Agent"@en ,
+                                      "une propriété objet owl:ObjectProperty reliant une ec:Annotation à un ec:Agent"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAnnotationCurationDateTime
+ec:hasAnnotationCurationDateTime rdf:type owl:ObjectProperty ;
+                                 dcterms:description "La date et l'heure auxquelles une annotation a été révisée."@fr ,
+                                                     "The date and time when an Annotation was reviewed."@en ;
+                                 rdfs:label "Annotation curation date & time"@en ,
+                                            "Date et heure de curation de l’annotation"@fr ;
+                                 skos:definition "an owl:ObjectProperty relating an ec:Annotation to a time:Instant"@en ,
+                                                 "une propriété d'objet owl:ObjectProperty reliant une ec:Annotation à un time:Instant"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAnnotationTarget
+ec:hasAnnotationTarget rdf:type owl:ObjectProperty ;
+                       dcterms:description "L'objet cible auquel l'annotation s'applique."@fr ,
+                                           "The target object to which the annotation applies."@en ;
+                       rdfs:label "Annotation target"@en ,
+                                  "Cible d'annotation"@fr ;
+                       skos:definition "an owl:ObjectProperty relating an ec:Annotation to an owl:Thing"@en ,
+                                       "une owl:ObjectProperty reliant une ec:Annotation à un owl:Thing"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasApprover
+ec:hasApprover rdf:type owl:ObjectProperty ;
+               dcterms:description "An Agent who approved an AuditReport."@en ,
+                                   "Un Agent qui a approuvé un AuditReport."@fr ;
+               rdfs:label "Approuvé par"@fr ,
+                          "Approved by"@en ;
+               skos:definition "an owl:ObjectProperty relating an ec:AuditReport to an ec:Agent"@en ,
+                               "une propriété d'objet owl reliant un ec:AuditReport à un ec:Agent"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasArtefactBuyer
+ec:hasArtefactBuyer rdf:type owl:ObjectProperty ;
+                    dcterms:description "L’Agent qui a acheté l’artefact."@fr ,
+                                        "The Agent who bought the Artefact."@en ;
+                    rdfs:label "Acheteur"@fr ,
+                               "Buyer"@en ;
+                    skos:definition "an owl:ObjectProperty relating an ec:Artefact to an ec:Agent"@en ,
+                                    "une propriété d’objet owl reliant un ec:Artefact à un ec:Agent"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasArtefactDateOfPurchase
+ec:hasArtefactDateOfPurchase rdf:type owl:ObjectProperty ;
+                             rdfs:subPropertyOf ec:hasDate ;
+                             dcterms:description "La date à laquelle un Artefact a été acheté."@fr ,
+                                                 "The date when an Artefact was purchased. ."@en ;
+                             rdfs:label "Artefact date of purchase"@en ,
+                                        "Date d'achat de l'artefact"@fr ;
+                             skos:definition "an owl:ObjectProperty relating an ec:Artefact to a time:Instant"@en ,
+                                             "une propriété objet owl reliant un ec:Artefact à un time:Instant"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasArtefactDateOfSale
+ec:hasArtefactDateOfSale rdf:type owl:ObjectProperty ;
+                         rdfs:subPropertyOf ec:hasDate ;
+                         dcterms:description "La date à laquelle un artefact a été vendu."@fr ,
+                                             "The date when an Artefact was sold."@en ;
+                         rdfs:label "Artefact date of sale"@en ,
+                                    "Date de vente de l’artefact"@fr ;
+                         skos:definition "an owl:ObjectProperty relating an ec:Artefact to a time:Instant"@en ,
+                                         "une propriété objet owl reliant un ec:Artefact à un time:Instant"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasArtefactOwner
+ec:hasArtefactOwner rdf:type owl:ObjectProperty ;
+                    dcterms:description "La personne ou l’organisation qui possède un Artefact."@fr ,
+                                        "The person or organisation that owns an Artefact."@en ;
+                    rdfs:label "Owner"@en ,
+                               "Propriétaire"@fr ;
+                    skos:definition "an owl:ObjectProperty relating an ec:Artefact to an ec:Agent"@en ,
+                                    "une propriété objet owl reliant un ec:Artefact à un ec:Agent"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasArtefactPriceCurrency
+ec:hasArtefactPriceCurrency rdf:type owl:ObjectProperty ;
+                            dcterms:description "La monnaie dans laquelle le prix d’un Artefact est exprimé."@fr ,
+                                                "The currency in which an Artefact’s price is expressed."@en ;
+                            rdfs:label "Artefact price currency"@en ,
+                                       "Devise de la monnaie de l’artefact"@fr ;
+                            skos:definition "an owl:ObjectProperty relating an ec:Artefact to an ec:CurrencyCode"@en ,
+                                            "une propriété d’objet owl reliant un ec:Artefact à un ec:CurrencyCode"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasArtefactRelatedLocation
+ec:hasArtefactRelatedLocation rdf:type owl:ObjectProperty ;
+                              dcterms:description "Associates an Artefact with a Location."@en ,
+                                                  "Associe un Artefact à un Location."@fr ;
+                              rdfs:label "Associated location"@en ,
+                                         "Emplacement associé"@fr ;
+                              skos:definition "an owl:ObjectProperty relating an ec:Artefact to an ec:Location"@en ,
+                                              "une propriété objet owl reliant un ec:Artefact à un ec:Location"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasArtefactRelatedPhysicalResource
+ec:hasArtefactRelatedPhysicalResource rdf:type owl:ObjectProperty ;
+                                      dcterms:description "Associates an artefact or prop with a physical resource."@en ,
+                                                          "Associe un artefact ou un accessoire à une ressource physique."@fr ;
+                                      rdfs:label "Associated physical resource"@en ,
+                                                 "Ressource physique associée"@fr ;
+                                      skos:definition "an owl:ObjectProperty relating an ec:Artefact to an ec:PhysicalResource"@en ,
+                                                      "une propriété objet owl reliant un ec:Artefact à un ec:PhysicalResource"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasArtefactRetailer
+ec:hasArtefactRetailer rdf:type owl:ObjectProperty ;
+                       dcterms:description "Le détaillant d’un Artefact."@fr ,
+                                           "The retailer of an Artefact."@en ;
+                       rdfs:label "Retailer"@en ,
+                                  "Revendeur"@fr ;
+                       skos:definition "an owl:ObjectProperty relating an ec:Artefact to an ec:Agent"@en ,
+                                       "une owl:ObjectProperty reliant un ec:Artefact à un ec:Agent"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasArtefactSupplier
+ec:hasArtefactSupplier rdf:type owl:ObjectProperty ;
+                       dcterms:description "Le fournisseur d’un artefact."@fr ,
+                                           "The supplier of an Artefact."@en ;
+                       rdfs:label "Fournisseur"@fr ,
+                                  "Supplier"@en ;
+                       skos:definition "an owl:ObjectProperty relating an ec:Artefact to an ec:Agent"@en ,
+                                       "une propriété objet owl reliant un ec:Artefact à un ec:Agent"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasArticle
+ec:hasArticle rdf:type owl:ObjectProperty ;
+              dcterms:description "Indicates that an Item has an associated Article. It is used to link content intended for incorporation into an article with the resulting article resource."@en ,
+                                  "Indique qu’un Item a un Article associé. Il est utilisé pour relier le contenu destiné à être intégré dans un article à la ressource Article obtenue."@fr ;
+              rdfs:label "A un article"@fr ,
+                         "Has article"@en ;
+              skos:definition "an owl:ObjectProperty relating an ec:Item to an ec:Article"@en ,
+                              "une propriété d’objet owl reliant un ec:Item à un ec:Article"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAsset
+ec:hasAsset rdf:type owl:ObjectProperty ;
+            dcterms:description "Les actifs associés à un PublicationPlan."@fr ,
+                                "The assets related to a PublicationPlan."@en ;
+            rdfs:label "Actif"@fr ,
+                       "Asset"@en ;
+            skos:definition "an owl:ObjectProperty relating an ec:PublicationPlan to an ec:Asset"@en ,
+                            "une propriété d'objet owl reliant un ec:PublicationPlan à un ec:Asset"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAssetValue
+ec:hasAssetValue rdf:type owl:ObjectProperty ;
+                 dcterms:description "Associates an Asset with its AssetValue."@en ,
+                                     "Associe un Asset à sa AssetValue."@fr ;
+                 rdfs:label "Asset value"@en ,
+                            "Valeur de l'actif"@fr ;
+                 skos:definition "an owl:ObjectProperty relating an ec:Asset to an ec:AssetValue"@en ,
+                                 "une propriété objet owl reliant un ec:Asset à un ec:AssetValue"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAssetValueCurrency
+ec:hasAssetValueCurrency rdf:type owl:ObjectProperty ;
+                         dcterms:description "La devise dans laquelle la valeur de l'actif est exprimée."@fr ,
+                                             "The currency in which the asset value is given."@en ;
+                         rdfs:label "Asset value currency"@en ,
+                                    "Devise de la valeur d’actif"@fr ;
+                         skos:definition "an owl:ObjectProperty relating an ec:AssetValue to a skos:Concept"@en ,
+                                         "une propriété d’objet owl:ObjectProperty reliant un ec:AssetValue à un skos:Concept"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAssociatedArtefact
+ec:hasAssociatedArtefact rdf:type owl:ObjectProperty ;
+                         dcterms:description "An Artefact related to an Agent."@en ,
+                                             "Un artefact lié à un agent."@fr ;
+                         rdfs:label "Artefact lié"@fr ,
+                                    "Related artefact"@en ;
+                         skos:definition "an owl:ObjectProperty relating an ec:Agent to an ec:Artefact"@en ,
+                                         "une propriété objet owl reliant un ec:Agent à un ec:Artefact"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAssociatedConsumer
+ec:hasAssociatedConsumer rdf:type owl:ObjectProperty ;
+                         dcterms:description "A consumer associated with a ResonanceEvent."@en ,
+                                             "Un consommateur associé à un ResonanceEvent."@fr ;
+                         rdfs:label "Associated consumer"@en ,
+                                    "Consommateur associé"@fr ;
+                         skos:definition "an owl:ObjectProperty relating an ec:ResonanceEvent to an ec:Consumer"@en ,
+                                         "une propriété d'objet owl reliant un ec:ResonanceEvent à un ec:Consumer"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAssociatedConsumptionEvent
+ec:hasAssociatedConsumptionEvent rdf:type owl:ObjectProperty ;
+                                 dcterms:description "L'ec:ConsumptionEvent associé à un ec:Consumer."@fr ,
+                                                     "The ConsumptionEvent associated with a Consumer."@en ;
+                                 rdfs:label "Consumption event"@en ,
+                                            "Événement de consommation"@fr ;
+                                 skos:definition "an owl:ObjectProperty relating an ec:Consumer to an ec:ConsumptionEvent"@en ,
+                                                 "une propriété d’objet owl reliant un ec:Consumer à un ec:ConsumptionEvent"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAssociatedProductionJob
+ec:hasAssociatedProductionJob rdf:type owl:ObjectProperty ;
+                              dcterms:description "An associated ProductionJob for the realisation of an EditorialObject."@en ,
+                                                  "Un ProductionJob associé pour la réalisation d’un EditorialObject."@fr ;
+                              rdfs:label "Production job"@en ,
+                                         "Travail de production"@fr ;
+                              skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:ProductionJob"@en ,
+                                              "une propriété d’objet owl reliant un ec:EditorialObject à un ec:ProductionJob"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAssociatedProductionOrder
+ec:hasAssociatedProductionOrder rdf:type owl:ObjectProperty ;
+                                dcterms:description "La commande de production associée à un plan de publication."@fr ,
+                                                    "The production order associated with a publication plan."@en ;
+                                rdfs:label "Ordre de production"@fr ,
+                                           "Production order"@en ;
+                                skos:definition "an owl:ObjectProperty relating an ec:PublicationPlan to an ec:ProductionOrder"@en ,
+                                                "une propriété objet owl reliant un ec:PublicationPlan à un ec:ProductionOrder"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAssociatedRelation
+ec:hasAssociatedRelation rdf:type owl:ObjectProperty ;
+                         dcterms:description "A relation associated with the resource."@en ,
+                                             "Une relation associée à la ressource."@fr ;
+                         rdfs:label "Relation"@en ,
+                                    "Relation"@fr ;
+                         skos:definition "an owl:ObjectProperty relating an ec:Resource to an ec:Relation"@en ,
+                                         "une propriété objet owl reliant une ec:Resource à une ec:Relation"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAudience
+ec:hasAudience rdf:type owl:ObjectProperty ;
+               dcterms:description "Indicates the audience associated with a consumption count."@en ,
+                                   "Indique l’audience associée à un nombre de consommation."@fr ;
+               rdfs:label "A une audience"@fr ,
+                          "Has audience"@en ;
+               skos:definition "an owl:ObjectProperty relating an ec:ConsumptionCount to an ec:Audience"@en ,
+                               "une propriété d’objet owl:ObjectProperty reliant un ec:ConsumptionCount à un ec:Audience"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAudienceScoreRecordingTechnique
+ec:hasAudienceScoreRecordingTechnique rdf:type owl:ObjectProperty ;
+                                      dcterms:description "La technique utilisée pour mesurer une audience score."@fr ,
+                                                          "The technique used to measure an audience score."@en ;
+                                      rdfs:label "Audience score recording technique"@en ,
+                                                 "Technique d'enregistrement du score d'audience"@fr ;
+                                      skos:definition "an owl:ObjectProperty relating an ec:AudienceRating to a skos:Concept"@en ,
+                                                      "une propriété d’objet owl:ObjectProperty reliant un ec:AudienceRating à un skos:Concept"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAudioCodec
+ec:hasAudioCodec rdf:type owl:ObjectProperty ;
+                 rdfs:subPropertyOf ec:hasCodec ;
+                 dcterms:description "Le codec audio associé à la ressource multimédia."@fr ,
+                                     "The audio codec associated with the media resource."@en ;
+                 rdfs:label "Audio codec"@en ,
+                            "Codec audio"@fr ;
+                 skos:definition "an ec:ObjectProperty relating an ec:MediaResource to an ec:AudioCodec"@en ,
+                                 "une ec:ObjectProperty reliant une ec:MediaResource à une ec:AudioCodec"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAudioDescription
+ec:hasAudioDescription rdf:type owl:ObjectProperty ;
+                       dcterms:description "Signale la présence d’une description audio."@fr ,
+                                           "Signals the presence of audio description."@en ;
+                       rdfs:label "Audio description"@en ,
+                                  "Description audio"@fr ;
+                       skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:AudioDescription"@en ,
+                                       "une propriété objet owl reliant un ec:EditorialObject à un ec:AudioDescription"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAudioEncodingFormat
+ec:hasAudioEncodingFormat rdf:type owl:ObjectProperty ;
+                          rdfs:subPropertyOf ec:hasFormat ;
+                          dcterms:description "An audio encoding format associated with a media resource."@en ,
+                                              "Un format d'encodage audio associé à une ressource multimédia."@fr ;
+                          rdfs:label "Audio encoding format"@en ,
+                                     "Format d’encodage audio"@fr ;
+                          skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:AudioEncodingFormat"@en ,
+                                          "une propriété d’objet owl reliant un ec:MediaResource à un ec:AudioEncodingFormat"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAudioTrack
+ec:hasAudioTrack rdf:type owl:ObjectProperty ;
+                 dcterms:description "A property that identifies the audio track associated with a media resource."@en ,
+                                     "Une propriété qui identifie la piste audio associée à une ressource média."@fr ;
+                 rdfs:label "Audio track"@en ,
+                            "Piste audio"@fr ;
+                 skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:AudioTrack"@en ,
+                                 "une propriété objet owl reliant un ec:MediaResource à un ec:AudioTrack"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAuditJobRelatedAuditReport
+ec:hasAuditJobRelatedAuditReport rdf:type owl:ObjectProperty ;
+                                 dcterms:description "An audit report associated with an audit job."@en ,
+                                                     "Un rapport d'audit associé à un travail d'audit."@fr ;
+                                 rdfs:label "Rapport d'audit associé"@fr ,
+                                            "Related audit report"@en ;
+                                 skos:definition "an owl:ObjectProperty relating an ec:AuditJob to an ec:AuditReport"@en ,
+                                                 "une propriété d’objet owl reliant un ec:AuditJob à un ec:AuditReport"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAuditReportDate
+ec:hasAuditReportDate rdf:type owl:ObjectProperty ;
+                      dcterms:description "La date de publication d’un AuditReport."@fr ,
+                                          "The date of release of an AuditReport."@en ;
+                      rdfs:label "Audit report date"@en ,
+                                 "Date du rapport d'audit"@fr ;
+                      skos:definition "an owl:ObjectProperty relating an ec:AuditReport to a time:Instant"@en ,
+                                      "une propriété objet owl reliant un ec:AuditReport à un time:Instant"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAuthor
+ec:hasAuthor rdf:type owl:ObjectProperty ;
+             owl:inverseOf ec:isAuthorOf ;
+             dcterms:description "Associe une Annotation à l’Agent qui l’a créée."@fr ,
+                                 "Links an Annotation to the Agent who created it."@en ;
+             rdfs:label "Agent"@en ,
+                        "Agent"@fr ;
+             skos:definition "an owl:ObjectProperty relating an ec:Annotation to an ec:Agent"@en ,
+                             "une propriété d'objet owl reliant une ec:Annotation à un ec:Agent"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasAwardDate
+ec:hasAwardDate rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf ec:hasDate ;
+                dcterms:description "La date à laquelle un Award a été remis."@fr ,
+                                    "The date when an Award was delivered."@en ;
+                rdfs:label "Award date"@en ,
+                           "Date de récompense"@fr ;
+                skos:definition "an ec:hasDate relating an ec:Award to a time:Instant"@en ,
+                                "un ec:hasDate reliant un ec:Award à un time:Instant"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasBrand
+ec:hasBrand rdf:type owl:ObjectProperty ;
+            dcterms:description "A brand associated with the editorial object or publication service."@en ,
+                                "Une marque associée à l'objet éditorial ou au service de publication."@fr ;
+            rdfs:label "Brand"@en ,
+                       "Marque"@fr ;
+            skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:MarketingBrand"@en ,
+                            "une propriété objet owl reliant un ec:EditorialObject à un ec:MarketingBrand"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasBusinessContract
+ec:hasBusinessContract rdf:type owl:ObjectProperty ;
+                       dcterms:description "Le contrat associé à un plan de publication."@fr ,
+                                           "The contract associated with a publication plan."@en ;
+                       rdfs:label "Business contract"@en ,
+                                  "Contrat commercial"@fr ;
+                       skos:definition "an owl:ObjectProperty relating an ec:PublicationPlan to an ec:Contract"@en ,
+                                       "une propriété objet owl reliant un ec:PublicationPlan à un ec:Contract"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasCaptioning
+ec:hasCaptioning rdf:type owl:ObjectProperty ;
+                 dcterms:description "A captioning track for transcribed dialogue or audio descriptions for the hard of hearing."@en ,
+                                     "Une piste de sous-titrage pour les dialogues transcrits ou des descriptions audio pour les malentendants."@fr ;
+                 rdfs:label "Captioning"@en ,
+                            "Sous-titrage"@fr ;
+                 skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Captioning"@en ,
+                                 "une propriété objet owl reliant un ec:EditorialObject à un ec:Captioning"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasCaptioningFormat
+ec:hasCaptioningFormat rdf:type owl:ObjectProperty ;
+                       rdfs:subPropertyOf ec:hasFormat ;
+                       dcterms:description "Le format du sous-titrage."@fr ,
+                                           "The format of Captioning."@en ;
+                       rdfs:label "Captioning format"@en ,
+                                  "Format de sous-titrage"@fr ;
+                       skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:CaptioningFormat"@en ,
+                                       "une propriété objet owl reliant un ec:MediaResource à un ec:CaptioningFormat"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasCaptioningSource
+ec:hasCaptioningSource rdf:type owl:ObjectProperty ;
+                       dcterms:description "La source du sous-titrage associé à la ressource média."@fr ,
+                                           "The source of the captioning associated with the media resource."@en ;
+                       rdfs:label "Captioning source"@en ,
+                                  "Source de sous-titrage"@fr ;
+                       skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:Agent"@en ,
+                                       "une propriété d'objet owl reliant un ec:MediaResource à un ec:Agent"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasCastMember
+ec:hasCastMember rdf:type owl:ObjectProperty ;
+                 dcterms:description "A member of the cast."@en ,
+                                     "Un membre de la distribution."@fr ;
+                 rdfs:label "Cast member"@en ,
+                            "Membre de la distribution"@fr ;
+                 skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:CastMember"@en ,
+                                 "une propriété objet owl reliant un ec:EditorialObject à un ec:CastMember"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasCharacter
+ec:hasCharacter rdf:type owl:ObjectProperty ;
+                dcterms:description "Identifie un ou plusieurs personnages fictifs associés à un objet éditorial."@fr ,
+                                    "Identifies one or more fictional characters associated with an editorial object."@en ;
+                rdfs:label "Character"@en ,
+                           "Personnage"@fr ;
+                skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Character"@en ,
+                                "une propriété d’objet owl reliant un ec:EditorialObject à un ec:Character"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasChild
+ec:hasChild rdf:type owl:ObjectProperty ;
+            owl:inverseOf ec:isChildOf ;
+            dcterms:description "Links an Asset to its parent Asset."@en ,
+                                "Relie un Asset à son Asset parent."@fr ;
+            rdfs:label "Child"@en ,
+                       "Enfant"@fr ;
+            skos:definition "an owl:ObjectProperty relating an ec:Asset to an ec:Asset"@en ,
+                            "une propriété d'objet owl reliant un ec:Asset à un ec:Asset"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasClip
+ec:hasClip rdf:type owl:ObjectProperty ;
+           dcterms:description "Indicates a clip associated with the resource."@en ,
+                               "Indique un clip associé à la ressource."@fr ;
+           rdfs:label "A un clip"@fr ,
+                      "Has clip"@en ;
+           skos:definition "an owl:ObjectProperty relating a resource to an associated clip"@en ,
+                           "une propriété d’objet owl reliant une ressource à un clip associé"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasClone
+ec:hasClone rdf:type owl:ObjectProperty ;
+            owl:inverseOf ec:isCloneOf ;
+            dcterms:description "Identifie la relation entre une instanciation numérique d’une MediaResource et sa copie directe, sans perte générationnelle."@fr ,
+                                "Identifies relationship between a digital instantiation of a MediaResource and its direct copy, with no generational loss."@en ;
+            rdfs:label "Cloned to"@en ,
+                       "Cloné vers"@fr ;
+            skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:MediaResource"@en ,
+                            "une propriété objet owl reliant une ec:MediaResource à une ec:MediaResource"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasCodec
+ec:hasCodec rdf:type owl:ObjectProperty ;
+            dcterms:description "Le codec utilisé pour créer une ressource."@fr ,
+                                "The codec used to create a resource."@en ;
+            rdfs:label "Codec"@en ,
+                       "Codec"@fr ;
+            skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:Codec"@en ,
+                            "une propriété objet owl reliant un ec:MediaResource à un ec:Codec"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasCodecVendor
+ec:hasCodecVendor rdf:type owl:ObjectProperty ;
+                  dcterms:description "Le fournisseur du codec."@fr ,
+                                      "The vendor of the codec."@en ;
+                  rdfs:label "Codec vendor"@en ,
+                             "Fournisseur de codec"@fr ;
+                  skos:definition "an owl:ObjectProperty relating an ec:Codec to an ec:Agent"@en ,
+                                  "une propriété d’objet owl reliant un ec:Codec à un ec:Agent"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasColourSpace
+ec:hasColourSpace rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf ec:hasFormat ;
+                  dcterms:description "L’espace colorimétrique associé à la ressource multimédia."@fr ,
+                                      "The colour space associated with the media resource."@en ;
+                  rdfs:label "Colour space"@en ,
+                             "Espace colorimétrique"@fr ;
+                  skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:ColourSpace"@en ,
+                                  "une propriété objet owl reliant un ec:MediaResource à un ec:ColourSpace"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasCommissioningContract
+ec:hasCommissioningContract rdf:type owl:ObjectProperty ;
+                            dcterms:description "Le contrat par lequel un EditorialObject est commandé."@fr ,
+                                                "The Contract through which an EditorialObject is commissioned."@en ;
+                            rdfs:label "Contract"@en ,
+                                       "Contrat"@fr ;
+                            skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Contract"@en ,
+                                            "une propriété objet owl reliant un ec:EditorialObject à un ec:Contract"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasConsumer
+ec:hasConsumer rdf:type owl:ObjectProperty ;
+               dcterms:description "Lie un ec:ConsumptionEvent au consommateur."@fr ,
+                                   "Links a ConsumptionEvent to the consumer."@en ;
+               rdfs:label "A pour consommateur"@fr ,
+                          "Has consumer"@en ;
+               skos:definition "an owl:ObjectProperty relating a ec:ConsumptionEvent to a ec:Consumer"@en ,
+                               "une propriété d’objet owl:ObjectProperty reliant une ec:ConsumptionEvent à un ec:Consumer"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasConsumptionContract
+ec:hasConsumptionContract rdf:type owl:ObjectProperty ;
+                          dcterms:description "A contract related to an account."@en ,
+                                              "Un contrat lié à un compte."@fr ;
+                          rdfs:label "Consumption contract"@en ,
+                                     "Contrat de consommation"@fr ;
+                          skos:definition "an owl:ObjectProperty relating an ec:Account to an ec:Contract"@en ,
+                                          "une propriété d’objet owl reliant un ec:Account à un ec:Contract"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasConsumptionCount
+ec:hasConsumptionCount rdf:type owl:ObjectProperty ;
+                       dcterms:description "Le comptage et la relation avec l’audience réelle."@fr ,
+                                           "The count of and relation to the real audience."@en ;
+                       rdfs:label "A un nombre de consommation"@fr ,
+                                  "Has consumption count"@en ;
+                       skos:definition "an owl:ObjectProperty relating an ec:Campaign to an ec:ConsumptionCount"@en ,
+                                       "une owl:ObjectProperty reliant un ec:Campaign à un ec:ConsumptionCount"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasConsumptionDeviceManufacturer
+ec:hasConsumptionDeviceManufacturer rdf:type owl:ObjectProperty ;
+                                    dcterms:description "Le fabricant d’un ConsumptionDevice."@fr ,
+                                                        "The manufacturer of a ConsumptionDevice."@en ;
+                                    rdfs:label "Consumption device manufacturer"@en ,
+                                               "Fabricant du dispositif de consommation"@fr ;
+                                    skos:definition "an owl:ObjectProperty relating an ec:ConsumptionDevice to an ec:Agent"@en ,
+                                                    "une propriété d'objet owl reliant un ec:ConsumptionDevice à un ec:Agent"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasConsumptionEvent
+ec:hasConsumptionEvent rdf:type owl:ObjectProperty ;
+                       dcterms:description "An event in which a consumer uses a device to consume an editorial object published in a publication event within a media service."@en ,
+                                           "Un événement au cours duquel un consommateur utilise un appareil pour consommer un objet éditorial publié lors d’un événement de publication au sein d’un service de médias."@fr ;
+                       rdfs:label "Consumption event"@en ,
+                                  "Événement de consommation"@fr ;
+                       skos:definition "an owl:ObjectProperty relating an ec:ConsumptionCount to an ec:ConsumptionEvent"@en ,
+                                       "une propriété d’objet owl reliant un ec:ConsumptionCount à un ec:ConsumptionEvent"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasConsumptionEventResumePoint
+ec:hasConsumptionEventResumePoint rdf:type owl:ObjectProperty ;
+                                  dcterms:description "La date et l’heure auxquelles la consommation a repris."@fr ,
+                                                      "The date and time point at which consumption has resumed."@en ;
+                                  rdfs:label "Consumption event resume point"@en ,
+                                             "Point de reprise de l’événement de consommation"@fr ;
+                                  skos:definition "an owl:ObjectProperty relating an ec:ConsumptionEvent to an ec:TimelinePoint"@en ,
+                                                  "une propriété objet owl reliant un ec:ConsumptionEvent à un ec:TimelinePoint"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasConsumptionLicenceLink
+ec:hasConsumptionLicenceLink rdf:type owl:ObjectProperty ;
+                             dcterms:description "A link to the terms of a ConsumptionLicence."@en ,
+                                                 "Un lien vers les conditions d’une ConsumptionLicence."@fr ;
+                             rdfs:label "Consumption licence link"@en ,
+                                        "Lien de licence de consommation"@fr ;
+                             skos:definition "an owl:ObjectProperty relating an ec:ConsumptionLicence to an ec:Contract"@en ,
+                                             "une propriété objet owl reliant un ec:ConsumptionLicence à un ec:Contract"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContact
+ec:hasContact rdf:type owl:ObjectProperty ;
+              dcterms:description "Information about a contact for an organisation or a person, such as the agent of an actor."@en ,
+                                  "Informations sur un contact pour une organisation ou une personne, comme l’agent d’un acteur."@fr ;
+              rdfs:label "Contact"@en ,
+                         "Contact"@fr ;
+              skos:definition "an owl:ObjectProperty relating an ec:Agent to an ec:Contact"@en ,
+                              "une propriété objet owl reliant un ec:Agent à un ec:Contact"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContainerCodec
+ec:hasContainerCodec rdf:type owl:ObjectProperty ;
+                     rdfs:subPropertyOf ec:hasCodec ;
+                     dcterms:description "Le codec utilisé dans un conteneur de contenu."@fr ,
+                                         "The codec used in a content container."@en ;
+                     rdfs:label "Codec de conteneur"@fr ,
+                                "Container codec"@en ;
+                     skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:ContainerCodec"@en ,
+                                     "une propriété d’objet owl reliant un ec:MediaResource à un ec:ContainerCodec"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContainerEncodingFormat
+ec:hasContainerEncodingFormat rdf:type owl:ObjectProperty ;
+                              rdfs:subPropertyOf ec:hasFormat ;
+                              dcterms:description "Le format d’encodage du conteneur associé à la ressource multimédia."@fr ,
+                                                  "The container encoding format associated with the media resource."@en ;
+                              rdfs:label "Container encoding format"@en ,
+                                         "Format d’encodage du conteneur"@fr ;
+                              skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:ContainerEncodingFormat"@en ,
+                                              "une owl:ObjectProperty reliant une ec:MediaResource à une ec:ContainerEncodingFormat"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContainerMimeType
+ec:hasContainerMimeType rdf:type owl:ObjectProperty ;
+                        rdfs:subPropertyOf ec:hasFormat ;
+                        dcterms:description "Le type MIME associé à la ressource."@fr ,
+                                            "The MIME type associated with the resource."@en ;
+                        rdfs:label "Mime type"@en ,
+                                   "Type MIME"@fr ;
+                        skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:MimeType"@en ,
+                                        "une propriété d'objet owl reliant un ec:MediaResource à un ec:MimeType"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContentEditorialFormat
+ec:hasContentEditorialFormat rdf:type owl:ObjectProperty ;
+                             dcterms:description "Describes a content editorial format, such as magazine."@en ,
+                                                 "Décrit un format éditorial de contenu, tel qu’un magazine."@fr ;
+                             rdfs:label "Editorial format"@en ,
+                                        "Format éditorial"@fr ;
+                             skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:ContentEditorialFormat"@en ,
+                                             "une propriété d'objet owl reliant un ec:EditorialObject à un ec:ContentEditorialFormat"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContractCostAmountCurrency
+ec:hasContractCostAmountCurrency rdf:type owl:ObjectProperty ;
+                                 dcterms:description "La devise du montant du coût du contrat."@fr ,
+                                                     "The currency of the amount of the ContractCost."@en ;
+                                 rdfs:label "Cost currency"@en ,
+                                            "Devise de coût"@fr ;
+                                 skos:definition "an owl:ObjectProperty relating an ec:ContractCost to a skos:Concept"@en ,
+                                                 "une propriété d’objet owl reliant un ec:ContractCost à un skos:Concept"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContractLink
+ec:hasContractLink rdf:type owl:ObjectProperty ;
+                   dcterms:description "A link to a location where information can be found about a Contract."@en ,
+                                       "Un lien vers un emplacement où des informations sur un contrat peuvent être trouvées."@fr ;
+                   rdfs:label "Contract link"@en ,
+                              "Lien de contrat"@fr ;
+                   skos:definition "an owl:ObjectProperty relating an ec:Contract to an ec:Resource"@en ,
+                                   "une owl:ObjectProperty reliant un ec:Contract à un ec:Resource"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContractRelatedCost
+ec:hasContractRelatedCost rdf:type owl:ObjectProperty ;
+                          dcterms:description "Les coûts financiers associés à un contrat."@fr ,
+                                              "The financial costs associated with a contract."@en ;
+                          rdfs:label "Contract related cost"@en ,
+                                     "Coût lié au contrat"@fr ;
+                          skos:definition "an owl:ObjectProperty relating an ec:Contract to an ec:ContractCost"@en ,
+                                          "une propriété objet owl:ObjectProperty reliant un ec:Contract à un ec:ContractCost"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContractTemplate
+ec:hasContractTemplate rdf:type owl:ObjectProperty ;
+                       dcterms:description "A Contract used as a template for another Contract."@en ,
+                                           "Un contrat utilisé comme modèle pour un autre contrat."@fr ;
+                       rdfs:label "Contract template"@en ,
+                                  "Modèle de contrat"@fr ;
+                       skos:definition "an owl:ObjectProperty relating an ec:Contract to an ec:Contract"@en ,
+                                       "une propriété objet owl reliant un ec:Contract à un ec:Contract"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContractualParty
+ec:hasContractualParty rdf:type owl:ObjectProperty ;
+                       dcterms:description "Les différentes parties impliquées dans un contrat."@fr ,
+                                           "The different parties involved in a contract."@en ;
+                       rdfs:label "Contract party"@en ,
+                                  "Partie contractante"@fr ;
+                       skos:definition "an owl:ObjectProperty relating an ec:Contract to an ec:Agent"@en ,
+                                       "une owl:ObjectProperty reliant un ec:Contract à un ec:Agent"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasContributor
+ec:hasContributor rdf:type owl:ObjectProperty ;
+                  dcterms:description "An agent or organization that contributes to a Resource, EditorialObject, or Event."@en ,
+                                      "Un agent ou une organisation qui contribue à une Resource, un EditorialObject ou un Event."@fr ;
+                  rdfs:label "Contributeur"@fr ,
+                             "Contributor"@en ;
+                  skos:definition "an owl:ObjectProperty relating an ec:EditorialObject or ec:ProductionJob to an ec:Involvement"@en ,
+                                  "une propriété d’objet owl reliant un ec:EditorialObject ou ec:ProductionJob à une ec:Involvement"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasCopyright
+ec:hasCopyright rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf ec:hasRights ;
+                dcterms:description "Les droits qui définissent les conditions dans lesquelles l’actif associé peut être copié."@fr ,
+                                    "The rights that define the conditions under which the associated asset may be copied."@en ;
+                rdfs:label "Copyright"@en ,
+                           "Droits d'auteur"@fr ;
+                skos:definition "an owl:ObjectProperty relating an ec:Asset to an ec:Copyright"@en ,
+                                "une propriété d’objet owl reliant un ec:Asset à un ec:Copyright"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasCountryOfBirth
+ec:hasCountryOfBirth rdf:type owl:ObjectProperty ;
+                     dcterms:description "Le pays où une personne est née."@fr ,
+                                         "The country where a person is born."@en ;
+                     rdfs:label "Country of birth"@en ,
+                                "Pays de naissance"@fr ;
+                     skos:definition "an owl:ObjectProperty relating an ec:Person to an ec:CountryCode"@en ,
+                                     "une owl:ObjectProperty reliant un ec:Person à un ec:CountryCode"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasCountryOfDeath
+ec:hasCountryOfDeath rdf:type owl:ObjectProperty ;
+                     dcterms:description "Le pays où la personne est décédée."@fr ,
+                                         "The country where the person died."@en ;
+                     rdfs:label "Country of death"@en ,
+                                "Pays de décès"@fr ;
+                     skos:definition "an owl:ObjectProperty relating an ec:Person to an ec:CountryCode"@en ,
+                                     "une propriété d'objet owl:ObjectProperty reliant un ec:Person à un ec:CountryCode"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasCoverage
+ec:hasCoverage rdf:type owl:ObjectProperty ;
+               dcterms:description "Coverage information associated with the editorial object."@en ,
+                                   "Informations de couverture associées à l’objet éditorial."@fr ;
+               rdfs:label "Couverture"@fr ,
+                          "Coverage"@en ;
+               skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Event or ec:Location"@en ,
+                               "une propriété d'objet owl reliant un ec:EditorialObject à un ec:Event ou ec:Location"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasCoverageRestrictions
+ec:hasCoverageRestrictions rdf:type owl:ObjectProperty ;
+                           rdfs:subPropertyOf ec:hasRights ;
+                           dcterms:description "Les limitations de couverture d’un asset ou d’un événement de publication, telles que la couverture temporelle ou spatiale."@fr ,
+                                               "The limitations on coverage for an asset or publication event, such as time or spatial coverage."@en ;
+                           rdfs:label "Coverage restrictions"@en ,
+                                      "Restrictions de couverture"@fr ;
+                           skos:definition "an owl:ObjectProperty relating an ec:Asset to an ec:CoverageRestrictions"@en ,
+                                           "une propriété d’objet owl:ObjectProperty reliant un ec:Asset à un ec:CoverageRestrictions"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasCreativeCommons
+ec:hasCreativeCommons rdf:type owl:ObjectProperty ;
+                      rdfs:subPropertyOf ec:hasRights ;
+                      dcterms:description "A property linking an asset to its Creative Commons license or licensing conditions."@en ,
+                                          "Une propriété reliant un asset à sa licence Creative Commons ou à ses conditions de licence."@fr ;
+                      rdfs:label "Creative Commons"@fr ,
+                                 "Creative commons"@en ;
+                      skos:definition "an owl:ObjectProperty relating an ec:Asset to ec:CreativeCommons"@en ,
+                                      "une propriété objet owl reliant un ec:Asset à ec:CreativeCommons"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasCreator
+ec:hasCreator rdf:type owl:ObjectProperty ;
+              dcterms:description "An Agent involved in the creation of the Resource or EditorialObject."@en ,
+                                  "Un Agent impliqué dans la création de la Resource ou de l'EditorialObject."@fr ;
+              rdfs:label "Creator"@en ,
+                         "Créateur"@fr ;
+              skos:definition "an owl:ObjectProperty relating an ec:Artefact or ec:EditorialObject to an ec:Involvement"@en ,
+                              "une propriété d'objet owl reliant un ec:Artefact ou un ec:EditorialObject à une ec:Involvement"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasCrewMember
+ec:hasCrewMember rdf:type owl:ObjectProperty ;
+                 dcterms:description "A member of the crew."@en ,
+                                     "Un membre de l'équipe."@fr ;
+                 rdfs:label "Crew member"@en ,
+                            "Membre de l'équipe"@fr ;
+                 skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:CrewMember"@en ,
+                                 "une propriété d’objet owl reliant un ec:EditorialObject à un ec:CrewMember"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasCuisineOrigin
+ec:hasCuisineOrigin rdf:type owl:ObjectProperty ;
+                    dcterms:description "Le pays ou la région d'origine de la cuisine."@fr ,
+                                        "The country/region of origin of the cuisine."@en ;
+                    rdfs:label "Cuisine origin"@en ,
+                               "Origine de la cuisine"@fr ;
+                    skos:definition "an owl:ObjectProperty relating an ec:Food to an ec:CountryCode"@en ,
+                                    "une propriété d’objet owl reliant un ec:Food à un ec:CountryCode"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasCuisineStyle
+ec:hasCuisineStyle rdf:type owl:ObjectProperty ;
+                   dcterms:description "Le style de la cuisine."@fr ,
+                                       "The style of the cuisine."@en ;
+                   rdfs:label "Cuisine style"@en ,
+                              "Style de cuisine"@fr ;
+                   skos:definition "an owl:ObjectProperty relating an ec:Food to an ec:CuisineStyle"@en ,
+                                   "une propriété d'objet owl reliant un ec:Food à un ec:CuisineStyle"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDataFormat
+ec:hasDataFormat rdf:type owl:ObjectProperty ;
+                 rdfs:subPropertyOf ec:hasFormat ;
+                 dcterms:description "Le format des données transportées dans une ressource."@fr ,
+                                     "The format of data carried in a resource."@en ;
+                 rdfs:label "Data format"@en ,
+                            "Format de données"@fr ;
+                 skos:definition "an owl:ObjectProperty relating an ec:DataTrack to an ec:DataFormat"@en ,
+                                 "une propriété objet owl reliant un ec:DataTrack à un ec:DataFormat"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDataTrack
+ec:hasDataTrack rdf:type owl:ObjectProperty ;
+                dcterms:description "Le flux de données associé à la ressource."@fr ,
+                                    "The data track associated with the resource."@en ;
+                rdfs:label "Data track"@en ,
+                           "Piste de données"@fr ;
+                skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:DataTrack"@en ,
+                                "une propriété d'objet owl reliant un ec:MediaResource à un ec:DataTrack"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDate
+ec:hasDate rdf:type owl:ObjectProperty ;
+           dc:description "Range: Litteral, on the instance level, this can be restricted to dateTime, date or another suitable format."@en ;
+           dcterms:description "A date associated with an Asset. Range: Literal, on the instance level, this can be restricted to dateTime, date or another suitable format."@en ,
+                               "Une date associée à un Asset. Plage : Literal ; au niveau des instances, celle-ci peut être restreinte à dateTime, date ou à un autre format approprié."@fr ;
+           rdfs:isDefinedBy dc:date ;
+           rdfs:label "Date"@en ,
+                      "Date"@fr ;
+           skos:definition "an owl:ObjectProperty relating an ec:Asset to a time:Instant"@en ,
+                           "une propriété objet owl reliant un ec:Asset à un time:Instant"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateArchived
+ec:hasDateArchived rdf:type owl:ObjectProperty ;
+                   rdfs:subPropertyOf ec:hasDate ;
+                   dcterms:description "La date à laquelle l’Asset a été archivé."@fr ,
+                                       "The date when the Asset was archived."@en ;
+                   rdfs:label "Archiving date"@en ,
+                              "Date d'archivage"@fr ;
+                   skos:definition "an owl:ObjectProperty relating an ec:Asset to a time:Instant"@en ,
+                                   "une propriété d’objet owl reliant un ec:Asset à un time:Instant"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateBroadcast
+ec:hasDateBroadcast rdf:type owl:ObjectProperty ;
+                    rdfs:subPropertyOf ec:hasDate ;
+                    dcterms:description "La date à laquelle l’Asset a été diffusé pour la première fois publiquement à la télévision, à la radio ou via un service de streaming."@fr ,
+                                        "The date when the Asset was first broadcast publicly on television or radio or via streaming."@en ;
+                    rdfs:label "Broadcast date"@en ,
+                               "Date de diffusion"@fr ;
+                    skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to a time:Instant"@en ,
+                                    "une propriété objet owl reliant un ec:EditorialObject à un time:Instant"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateCreated
+ec:hasDateCreated rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf ec:hasDate ;
+                  dcterms:description "La date de création de l’Asset."@fr ,
+                                      "The date of creation of the Asset."@en ;
+                  rdfs:label "Creation date/time"@en ,
+                             "Date/heure de création"@fr ;
+                  skos:definition "an owl:ObjectProperty relating an ec:Asset to a time:Instant"@en ,
+                                  "une propriété objet owl reliant un ec:Asset à une time:Instant"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateDeleted
+ec:hasDateDeleted rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf ec:hasDate ;
+                  dcterms:description "La date à laquelle la ressource a été supprimée."@fr ,
+                                      "The date when the Resource was deleted."@en ;
+                  rdfs:label "Date de suppression"@fr ,
+                             "Deletion date"@en ;
+                  skos:definition "an owl:ObjectProperty relating an ec:Asset to a time:Instant"@en ,
+                                  "une propriété d'objet owl:ObjectProperty reliant un ec:Asset à un time:Instant"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateDigitised
+ec:hasDateDigitised rdf:type owl:ObjectProperty ;
+                    rdfs:subPropertyOf ec:hasDate ;
+                    dcterms:description "La date à laquelle la ressource a été numérisée."@fr ,
+                                        "The date when the Resource was digitised."@en ;
+                    rdfs:label "Date de numérisation"@fr ,
+                               "Digitisation date"@en ;
+                    skos:definition "an owl:ObjectProperty relating an ec:MediaResource to a time:Instant"@en ,
+                                    "une propriété d’objet owl reliant une ec:MediaResource à un time:Instant"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateDistributed
+ec:hasDateDistributed rdf:type owl:ObjectProperty ;
+                      rdfs:subPropertyOf ec:hasDate ;
+                      dcterms:description "La date à laquelle la ressource a été rendue disponible pour la première fois au public à l'achat, au téléchargement ou en accès en ligne."@fr ,
+                                          "The date when the Resource was first made available to the public for purchase, download, or online access."@en ;
+                      rdfs:label "Date de distribution"@fr ,
+                                 "Distribution date"@en ;
+                      skos:definition "an ec:hasDate relation relating an ec:Asset to a time:Instant"@en ,
+                                      "une relation ec:hasDate reliant un ec:Asset à un time:Instant"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateIngested
+ec:hasDateIngested rdf:type owl:ObjectProperty ;
+                   rdfs:subPropertyOf ec:hasDate ;
+                   dcterms:description "La date à laquelle la ressource a été ingérée ou acquise dans les fonds institutionnels."@fr ,
+                                       "The date when the Resource was ingested/acquired in institutional holdings."@en ;
+                   rdfs:label "Date d’ingestion"@fr ,
+                              "Ingest date"@en ;
+                   skos:definition "an owl:ObjectProperty relating an ec:MediaResource to a time:Instant"@en ,
+                                   "une propriété d’objet owl reliant un ec:MediaResource à un time:Instant"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateIssued
+ec:hasDateIssued rdf:type owl:ObjectProperty ;
+                 rdfs:subPropertyOf ec:hasDate ;
+                 dcterms:description "La date à laquelle l’Asset a été émis."@fr ,
+                                     "The date when the Asset was issued."@en ;
+                 rdfs:label "Date d'émission"@fr ,
+                            "Date issued"@en ;
+                 skos:definition "an ec:hasDate relation relating an ec:EditorialObject to a time:Instant"@en ,
+                                 "une relation ec:hasDate reliant un ec:EditorialObject à un time:Instant"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateLicenseEnd
+ec:hasDateLicenseEnd rdf:type owl:ObjectProperty ;
+                     rdfs:subPropertyOf ec:hasDate ;
+                     dcterms:description "La date à laquelle la licence de l’Asset prend fin."@fr ,
+                                         "The date when the licence for the Asset ends."@en ;
+                     rdfs:label "Date de fin de licence"@fr ,
+                                "Licence end date"@en ;
+                     skos:definition "an owl:ObjectProperty relating an ec:Asset to a time:Instant"@en ,
+                                     "une propriété d'objet owl reliant un ec:Asset à un time:Instant"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateLicensedStart
+ec:hasDateLicensedStart rdf:type owl:ObjectProperty ;
+                        rdfs:subPropertyOf ec:hasDate ;
+                        dcterms:description "La date à laquelle la licence de l’Asset commence."@fr ,
+                                            "The date when the licence for the Asset begins."@en ;
+                        rdfs:label "Date de début de licence"@fr ,
+                                   "Licence start date"@en ;
+                        skos:definition "an owl:ObjectProperty relating an ec:Asset to a time:Instant"@en ,
+                                        "une propriété objet owl reliant un ec:Asset à un time:Instant"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateMigrated
+ec:hasDateMigrated rdf:type owl:ObjectProperty ;
+                   rdfs:subPropertyOf ec:hasDate ;
+                   dcterms:description "La date à laquelle la ressource a été copiée ou convertie d’un format d’origine obsolète ou menacé vers un format plus récent afin d’en assurer la préservation."@fr ,
+                                       "The date when the Resource was copied or converted from an obsolete or endangered original format to a more updated format for preservation."@en ;
+                   rdfs:label "Date de migration"@fr ,
+                              "Migration date"@en ;
+                   skos:definition "an owl:ObjectProperty relating an ec:MediaResource to a time:Instant"@en ,
+                                   "une propriété d’objet owl reliant une ec:MediaResource à un time:Instant"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateModified
+ec:hasDateModified rdf:type owl:ObjectProperty ;
+                   rdfs:subPropertyOf ec:hasDate ;
+                   dcterms:description "La date et l’heure auxquelles l’Asset a été modifié."@fr ,
+                                       "The date and time when the Asset was modified."@en ;
+                   rdfs:label "Date de modification"@fr ,
+                              "Modification date/time"@en ;
+                   skos:definition "an owl:ObjectProperty relating an ec:Asset to a time:Instant"@en ,
+                                   "une propriété objet owl reliant un ec:Asset à un time:Instant"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateNormalized
+ec:hasDateNormalized rdf:type owl:ObjectProperty ;
+                     rdfs:subPropertyOf ec:hasDate ;
+                     dcterms:description "La date à laquelle la ressource a été convertie de son format d'origine en un format choisi par l'institution pour la préservation."@fr ,
+                                         "The date when the Resource was converted from its original format into a format selected by the institution for preservation."@en ;
+                     rdfs:label "Date de normalisation"@fr ,
+                                "Normalization date"@en ;
+                     skos:definition "an ec:hasDate relation relating an ec:MediaResource to a time:Instant"@en ,
+                                     "une relation ec:hasDate reliant un ec:MediaResource à un time:Instant"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateOfBirth
+ec:hasDateOfBirth rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf ec:hasDate ;
+                  dcterms:description "La date à laquelle une personne de contact naît."@fr ,
+                                      "The date when a Contact/Person is born."@en ;
+                  rdfs:label "Date de naissance"@fr ,
+                             "Date of birth"@en ;
+                  skos:definition "an owl:ObjectProperty relating an ec:Person to a time:Instant"@en ,
+                                  "une propriété d'objet owl reliant une ec:Person à un time:Instant"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateOfDeath
+ec:hasDateOfDeath rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf ec:hasDate ;
+                  dcterms:description "La date à laquelle un Contact/Personne est décédé(e)."@fr ,
+                                      "The date when a Contact/Person has passed away."@en ;
+                  rdfs:label "Date de décès"@fr ,
+                             "Date of death"@en ;
+                  skos:definition "an owl:ObjectProperty relating an ec:Person to a time:Instant"@en ,
+                                  "une owl:ObjectProperty reliant un ec:Person à un time:Instant"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateOfRetirement
+ec:hasDateOfRetirement rdf:type owl:ObjectProperty ;
+                       rdfs:subPropertyOf ec:hasDate ;
+                       dcterms:description "La date à laquelle un Contact/Personne a pris sa retraite."@fr ,
+                                           "The date when a Contact/Person has retired."@en ;
+                       rdfs:label "Date de départ à la retraite"@fr ,
+                                  "Date of retirement"@en ;
+                       skos:definition "an owl:ObjectProperty relating an ec:Person to a time:Instant"@en ,
+                                       "une propriété d’objet owl reliant une ec:Person à une time:Instant"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateProduced
+ec:hasDateProduced rdf:type owl:ObjectProperty ;
+                   rdfs:subPropertyOf ec:hasDate ;
+                   dcterms:description "La date de production de l’Asset."@fr ,
+                                       "The date of production of the Asset."@en ;
+                   rdfs:label "Date de production"@fr ,
+                              "Production date"@en ;
+                   skos:definition "an owl:ObjectProperty relating an ec:Asset to a time:Instant"@en ,
+                                   "une propriété objet owl reliant une ec:Asset à un time:Instant"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateReleased
+ec:hasDateReleased rdf:type owl:ObjectProperty ;
+                   rdfs:subPropertyOf ec:hasDate ;
+                   dcterms:description "La date à laquelle la ressource a été mise pour la première fois à la disposition du public pour achat, téléchargement ou accès en ligne."@fr ,
+                                       "The date when the Resource was first made available to the public for purchase, download, or online access."@en ;
+                   rdfs:label "Date de publication"@fr ,
+                              "Release date"@en ;
+                   skos:definition "an owl:ObjectProperty relating an ec:Asset to a time:Instant"@en ,
+                                   "une propriété d’objet owl:ObjectProperty reliant un ec:Asset à un time:Instant"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateTransferred
+ec:hasDateTransferred rdf:type owl:ObjectProperty ;
+                      rdfs:subPropertyOf ec:hasDate ;
+                      dcterms:description "La date à laquelle l’Asset a été déplacé d’un emplacement numérique ou physique à un autre."@fr ,
+                                          "The date when the Asset was moved from one digital or physical location to another."@en ;
+                      rdfs:label "Date de transfert"@fr ,
+                                 "Transfer date"@en ;
+                      skos:definition "an ec:hasDate relation relating an ec:MediaResource to a time:Instant"@en ,
+                                      "une relation ec:hasDate reliant une ec:MediaResource à un time:Instant"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDateValidated
+ec:hasDateValidated rdf:type owl:ObjectProperty ;
+                    rdfs:subPropertyOf ec:hasDate ;
+                    dcterms:description "La date la plus récente à laquelle la ressource a été confirmée comme valide par un contrôle qualité manuel ou numérique."@fr ,
+                                        "The most recent date when the Resource was confirmed to be valid through manual or digital QC."@en ;
+                    rdfs:label "Date de validation"@fr ,
+                               "Validation date"@en ;
+                    skos:definition "an owl:ObjectProperty relating an ec:Resource to a time:Instant"@en ,
+                                    "une propriété objet owl reliant une ec:Resource à un time:Instant"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDepartment
+ec:hasDepartment rdf:type owl:ObjectProperty ;
+                 dcterms:description "Le département associé à une organisation."@fr ,
+                                     "The department associated with an organisation."@en ;
+                 rdfs:label "Department"@en ,
+                            "Département"@fr ;
+                 skos:definition "an owl:ObjectProperty relating an ec:Organisation to an ec:Department"@en ,
+                                 "une propriété objet owl reliant une ec:Organisation à un ec:Department"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDevice
+ec:hasDevice rdf:type owl:ObjectProperty ;
+             dcterms:description "Le ec:ConsumptionDevice utilisé pendant un ec:ConsumptionEvent."@fr ,
+                                 "The ConsumptionDevice used during a ConsumptionEvent."@en ;
+             rdfs:label "A le dispositif"@fr ,
+                        "Has device"@en ;
+             skos:definition "an owl:ObjectProperty relating an ec:ConsumptionEvent to an ec:ConsumptionDevice"@en ,
+                             "une propriété d’objet owl reliant un ec:ConsumptionEvent à un ec:ConsumptionDevice"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDisclaimer
+ec:hasDisclaimer rdf:type owl:ObjectProperty ;
+                 rdfs:subPropertyOf ec:hasRights ;
+                 dcterms:description "A right or claim that is intentionally waived for an asset."@en ,
+                                     "Un droit ou une revendication qui est volontairement abandonné pour un actif."@fr ;
+                 rdfs:label "Clause de non-responsabilité"@fr ,
+                            "Disclaimer"@en ;
+                 skos:definition "an owl:ObjectProperty relating an ec:Asset to an ec:Disclaimer"@en ,
+                                 "une propriété objet owl reliant un ec:Asset à un ec:Disclaimer"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDisplayAspectRatio
+ec:hasDisplayAspectRatio rdf:type owl:ObjectProperty ;
+                         dcterms:description "Le rapport d’aspect tel qu’il est affiché."@fr ,
+                                             "The aspect ratio when displayed."@en ;
+                         rdfs:label "Display aspect ratio"@en ,
+                                    "Rapport hauteur/largeur d'affichage"@fr ;
+                         skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:ActiveFormatDescriptorCode"@en ,
+                                         "une propriété d'objet owl reliant un ec:MediaResource à un ec:ActiveFormatDescriptorCode"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDocumentFormat
+ec:hasDocumentFormat rdf:type owl:ObjectProperty ;
+                     rdfs:subPropertyOf ec:hasFormat ;
+                     dcterms:description "Le format d’un document."@fr ,
+                                         "The format of a document."@en ;
+                     rdfs:label "Document format"@en ,
+                                "Format du document"@fr ;
+                     skos:definition "an owl:ObjectProperty relating an ec:Document to an ec:DocumentFormat"@en ,
+                                     "une propriété d’objet owl reliant un ec:Document à un ec:DocumentFormat"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDopesheet
+ec:hasDopesheet rdf:type owl:ObjectProperty ;
+                dcterms:description "Le dopesheet d’un NewsItem."@fr ,
+                                    "The dopesheet of a NewsItem."@en ;
+                rdfs:label "Dopesheet"@en ,
+                           "Feuille de dépouillement"@fr ;
+                skos:definition "an ec:ObjectProperty relating an ec:Item to an ec:Dopesheet"@en ,
+                                "une ec:ObjectProperty reliant un ec:Item à un ec:Dopesheet"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDub
+ec:hasDub rdf:type owl:ObjectProperty ;
+          owl:inverseOf ec:isDubOf ;
+          dcterms:description "La ressource a une autre version linguistique."@fr ,
+                              "The resource have another language version."@en ;
+          rdfs:label "Doublé en"@fr ,
+                     "Dubbed to"@en ;
+          skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:MediaResource"@en ,
+                          "une propriété d'objet owl reliant un ec:MediaResource à un ec:MediaResource"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDubbedLanguage
+ec:hasDubbedLanguage rdf:type owl:ObjectProperty ;
+                     rdfs:subPropertyOf ec:hasLanguage ;
+                     dcterms:description "Les langues doublées disponibles pour l’actif."@fr ,
+                                         "The dubbed languages available for the asset."@en ;
+                     rdfs:label "Dubbed language"@en ,
+                                "Langue doublée"@fr ;
+                     skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Language"@en ,
+                                     "une propriété d’objet owl reliant un ec:EditorialObject à une ec:Language"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasDuration
+ec:hasDuration rdf:type owl:ObjectProperty ;
+               dcterms:description "A property that links an editorial object to its duration on a timeline."@en ,
+                                   "Une propriété qui relie un objet éditorial à sa durée sur une ligne de temps."@fr ;
+               rdfs:label "A une durée"@fr ,
+                          "Has duration"@en ;
+               skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:TimelinePoint"@en ,
+                               "une owl:ObjectProperty reliant un ec:EditorialObject à un ec:TimelinePoint"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasEditorialFormat
+ec:hasEditorialFormat rdf:type owl:ObjectProperty ;
+                      dcterms:description "Relates an EditorialObject to the EditorialFormat it uses."@en ,
+                                          "Relie un ec:EditorialObject à l'ec:EditorialFormat qu'il utilise."@fr ;
+                      rdfs:label "A le format éditorial"@fr ,
+                                 "Has editorial format"@en ;
+                      skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:EditorialFormat"@en ,
+                                      "une propriété objet owl reliant un ec:EditorialObject à un ec:EditorialFormat"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasEditorialFormatOf
+ec:hasEditorialFormatOf rdf:type owl:ObjectProperty ;
+                        dcterms:description "An editorial object based on the same editorial format."@en ,
+                                            "Un objet éditorial basé sur le même format éditorial."@fr ;
+                        rdfs:label "Même format éditorial"@fr ,
+                                   "Same editorial format"@en ;
+                        skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:EditorialObject with the same editorial format"@en ,
+                                        "une propriété objet owl reliant un ec:EditorialObject à un ec:EditorialObject avec le même format éditorial"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasEditorialGroup
+ec:hasEditorialGroup rdf:type owl:ObjectProperty ;
+                     rdfs:subPropertyOf ec:isMemberOf ;
+                     dcterms:description "Cette propriété identifie un groupe éditorial auquel appartient un objet éditorial."@fr ,
+                                         "This property identifies an editorial group that an editorial object belongs to."@en ;
+                     rdfs:label "A un groupe éditorial"@fr ,
+                                "Has editorial group"@en ;
+                     skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:EditorialGroup"@en ,
+                                     "une owl:ObjectProperty reliant un ec:EditorialObject à un ec:EditorialGroup"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasEditorialWork
+ec:hasEditorialWork rdf:type owl:ObjectProperty ;
+                    rdfs:subPropertyOf ec:isMemberOf ;
+                    dcterms:description "Identifie une œuvre éditoriale associée à cette propriété, généralement une ec:EditorialWork liée depuis un ec:EditorialSegment."@fr ,
+                                        "Identifies an editorial work associated with this property, typically an ec:EditorialWork linked from an ec:EditorialSegment."@en ;
+                    rdfs:label "A de travail éditorial"@fr ,
+                               "Has editorial work"@en ;
+                    skos:definition "an owl:ObjectProperty relating an ec:EditorialSegment to an ec:EditorialWork"@en ,
+                                    "une owl:ObjectProperty reliant un ec:EditorialSegment à un ec:EditorialWork"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasEmbodyingArtefact
+ec:hasEmbodyingArtefact rdf:type owl:ObjectProperty ;
+                        owl:inverseOf ec:isEmbodiedBy ;
+                        dcterms:description "Character depicted by an Artifact."@en ,
+                                            "Personnage représenté par un artefact."@fr ;
+                        rdfs:label "Est incarné par"@fr ,
+                                   "Is embodied by"@en ;
+                        skos:definition "an owl:ObjectProperty relating an ec:Character to an ec:Artefact"@en ,
+                                        "une propriété d’objet owl reliant un ec:Character à un ec:Artefact"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasEncodingFormat
+ec:hasEncodingFormat rdf:type owl:ObjectProperty ;
+                     rdfs:subPropertyOf ec:hasFormat ;
+                     dcterms:description "An encoding format used to produce content."@en ,
+                                         "Un format d’encodage utilisé pour produire du contenu."@fr ;
+                     rdfs:label "Encoding format"@en ,
+                                "Format d'encodage"@fr ;
+                     skos:definition "an owl:ObjectProperty relating an ec:Document, ec:MediaResource, or ec:Picture to an ec:EncodingFormat"@en ,
+                                     "une propriété objet owl reliant un ec:Document, ec:MediaResource ou ec:Picture à un ec:EncodingFormat"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasEnd
+ec:hasEnd rdf:type owl:ObjectProperty ;
+          dcterms:description "A property that links an action or content-related entity to its ending timeline point."@en ,
+                              "Une propriété qui relie une entité liée à une action ou au contenu à son point de fin sur la chronologie."@fr ;
+          rdfs:label "A une fin"@fr ,
+                     "Has end"@en ;
+          skos:definition "an owl:ObjectProperty relating an ec:Action to an ec:TimelinePoint"@en ,
+                          "une owl:ObjectProperty reliant une ec:Action à une ec:TimelinePoint"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasEndDateTime
+ec:hasEndDateTime rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf ec:hasDate ;
+                  dcterms:description "Describing an end of an interval."@en ,
+                                      "Décrire la fin d’un intervalle."@fr ;
+                  rdfs:label "Date de fin"@fr ,
+                             "End date time"@en ;
+                  skos:definition "an owl:ObjectProperty relating an ec:Affiliation to a time:Instant"@en ,
+                                  "une owl:ObjectProperty reliant une ec:Affiliation à un time:Instant"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasEpisode
+ec:hasEpisode rdf:type owl:ObjectProperty ;
+              dcterms:description "Identifie les épisodes d’une série."@fr ,
+                                  "Identifies episodes in a series."@en ;
+              rdfs:label "Episode"@en ,
+                         "Épisode"@fr ;
+              skos:definition "an owl:ObjectProperty relating an ec:Season, ec:Serial or ec:Series to an ec:Programme"@en ,
+                              "une propriété objet owl reliant un ec:Season, ec:Serial ou ec:Series à un ec:Programme"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasExploitationIssues
+ec:hasExploitationIssues rdf:type owl:ObjectProperty ;
+                         rdfs:subPropertyOf ec:hasRights ;
+                         dcterms:description "A potential problem arising from the use of a work."@en ,
+                                             "Un problème potentiel découlant de l’utilisation d’une œuvre."@fr ;
+                         rdfs:label "Exploitation issues"@en ,
+                                    "Problèmes d’exploitation"@fr ;
+                         skos:definition "an owl:ObjectProperty relating an ec:Asset to ec:ExploitationIssues"@en ,
+                                         "une propriété d’objet owl reliant un ec:Asset à ec:ExploitationIssues"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasFictitiousPerson
+ec:hasFictitiousPerson rdf:type owl:ObjectProperty ;
+                       dcterms:description "Indicates that the associated person is fictitious."@en ,
+                                           "Indique que la personne associée est fictive."@fr ;
+                       rdfs:label "Contact fictif"@fr ,
+                                  "Fictitious contact"@en ;
+                       skos:definition "an owl:ObjectProperty relating an ec:Character to an ec:Person"@en ,
+                                       "une propriété objet owl reliant un ec:Character à une ec:Person"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasFileFormat
+ec:hasFileFormat rdf:type owl:ObjectProperty ;
+                 dcterms:description "Le format d’un fichier."@fr ,
+                                     "The format of a file."@en ;
+                 rdfs:label "File format"@en ,
+                            "Format de fichier"@fr ;
+                 skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:FileFormat"@en ,
+                                 "une propriété d'objet owl:ObjectProperty reliant un ec:MediaResource à un ec:FileFormat"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasFoodStyle
+ec:hasFoodStyle rdf:type owl:ObjectProperty ;
+                dcterms:description "Le style de l’aliment."@fr ,
+                                    "The style of Food."@en ;
+                rdfs:label "Food style"@en ,
+                           "Style alimentaire"@fr ;
+                skos:definition "an owl:ObjectProperty relating an ec:Food to an ec:FoodStyle"@en ,
+                                "une propriété objet owl reliant un ec:Food à un ec:FoodStyle"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasFormat
+ec:hasFormat rdf:type owl:ObjectProperty ;
+             dcterms:description "Le format associé à une ressource."@fr ,
+                                 "The format associated with a resource."@en ;
+             rdfs:label "Format"@en ,
+                        "Format"@fr ;
+             skos:definition "an owl:ObjectProperty relating an ec:Resource to an ec:Format"@en ,
+                             "une propriété d’objet owl reliant un ec:Resource à un ec:Format"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasFormatId
+ec:hasFormatId rdf:type owl:ObjectProperty ;
+               dcterms:description "An identifier attributed to a Format."@en ,
+                                   "Un identifiant attribué à un format."@fr ;
+               rdfs:label "Format identifier"@en ,
+                          "Identifiant de format"@fr ;
+               skos:definition "an owl:ObjectProperty relating an ec:Format to an ec:Identifier"@en ,
+                               "une propriété d'objet owl reliant un ec:Format à un ec:Identifier"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasFormatVersionId
+ec:hasFormatVersionId rdf:type owl:ObjectProperty ;
+                      dcterms:description "A version identifier attributed to a Format."@en ,
+                                          "Un identifiant de version attribué à un format."@fr ;
+                      rdfs:label "Format version identifier"@en ,
+                                 "Identifiant de version de format"@fr ;
+                      skos:definition "an owl:ObjectProperty relating an ec:Format to an ec:Identifier"@en ,
+                                      "une propriété objet owl reliant un ec:Format à un ec:Identifier"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasGeneration
+ec:hasGeneration rdf:type owl:ObjectProperty ;
+                 dcterms:description "Identifie la génération d’une version d’une ressource, c’est-à-dire master, master d’édition, copie de distribution, etc."@fr ,
+                                     "Identifies the generation of a version of a resource, i.e. master, edit master, distribution copy, etc."@en ;
+                 rdfs:label "Generation"@en ,
+                            "Génération"@fr ;
+                 skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:MediaResource"@en ,
+                                 "une propriété objet owl reliant un ec:MediaResource à un ec:MediaResource"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasGenre
+ec:hasGenre rdf:type owl:ObjectProperty ;
+            dcterms:description "Le genre ou la catégorie associé à l’EditorialObject."@fr ,
+                                "The genre or category associated with the EditorialObject."@en ;
+            rdfs:label "Genre"@en ,
+                       "Genre"@fr ;
+            skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to a skos:Concept"@en ,
+                            "une propriété objet owl reliant un ec:EditorialObject à un skos:Concept"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasGeoBlockingBlacklist
+ec:hasGeoBlockingBlacklist rdf:type owl:ObjectProperty ;
+                           dcterms:description "Checking a users IP-address against a blacklist."@en ,
+                                               "Vérification de l’adresse IP d’un utilisateur par rapport à une liste noire."@fr ;
+                           rdfs:label "Geo-blocking blacklist"@en ,
+                                      "Liste noire de géoblocage"@fr ;
+                           skos:definition "an owl:ObjectProperty relating an ec:AccessConditions to a skos:Concept"@en ,
+                                           "une propriété d'objet owl reliant un ec:AccessConditions à un skos:Concept"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasGeoBlockingWhitelist
+ec:hasGeoBlockingWhitelist rdf:type owl:ObjectProperty ;
+                           dcterms:description "Checking a users IP-address against a whitelist."@en ,
+                                               "Vérification de l'adresse IP d'un utilisateur par rapport à une liste blanche."@fr ;
+                           rdfs:label "Geo-blocking whitelist"@en ,
+                                      "Liste blanche de géoblocage"@fr ;
+                           skos:definition "an owl:ObjectProperty relating an ec:AccessConditions to a skos:Concept"@en ,
+                                           "une propriété objet owl reliant un ec:AccessConditions à un skos:Concept"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasGeoLocation
+ec:hasGeoLocation rdf:type owl:ObjectProperty ;
+                  dcterms:description "L’emplacement d’un ConsumptionDevice."@fr ,
+                                      "The Location of a ConsumptionDevice."@en ;
+                  rdfs:label "Device location"@en ,
+                             "Emplacement de l'appareil"@fr ;
+                  skos:definition "an owl:ObjectProperty relating an ec:ConsumptionDeviceProfile to an ec:Location"@en ,
+                                  "une propriété d’objet owl reliant un ec:ConsumptionDeviceProfile à une ec:Location"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasGroupMember
+ec:hasGroupMember rdf:type owl:ObjectProperty ;
+                  dcterms:description "Relates an Agent to another Agent that is a member of the same group."@en ,
+                                      "Relie un Agent à un autre Agent qui est membre du même groupe."@fr ;
+                  rdfs:label "Group member"@en ,
+                             "Membre du groupe"@fr ;
+                  skos:definition "an owl:ObjectProperty relating an ec:Agent to an ec:Agent"@en ,
+                                  "une propriété d’objet owl reliant un ec:Agent à un ec:Agent"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasIPRRestrictions
+ec:hasIPRRestrictions rdf:type owl:ObjectProperty ;
+                      rdfs:subPropertyOf ec:hasRights ;
+                      dcterms:description "A property that links an asset to its intellectual property restrictions."@en ,
+                                          "Une propriété qui relie un actif à ses restrictions de propriété intellectuelle."@fr ;
+                      rdfs:label "IPR restrictions"@en ,
+                                 "Restrictions de PI"@fr ;
+                      skos:definition "an owl:ObjectProperty relating an ec:Asset to an ec:IPRRestrictions"@en ,
+                                      "une propriété d’objet owl:ObjectProperty reliant un ec:Asset à un ec:IPRRestrictions"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasIdPicture
+ec:hasIdPicture rdf:type owl:ObjectProperty ;
+                dcterms:description "A link to an identification picture associated with a person."@en ,
+                                    "Un lien vers une photo d'identification associée à une personne."@fr ;
+                rdfs:label "Identification picture"@en ,
+                           "Photo d'identification"@fr ;
+                skos:definition "an owl:ObjectProperty relating an ec:Person to an ec:Picture"@en ,
+                                "une propriété objet owl reliant un ec:Person à un ec:Picture"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasIdentifier
+ec:hasIdentifier rdf:type owl:ObjectProperty ;
+                 dcterms:description "An identifier associated with an asset."@en ,
+                                     "Un identifiant associé à un actif."@fr ;
+                 rdfs:label "Identifiant"@fr ,
+                            "Identifier"@en ;
+                 skos:definition "an owl:ObjectProperty relating an ec:Asset to an ec:Identifier"@en ,
+                                 "une propriété d’objet owl reliant un ec:Asset à un ec:Identifier"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasImageCodec
+ec:hasImageCodec rdf:type owl:ObjectProperty ;
+                 dcterms:description "Le codec utilisé pour une image."@fr ,
+                                     "The codec used for an image."@en ;
+                 rdfs:label "Codec image"@fr ,
+                            "Image codec"@en ;
+                 skos:definition "an owl:ObjectProperty relating an ec:MediaResource or ec:Picture to an ec:ImageCodec"@en ,
+                                 "une owl:ObjectProperty reliant un ec:MediaResource ou ec:Picture à un ec:ImageCodec"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasImageFormat
+ec:hasImageFormat rdf:type owl:ObjectProperty ;
+                  dcterms:description "Le format d’une image, comme le rapport hauteur/largeur de l’image."@fr ,
+                                      "The format of an image, such as an image aspect ratio."@en ;
+                  rdfs:label "Format d'image"@fr ,
+                             "Image format"@en ;
+                  skos:definition "an owl:ObjectProperty relating an ec:MediaResource or ec:Picture to an ec:ImageFormat"@en ,
+                                  "une propriété d’objet owl reliant un ec:MediaResource ou ec:Picture à un ec:ImageFormat"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasInputMediaResource
+ec:hasInputMediaResource rdf:type owl:ObjectProperty ;
+                         dcterms:description "La MediaResource utilisée comme entrée d’un ProductionJob ou d’un processus."@fr ,
+                                             "The MediaResource used as an input to a ProductionJob or process."@en ;
+                         rdfs:label "Resource input"@en ,
+                                    "Ressource d’entrée"@fr ;
+                         skos:definition "an owl:ObjectProperty relating an ec:ProductionJob to an ec:MediaResource"@en ,
+                                         "une propriété objet owl reliant un ec:ProductionJob à un ec:MediaResource"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasInputResonance
+ec:hasInputResonance rdf:type owl:ObjectProperty ;
+                     dcterms:description "A set of Resonance data used as input to influence the definition of a better targeted Campaign."@en ,
+                                         "Un ensemble de données de Résonance utilisé comme entrée pour influencer la définition d’une campagne mieux ciblée."@fr ;
+                     rdfs:label "Input resonance"@en ,
+                                "Résonance d'entrée"@fr ;
+                     skos:definition "an owl:ObjectProperty relating an ec:Campaign to an ec:ResonanceCount"@en ,
+                                     "une owl:ObjectProperty reliant une ec:Campaign à une ec:ResonanceCount"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasInputResource
+ec:hasInputResource rdf:type owl:ObjectProperty ;
+                    dcterms:description "A resource used as an input to a production job or process."@en ,
+                                        "Une ressource utilisée comme entrée d’un travail ou d’un processus de production."@fr ;
+                    rdfs:label "Resource input"@en ,
+                               "Ressource d'entrée"@fr ;
+                    skos:definition "an owl:ObjectProperty relating an ec:ProductionJob to an ec:Resource"@en ,
+                                    "une propriété objet owl reliant un ec:ProductionJob à une ec:Resource"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasIssuer
+ec:hasIssuer rdf:type owl:ObjectProperty ;
+             dcterms:description "L’émetteur d’un identifiant."@fr ,
+                                 "The issuer of an identifier."@en ;
+             rdfs:label "Issuer"@en ,
+                        "Émetteur"@fr ;
+             skos:definition "an owl:ObjectProperty relating an ec:Identifier to an ec:Agent"@en ,
+                             "une propriété objet owl reliant un ec:Identifier à un ec:Agent"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasJob
+ec:hasJob rdf:type owl:ObjectProperty ;
+          owl:inverseOf ec:isOrderedBy ;
+          dcterms:description "A property that links a production job to the contract by which it is ordered."@en ,
+                              "Une propriété qui relie une tâche de production au contrat par lequel elle est commandée."@fr ;
+          rdfs:label "A un travail"@fr ,
+                     "Has job"@en ;
+          skos:definition "an owl:ObjectProperty relating a ec:Contract to an ec:ProductionJob"@en ,
+                          "une propriété d'objet owl reliant un ec:Contract à un ec:ProductionJob"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasKeyCareerEvent
+ec:hasKeyCareerEvent rdf:type owl:ObjectProperty ;
+                     dcterms:description "Les principaux événements de carrière associés à une personne."@fr ,
+                                         "The key career events associated with a person."@en ;
+                     rdfs:label "Career event"@en ,
+                                "Événement de carrière"@fr ;
+                     skos:definition "an owl:ObjectProperty relating an ec:Person to an ec:KeyCareerEvent"@en ,
+                                     "une propriété d'objet owl:ObjectProperty reliant une ec:Person à une ec:KeyCareerEvent"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasKeyPersonalEvent
+ec:hasKeyPersonalEvent rdf:type owl:ObjectProperty ;
+                       dcterms:description "Les principaux événements personnels associés à une personne."@fr ,
+                                           "The key personal events associated with a Person."@en ;
+                       rdfs:label "Personal event"@en ,
+                                  "Événement personnel"@fr ;
+                       skos:definition "an owl:ObjectProperty relating an ec:Person to an ec:KeyPersonalEvent"@en ,
+                                       "une propriété d’objet owl reliant un ec:Person à un ec:KeyPersonalEvent"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasKeyword
+ec:hasKeyword rdf:type owl:ObjectProperty ;
+              dcterms:description "Associates a concept, descriptive phrase, or keyword that specifies the topic of an editorial object."@en ,
+                                  "Associe un concept, une expression descriptive ou un mot-clé qui précise le sujet d'un objet éditorial."@fr ;
+              rdfs:label "Keyword"@en ,
+                         "Mot-clé"@fr ;
+              skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Keyword"@en ,
+                              "une propriété d'objet owl reliant un ec:EditorialObject à un ec:Keyword"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasLanguage
+ec:hasLanguage rdf:type owl:ObjectProperty ;
+               dcterms:description "La langue associée à un objet éditorial. Un vocabulaire contrôlé basé sur BCP 47 est recommandé. Cette propriété peut également être utilisée pour indiquer la présence de langue des signes (RFC 5646). Par héritage, elle s’applique aux niveaux MediaResource, Fragment et Track lorsque l’usage de la langue est défini. La bonne pratique consiste à utiliser le niveau de granularité le plus spécifique possible pour décrire l’usage de la langue au sein d’un MediaResource, y compris aux niveaux Fragment et Track."@fr ,
+                                   "The language associated with an editorial object. A controlled vocabulary based on BCP 47 is recommended. This property can also be used to indicate the presence of sign language (RFC 5646). By inheritance, it applies at the MediaResource, Fragment, and Track levels where language usage is defined. Best practice is to use the most specific level of granularity possible to describe language usage within a MediaResource, including Fragment and Track levels."@en ;
+               rdfs:label "Language"@en ,
+                          "Langue"@fr ;
+               skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Language"@en ,
+                               "une propriété d’objet owl reliant un ec:EditorialObject à un ec:Language"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasLicensing
+ec:hasLicensing rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf ec:hasRights ;
+                dcterms:description "Lie un asset aux conditions de licence qui s’appliquent à lui."@fr ,
+                                    "Links an asset to the licensing conditions that apply to it."@en ;
+                rdfs:label "Licensing"@en ,
+                           "Octroi de licence"@fr ;
+                skos:definition "an owl:ObjectProperty relating an ec:Asset to an ec:Licensing"@en ,
+                                "une propriété d’objet owl:ObjectProperty reliant un ec:Asset à un ec:Licensing"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasLocation
+ec:hasLocation rdf:type owl:ObjectProperty ;
+               dcterms:description "A location associated with the object or concept."@en ,
+                                   "Un emplacement associé à l'objet ou au concept."@fr ;
+               rdfs:example "Lieu où le contenu a été capturé."@fr ,
+                            "The Location where content has been captured."@en ;
+               rdfs:label "Lieu"@fr ,
+                          "Location"@en ;
+               skos:definition "an owl:ObjectProperty relating an ec:Annotation to an ec:Location"@en ,
+                               "une propriété objet owl reliant une ec:Annotation à une ec:Location"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasLocationCode
+ec:hasLocationCode rdf:type owl:ObjectProperty ;
+                   dcterms:description "Pour fournir le code d’un lieu."@fr ,
+                                       "To give the code of a Location."@en ;
+                   rdfs:label "Code de localisation"@fr ,
+                              "Locationcode"@en ;
+                   skos:definition "an owl:ObjectProperty relating an ec:Location to an ec:LocationCode"@en ,
+                                   "une propriété objet owl reliant un ec:Location à un ec:LocationCode"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasLocationPicture
+ec:hasLocationPicture rdf:type owl:ObjectProperty ;
+                      dcterms:description "A picture associated with a Location."@en ,
+                                          "Une image associée à un lieu."@fr ;
+                      rdfs:label "Image"@fr ,
+                                 "Picture"@en ;
+                      skos:definition "an owl:ObjectProperty relating an ec:Location to an ec:Picture"@en ,
+                                      "une owl:ObjectProperty reliant une ec:Location à une ec:Picture"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasLocator
+ec:hasLocator rdf:type owl:ObjectProperty ;
+              dcterms:description "A locator from where the Resource can be accessed."@en ,
+                                  "Un localisateur à partir duquel la ressource peut être consultée."@fr ;
+              rdfs:label "Localisateur"@fr ,
+                         "Locator"@en ;
+              skos:definition "an owl:ObjectProperty relating an ec:Resource to an ec:Locator"@en ,
+                              "une propriété d’objet owl reliant une ec:Resource à un ec:Locator"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasLogo
+ec:hasLogo rdf:type owl:ObjectProperty ;
+           dcterms:description "A link to a logo representing an organisation, award, brand, publication platform, publication channel, publication service, or rating."@en ,
+                               "Un lien vers un logo représentant une organisation, un prix, une marque, une plateforme de publication, un canal de publication, un service de publication ou une évaluation."@fr ;
+           rdfs:label "Logo"@en ,
+                      "Logo"@fr ;
+           skos:definition "an owl:ObjectProperty relating an ec:Award, ec:Costume, ec:MarketingBrand, ec:Organisation, ec:PublicationChannel, ec:PublicationPlatform, ec:PublicationService, or ec:Rating to an ec:Logo"@en ,
+                           "une owl:ObjectProperty reliant un ec:Award, ec:Costume, ec:MarketingBrand, ec:Organisation, ec:PublicationChannel, ec:PublicationPlatform, ec:PublicationService ou ec:Rating à un ec:Logo"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasManifestation
+ec:hasManifestation rdf:type owl:ObjectProperty ;
+                    dcterms:description "A manifestation is the physical embodiment of work e.g. a tape, a file..."@en ,
+                                        "Une manifestation est l'incarnation physique d'une œuvre, par exemple une cassette, un fichier..."@fr ;
+                    rdfs:label "Manifestation"@en ,
+                               "Manifestation"@fr ;
+                    skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Resource"@en ,
+                                    "une propriété d’objet owl reliant un ec:EditorialObject à une ec:Resource"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasMaster
+ec:hasMaster rdf:type owl:ObjectProperty ;
+             owl:inverseOf ec:isMasterOf ;
+             dcterms:description "Le master associé à une ressource multimédia."@fr ,
+                                 "The master associated with a media resource."@en ;
+             rdfs:label "Master"@en ,
+                        "Maître"@fr ;
+             skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:MediaResource"@en ,
+                             "une propriété objet owl reliant un ec:MediaResource à un ec:MediaResource"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasMeasurementAgent
+ec:hasMeasurementAgent rdf:type owl:ObjectProperty ;
+                       dcterms:description "L’Agent qui analyse les données pour définir une Resonance."@fr ,
+                                           "The Agent who analyses data to define a Resonance."@en ;
+                       rdfs:label "Measured by"@en ,
+                                  "Mesuré par"@fr ;
+                       skos:definition "an owl:ObjectProperty relating an ec:ResonanceCount to an ec:Agent"@en ,
+                                       "une propriété d'objet owl reliant un ec:ResonanceCount à un ec:Agent"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasMediaFragment
+ec:hasMediaFragment rdf:type owl:ObjectProperty ;
+                    owl:inverseOf ec:isMediaFragmentOf ;
+                    dcterms:description "Relates a media resource to a media fragment contained within it."@en ,
+                                        "Relie une ressource média à un fragment média qu’elle contient."@fr ;
+                    rdfs:label "Fragment"@en ,
+                               "Fragment"@fr ;
+                    skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:MediaFragment"@en ,
+                                    "une propriété d’objet owl reliant un ec:MediaResource à un ec:MediaFragment"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasMedium
+ec:hasMedium rdf:type owl:ObjectProperty ;
+             rdfs:subPropertyOf ec:hasFormat ;
+             dcterms:description "Le support sur lequel la ressource est disponible."@fr ,
+                                 "The medium on which the resource is available."@en ;
+             rdfs:label "Medium"@en ,
+                        "Média"@fr ;
+             skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:Medium"@en ,
+                             "une propriété d’objet owl reliant un ec:MediaResource à un ec:Medium"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasMember
+ec:hasMember rdf:type owl:ObjectProperty ;
+             owl:inverseOf ec:isMemberOf ;
+             dcterms:description "To establish group/collection relationship between EditorialObjects."@en ,
+                                 "Établir une relation de groupe/collection entre les EditorialObjects."@fr ;
+             rdfs:label "Member"@en ,
+                        "Membre"@fr ;
+             skos:definition "an owl:ObjectProperty relating an ec:EditorialGroup to an ec:EditorialObject"@en ,
+                             "une propriété d’objet owl reliant un ec:EditorialGroup à un ec:EditorialObject"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasMemberAudience
+ec:hasMemberAudience rdf:type owl:ObjectProperty ;
+                     dcterms:description "An audience member included in the current audience group."@en ,
+                                         "Un membre du public inclus dans le groupe de public actuel."@fr ;
+                     rdfs:label "Member audience"@en ,
+                                "Public de l'audience"@fr ;
+                     skos:definition "an owl:ObjectProperty relating an ec:AudienceGroup to an ec:AudienceMember"@en ,
+                                     "une propriété objet owl reliant un ec:AudienceGroup à un ec:AudienceMember"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasMetadataTrack
+ec:hasMetadataTrack rdf:type owl:ObjectProperty ;
+                    dcterms:description "La propriété qui identifie la piste de métadonnées associée à une ressource multimédia."@fr ,
+                                        "The property that identifies the metadata track associated with a media resource."@en ;
+                    rdfs:label "Metadata track"@en ,
+                               "Piste de métadonnées"@fr ;
+                    skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:MetadataTrack"@en ,
+                                    "une propriété objet owl reliant un ec:MediaResource à un ec:MetadataTrack"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasMimeType
+ec:hasMimeType rdf:type owl:ObjectProperty ;
+               rdfs:subPropertyOf ec:hasFormat ;
+               dcterms:description "Le type MIME d'une ressource multimédia."@fr ,
+                                   "The MIME type of a media resource."@en ;
+               rdfs:label "Mime type"@en ,
+                          "Type MIME"@fr ;
+               skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:MimeType"@en ,
+                               "une propriété objet owl reliant un ec:MediaResource à un ec:MimeType"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasObjectType
+ec:hasObjectType rdf:type owl:ObjectProperty ;
+                 dcterms:description "Le type ou le genre de la ressource."@fr ,
+                                     "The kind or genre of the resource."@en ;
+                 rdfs:label "Type"@en ,
+                            "Type"@fr ;
+                 skos:definition "an owl:ObjectProperty relating a resource to a skos:Concept classifying its kind or genre"@en ,
+                                 "une propriété objet owl reliant une ressource à un skos:Concept classant son type ou son genre"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasOrganisationStaff
+ec:hasOrganisationStaff rdf:type owl:ObjectProperty ;
+                        dcterms:description "Les membres du personnel d’une organisation."@fr ,
+                                            "The staff members in an organisation."@en ;
+                        rdfs:label "Personnel"@fr ,
+                                   "Staff"@en ;
+                        skos:definition "an owl:ObjectProperty relating an ec:Organisation to an ec:StaffMember"@en ,
+                                        "une propriété d'objet owl reliant une ec:Organisation à un ec:StaffMember"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasOriginalLanguage
+ec:hasOriginalLanguage rdf:type owl:ObjectProperty ;
+                       rdfs:subPropertyOf ec:hasLanguage ;
+                       dcterms:description "La langue originale d'un objet éditorial."@fr ,
+                                           "The original language of an editorial object."@en ;
+                       rdfs:label "Langue d'origine"@fr ,
+                                  "Original language"@en ;
+                       skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Language"@en ,
+                                       "une propriété d’objet owl:ObjectProperty reliant un ec:EditorialObject à un ec:Language"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasOutputEssence
+ec:hasOutputEssence rdf:type owl:ObjectProperty ;
+                    dcterms:description "An Essence resulting from a ProductionJob."@en ,
+                                        "Une Essence résultant d'un ProductionJob."@fr ;
+                    rdfs:label "Essence de sortie"@fr ,
+                               "Output essence"@en ;
+                    skos:definition "an owl:ObjectProperty relating an ec:ProductionJob to an ec:Essence"@en ,
+                                    "une propriété d’objet owl reliant un ec:ProductionJob à un ec:Essence"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasOutputMediaResource
+ec:hasOutputMediaResource rdf:type owl:ObjectProperty ;
+                          dcterms:description "A media resource resulting from a production job."@en ,
+                                              "Une ressource média résultant d’un travail de production."@fr ;
+                          rdfs:label "Output media resource"@en ,
+                                     "Ressource multimédia de sortie"@fr ;
+                          skos:definition "an owl:ObjectProperty relating an ec:ProductionJob to an ec:MediaResource"@en ,
+                                          "une propriété d’objet owl reliant un ec:ProductionJob à un ec:MediaResource"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasOutputResource
+ec:hasOutputResource rdf:type owl:ObjectProperty ;
+                     dcterms:description "A resource resulting from a ProductionJob."@en ,
+                                         "Une ressource résultant d’un ProductionJob."@fr ;
+                     rdfs:label "Output resource"@en ,
+                                "Ressource de sortie"@fr ;
+                     skos:definition "an owl:ObjectProperty relating an ec:ProductionJob to an ec:Resource"@en ,
+                                     "une propriété objet owl reliant un ec:ProductionJob à une ec:Resource"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasOwner
+ec:hasOwner rdf:type owl:ObjectProperty ;
+            dcterms:description "Le propriétaire d’un animal."@fr ,
+                                "The owner of an animal."@en ;
+            rdfs:label "Animal owner"@en ,
+                       "Propriétaire d'animal"@fr ;
+            skos:definition "an owl:ObjectProperty relating an ec:Animal to an ec:Agent"@en ,
+                            "une owl:ObjectProperty reliant une ec:Animal à un ec:Agent"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasParentEditorialObject
+ec:hasParentEditorialObject rdf:type owl:ObjectProperty ;
+                            dcterms:description "Lie un EditorialObject à son objet éditorial parent."@fr ,
+                                                "Links an EditorialObject to its parent editorial object."@en ;
+                            rdfs:label "Objet éditorial parent"@fr ,
+                                       "Parent editorial object"@en ;
+                            skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:EditorialObject"@en ,
+                                            "une propriété d’objet owl reliant un ec:EditorialObject à un ec:EditorialObject"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasParentEditorialSegment
+ec:hasParentEditorialSegment rdf:type owl:ObjectProperty ;
+                             dcterms:description "Lie un segment éditorial à son segment éditorial parent."@fr ,
+                                                 "Links an editorial segment to its parent editorial segment."@en ;
+                             rdfs:label "A un segment éditorial parent"@fr ,
+                                        "Has parent editorial segment"@en ;
+                             skos:definition "an owl:ObjectProperty relating an ec:EditorialSegment to an ec:EditorialSegment"@en ,
+                                             "une propriété d'objet owl reliant un ec:EditorialSegment à un ec:EditorialSegment"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasParentMediaResource
+ec:hasParentMediaResource rdf:type owl:ObjectProperty ;
+                          dcterms:description "Links a media resource to its parent media resource."@en ,
+                                              "Relie une ressource média à sa ressource média parente."@fr ;
+                          rdfs:label "Parent resource"@en ,
+                                     "Ressource parente"@fr ;
+                          skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:MediaResource"@en ,
+                                          "une propriété objet owl reliant une ec:MediaResource à une ec:MediaResource"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasPart
+ec:hasPart rdf:type owl:ObjectProperty ;
+           owl:inverseOf ec:isPartOf ;
+           dcterms:description "Defines Parts (segments, fragments, shots, etc.) within an EditorialObject."@en ,
+                               "Définit les parties (segments, fragments, plans, etc.) au sein d’un EditorialObject."@fr ;
+           rdfs:label "Part"@en ,
+                      "Partie"@fr ;
+           skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:EditorialSegment"@en ,
+                           "une propriété d'objet owl reliant un ec:EditorialObject à un ec:EditorialSegment"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasParticipatingAgent
+ec:hasParticipatingAgent rdf:type owl:ObjectProperty ;
+                         dcterms:description "Identifie l’agent participant à l’actif."@fr ,
+                                             "Identifies the agent participating in the asset."@en ;
+                         rdfs:label "Agent participant"@fr ,
+                                    "Participating agent"@en ;
+                         skos:definition "an owl:ObjectProperty relating an ec:Asset to an ec:Agent"@en ,
+                                         "une propriété objet owl reliant un ec:Asset à un ec:Agent"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasPictogram
+ec:hasPictogram rdf:type owl:ObjectProperty ;
+                dcterms:description "A visual representation used for a Rating, AudienceRating, or AudienceLevel."@en ,
+                                    "Une représentation visuelle utilisée pour une Rating, AudienceRating ou AudienceLevel."@fr ;
+                rdfs:label "Pictogram"@en ,
+                           "Pictogramme"@fr ;
+                skos:definition "an owl:ObjectProperty relating an ec:Rating to an ec:Picture"@en ,
+                                "une propriété d’objet owl reliant un ec:Rating à une ec:Picture"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasPlaceOfBirth
+ec:hasPlaceOfBirth rdf:type owl:ObjectProperty ;
+                   dcterms:description "L’endroit où une personne est née."@fr ,
+                                       "The place where a person was born."@en ;
+                   rdfs:label "Birth place"@en ,
+                              "Lieu de naissance"@fr ;
+                   skos:definition "an owl:ObjectProperty relating an ec:Person to an ec:Location"@en ,
+                                   "une propriété d’objet owl reliant une ec:Person à une ec:Location"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasPlaceOfDeath
+ec:hasPlaceOfDeath rdf:type owl:ObjectProperty ;
+                   dcterms:description "L’endroit où une personne est décédée."@fr ,
+                                       "The place where a person died."@en ;
+                   rdfs:label "Death place"@en ,
+                              "Lieu de décès"@fr ;
+                   skos:definition "an owl:ObjectProperty relating an ec:Person to an ec:Location"@en ,
+                                   "une propriété d'objet owl reliant une ec:Person à une ec:Location"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasPost
+ec:hasPost rdf:type owl:ObjectProperty ;
+           dcterms:description "Connecte un élément à un post auquel il est associé ou dans lequel il est incorporé."@fr ,
+                               "Connects an item to a post it is associated with or incorporated into."@en ;
+           rdfs:label "A un post"@fr ,
+                      "Has post"@en ;
+           skos:definition "an owl:ObjectProperty relating an ec:Item to an ec:Post"@en ,
+                           "une propriété objet owl reliant un ec:Item à un ec:Post"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasPreviousRelated
+ec:hasPreviousRelated rdf:type owl:ObjectProperty ;
+                      dcterms:description "Le ProductionJob associé précédent."@fr ,
+                                          "The previous associated ProductionJob."@en ;
+                      rdfs:label "Emploi précédent"@fr ,
+                                 "Previous job"@en ;
+                      skos:definition "an owl:ObjectProperty relating an ec:ProductionJob to an ec:ProductionJob"@en ,
+                                      "une propriété objet owl reliant un ec:ProductionJob à un ec:ProductionJob"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasPriority
+ec:hasPriority rdf:type owl:ObjectProperty ;
+               dcterms:description "La priorité associée à une Rule."@fr ,
+                                   "The priority associated with a Rule."@en ;
+               rdfs:label "Priorité de règle"@fr ,
+                          "Rule priority"@en ;
+               skos:definition "an owl:ObjectProperty relating an ec:Rule to a skos:Concept"@en ,
+                               "une propriété d'objet owl reliant un ec:Rule à un skos:Concept"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasProducer
+ec:hasProducer rdf:type owl:ObjectProperty ;
+               dcterms:description "L’agent impliqué dans la production de la ressource ou de l’objet éditorial."@fr ,
+                                   "The Agent involved in the production of the Resource or EditorialObject."@en ;
+               rdfs:label "Producer"@en ,
+                          "Producteur"@fr ;
+               skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Agent"@en ,
+                               "une owl:ObjectProperty reliant une ec:EditorialObject à une ec:Agent"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasProductionContract
+ec:hasProductionContract rdf:type owl:ObjectProperty ;
+                         dcterms:description "Cette propriété relie un ordre de production aux contrats qui lui sont associés."@fr ,
+                                             "This property links a production order to the contracts associated with it."@en ;
+                         rdfs:label "Contract"@en ,
+                                    "Contrat"@fr ;
+                         skos:definition "an owl:ObjectProperty relating an ec:ProductionOrder to an ec:Contract"@en ,
+                                         "une propriété d’objet owl reliant un ec:ProductionOrder à un ec:Contract"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasProductionDevice
+ec:hasProductionDevice rdf:type owl:ObjectProperty ;
+                       dcterms:description "A production device associated with a media resource."@en ,
+                                           "Un dispositif de production associé à une ressource média."@fr ;
+                       rdfs:label "Dispositif de production"@fr ,
+                                  "Production device"@en ;
+                       skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:ProductionDevice"@en ,
+                                       "une propriété d'objet owl reliant un ec:MediaResource à un ec:ProductionDevice"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasProductionDeviceOnStagePosition
+ec:hasProductionDeviceOnStagePosition rdf:type owl:ObjectProperty ;
+                                      dcterms:description "La position sur scène d’un dispositif de production sur une scène."@fr ,
+                                                          "The OnStagePosition of a ProductionDevice on Stage."@en ;
+                                      rdfs:label "Dispositif de production"@fr ,
+                                                 "Production device"@en ;
+                                      skos:definition "an owl:ObjectProperty relating an ec:ProductionDevice to an ec:OnStagePosition"@en ,
+                                                      "une propriété objet owl reliant un ec:ProductionDevice à un ec:OnStagePosition"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasProductionJobEvent
+ec:hasProductionJobEvent rdf:type owl:ObjectProperty ;
+                         dcterms:description "An event associated with a production job."@en ,
+                                             "Un événement associé à un travail de production."@fr ;
+                         rdfs:label "Production job event"@en ,
+                                    "Événement de travail de production"@fr ;
+                         skos:definition "an owl:ObjectProperty relating an ec:ProductionJob to an ec:Event"@en ,
+                                         "une propriété d'objet owl reliant un ec:ProductionJob à un ec:Event"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasProductionJobLocation
+ec:hasProductionJobLocation rdf:type owl:ObjectProperty ;
+                            dcterms:description "Le lieu où un ProductionJob a eu lieu ou est prévu de se dérouler."@fr ,
+                                                "The location where a ProductionJob has taken place or is scheduled to take place."@en ;
+                            rdfs:label "Lieu du travail de production"@fr ,
+                                       "Production job location"@en ;
+                            skos:definition "an owl:ObjectProperty relating an ec:ProductionJob to an ec:Location"@en ,
+                                            "une propriété objet owl reliant un ec:ProductionJob à une ec:Location"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasProgramme
+ec:hasProgramme rdf:type owl:ObjectProperty ;
+                dcterms:description "Relates a resource to a programme it has or includes as part of its content. It is used for editorial extras, items, and scenes that are associated with a programme."@en ,
+                                    "Relie une ressource à un programme qu’elle possède ou qu’elle inclut dans son contenu. Elle est utilisée pour les compléments éditoriaux, les éléments et les scènes associés à un programme."@fr ;
+                rdfs:label "A le programme"@fr ,
+                           "Has programme"@en ;
+                skos:definition "an owl:ObjectProperty relating an ec:EditorialExtra, ec:Item or ec:Scene to an ec:Programme"@en ,
+                                "une propriété d’objet owl reliant un ec:EditorialExtra, ec:Item ou ec:Scene à un ec:Programme"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasPromotion
+ec:hasPromotion rdf:type owl:ObjectProperty ;
+                dcterms:description "A reminder that refers to a previous promotion and helps remind the consumer of the advertised object."@en ,
+                                    "Un rappel qui fait référence à une promotion précédente et aide à rappeler au consommateur l'objet annoncé."@fr ;
+                rdfs:label "A une promotion"@fr ,
+                           "Has promotion"@en ;
+                skos:definition "an owl:ObjectProperty relating an ec:Reminder to an ec:Promotion"@en ,
+                                "une propriété d’objet owl reliant un ec:Reminder à un ec:Promotion"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasProvenance
+ec:hasProvenance rdf:type owl:ObjectProperty ;
+                 owl:inverseOf ec:hasProvenanceTarget ;
+                 dcterms:description "La personne ou l'entreprise fournissant les métadonnées."@fr ,
+                                     "The person or company providing the metadata."@en ;
+                 rdfs:label "Provenance"@en ,
+                            "Provenance"@fr ;
+                 skos:definition "an owl:ObjectProperty relating an ec:Provenance to an owl:Thing"@en ,
+                                 "une propriété d'objet owl reliant un ec:Provenance à un owl:Thing"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasProvenanceTarget
+ec:hasProvenanceTarget rdf:type owl:ObjectProperty ;
+                       dcterms:description "L’instance d’un objet provenant de la provenance."@fr ,
+                                           "The instance of an object sourced by the Provenance."@en ;
+                       rdfs:label "Cible de provenance"@fr ,
+                                  "Provenance target"@en ;
+                       skos:definition "an owl:ObjectProperty relating an ec:Provenance to an owl:Thing"@en ,
+                                       "une propriété d'objet owl reliant une ec:Provenance à une owl:Thing"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasPublication
+ec:hasPublication rdf:type owl:ObjectProperty ;
+                  owl:inverseOf ec:publishes ;
+                  dcterms:description "L’événement de publication au cours duquel un objet éditorial est rendu disponible à la consommation."@fr ,
+                                      "The PublicationEvent in which an EditorialObject is made available for consumption."@en ;
+                  rdfs:label "Publication event"@en ,
+                             "Événement de publication"@fr ;
+                  skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:PublicationEvent"@en ,
+                                  "une propriété objet owl reliant un ec:EditorialObject à un ec:PublicationEvent"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasPublicationChannel
+ec:hasPublicationChannel rdf:type owl:ObjectProperty ;
+                         dcterms:description "An object property that links a publication event or publication platform to a publication channel used for technical access to a service."@en ,
+                                             "Une propriété d'objet qui relie un événement de publication ou une plateforme de publication à un canal de publication utilisé pour l'accès technique à un service."@fr ;
+                         rdfs:label "A un canal de publication"@fr ,
+                                    "Has publication channel"@en ;
+                         skos:definition "an owl:ObjectProperty relating an ec:PublicationEvent or ec:PublicationPlatform to an ec:PublicationChannel"@en ,
+                                         "une propriété d’objet owl:ObjectProperty reliant une ec:PublicationEvent ou une ec:PublicationPlatform à une ec:PublicationChannel"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasPublicationEvent
+ec:hasPublicationEvent rdf:type owl:ObjectProperty ;
+                       dcterms:description "Associates publication events with publication channels, publication histories, or publication plans."@en ,
+                                           "Associe les événements de publication aux canaux de publication, aux historiques de publication ou aux plans de publication."@fr ;
+                       rdfs:label "Publication event"@en ,
+                                  "Événement de publication"@fr ;
+                       skos:definition "an owl:ObjectProperty relating an ec:PublicationEvent to an ec:PublicationEvent"@en ,
+                                       "une propriété d'objet owl:ObjectProperty reliant un ec:PublicationEvent à un ec:PublicationEvent"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasPublicationHistory
+ec:hasPublicationHistory rdf:type owl:ObjectProperty ;
+                         dcterms:description "L'historique de publication d'un EditorialObject ou d'une MediaResource."@fr ,
+                                             "The publication history of an EditorialObject or MediaResource."@en ;
+                         rdfs:label "Historique de publication"@fr ,
+                                    "Publication history"@en ;
+                         skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:PublicationHistory"@en ,
+                                         "une propriété d'objet owl reliant un ec:EditorialObject à un ec:PublicationHistory"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasPublicationMedium
+ec:hasPublicationMedium rdf:type owl:ObjectProperty ;
+                        dcterms:description "Le support de publication associé à l’événement de publication."@fr ,
+                                            "The publication medium associated with the publication event."@en ;
+                        rdfs:label "Publication medium"@en ,
+                                   "Support de publication"@fr ;
+                        skos:definition "an owl:ObjectProperty relating an ec:PublicationEvent to an ec:PublicationMedium"@en ,
+                                        "une propriété d’objet owl:ObjectProperty reliant une ec:PublicationEvent à une ec:PublicationMedium"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasPublicationPlan
+ec:hasPublicationPlan rdf:type owl:ObjectProperty ;
+                      dcterms:description "A PublicationPlan associated with a Campaign."@en ,
+                                          "Un ec:PublicationPlan associé à une ec:Campaign."@fr ;
+                      rdfs:label "Plan de publication"@fr ,
+                                 "Publication plan"@en ;
+                      skos:definition "an owl:ObjectProperty relating an ec:Campaign to an ec:PublicationPlan"@en ,
+                                      "une propriété d'objet owl reliant une ec:Campaign à une ec:PublicationPlan"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasPublicationPlanMember
+ec:hasPublicationPlanMember rdf:type owl:ObjectProperty ;
+                            dcterms:description "Identifie un sous-plan d’un plan de publication."@fr ,
+                                                "Identifies a sub-plan of a publication plan."@en ;
+                            rdfs:label "Membre du plan de publication"@fr ,
+                                       "Publication plan member"@en ;
+                            skos:definition "an owl:ObjectProperty relating an ec:PublicationPlan to an ec:PublicationPlan"@en ,
+                                            "une propriété d’objet owl reliant un ec:PublicationPlan à un ec:PublicationPlan"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasPublicationPlanStatus
+ec:hasPublicationPlanStatus rdf:type owl:ObjectProperty ;
+                            dcterms:description "Le statut associé à un plan de publication."@fr ,
+                                                "The status associated with a publication plan."@en ;
+                            rdfs:label "PublicationPlan status"@en ,
+                                       "Statut du plan de publication"@fr ;
+                            skos:definition "an owl:ObjectProperty relating an ec:PublicationPlan to a skos:Collection"@en ,
+                                            "une propriété d’objet owl reliant un ec:PublicationPlan à une skos:Collection"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasPublicationRegion
+ec:hasPublicationRegion rdf:type owl:ObjectProperty ;
+                        dcterms:description "La région où la publication a lieu."@fr ,
+                                            "The region where the publication takes place."@en ;
+                        rdfs:label "Publication region"@en ,
+                                   "Région de publication"@fr ;
+                        skos:definition "an owl:ObjectProperty relating an ec:PublicationEvent to an ec:Location"@en ,
+                                        "une propriété d'objet owl:ObjectProperty reliant une ec:PublicationEvent à une ec:Location"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasPublisher
+ec:hasPublisher rdf:type owl:ObjectProperty ;
+                dcterms:description "An agent involved in the publication of an editorial object."@en ,
+                                    "Un agent impliqué dans la publication d’un objet éditorial."@fr ;
+                rdfs:label "Publisher"@en ,
+                           "Éditeur"@fr ;
+                skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Involvement"@en ,
+                                "une propriété objet owl reliant un ec:EditorialObject à un ec:Involvement"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRating
+ec:hasRating rdf:type owl:ObjectProperty ;
+             dcterms:description "La présence d’une Rating attribuée à un EditorialObject."@fr ,
+                                 "The presence of a Rating attributed to an EditorialObject."@en ;
+             rdfs:label "Rating"@en ,
+                        "Évaluation"@fr ;
+             skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Rating"@en ,
+                             "une propriété objet owl reliant un ec:EditorialObject à un ec:Rating"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRatingProvider
+ec:hasRatingProvider rdf:type owl:ObjectProperty ;
+                     dcterms:description "An Agent who provided the Rating."@en ,
+                                         "Un agent qui a fourni la notation."@fr ;
+                     rdfs:label "Rating source / agent"@en ,
+                                "Source de notation / agent"@fr ;
+                     skos:definition "an owl:ObjectProperty relating an ec:Rating to an ec:Agent"@en ,
+                                     "une propriété d’objet owl reliant un ec:Rating à un ec:Agent"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRegionCode
+ec:hasRegionCode rdf:type owl:ObjectProperty ;
+                 dcterms:description "A region code associated with a location."@en ,
+                                     "Un code de région associé à une localisation."@fr ;
+                 rdfs:label "Region"@en ,
+                            "Région"@fr ;
+                 skos:definition "an owl:ObjectProperty relating an ec:Location to an ec:RegionCode"@en ,
+                                 "une propriété objet owl reliant un ec:Location à un ec:RegionCode"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRegistration
+ec:hasRegistration rdf:type owl:ObjectProperty ;
+                   dcterms:description "Les détails du compte d’un consommateur enregistré."@fr ,
+                                       "The account details of a registered consumer."@en ;
+                   rdfs:label "Enregistrement"@fr ,
+                              "Registration"@en ;
+                   skos:definition "an owl:ObjectProperty relating an ec:Consumer to an ec:Account"@en ,
+                                   "une propriété d'objet owl:ObjectProperty reliant un ec:Consumer à un ec:Account"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedAccount
+ec:hasRelatedAccount rdf:type owl:ObjectProperty ,
+                              owl:IrreflexiveProperty ;
+                     dcterms:description "Lie un compte à des comptes associés."@fr ,
+                                         "Links one account to related accounts."@en ;
+                     rdfs:label "Compte associé"@fr ,
+                                "Related account"@en ;
+                     skos:definition "an owl:ObjectProperty relating an ec:Account to an ec:Account"@en ,
+                                     "une propriété d’objet owl reliant un ec:Account à un ec:Account"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedAgent
+ec:hasRelatedAgent rdf:type owl:ObjectProperty ;
+                   owl:inverseOf ec:isRelatedAgent ;
+                   rdf:type owl:IrreflexiveProperty ;
+                   dcterms:description "Lie une entité à un Agent مرتبط, tel qu'une Personne ou un Personnage."@fr ,
+                                       "Links an entity to a related Agent, such as a Person or Character."@en ;
+                   rdfs:label "Agent lié"@fr ,
+                              "Related agent"@en ;
+                   skos:definition "an owl:ObjectProperty relating an ec:Action to an ec:Agent"@en ,
+                                   "une propriété d'objet owl reliant un ec:Action à un ec:Agent"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedAnimal
+ec:hasRelatedAnimal rdf:type owl:ObjectProperty ;
+                    dcterms:description "Animals related to the editorial object or depicted in it."@en ,
+                                        "Animaux liés à l’objet éditorial ou représentés dans celui-ci."@fr ;
+                    rdfs:label "Animal lié"@fr ,
+                               "Related animal"@en ;
+                    skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Animal"@en ,
+                                    "une owl:ObjectProperty reliant un ec:EditorialObject à un ec:Animal"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedArtefact
+ec:hasRelatedArtefact rdf:type owl:ObjectProperty ;
+                      dcterms:description "An artefact related to an annotation, asset, event, involvement, or location."@en ,
+                                          "Un artefact lié à une annotation, un actif, un événement, une implication ou un lieu."@fr ;
+                      rdfs:label "Artefact lié"@fr ,
+                                 "Related artefact"@en ;
+                      skos:definition "an owl:ObjectProperty relating an ec:Annotation or ec:Asset, ec:Event, ec:Involvement, or ec:Location to an ec:Artefact"@en ,
+                                      "une owl:ObjectProperty reliant une ec:Annotation ou un ec:Asset, ec:Event, ec:Involvement ou ec:Location à un ec:Artefact"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedAsset
+ec:hasRelatedAsset rdf:type owl:ObjectProperty ,
+                            owl:IrreflexiveProperty ;
+                   dcterms:description "Lie un Asset à un autre Asset مرتبط."@fr ,
+                                       "Links an Asset to another related Asset."@en ;
+                   rdfs:label "Actif lié"@fr ,
+                              "Related asset"@en ;
+                   skos:definition "an owl:ObjectProperty relating an ec:Asset to an ec:Asset"@en ,
+                                   "une propriété d’objet owl reliant un ec:Asset à un ec:Asset"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedAudioContent
+ec:hasRelatedAudioContent rdf:type owl:ObjectProperty ,
+                                   owl:IrreflexiveProperty ;
+                          dcterms:description "Contenu audio associé à l'objet éditorial."@fr ,
+                                              "Related audio content associated with the editorial object."@en ;
+                          rdfs:label "Audio content"@en ,
+                                     "Contenu audio"@fr ;
+                          skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:AudioContent"@en ,
+                                          "une owl:ObjectProperty reliant un ec:EditorialObject à un ec:AudioContent"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedAudioObject
+ec:hasRelatedAudioObject rdf:type owl:ObjectProperty ;
+                         dcterms:description "A property that identifies a related audio object."@en ,
+                                             "Une propriété qui identifie un objet audio associé."@fr ;
+                         rdfs:label "Audio object"@en ,
+                                    "Objet audio"@fr ;
+                         skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:AudioObject"@en ,
+                                         "une propriété d'objet owl reliant un ec:MediaResource à un ec:AudioObject"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedAudioProgramme
+ec:hasRelatedAudioProgramme rdf:type owl:ObjectProperty ,
+                                     owl:IrreflexiveProperty ;
+                            dcterms:description "A related audio programme."@en ,
+                                                "Un programme audio associé."@fr ;
+                            rdfs:label "Audio programme"@en ,
+                                       "Programme audio"@fr ;
+                            skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:AudioProgramme"@en ,
+                                            "une propriété d'objet owl reliant un ec:EditorialObject à un ec:AudioProgramme"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedAudioTrack
+ec:hasRelatedAudioTrack rdf:type owl:ObjectProperty ;
+                        dcterms:description "A related audio track associated with the media resource."@en ,
+                                            "Une piste audio associée à la ressource multimédia."@fr ;
+                        rdfs:label "Audio track"@en ,
+                                   "Piste audio"@fr ;
+                        skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:AudioTrack"@en ,
+                                        "une propriété objet owl reliant une ec:MediaResource à une ec:AudioTrack"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedAuditJob
+ec:hasRelatedAuditJob rdf:type owl:ObjectProperty ;
+                      dcterms:description "La tâche ou les tâches d’audit liées à un rapport d’audit."@fr ,
+                                          "The AuditJob or AuditJobs related to an AuditReport."@en ;
+                      rdfs:label "Audit job(s)"@en ,
+                                 "Tâche(s) d'audit"@fr ;
+                      skos:definition "an owl:ObjectProperty relating an ec:AuditReport to an ec:AuditJob"@en ,
+                                      "une propriété d'objet owl reliant un ec:AuditReport à un ec:AuditJob"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedAuditReport
+ec:hasRelatedAuditReport rdf:type owl:ObjectProperty ;
+                         dcterms:description "An audit report associated with an asset."@en ,
+                                             "Un rapport d'audit associé à un actif."@fr ;
+                         rdfs:label "Rapport d'audit مرتبط"@fr ,
+                                    "Related audit report"@en ;
+                         skos:definition "an owl:ObjectProperty relating an ec:Asset to an ec:AuditReport"@en ,
+                                         "une owl:ObjectProperty reliant un ec:Asset à un ec:AuditReport"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedAward
+ec:hasRelatedAward rdf:type owl:ObjectProperty ;
+                   dcterms:description "An award related to an EditorialObject."@en ,
+                                       "Un prix lié à un EditorialObject."@fr ;
+                   rdfs:label "Prix lié"@fr ,
+                              "Related award"@en ;
+                   skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Award"@en ,
+                                   "une propriété d'objet owl reliant un ec:EditorialObject à un ec:Award"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedCharacter
+ec:hasRelatedCharacter rdf:type owl:ObjectProperty ;
+                       dcterms:description "Le caractère lié au concept."@fr ,
+                                           "The Character related to the concept."@en ;
+                       rdfs:label "Personnage lié"@fr ,
+                                  "Related character"@en ;
+                       skos:definition "an owl:ObjectProperty relating an ec:TextLine to an ec:Character"@en ,
+                                       "une propriété d'objet owl reliant un ec:TextLine à un ec:Character"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedConsumptionEvent
+ec:hasRelatedConsumptionEvent rdf:type owl:ObjectProperty ,
+                                       owl:IrreflexiveProperty ;
+                              dcterms:description "A related consumption event."@en ,
+                                                  "Un événement de consommation associé."@fr ;
+                              rdfs:label "Related consumption event"@en ,
+                                         "Événement de consommation lié"@fr ;
+                              skos:definition "an owl:ObjectProperty relating an ec:ConsumptionEvent to an ec:ConsumptionEvent"@en ,
+                                              "une propriété objet owl reliant un ec:ConsumptionEvent à un ec:ConsumptionEvent"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedEditorialObject
+ec:hasRelatedEditorialObject rdf:type owl:ObjectProperty ,
+                                      owl:IrreflexiveProperty ;
+                             dcterms:description "Objets éditoriaux liés associés à cette propriété."@fr ,
+                                                 "Related editorial objects associated with this property."@en ;
+                             rdfs:label "Objet éditorial lié"@fr ,
+                                        "Related editorial object"@en ;
+                             skos:definition "an owl:ObjectProperty relating an ec:Artefact, ec:Asset, or ec:EditorialObject to an ec:EditorialObject"@en ,
+                                             "une propriété d’objet owl liant un ec:Artefact, un ec:Asset ou un ec:EditorialObject à un ec:EditorialObject"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedEssence
+ec:hasRelatedEssence rdf:type owl:ObjectProperty ,
+                              owl:IrreflexiveProperty ;
+                     dcterms:description "To establish a relation between a MediaResource and an Essence."@en ,
+                                         "Établir une relation entre une MediaResource et une Essence."@fr ;
+                     rdfs:label "Essence liée"@fr ,
+                                "Related essence"@en ;
+                     skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:Essence"@en ,
+                                     "une propriété objet owl reliant un ec:MediaResource à un ec:Essence"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedEvent
+ec:hasRelatedEvent rdf:type owl:ObjectProperty ,
+                            owl:IrreflexiveProperty ;
+                   dcterms:description "An event associated with the concept."@en ,
+                                       "Un événement associé au concept."@fr ;
+                   rdfs:label "Related event"@en ,
+                              "Événement lié"@fr ;
+                   skos:definition "an owl:ObjectProperty relating an ec:Annotation to an ec:Event"@en ,
+                                   "une propriété objet owl:ObjectProperty reliant une ec:Annotation à un ec:Event"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedMediaFragment
+ec:hasRelatedMediaFragment rdf:type owl:ObjectProperty ,
+                                    owl:IrreflexiveProperty ;
+                           dcterms:description "Associates a resource with a related media fragment, such as a temporal or spatial segment of that resource."@en ,
+                                               "Associe une ressource à un fragment multimédia مرتبط, tel qu’un segment temporel ou spatial de cette ressource."@fr ;
+                           rdfs:label "Fragment média"@fr ,
+                                      "Media fragment"@en ;
+                           skos:definition "an owl:ObjectProperty relating an ec:Resource to an ec:MediaFragment"@en ,
+                                           "une propriété d’objet owl reliant un ec:Resource à un ec:MediaFragment"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedMediaResource
+ec:hasRelatedMediaResource rdf:type owl:ObjectProperty ;
+                           dcterms:description "A media resource associated with an editorial object."@en ,
+                                               "Une ressource média associée à un objet éditorial."@fr ;
+                           rdfs:label "Related media resource"@en ,
+                                      "Ressource média associée"@fr ;
+                           skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:MediaResource"@en ,
+                                           "une owl:ObjectProperty reliant un ec:EditorialObject à un ec:MediaResource"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedPicture
+ec:hasRelatedPicture rdf:type owl:ObjectProperty ;
+                     dcterms:description "Associates a Picture with an EditorialObject."@en ,
+                                         "Associe une Picture à un EditorialObject."@fr ;
+                     rdfs:label "Image"@fr ,
+                                "Picture"@en ;
+                     skos:definition "an owl:ObjectProperty relating an ec:Asset to an ec:Picture"@en ,
+                                     "une owl:ObjectProperty reliant une ec:Asset à une ec:Picture"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedPublicationChannel
+ec:hasRelatedPublicationChannel rdf:type owl:ObjectProperty ,
+                                         owl:IrreflexiveProperty ;
+                                dcterms:description "A property that identifies a related publication channel."@en ,
+                                                    "Une propriété qui identifie un canal de publication مرتبط."@fr ;
+                                rdfs:label "Canal de publication"@fr ,
+                                           "Publication channel"@en ;
+                                skos:definition "an owl:ObjectProperty relating an ec:PublicationChannel to an ec:PublicationChannel"@en ,
+                                                "une propriété d'objet owl reliant un ec:PublicationChannel à un ec:PublicationChannel"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedPublicationEvent
+ec:hasRelatedPublicationEvent rdf:type owl:ObjectProperty ,
+                                       owl:IrreflexiveProperty ;
+                              dcterms:description "L'PublicationEvent associée à la ressource."@fr ,
+                                                  "The PublicationEvent associated with the resource."@en ;
+                              rdfs:label "Publication event"@en ,
+                                         "Événement de publication"@fr ;
+                              skos:definition "an ec:ObjectProperty relating an ec:ConsumptionEvent or ec:Essence to an ec:PublicationEvent"@en ,
+                                              "une ec:ObjectProperty reliant un ec:ConsumptionEvent ou une ec:Essence à un ec:PublicationEvent"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedPublicationService
+ec:hasRelatedPublicationService rdf:type owl:ObjectProperty ,
+                                         owl:IrreflexiveProperty ;
+                                dcterms:description "To establish a relation to publication services."@en ,
+                                                    "Établir une relation avec des services de publication."@fr ;
+                                rdfs:label "Related publication service"@en ,
+                                           "Service de publication associé"@fr ;
+                                skos:definition "an owl:ObjectProperty relating an ec:PublicationPlatform to an ec:PublicationService"@en ,
+                                                "une propriété d'objet owl reliant une ec:PublicationPlatform à une ec:PublicationService"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedRecord
+ec:hasRelatedRecord rdf:type owl:ObjectProperty ,
+                             owl:IrreflexiveProperty ;
+                    dcterms:description "Le dossier associé à un actif."@fr ,
+                                        "The record associated with an asset."@en ;
+                    rdfs:label "Enregistrement lié"@fr ,
+                               "Related record"@en ;
+                    skos:definition "an owl:ObjectProperty relating an ec:Asset to an ec:Record"@en ,
+                                    "une propriété d'objet owl reliant un ec:Asset à un ec:Record"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedResonanceEvent
+ec:hasRelatedResonanceEvent rdf:type owl:ObjectProperty ;
+                            dcterms:description "Associates a ResonanceEvent with an EditorialObject."@en ,
+                                                "Associe un ResonanceEvent à un EditorialObject."@fr ;
+                            rdfs:label "Related resonance event"@en ,
+                                       "Événement de résonance associé"@fr ;
+                            skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:ResonanceEvent"@en ,
+                                            "une propriété objet owl reliant un ec:EditorialObject à un ec:ResonanceEvent"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedResource
+ec:hasRelatedResource rdf:type owl:ObjectProperty ;
+                      dcterms:description "A resource associated with an asset, editorial object, publication event, or another resource."@en ,
+                                          "Une ressource associée à un asset, un objet éditorial, un événement de publication ou une autre ressource."@fr ;
+                      rdfs:label "Related resource"@en ,
+                                 "Ressource liée"@fr ;
+                      skos:definition "an owl:ObjectProperty relating an ec:Asset or ec:EditorialObject or ec:PublicationEvent or ec:Resource to an ec:Resource"@en ,
+                                      "une propriété objet owl reliant un ec:Asset ou ec:EditorialObject ou ec:PublicationEvent ou ec:Resource à un ec:Resource"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedRule
+ec:hasRelatedRule rdf:type owl:ObjectProperty ;
+                  dcterms:description "References to a Rule."@en ,
+                                      "Références à une règle."@fr ;
+                  rdfs:label "Rule reference"@en ,
+                             "Référence de règle"@fr ;
+                  skos:definition "an owl:ObjectProperty relating an ec:Rule to an ec:Rule"@en ,
+                                  "une propriété objet owl reliant une ec:Rule à une ec:Rule"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedScene
+ec:hasRelatedScene rdf:type owl:ObjectProperty ;
+                   dcterms:description "A property that associates a concept with a scene."@en ,
+                                       "Une propriété qui associe un concept à une scène."@fr ;
+                   rdfs:label "Related scene"@en ,
+                              "Scène liée"@fr ;
+                   skos:definition "an owl:ObjectProperty relating an ec:Action, ec:Emotion, or ec:TextLine to an ec:Scene"@en ,
+                                   "une propriété objet owl reliant une ec:Action, une ec:Emotion ou une ec:TextLine à une ec:Scene"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedStage
+ec:hasRelatedStage rdf:type owl:ObjectProperty ;
+                   dcterms:description "A relationship that links an on-stage position to the stage it is on."@en ,
+                                       "Une relation qui relie une position sur scène à la scène sur laquelle elle se trouve."@fr ;
+                   rdfs:label "Related stage"@en ,
+                              "Stage lié"@fr ;
+                   skos:definition "an owl:ObjectProperty relating an ec:OnStagePosition to an ec:Stage"@en ,
+                                   "une propriété d’objet owl reliant une ec:OnStagePosition à une ec:Stage"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelatedTextLine
+ec:hasRelatedTextLine rdf:type owl:ObjectProperty ;
+                      dcterms:description "A TextLine or free text related to an EditorialObject."@en ,
+                                          "Une TextLine ou un texte libre lié à un EditorialObject."@fr ;
+                      rdfs:label "Ligne de texte liée"@fr ,
+                                 "Related text line"@en ;
+                      skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:TextLine"@en ,
+                                      "une propriété d’objet owl reliant un ec:EditorialObject à un ec:TextLine"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelationLink
+ec:hasRelationLink rdf:type owl:ObjectProperty ;
+                   dcterms:description "A link within a Relation."@en ,
+                                       "Un lien au sein d’une relation."@fr ;
+                   rdfs:label "Lien"@fr ,
+                              "Link"@en ;
+                   skos:definition "an owl:ObjectProperty relating an ec:Relation to an owl:Thing"@en ,
+                                   "une propriété d’objet owl reliant une ec:Relation à une owl:Thing"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRelationSource
+ec:hasRelationSource rdf:type owl:ObjectProperty ;
+                     dcterms:description "La source d’une relation."@fr ,
+                                         "The source of a relation."@en ;
+                     rdfs:label "Relation source"@en ,
+                                "Relation source"@fr ;
+                     skos:definition "an owl:ObjectProperty relating an ec:Relation to an ec:Agent"@en ,
+                                     "une propriété d’objet owl reliant un ec:Relation à un ec:Agent"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasResourceOffset
+ec:hasResourceOffset rdf:type owl:ObjectProperty ;
+                     dcterms:description "Le décalage de début à l'intérieur d'une ressource."@fr ,
+                                         "The start offset within a Resource."@en ;
+                     rdfs:label "Décalage de ressource"@fr ,
+                                "Resource offset"@en ;
+                     skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:TimelinePoint"@en ,
+                                     "une propriété d’objet owl reliant un ec:EditorialObject à un ec:TimelinePoint"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRestrictedAudience
+ec:hasRestrictedAudience rdf:type owl:ObjectProperty ;
+                         dcterms:description "An Audience for which access is restricted."@en ,
+                                             "Un public dont l’accès est restreint."@fr ;
+                         rdfs:label "Public restreint"@fr ,
+                                    "Restricted audience"@en ;
+                         skos:definition "an owl:ObjectProperty relating an ec:PublicationEvent to an ec:Audience"@en ,
+                                         "une propriété objet owl reliant un ec:PublicationEvent à un ec:Audience"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasReview
+ec:hasReview rdf:type owl:ObjectProperty ;
+             dcterms:description "An audio or audio-visual report in which somebody gives their opinion of a play, film, or other editorial object."@en ,
+                                 "Un reportage audio ou audiovisuel dans lequel quelqu’un donne son opinion sur une pièce de théâtre, un film ou tout autre objet éditorial."@fr ;
+             rdfs:label "Critique"@fr ,
+                        "Review"@en ;
+             skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Review"@en ,
+                             "une propriété d'objet owl reliant un ec:EditorialObject à un ec:Review"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRights
+ec:hasRights rdf:type owl:ObjectProperty ;
+             dcterms:description "An object property that links an asset or publication event to the rights that cover it."@en ,
+                                 "Une propriété d'objet qui relie un actif ou un événement de publication aux droits qui le couvrent."@fr ;
+             rdfs:label "Est couvert par"@fr ,
+                        "Is covered by"@en ;
+             skos:definition "an owl:ObjectProperty relating an ec:Asset to ec:Rights"@en ,
+                             "une propriété d'objet owl:ObjectProperty reliant un ec:Asset à ec:Rights"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRightsClearance
+ec:hasRightsClearance rdf:type owl:ObjectProperty ;
+                      rdfs:subPropertyOf ec:hasRights ;
+                      dcterms:description "Le dégagement des droits associé à un actif."@fr ,
+                                          "The rights clearance associated with an asset."@en ;
+                      rdfs:label "Clearing des droits"@fr ,
+                                 "Rights clearance"@en ;
+                      skos:definition "an owl:ObjectProperty relating an ec:Asset to an ec:RightsClearance"@en ,
+                                      "une owl:ObjectProperty reliant un ec:Asset à un ec:RightsClearance"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRightsHolder
+ec:hasRightsHolder rdf:type owl:ObjectProperty ;
+                   dcterms:description "L’agent qui détient ou gère les droits associés à la ressource."@fr ,
+                                       "The agent that holds or manages the rights associated with the resource."@en ;
+                   rdfs:label "Rights holder"@en ,
+                              "Titulaire des droits"@fr ;
+                   skos:definition "an owl:ObjectProperty relating an ec:Rights to an ec:Agent"@en ,
+                                   "une propriété objet owl reliant un ec:Rights à un ec:Agent"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRightsTargetService
+ec:hasRightsTargetService rdf:type owl:ObjectProperty ;
+                          dcterms:description "Le service associé aux droits."@fr ,
+                                              "The service associated with the rights."@en ;
+                          rdfs:label "Service cible"@fr ,
+                                     "Target service"@en ;
+                          skos:definition "an owl:ObjectProperty relating an ec:Rights to an ec:PublicationService"@en ,
+                                          "une propriété objet owl reliant ec:Rights à ec:PublicationService"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRightsTerritoryExcludes
+ec:hasRightsTerritoryExcludes rdf:type owl:ObjectProperty ;
+                              dcterms:description "A list of country or region codes to which Rights do not apply."@en ,
+                                                  "Une liste de codes de pays ou de régions auxquels les droits ne s'appliquent pas."@fr ;
+                              rdfs:label "Excluded territories"@en ,
+                                         "Territoires exclus"@fr ;
+                              skos:definition "an owl:ObjectProperty relating an ec:Rights to an ec:CountryCode"@en ,
+                                              "une propriété d’objet owl:ObjectProperty reliant un ec:Rights à un ec:CountryCode"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasRightsTerritoryIncludes
+ec:hasRightsTerritoryIncludes rdf:type owl:ObjectProperty ;
+                              dcterms:description "A list of country or region codes to which Rights apply."@en ,
+                                                  "Une liste de codes de pays ou de régions auxquels les droits s'appliquent."@fr ;
+                              rdfs:label "Included territories"@en ,
+                                         "Territoires inclus"@fr ;
+                              skos:definition "an owl:ObjectProperty relating an ec:Rights to an ec:CountryCode"@en ,
+                                              "une propriété d'objet owl reliant un ec:Rights à un ec:CountryCode"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasScene
+ec:hasScene rdf:type owl:ObjectProperty ;
+            rdfs:subPropertyOf ec:hasPart ;
+            dcterms:description "Identifie une scène qui fait partie d’un plan ou d’une prise."@fr ,
+                                "Identifies a scene that is part of a shot or take."@en ;
+            rdfs:label "A une scène"@fr ,
+                       "Has scene"@en ;
+            skos:definition "an owl:ObjectProperty relating an ec:Shot or ec:Take to an ec:Scene"@en ,
+                            "une propriété objet owl reliant un ec:Shot ou un ec:Take à un ec:Scene"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasScheduleDate
+ec:hasScheduleDate rdf:type owl:ObjectProperty ;
+                   dcterms:description "La date de programmation associée à un ec:PublicationEvent, en particulier lorsque l’heure de diffusion est après minuit. Par exemple, la date de programmation peut être le 29 mai, alors que le programme est publié à 1 h le 30 mai, tout en restant associé dans le planning à la nuit du 29 mai."@fr ,
+                                       "The schedule date associated with a PublicationEvent, especially when the broadcast time is after midnight. For example, the schedule date may be May 29th while the programme is published at 1 am on May 30th, yet remains associated in the schedule with the night of May 29th."@en ;
+                   rdfs:label "Date de programmation"@fr ,
+                              "Schedule date"@en ;
+                   skos:definition "an owl:ObjectProperty relating an ec:PublicationEvent to a time:Instant"@en ,
+                                   "une propriété objet owl reliant un ec:PublicationEvent à un time:Instant"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasSeason
+ec:hasSeason rdf:type owl:ObjectProperty ;
+             dcterms:description "Associates a serial or series with a season."@en ,
+                                 "Associe une série ou une série sérielle à une saison."@fr ;
+             rdfs:label "Saison"@fr ,
+                        "Season"@en ;
+             skos:definition "an owl:ObjectProperty relating an ec:Serial or ec:Series to an ec:Season"@en ,
+                             "une owl:ObjectProperty reliant un ec:Serial ou un ec:Series à un ec:Season"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasSerial
+ec:hasSerial rdf:type owl:ObjectProperty ;
+             dcterms:description "A property that links a season to the serial it contains or is associated with."@en ,
+                                 "Une propriété qui relie une saison au serial qu’elle contient ou à laquelle elle est associée."@fr ;
+             rdfs:label "A un serial"@fr ,
+                        "Has serial"@en ;
+             skos:definition "an owl:ObjectProperty relating an ec:Season to an ec:Serial"@en ,
+                             "une owl:ObjectProperty reliant une ec:Season à une ec:Serial"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasServiceGenre
+ec:hasServiceGenre rdf:type owl:ObjectProperty ;
+                   dcterms:description "Le genre du contenu associé au service."@fr ,
+                                       "The genre of content associated with the Service."@en ;
+                   rdfs:label "Genre de service"@fr ,
+                              "Service genre"@en ;
+                   skos:definition "an owl:ObjectProperty relating an ec:PublicationService to a skos:Concept"@en ,
+                                   "une propriété d'objet owl:ObjectProperty reliant un ec:PublicationService à un skos:Concept"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasShot
+ec:hasShot rdf:type owl:ObjectProperty ;
+           rdfs:subPropertyOf ec:hasPart ;
+           dcterms:description "Identifie un plan qui fait partie d'une scène."@fr ,
+                               "Identifies a shot that is part of a scene."@en ;
+           rdfs:label "A un plan"@fr ,
+                      "Has shot"@en ;
+           skos:definition "an owl:ObjectProperty relating an ec:Scene to an ec:Shot"@en ,
+                           "une owl:ObjectProperty reliant une ec:Scene à une ec:Shot"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasSigning
+ec:hasSigning rdf:type owl:ObjectProperty ;
+              dcterms:description "Presence of signing associated with the editorial object."@en ,
+                                  "Présence de sous-titrage associée à l’objet éditorial."@fr ;
+              rdfs:label "Accessibility - signing"@en ,
+                         "Accessibilité - sous-titrage"@fr ;
+              skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Signing"@en ,
+                              "une owl:ObjectProperty reliant un ec:EditorialObject à un ec:Signing"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasSigningFormat
+ec:hasSigningFormat rdf:type owl:ObjectProperty ;
+                    dcterms:description "Le format utilisé pour l'interprétation en langue des signes."@fr ,
+                                        "The format used for sign language interpretation."@en ;
+                    rdfs:label "Format de sous-titrage"@fr ,
+                               "Signing format"@en ;
+                    skos:definition "an owl:ObjectProperty relating an ec:Signing to an ec:SigningFormat"@en ,
+                                    "une propriété d’objet owl:ObjectProperty reliant un ec:Signing à un ec:SigningFormat"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasSigningSource
+ec:hasSigningSource rdf:type owl:ObjectProperty ;
+                    dcterms:description "La source utilisée pour le signé."@fr ,
+                                        "The source used for signing."@en ;
+                    rdfs:label "Signing source"@en ,
+                               "Source de signature"@fr ;
+                    skos:definition "an owl:ObjectProperty relating an ec:Signing to an ec:Agent"@en ,
+                                    "une propriété objet owl reliant un ec:Signing à un ec:Agent"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasSource
+ec:hasSource rdf:type owl:ObjectProperty ;
+             dcterms:description "La source associée à une MediaResource."@fr ,
+                                 "The source associated with a MediaResource."@en ;
+             rdfs:label "Source"@en ,
+                        "Source"@fr ;
+             skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:MediaResource"@en ,
+                             "une propriété d’objet owl reliant un ec:MediaResource à un ec:MediaResource"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasStaffMember
+ec:hasStaffMember rdf:type owl:ObjectProperty ;
+                  dcterms:description "A person who is a member of staff in an organisation."@en ,
+                                      "Une personne qui est membre du personnel d’une organisation."@fr ;
+                  rdfs:label "Member of staff"@en ,
+                             "Membre du personnel"@fr ;
+                  skos:definition "an owl:ObjectProperty relating an ec:Organisation to an ec:StaffMember"@en ,
+                                  "une propriété objet owl reliant une ec:Organisation à un ec:StaffMember"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasStageLocation
+ec:hasStageLocation rdf:type owl:ObjectProperty ;
+                    dcterms:description "L’emplacement associé à une scène."@fr ,
+                                        "The location associated with a stage."@en ;
+                    rdfs:label "Lieu de scène"@fr ,
+                               "Stage location"@en ;
+                    skos:definition "an owl:ObjectProperty relating an ec:Stage to an ec:Location"@en ,
+                                    "une propriété d'objet owl reliant un ec:Stage à un ec:Location"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasStakeholder
+ec:hasStakeholder rdf:type owl:ObjectProperty ;
+                  dcterms:description "An Agent related to a PublicationPlan."@en ,
+                                      "Un Agent lié à une PublicationPlan."@fr ;
+                  rdfs:label "Partie prenante du plan de publication"@fr ,
+                             "Publication plan stakeholder"@en ;
+                  skos:definition "an owl:ObjectProperty relating an ec:PublicationPlan to an ec:Agent"@en ,
+                                  "une propriété d'objet owl:ObjectProperty reliant un ec:PublicationPlan à un ec:Agent"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasStandard
+ec:hasStandard rdf:type owl:ObjectProperty ;
+               rdfs:subPropertyOf ec:hasFormat ;
+               dcterms:description "Identifie la norme vidéo technique d'une MediaResource, c'est-à-dire NTSC ou PAL."@fr ,
+                                   "Identifies the technical video standard of a MediaResource, i.e. NTSC or PAL."@en ;
+               rdfs:label "Norme"@fr ,
+                          "Standard"@en ;
+               skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:Standard"@en ,
+                               "une propriété d'objet owl reliant un ec:MediaResource à un ec:Standard"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasStart
+ec:hasStart rdf:type owl:ObjectProperty ;
+            dcterms:description "A property that links an action, event, or related content entity to its starting point on a timeline."@en ,
+                                "Une propriété qui relie une action, un événement ou une entité de contenu associée à son point de départ sur une chronologie."@fr ;
+            rdfs:label "Début"@fr ,
+                       "Start"@en ;
+            skos:definition "an owl:ObjectProperty relating an ec:Action to an ec:TimelinePoint"@en ,
+                            "une propriété objet owl reliant un ec:Action à un ec:TimelinePoint"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasStartDateTime
+ec:hasStartDateTime rdf:type owl:ObjectProperty ;
+                    rdfs:subPropertyOf ec:hasDate ;
+                    dcterms:description "A point of time or start of an interval."@en ,
+                                        "Un point dans le temps ou le début d’un intervalle."@fr ;
+                    rdfs:label "Date et heure de début"@fr ,
+                               "Start date time"@en ;
+                    skos:definition "an owl:ObjectProperty relating an ec:Affiliation to a time:Instant"@en ,
+                                    "une propriété objet owl reliant une ec:Affiliation à un time:Instant"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasSticker
+ec:hasSticker rdf:type owl:ObjectProperty ;
+              dcterms:description "A link to a Sticker associated with a Costume."@en ,
+                                  "Un lien vers un sticker associé à un costume."@fr ;
+              rdfs:label "Lien vers l’autocollant"@fr ,
+                         "Link to sticker"@en ;
+              skos:definition "an owl:ObjectProperty relating an ec:Costume to an ec:Sticker"@en ,
+                              "une owl:ObjectProperty reliant un ec:Costume à un ec:Sticker"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasStorageId
+ec:hasStorageId rdf:type owl:ObjectProperty ;
+                dcterms:description "Le stockage associé à un localisateur à partir duquel une ressource peut être accessible ou récupérée."@fr ,
+                                    "The storage associated with a locator from which a resource can be accessed or retrieved."@en ;
+                rdfs:label "Identifiant de stockage"@fr ,
+                           "Storage identifier"@en ;
+                skos:definition "an owl:ObjectProperty relating an ec:Resource to an ec:Identifier"@en ,
+                                "une propriété objet owl reliant un ec:Resource à un ec:Identifier"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasStorageType
+ec:hasStorageType rdf:type owl:ObjectProperty ;
+                  dcterms:description "A storage type associated with a locator from which a resource can be accessed or retrieved."@en ,
+                                      "Un type de stockage associé à un localisateur à partir duquel une ressource peut être accédée ou récupérée."@fr ;
+                  rdfs:label "Storage type"@en ,
+                             "Type de stockage"@fr ;
+                  skos:definition "an owl:ObjectProperty relating an ec:Resource to an ec:StorageType"@en ,
+                                  "une owl:ObjectProperty reliant un ec:Resource à un ec:StorageType"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasSubJob
+ec:hasSubJob rdf:type owl:ObjectProperty ;
+             dcterms:description "A production job that is part of a complex production job."@en ,
+                                 "Un travail de production qui fait partie d'un travail de production complexe."@fr ;
+             rdfs:label "Production job"@en ,
+                        "Travail de production"@fr ;
+             skos:definition "an owl:ObjectProperty relating an ec:ProductionJob to an ec:ProductionJob"@en ,
+                             "une propriété objet owl reliant un ec:ProductionJob à un ec:ProductionJob"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasSubject
+ec:hasSubject rdf:type owl:ObjectProperty ;
+              dcterms:description "Cette propriété permet d’associer un Asset à un sujet, qui peut être une chaîne ou une URI pointant vers un terme d’un vocabulaire नियंत्रlé."@fr ,
+                                  "This property enables to associate an Asset with a subject which can be a string or a URI pointing to a term from a controlled vocabulary."@en ;
+              rdfs:label "Subject"@en ,
+                         "Sujet"@fr ;
+              skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Subject"@en ,
+                              "une propriété objet owl reliant un ec:EditorialObject à un ec:Subject"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasSubtitling
+ec:hasSubtitling rdf:type owl:ObjectProperty ;
+                 dcterms:description "Existing subtitling for the editorial object."@en ,
+                                     "Sous-titrage existant pour l’objet éditorial."@fr ;
+                 rdfs:label "Sous-titrage"@fr ,
+                            "Subtitling"@en ;
+                 skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Subtitling"@en ,
+                                 "une owl:ObjectProperty reliant un ec:EditorialObject à un ec:Subtitling"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasSubtitlingFormat
+ec:hasSubtitlingFormat rdf:type owl:ObjectProperty ;
+                       rdfs:subPropertyOf ec:hasFormat ;
+                       dcterms:description "Le format du sous-titrage."@fr ,
+                                           "The format of Subtitling."@en ;
+                       rdfs:label "Format de sous-titrage"@fr ,
+                                  "Subtitling format"@en ;
+                       skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:SubtitlingFormat"@en ,
+                                       "une owl:ObjectProperty reliant une ec:MediaResource à une ec:SubtitlingFormat"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasSubtitlingSource
+ec:hasSubtitlingSource rdf:type owl:ObjectProperty ;
+                       dcterms:description "La source de la ressource de sous-titrage."@fr ,
+                                           "The source of the subtitling resource."@en ;
+                       rdfs:label "Source de sous-titrage"@fr ,
+                                  "Subtitling source"@en ;
+                       skos:definition "an owl:ObjectProperty relating an ec:Subtitling to an ec:Agent"@en ,
+                                       "une propriété d’objet owl reliant un ec:Subtitling à un ec:Agent"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasTake
+ec:hasTake rdf:type owl:ObjectProperty ;
+           rdfs:subPropertyOf ec:hasPart ;
+           dcterms:description "Cette propriété relie une scène ou un plan à l’une de ses prises. C’est une sous-propriété de ec:hasPart et elle est utilisée pour identifier les enregistrements répétés d’une scène ou d’un plan."@fr ,
+                               "This property relates a scene or shot to one of its takes. It is a sub-property of ec:hasPart and is used to identify repeated recordings of a scene or shot."@en ;
+           rdfs:label "A un take"@fr ,
+                      "Has take"@en ;
+           skos:definition "an owl:ObjectProperty relating an ec:Scene or ec:Shot to an ec:Take"@en ,
+                           "une propriété d’objet owl reliant un ec:Scene ou un ec:Shot à un ec:Take"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasTargetAudience
+ec:hasTargetAudience rdf:type owl:ObjectProperty ;
+                     dcterms:description "Le public cible associé à un objet éditorial, une campagne, un événement de publication, un canal de publication, une plateforme de publication ou un service de publication."@fr ,
+                                         "The target audience associated with an editorial object, campaign, publication event, publication channel, publication platform, or publication service."@en ;
+                     rdfs:label "Public cible"@fr ,
+                                "Target audience"@en ;
+                     skos:definition "an owl:ObjectProperty relating an ec:EditorialObject or ec:Campaign to an ec:Audience"@en ,
+                                     "une propriété objet owl reliant un ec:EditorialObject ou une ec:Campaign à une ec:Audience"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasTargetChannel
+ec:hasTargetChannel rdf:type owl:ObjectProperty ;
+                    dcterms:description "Le canal cible pour la publication."@fr ,
+                                        "The target channel for publication."@en ;
+                    rdfs:label "A un canal de destination"@fr ,
+                               "Has target channel"@en ;
+                    skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:PublicationChannel"@en ,
+                                    "une propriété d'objet owl reliant un ec:EditorialObject à un ec:PublicationChannel"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasTargetPlatform
+ec:hasTargetPlatform rdf:type owl:ObjectProperty ;
+                     dcterms:description "La plateforme utilisée pour la publication ou la distribution de l’objet éditorial."@fr ,
+                                         "The platform used for publication or distribution of the editorial object."@en ;
+                     rdfs:label "Plateforme cible"@fr ,
+                                "Target platform"@en ;
+                     skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:PublicationPlatform"@en ,
+                                     "une propriété d’objet owl reliant un ec:EditorialObject à un ec:PublicationPlatform"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasTargetService
+ec:hasTargetService rdf:type owl:ObjectProperty ;
+                    dcterms:description "Le service cible pour la publication."@fr ,
+                                        "The target service for publication."@en ;
+                    rdfs:label "A un service cible"@fr ,
+                               "Has target service"@en ;
+                    skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:PublicationService"@en ,
+                                    "une propriété d’objet owl reliant un ec:EditorialObject à un ec:PublicationService"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasTeamMember
+ec:hasTeamMember rdf:type owl:ObjectProperty ;
+                 dcterms:description "Les membres d'une équipe."@fr ,
+                                     "The members of a Team."@en ;
+                 rdfs:label "Membre de l'équipe"@fr ,
+                            "Team member"@en ;
+                 skos:definition "an owl:ObjectProperty relating an ec:Team to an ec:Person"@en ,
+                                 "une propriété d'objet owl reliant un ec:Team à une ec:Person"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasTerritoryExcludes
+ec:hasTerritoryExcludes rdf:type owl:ObjectProperty ;
+                        dcterms:description "Le lieu, tel qu’un pays ou une région, où la classification et le public cible ne s’appliquent pas."@fr ,
+                                            "The location, such as a country or region, where the rating and target audience do not apply."@en ;
+                        rdfs:label "Exclusion area"@en ,
+                                   "Zone d'exclusion"@fr ;
+                        skos:definition "an owl:ObjectProperty relating an ec:Rating to an ec:CountryCode"@en ,
+                                        "une propriété d'objet owl reliant une ec:Rating à une ec:CountryCode"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasTerritoryIncludes
+ec:hasTerritoryIncludes rdf:type owl:ObjectProperty ;
+                        dcterms:description "L’actif auquel la notation s’applique."@fr ,
+                                            "The asset to which the rating applies."@en ;
+                        rdfs:label "Applies to"@en ,
+                                   "S’applique à"@fr ;
+                        skos:definition "an owl:ObjectProperty relating an ec:Rating to an ec:CountryCode"@en ,
+                                        "une propriété objet owl reliant un ec:Rating à un ec:CountryCode"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasTextLineSource
+ec:hasTextLineSource rdf:type owl:ObjectProperty ;
+                     dcterms:description "La source d’une TextLine."@fr ,
+                                         "The source of a TextLine."@en ;
+                     rdfs:label "Source de ligne de texte"@fr ,
+                                "Text line source"@en ;
+                     skos:definition "an owl:ObjectProperty relating an ec:TextLine to an ec:Agent"@en ,
+                                     "une propriété objet owl reliant un ec:TextLine à un ec:Agent"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasTheme
+ec:hasTheme rdf:type owl:ObjectProperty ;
+            dcterms:description "Cette propriété permet d’associer un Asset à un thème, qui peut être une chaîne ou une URI pointant vers un terme d’un vocabulaire contrôlé. Un exemple typique est la classification NACE d’Eurostat."@fr ,
+                                "This property enables an Asset to be associated with a theme, which can be a string or a URI pointing to a term from a controlled vocabulary. A typical example is the Eurostat NACE classification."@en ;
+            rdfs:label "Theme"@en ,
+                       "Thème"@fr ;
+            skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Theme"@en ,
+                            "une owl:ObjectProperty reliant un ec:EditorialObject à un ec:Theme"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasTimecodeTrack
+ec:hasTimecodeTrack rdf:type owl:ObjectProperty ;
+                    dcterms:description "A track that identifies the timecode track associated with a MediaResource."@en ,
+                                        "Un parcours qui identifie la piste de timecode associée à une MediaResource."@fr ;
+                    rdfs:label "Piste de code temporel"@fr ,
+                               "Timecode track"@en ;
+                    skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:TimecodeTrack"@en ,
+                                    "une owl:ObjectProperty reliant une ec:MediaResource à une ec:TimecodeTrack"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasTimelineTrack
+ec:hasTimelineTrack rdf:type owl:ObjectProperty ;
+                    dcterms:description "Associates a TimelineTrack with an EditorialObject."@en ,
+                                        "Associe un TimelineTrack à un EditorialObject."@fr ;
+                    rdfs:label "Piste temporelle"@fr ,
+                               "Timeline track"@en ;
+                    skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:TimelineTrack"@en ,
+                                    "une propriété d’objet owl reliant un ec:EditorialObject à un ec:TimelineTrack"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasTimelineTrackPart
+ec:hasTimelineTrackPart rdf:type owl:ObjectProperty ;
+                        owl:inverseOf ec:isTimelineTrackPartOf ;
+                        dcterms:description "An EditorialObject associated with a TimelineTrack as a TimelineTrack part."@en ,
+                                            "Un EditorialObject associé à un TimelineTrack en tant que partie de TimelineTrack."@fr ;
+                        rdfs:label "Partie de piste temporelle"@fr ,
+                                   "Timeline track part"@en ;
+                        skos:definition "an owl:ObjectProperty relating an ec:TimelineTrack to an ec:EditorialObject"@en ,
+                                        "une propriété objet owl reliant un ec:TimelineTrack à un ec:EditorialObject"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasTopic
+ec:hasTopic rdf:type owl:ObjectProperty ;
+            dcterms:description "Cette propriété permet d’associer un Asset à un topic, qui peut être une chaîne de caractères ou une URI pointant vers un terme d’un vocabulaire contrôlé. Un exemple typique est d’utiliser les IPTC Media Topics définis à http://cv.iptc.org/newscodes/mediatopic/."@fr ,
+                                "This property enables to associate an Asset with a topic which can be a string or a URI pointing to a term from a controlled vocabulary. A typical example is to make use of the IPTC Media Topics defined at http://cv.iptc.org/newscodes/mediatopic/."@en ;
+            rdfs:label "Sujet"@fr ,
+                       "Topic"@en ;
+            skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Topic"@en ,
+                            "une propriété d’objet owl reliant un ec:EditorialObject à un ec:Topic"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasTrack
+ec:hasTrack rdf:type owl:ObjectProperty ;
+            dcterms:description "Associates audio, video, or data tracks with a media resource."@en ,
+                                "Associe des pistes audio, vidéo ou de données à une ressource multimédia."@fr ;
+            rdfs:label "Piste"@fr ,
+                       "Track"@en ;
+            skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:Track"@en ,
+                            "une owl:ObjectProperty reliant une ec:MediaResource à une ec:Track"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasTrackPart
+ec:hasTrackPart rdf:type owl:ObjectProperty ;
+                owl:inverseOf ec:isTrackPartOf ;
+                dcterms:description "An element to identify a part of a track by a title, a start time and an end time in both the media source and media destination."@en ,
+                                    "Un élément permettant d’identifier une partie d’une piste par un titre, une heure de début et une heure de fin, tant dans la source média que dans la destination média."@fr ;
+                rdfs:label "Source de la partie de piste"@fr ,
+                           "Track part source"@en ;
+                skos:definition "an owl:ObjectProperty relating an ec:Track to an ec:MediaResource"@en ,
+                                "une propriété objet owl reliant un ec:Track à un ec:MediaResource"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasTrackPurpose
+ec:hasTrackPurpose rdf:type owl:ObjectProperty ;
+                   dcterms:description "Le but pour lequel la piste est fournie."@fr ,
+                                       "The purpose for which the Track is provided."@en ;
+                   rdfs:label "Objectif de piste"@fr ,
+                              "Track purpose"@en ;
+                   skos:definition "an owl:ObjectProperty relating an ec:Track to an ec:TrackPurpose"@en ,
+                                   "une propriété objet owl reliant un ec:Track à un ec:TrackPurpose"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasTrackType
+ec:hasTrackType rdf:type owl:ObjectProperty ;
+                dcterms:description "Le type attribué à une piste."@fr ,
+                                    "The type attributed to a Track."@en ;
+                rdfs:label "Nom de piste"@fr ,
+                           "Track name"@en ;
+                skos:definition "an owl:ObjectProperty relating an ec:Track to an ec:TrackType"@en ,
+                                "une propriété objet owl reliant un ec:Track à un ec:TrackType"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasUnit
+ec:hasUnit rdf:type owl:ObjectProperty ;
+           dcterms:description "L’unité dans laquelle la valeur d’une mesure est exprimée, le cas échéant."@fr ,
+                               "The unit in which the value of a Measure is expressed, when applicable."@en ;
+           rdfs:label "Measure unit"@en ,
+                      "Unité de mesure"@fr ;
+           skos:definition "an owl:ObjectProperty relating an ec:Measure to a skos:Concept"@en ,
+                           "une propriété objet owl reliant une ec:Measure à un skos:Concept"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasUsageContract
+ec:hasUsageContract rdf:type owl:ObjectProperty ;
+                    dcterms:description "Les conditions contractuelles dans lesquelles un ProductionDevice doit être utilisé."@fr ,
+                                        "The contractual terms under which a ProductionDevice shall be used."@en ;
+                    rdfs:label "Contrat d'utilisation"@fr ,
+                               "Usage contract"@en ;
+                    skos:definition "an owl:ObjectProperty relating an ec:ProductionDevice to an ec:Contract"@en ,
+                                    "une propriété d’objet owl reliant un ec:ProductionDevice à un ec:Contract"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasUsageRestrictions
+ec:hasUsageRestrictions rdf:type owl:ObjectProperty ;
+                        rdfs:subPropertyOf ec:hasRights ;
+                        dcterms:description "Les restrictions d'utilisation associées à un actif ou à un événement de publication."@fr ,
+                                            "The usage restrictions associated with an asset or publication event."@en ;
+                        rdfs:label "Restrictions d'utilisation"@fr ,
+                                   "Usage restrictions"@en ;
+                        skos:definition "an owl:ObjectProperty relating an ec:Asset to ec:UsageRestrictions"@en ,
+                                        "une propriété d’objet owl reliant un ec:Asset à ec:UsageRestrictions"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasUsageRights
+ec:hasUsageRights rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf ec:hasRights ;
+                  dcterms:description "Les droits d’utilisation associés à un actif."@fr ,
+                                      "The usage rights associated with an asset."@en ;
+                  rdfs:label "Droits d'utilisation"@fr ,
+                             "Usage rights"@en ;
+                  skos:definition "an owl:ObjectProperty relating an ec:Asset to an ec:UsageRights"@en ,
+                                  "une propriété d’objet owl:ObjectProperty reliant un ec:Asset à un ec:UsageRights"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasVersion
+ec:hasVersion rdf:type owl:ObjectProperty ;
+              owl:inverseOf ec:isVersionOf ;
+              dcterms:description "An asset, editorial object, or resource that represents another version of the current entity."@en ,
+                                  "Un asset, un objet éditorial ou une ressource qui représente une autre version de l’entité courante."@fr ;
+              rdfs:label "Version"@en ,
+                         "Version"@fr ;
+              skos:definition "an owl:ObjectProperty relating an ec:Asset, ec:EditorialObject or resource to another version of that same entity"@en ,
+                              "une propriété d’objet owl reliant un ec:Asset, ec:EditorialObject ou ressource à une autre version de cette même entité"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasVersionType
+ec:hasVersionType rdf:type owl:ObjectProperty ;
+                  dcterms:description "Specifies the type of version associated with an EditorialObject."@en ,
+                                      "Spécifie le type de version associé à un EditorialObject."@fr ;
+                  rdfs:label "Type de version"@fr ,
+                             "Version type"@en ;
+                  skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to a skos:Concept"@en ,
+                                  "une propriété d’objet owl reliant un ec:EditorialObject à un skos:Concept"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasVideoCodec
+ec:hasVideoCodec rdf:type owl:ObjectProperty ;
+                 rdfs:subPropertyOf ec:hasCodec ;
+                 dcterms:description "Le codec vidéo utilisé pour encoder une ressource multimédia."@fr ,
+                                     "The video codec used to encode a media resource."@en ;
+                 rdfs:label "Codec vidéo"@fr ,
+                            "Video codec"@en ;
+                 skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:VideoCodec"@en ,
+                                 "une propriété objet owl reliant un ec:MediaResource à un ec:VideoCodec"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasVideoEncodingFormat
+ec:hasVideoEncodingFormat rdf:type owl:ObjectProperty ;
+                          rdfs:subPropertyOf ec:hasFormat ;
+                          dcterms:description "Le format d’encodage vidéo associé à une ressource multimédia."@fr ,
+                                              "The video encoding format associated with a media resource."@en ;
+                          rdfs:label "Audio encoding format"@en ,
+                                     "Format d'encodage audio"@fr ;
+                          skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:VideoEncodingFormat"@en ,
+                                          "une owl:ObjectProperty reliant une ec:MediaResource à une ec:VideoEncodingFormat"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasVideoTrack
+ec:hasVideoTrack rdf:type owl:ObjectProperty ;
+                 dcterms:description "A video track associated with the media resource."@en ,
+                                     "Une piste vidéo associée à la ressource multimédia."@fr ;
+                 rdfs:label "Piste vidéo"@fr ,
+                            "Video track"@en ;
+                 skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:VideoTrack"@en ,
+                                 "une propriété d’objet owl reliant un ec:MediaResource à un ec:VideoTrack"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hasWrappingType
+ec:hasWrappingType rdf:type owl:ObjectProperty ;
+                   dcterms:description "Le type d’emballage associé à la ressource."@fr ,
+                                       "The type of wrapping associated with the resource."@en ;
+                   rdfs:label "Type d'enveloppe"@fr ,
+                              "Wrapping type"@en ;
+                   skos:definition "an owl:ObjectProperty relating an ec:AncillaryData to an ec:WrappingType"@en ,
+                                   "une propriété d'objet owl reliant un ec:AncillaryData à un ec:WrappingType"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#holdsAward
+ec:holdsAward rdf:type owl:ObjectProperty ;
+              owl:inverseOf ec:isAwardedTo ;
+              dcterms:description "An Award held by an Agent, representing an award relationship from the agent to the award."@en ,
+                                  "Un Award détenu par un Agent, représentant une relation de récompense de l’agent vers le prix."@fr ;
+              rdfs:label "Est tenu"@fr ,
+                         "Holds"@en ;
+              skos:definition "an owl:ObjectProperty relating an ec:Agent to an ec:Award"@en ,
+                              "une propriété d’objet owl reliant un ec:Agent à un ec:Award"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#holdsLicence
+ec:holdsLicence rdf:type owl:ObjectProperty ;
+                dcterms:description "Les termes d'une ConsumptionLicence associée à un Contract."@fr ,
+                                    "The terms of a ConsumptionLicence associated with a Contract."@en ;
+                rdfs:label "Consumption licence"@en ,
+                           "Licence de consommation"@fr ;
+                skos:definition "an owl:ObjectProperty relating an ec:Account to an ec:ConsumptionLicence"@en ,
+                                "une propriété d'objet owl reliant un ec:Account à un ec:ConsumptionLicence"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#includesAudience
+ec:includesAudience rdf:type owl:ObjectProperty ;
+                    dcterms:description "A defined audience group that is included in the audience."@en ,
+                                        "Un groupe d’audience défini qui est inclus dans l’audience."@fr ;
+                    rdfs:label "Includes audience"@en ,
+                               "Inclut l’audience"@fr ;
+                    skos:definition "an owl:ObjectProperty relating an ec:Audience to an ec:Audience"@en ,
+                                    "une propriété d'objet owl reliant une ec:Audience à une ec:Audience"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#instantiates
+ec:instantiates rdf:type owl:ObjectProperty ;
+                owl:inverseOf ec:isInstantiatedBy ;
+                dcterms:description "A particular manifestation of an EditorialObject linked to its corresponding Resource."@en ,
+                                    "Une manifestation particulière d’un EditorialObject liée à sa Resource correspondante."@fr ;
+                rdfs:label "Editorial object"@en ,
+                           "Objet éditorial"@fr ;
+                skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:EditorialObject"@en ,
+                                "une propriété d’objet owl reliant un ec:MediaResource à un ec:EditorialObject"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isAbout
+ec:isAbout rdf:type owl:ObjectProperty ;
+           rdfs:range ec:Asset ;
+           dcterms:description "Cette propriété est utilisée lorsqu’un autre objet éditorial, par exemple un livre, un film ou un programme, est le sujet de l’objet éditorial."@fr ,
+                               "This property is used when another editorial object, e.g. a book, a movie or a programme is the topic of the editorial object."@en ;
+           rdfs:label "Is about"@en ,
+                      "À propos de"@fr ;
+           skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Asset"@en ,
+                           "une propriété objet owl reliant un ec:EditorialObject à un ec:Asset"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isAffiliatedTo
+ec:isAffiliatedTo rdf:type owl:ObjectProperty ;
+                  dcterms:description "Relation to the organisation the affiliation represents."@en ,
+                                      "Relation à l'organisation que l'affiliation représente."@fr ;
+                  rdfs:label "Est affilié à"@fr ,
+                             "Is affiliated to"@en ;
+                  skos:definition "an owl:ObjectProperty relating an ec:Affiliation to an ec:Organisation"@en ,
+                                  "une owl:ObjectProperty reliant une ec:Affiliation à une ec:Organisation"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isAffiliationFor
+ec:isAffiliationFor rdf:type owl:ObjectProperty ;
+                    dcterms:description "A property that relates an Affiliation to the Person for whom it is valid."@en ,
+                                        "Une propriété qui relie une affiliation à la personne pour laquelle elle est valide."@fr ;
+                    rdfs:label "Affiliation for"@en ,
+                               "Affiliation pour"@fr ;
+                    skos:definition "an owl:ObjectProperty relating an ec:Affiliation to an ec:Person"@en ,
+                                    "une propriété objet owl reliant une ec:Affiliation à une ec:Person"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isAnimalGroomFor
+ec:isAnimalGroomFor rdf:type owl:ObjectProperty ;
+                    dcterms:description "L’animal toiletté ou soigné par l’agent associé."@fr ,
+                                        "The animal groomed or cared for by the associated agent."@en ;
+                    rdfs:label "Animal groom for"@en ,
+                               "Toilettage d'animal pour"@fr ;
+                    skos:definition "an owl:ObjectProperty inverse of ec:hasAnimalGroom relating an ec:Agent to an ec:Animal"@en ,
+                                    "une propriété d’objet owl inverse de ec:hasAnimalGroom reliant un ec:Agent à un ec:Animal"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isAnimatedBy
+ec:isAnimatedBy rdf:type owl:ObjectProperty ;
+                dcterms:description "Character, animated by a person using an artifact."@en ,
+                                    "Personnage animé par une personne à l’aide d’un artefact."@fr ;
+                rdfs:label "Est animé par"@fr ,
+                           "Is animated by"@en ;
+                skos:definition "an owl:ObjectProperty relating an ec:Character to an ec:Person"@en ,
+                                "une propriété objet owl reliant un ec:Character à un ec:Person"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isAnnotatedMediaResource
+ec:isAnnotatedMediaResource rdf:type owl:ObjectProperty ;
+                            dcterms:description "Lie une Annotation à une MediaResource."@fr ,
+                                                "Links an Annotation to a MediaResource."@en ;
+                            rdfs:label "Media resource"@en ,
+                                       "Ressource média"@fr ;
+                            skos:definition "an owl:ObjectProperty relating an ec:Annotation to an ec:MediaResource"@en ,
+                                            "une propriété d'objet owl liant une ec:Annotation à une ec:MediaResource"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isAttributedTo
+ec:isAttributedTo rdf:type owl:ObjectProperty ;
+                  dcterms:description "An association between a Provenance instance and the Agent it is attributed to."@en ,
+                                      "Une association entre une instance de Provenance et l’Agent auquel elle est attribuée."@fr ;
+                  rdfs:label "Cible de provenance"@fr ,
+                             "Provenance target"@en ;
+                  skos:definition "an owl:ObjectProperty relating an ec:Provenance to an ec:Agent"@en ,
+                                  "une propriété objet owl reliant une ec:Provenance à un ec:Agent"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isAuthorOf
+ec:isAuthorOf rdf:type owl:ObjectProperty ;
+              dcterms:description "An object property that links an Agent to the Annotation it authored."@en ,
+                                  "Une propriété d’objet qui relie un Agent à l’Annotation qu’il a rédigée."@fr ;
+              rdfs:label "Auteur de"@fr ,
+                         "Author of"@en ;
+              skos:definition "an owl:ObjectProperty relating an ec:Agent to an ec:Annotation"@en ,
+                              "une owl:ObjectProperty reliant un ec:Agent à une ec:Annotation"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isAwardedTo
+ec:isAwardedTo rdf:type owl:ObjectProperty ;
+               dcterms:description "Identifie l’agent auquel une récompense est attribuée."@fr ,
+                                   "Identifies the agent to whom an award is given."@en ;
+               rdfs:label "Attribué à"@fr ,
+                          "Awarded to"@en ;
+               skos:definition "an owl:ObjectProperty relating an ec:Award to an ec:Agent"@en ,
+                               "une propriété objet owl reliant un ec:Award à un ec:Agent"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isChildOf
+ec:isChildOf rdf:type owl:ObjectProperty ;
+             dcterms:description "L’asset parent de cet asset."@fr ,
+                                 "The parent asset of this asset."@en ;
+             rdfs:label "Parent"@en ,
+                        "Parent"@fr ;
+             skos:definition "an owl:ObjectProperty relating an ec:Asset to an ec:Asset"@en ,
+                             "une propriété objet owl reliant un ec:Asset à un ec:Asset"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isCloneOf
+ec:isCloneOf rdf:type owl:ObjectProperty ;
+             dcterms:description "La MediaResource source d'un clone."@fr ,
+                                 "The source MediaResource of a clone."@en ;
+             rdfs:label "Clone source"@en ,
+                        "Source de clone"@fr ;
+             skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:MediaResource"@en ,
+                             "une propriété d'objet owl reliant un ec:MediaResource à un ec:MediaResource"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isCommissionedBy
+ec:isCommissionedBy rdf:type owl:ObjectProperty ;
+                    dcterms:description "Le contrat par lequel une ressource est commandée."@fr ,
+                                        "The Contract through which a Resource is commissioned."@en ;
+                    rdfs:label "Contract"@en ,
+                               "Contrat"@fr ;
+                    skos:definition "an owl:ObjectProperty relating an ec:Resource to an ec:Contract"@en ,
+                                    "une propriété objet owl reliant une ec:Resource à une ec:Contract"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isComposedOf
+ec:isComposedOf rdf:type owl:ObjectProperty ;
+                dcterms:description "Les ressources média utilisées pour composer une Essence."@fr ,
+                                    "The media resources used to compose an Essence."@en ;
+                rdfs:label "Media resource"@en ,
+                           "Ressource média"@fr ;
+                skos:definition "an owl:ObjectProperty relating an ec:Essence to an ec:MediaResource"@en ,
+                                "une propriété objet owl reliant un ec:Essence à un ec:MediaResource"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isDefinedBy
+ec:isDefinedBy rdf:type owl:ObjectProperty ;
+               dcterms:description "Le contrat par lequel une règle a été définie."@fr ,
+                                   "The Contract by which a Rule has been defined."@en ;
+               rdfs:label "Contrat associé"@fr ,
+                          "Related contract"@en ;
+               skos:definition "an owl:ObjectProperty relating an ec:Rule to an ec:Contract"@en ,
+                               "une propriété objet owl reliant un ec:Rule à un ec:Contract"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isDerivedFrom
+ec:isDerivedFrom rdf:type owl:ObjectProperty ;
+                 dcterms:description "Identifie une relation basée sur le contenu entre deux ressources."@fr ,
+                                     "Identifies a content-based relationship between two resources."@en ;
+                 rdfs:label "Derived from"@en ,
+                            "Dérivé de"@fr ;
+                 skos:definition "an owl:ObjectProperty relating an ec:Asset to an ec:Asset"@en ,
+                                 "une propriété d’objet owl reliant un ec:Asset à un ec:Asset"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isDistributedOn
+ec:isDistributedOn rdf:type owl:ObjectProperty ;
+                   dcterms:description "La plateforme sur laquelle le contenu est distribué."@fr ,
+                                       "The platform on which the content is distributed."@en ;
+                   rdfs:label "Plateforme/service/canal de publication"@fr ,
+                              "Platform/service/publication channel"@en ;
+                   skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:PublicationService"@en ,
+                                   "une propriété objet owl reliant un ec:EditorialObject à un ec:PublicationService"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isDubOf
+ec:isDubOf rdf:type owl:ObjectProperty ;
+           dcterms:description "L'origine d'une ressource multimédia doublée."@fr ,
+                               "The origin of a dubbed MediaResource."@en ;
+           rdfs:label "Doublé de"@fr ,
+                      "Dubbed from"@en ;
+           skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:MediaResource"@en ,
+                           "une propriété objet owl reliant une ec:MediaResource à une ec:MediaResource"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isEmbodiedBy
+ec:isEmbodiedBy rdf:type owl:ObjectProperty ;
+                dcterms:description "Indicates that a character is embodied by an artefact in a production context."@en ,
+                                    "Indique qu’un personnage est incarné par un artefact dans un contexte de production."@fr ;
+                rdfs:label "Est incarné par"@fr ,
+                           "Is embodied by"@en ;
+                skos:definition "an owl:ObjectProperty relating an ec:Character to an ec:Artefact"@en ,
+                                "une propriété d’objet owl reliant un ec:Character à un ec:Artefact"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isEpisodeOfSeason
+ec:isEpisodeOfSeason rdf:type owl:ObjectProperty ;
+                     dcterms:description "L’épisode d’une saison."@fr ,
+                                         "The Episode of a Season."@en ;
+                     rdfs:label "Parent season"@en ,
+                                "Season parente"@fr ;
+                     skos:definition "an owl:ObjectProperty relating an ec:Programme to an ec:Season"@en ,
+                                     "une propriété d'objet owl reliant un ec:Programme à un ec:Season"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isEpisodeOfSerial
+ec:isEpisodeOfSerial rdf:type owl:ObjectProperty ;
+                     dcterms:description "Indicates that a programme is an episode of a serial."@en ,
+                                         "Indique qu’un programme est un épisode d’un feuilleton."@fr ;
+                     rdfs:label "Est épisode de série"@fr ,
+                                "Is episode of serial"@en ;
+                     skos:definition "an owl:ObjectProperty relating an ec:Programme to an ec:Serial"@en ,
+                                     "une propriété objet owl reliant un ec:Programme à un ec:Serial"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isEpisodeOfSeries
+ec:isEpisodeOfSeries rdf:type owl:ObjectProperty ;
+                     dcterms:description "L’épisode d’une série."@fr ,
+                                         "The Episode of a Series."@en ;
+                     rdfs:label "Parent series"@en ,
+                                "Série parente"@fr ;
+                     skos:definition "an owl:ObjectProperty relating an ec:Programme to an ec:Series"@en ,
+                                     "une propriété objet owl reliant un ec:Programme à un ec:Series"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isExtractOf
+ec:isExtractOf rdf:type owl:ObjectProperty ;
+               dcterms:description "Used for representing an extract, i. e. the playout of a part or the whole of some archived material on the playout. For attributes like duration and start, the data is placed in the instance representing the abstract. Other metadata is read from the original instance that is extracted."@en ,
+                                   "Utilisé pour représenter un extrait, c’est-à-dire la diffusion d’une partie ou de l’ensemble de certains éléments archivés lors de la diffusion. Pour des attributs comme la durée et le début, les données sont placées dans l’instance représentant l’abstrait. Les autres métadonnées sont lues à partir de l’instance originale dont l’extrait est tiré."@fr ;
+               rdfs:label "Est extrait de"@fr ,
+                          "Is extract of"@en ;
+               skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:EditorialObject"@en ,
+                               "une propriété d’objet owl reliant un ec:EditorialObject à un ec:EditorialObject"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isInstantiatedBy
+ec:isInstantiatedBy rdf:type owl:ObjectProperty ;
+                    dcterms:description "An object property that links an EditorialObject to the MediaResource it instantiates."@en ,
+                                        "Une propriété d’objet qui relie un EditorialObject à la MediaResource qu’il instancie."@fr ;
+                    rdfs:label "Media resource"@en ,
+                               "Ressource média"@fr ;
+                    skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:MediaResource"@en ,
+                                    "une propriété d’objet owl reliant un ec:EditorialObject à un ec:MediaResource"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isMasterOf
+ec:isMasterOf rdf:type owl:ObjectProperty ;
+              dcterms:description "La ressource maîtresse d'une ressource média dérivée."@fr ,
+                                  "The master resource of a derived media resource."@en ;
+              rdfs:label "Derived media resource"@en ,
+                         "Ressource média dérivée"@fr ;
+              skos:definition "an owl:ObjectProperty relating an ec:MediaResource to an ec:MediaResource"@en ,
+                              "une propriété objet owl reliant un ec:MediaResource à un ec:MediaResource"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isMediaFragmentOf
+ec:isMediaFragmentOf rdf:type owl:ObjectProperty ;
+                     dcterms:description "La ressource média à laquelle appartient un fragment média."@fr ,
+                                         "The Media Resource to which a Media Fragment belongs."@en ;
+                     rdfs:label "Media fragment source"@en ,
+                                "Source de fragment média"@fr ;
+                     skos:definition "an owl:ObjectProperty relating an ec:MediaFragment to an ec:MediaResource"@en ,
+                                     "une owl:ObjectProperty reliant un ec:MediaFragment à un ec:MediaResource"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isMemberOf
+ec:isMemberOf rdf:type owl:ObjectProperty ;
+              dcterms:description "A group to which an EditorialObject belongs."@en ,
+                                  "Un groupe auquel appartient un EditorialObject."@fr ;
+              rdfs:label "Member of"@en ,
+                         "Membre de"@fr ;
+              skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:EditorialGroup"@en ,
+                              "une owl:ObjectProperty reliant un ec:EditorialObject à un ec:EditorialGroup"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isNextInSequence
+ec:isNextInSequence rdf:type owl:ObjectProperty ;
+                    owl:inverseOf ec:isPreviousInSequence ;
+                    dcterms:description "A link to an Editorial Object following the current Editorial Object in an ordered sequence."@en ,
+                                        "Un lien vers un objet éditorial suivant l'objet éditorial actuel dans une séquence ordonnée."@fr ;
+                    rdfs:label "Next"@en ,
+                               "Suivant"@fr ;
+                    skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:EditorialObject"@en ,
+                                    "une propriété objet owl reliant un ec:EditorialObject à un ec:EditorialObject"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isOfferedBy
+ec:isOfferedBy rdf:type owl:ObjectProperty ;
+               owl:inverseOf ec:offers ;
+               dcterms:description "Associates a PublicationEvent with the PublicationService that offers it."@en ,
+                                   "Associe un PublicationEvent au PublicationService qui le propose."@fr ;
+               rdfs:label "Service"@en ,
+                          "Service"@fr ;
+               skos:definition "an owl:ObjectProperty relating an ec:PublicationEvent to an ec:PublicationService"@en ,
+                               "une propriété d'objet owl reliant un ec:PublicationEvent à un ec:PublicationService"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isOperatedBy
+ec:isOperatedBy rdf:type owl:ObjectProperty ;
+                dcterms:description "A service that operates the publication channel."@en ,
+                                    "Un service qui exploite le canal de publication."@fr ;
+                rdfs:label "Operator, owner"@en ,
+                           "Opérateur, propriétaire"@fr ;
+                skos:definition "an owl:ObjectProperty relating a ec:PublicationChannel to a ec:PublicationService"@en ,
+                                "une propriété d’objet owl reliant un ec:PublicationChannel à un ec:PublicationService"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isOrderedBy
+ec:isOrderedBy rdf:type owl:ObjectProperty ;
+               dcterms:description "Le contrat par lequel une ProductionJob est commandée."@fr ,
+                                   "The Contract through which an ProductionJob is ordered."@en ;
+               rdfs:label "Contract"@en ,
+                          "Contrat"@fr ;
+               skos:definition "an owl:ObjectProperty relating an ec:ProductionJob to an ec:Contract"@en ,
+                               "une propriété d’objet owl:ObjectProperty reliant un ec:ProductionJob à un ec:Contract"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isOwnedBy
+ec:isOwnedBy rdf:type owl:ObjectProperty ;
+             owl:inverseOf ec:owns ;
+             dcterms:description "L’Agent (Contact, Personne ou Organisation) qui possède une MarketingBrand, une PublicationChannel, une PublicationPlatform ou une PublicationService."@fr ,
+                                 "The Agent (Contact, Person, or Organisation) that owns a MarketingBrand, PublicationChannel, PublicationPlatform, or PublicationService."@en ;
+             rdfs:label "Est détenu par"@fr ,
+                        "Is owned by"@en ;
+             skos:definition "an owl:ObjectProperty relating an ec:MarketingBrand, ec:PublicationChannel, ec:PublicationPlatform, or ec:PublicationService to an ec:Agent"@en ,
+                             "une propriété objet owl reliant un ec:MarketingBrand, ec:PublicationChannel, ec:PublicationPlatform ou ec:PublicationService à un ec:Agent"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isPartOf
+ec:isPartOf rdf:type owl:ObjectProperty ;
+            dcterms:description "L’objet éditorial qui contient une partie."@fr ,
+                                "The editorial object that contains a part."@en ;
+            rdfs:label "Editorial object"@en ,
+                       "Objet éditorial"@fr ;
+            skos:definition "an owl:ObjectProperty relating an ec:EditorialSegment to an ec:EditorialObject"@en ,
+                            "une propriété d’objet owl reliant un ec:EditorialSegment à un ec:EditorialObject"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isPlayedBy
+ec:isPlayedBy rdf:type owl:ObjectProperty ;
+              owl:inverseOf ec:playsCharacter ;
+              owl:propertyDisjointWith ec:isPortrayedBy ;
+              dcterms:description "Relation entre un personnage fictif et l'acteur qui joue le rôle."@fr ,
+                                  "Relationship between a fictional character and the actor playing the part."@en ;
+              rdfs:label "Est joué par"@fr ,
+                         "Is played by"@en ;
+              skos:definition "an owl:ObjectProperty relating an ec:Character to an ec:Involvement"@en ,
+                              "une owl:ObjectProperty reliant un ec:Character à un ec:Involvement"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isPortrayedBy
+ec:isPortrayedBy rdf:type owl:ObjectProperty ;
+                 owl:inverseOf ec:portrays ;
+                 dcterms:description "Relation entre un personnage fictif et l’animal représenté dans la scène."@fr ,
+                                     "Relationship between a fictional character and the animal that is depicted in the scene."@en ;
+                 rdfs:label "Est représenté par"@fr ,
+                            "Is portrayed by"@en ;
+                 skos:definition "an owl:ObjectProperty relating an ec:Character to an ec:Animal"@en ,
+                                 "une owl:ObjectProperty reliant un ec:Character à un ec:Animal"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isPreviousInSequence
+ec:isPreviousInSequence rdf:type owl:ObjectProperty ;
+                        dcterms:description "A link to an Editorial Object preceding the current Editorial Object in an ordered sequence."@en ,
+                                            "Un lien vers un objet éditorial qui précède l’objet éditorial courant dans une séquence ordonnée."@fr ;
+                        rdfs:label "Preceding"@en ,
+                                   "Précédent"@fr ;
+                        skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:EditorialObject"@en ,
+                                        "une propriété objet owl reliant un ec:EditorialObject à un ec:EditorialObject"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isReferencedBy
+ec:isReferencedBy rdf:type owl:ObjectProperty ;
+                  owl:inverseOf ec:references ;
+                  dcterms:description "A related resource that references, cites, or otherwise points to the described resource."@en ,
+                                      "Une ressource liée qui référence, cite ou pointe autrement vers la ressource décrite."@fr ;
+                  rdfs:label "Reference source"@en ,
+                             "Source de référence"@fr ;
+                  skos:definition "an owl:ObjectProperty relating a resource to a related resource that references, cites, or otherwise points to it"@en ,
+                                  "une propriété d'objet owl reliant une ressource à une ressource liée qui la référence, la cite ou y pointe autrement"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isRelatedAgent
+ec:isRelatedAgent rdf:type owl:ObjectProperty ;
+                  dcterms:description "Relier un Agent à un concept qui lui est associé, tel qu’une Personne ou un Personnage."@fr ,
+                                      "To relate an Agent to a concept associated with it, such as a Person or Character."@en ;
+                  rdfs:label "Agent lié"@fr ,
+                             "Related agent"@en ;
+                  skos:definition "an owl:ObjectProperty relating an ec:Concept to an ec:Agent"@en ,
+                                  "une propriété objet owl reliant un ec:Concept à un ec:Agent"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isReplacedBy
+ec:isReplacedBy rdf:type owl:ObjectProperty ;
+                owl:inverseOf ec:replaces ;
+                dcterms:description "Identifie un actif qui est remplacé par un autre actif."@fr ,
+                                    "Identifies an asset that is substituted by another asset."@en ;
+                rdfs:label "Remplacement"@fr ,
+                           "Replacement"@en ;
+                skos:definition "an owl:ObjectProperty relating an ec:Asset to an ec:Asset"@en ,
+                                "une propriété d'objet owl reliant un ec:Asset à un ec:Asset"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isRequiredBy
+ec:isRequiredBy rdf:type owl:ObjectProperty ;
+                owl:inverseOf ec:requires ;
+                dcterms:description "Relation forte entre les objets éditoriaux."@fr ,
+                                    "Strong relation between EditorialObjects."@en ;
+                rdfs:label "Required"@en ,
+                           "Requis"@fr ;
+                skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:EditorialObject"@en ,
+                                "une propriété d’objet owl reliant un ec:EditorialObject à un ec:EditorialObject"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isSeasonOf
+ec:isSeasonOf rdf:type owl:ObjectProperty ;
+              dcterms:description "Associates a season with the series to which it belongs."@en ,
+                                  "Associe une saison à la série à laquelle elle appartient."@fr ;
+              rdfs:label "Series"@en ,
+                         "Série"@fr ;
+              skos:definition "an owl:ObjectProperty relating an ec:Season to an ec:Series"@en ,
+                              "une propriété objet owl reliant une ec:Season à une ec:Series"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isTimelineTrackPartOf
+ec:isTimelineTrackPartOf rdf:type owl:ObjectProperty ;
+                         dcterms:description "Associates an EditorialObject with a part of a TimelineTrack."@en ,
+                                             "Associe un EditorialObject à une partie d’un TimelineTrack."@fr ;
+                         rdfs:label "Partie de piste chronologique"@fr ,
+                                    "Timeline track part"@en ;
+                         skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to a ec:TimelineTrack"@en ,
+                                         "une propriété d’objet owl reliant un ec:EditorialObject à un ec:TimelineTrack"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isTrackPartOf
+ec:isTrackPartOf rdf:type owl:ObjectProperty ;
+                 dcterms:description "An element to identify a part of a track by a title, a start time and an end time in both the media source and media destination."@en ,
+                                     "Un élément permettant d’identifier une partie d’une piste par un titre, une heure de début et une heure de fin, à la fois dans la source média et dans la destination média."@fr ;
+                 rdfs:label "Source de partie de piste"@fr ,
+                            "Track part source"@en ;
+                 skos:definition "an owl:ObjectProperty relating an ec:Track to an ec:MediaResource"@en ,
+                                 "une propriété d'objet owl reliant un ec:Track à un ec:MediaResource"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isVersionOf
+ec:isVersionOf rdf:type owl:ObjectProperty ;
+               dcterms:description "Related versions of an EditorialObject or Resource."@en ,
+                                   "Versions liées d’un EditorialObject ou d’une Resource."@fr ;
+               rdfs:label "Version de"@fr ,
+                          "Version of"@en ;
+               skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:EditorialObject"@en ,
+                               "une propriété objet owl reliant un ec:EditorialObject à un ec:EditorialObject"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#logs
+ec:logs rdf:type owl:ObjectProperty ;
+        dcterms:description "Links a publication log to its publication events."@en ,
+                            "Relie un journal de publication à ses événements de publication."@fr ;
+        rdfs:label "Journaux"@fr ,
+                   "Logs"@en ;
+        skos:definition "an owl:ObjectProperty relating an ec:PublicationLog to an ec:PublicationEvent"@en ,
+                        "une propriété objet owl reliant une ec:PublicationLog à un ec:PublicationEvent"@fr ;
+        skos:note "consigne un événement de publication"@fr ,
+                  "logs publication event"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#measures
+ec:measures rdf:type owl:ObjectProperty ;
+            dcterms:description "Associates a Measure with a Rule."@en ,
+                                "Associe une Measure à une Rule."@fr ;
+            rdfs:label "Related rule"@en ,
+                       "Règle associée"@fr ;
+            skos:definition "an owl:ObjectProperty relating an ec:Measure to an ec:Rule"@en ,
+                            "une propriété d’objet owl reliant un ec:Measure à une ec:Rule"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#occursIn
+ec:occursIn rdf:type owl:ObjectProperty ;
+            dcterms:description "A property that links a consumption event to the publication channel or publication service in which it occurs."@en ,
+                                "Une propriété qui relie un événement de consommation au canal de publication ou au service de publication dans lequel il se produit."@fr ;
+            rdfs:label "Occurs in"@en ,
+                       "Se produit dans"@fr ;
+            skos:definition "an owl:ObjectProperty relating an ec:ConsumptionEvent to a ec:PublicationService or ec:PublicationChannel"@en ,
+                            "une owl:ObjectProperty reliant une ec:ConsumptionEvent à une ec:PublicationService ou ec:PublicationChannel"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#occursOn
+ec:occursOn rdf:type owl:ObjectProperty ;
+            dcterms:description "A property that links a consumption event to the publication platform on which it occurs."@en ,
+                                "Une propriété qui relie un événement de consommation à la plateforme de publication sur laquelle il se produit."@fr ;
+            rdfs:label "Occurs on"@en ,
+                       "S'applique à"@fr ;
+            skos:definition "an owl:ObjectProperty relating an ec:ConsumptionEvent to an ec:PublicationPlatform"@en ,
+                            "une propriété objet owl reliant un ec:ConsumptionEvent à un ec:PublicationPlatform"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#offers
+ec:offers rdf:type owl:ObjectProperty ;
+          dcterms:description "Les événements de publication accessibles via un service."@fr ,
+                              "The publication events available through a service."@en ;
+          rdfs:label "Offers service"@en ,
+                     "Offre un service"@fr ;
+          skos:definition "an owl:ObjectProperty relating an ec:PublicationPlatform to an ec:PublicationService"@en ,
+                          "une propriété d'objet owl reliant une ec:PublicationPlatform à une ec:PublicationService"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#originatesFrom
+ec:originatesFrom rdf:type owl:ObjectProperty ;
+                  dcterms:description "Le contrat dont les droits sont issus."@fr ,
+                                      "The Contract from which the Rights originate."@en ;
+                  rdfs:label "Contract"@en ,
+                             "Contrat"@fr ;
+                  skos:definition "an owl:ObjectProperty relating an ec:Rights to an ec:Contract"@en ,
+                                  "une propriété objet owl reliant une ec:Rights à une ec:Contract"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#owns
+ec:owns rdf:type owl:ObjectProperty ;
+        dcterms:description "La MarketingBrand, le PublicationChannel, la PublicationPlatform ou le PublicationService détenu par un Agent donné (Contact, Personne ou Organisation)."@fr ,
+                            "The MarketingBrand, PublicationChannel, PublicationPlatform, or PublicationService owned by a given Agent (Contact, Person, or Organisation)."@en ;
+        rdfs:label "Owns"@en ,
+                   "Possède"@fr ;
+        skos:definition "an owl:ObjectProperty relating an ec:Agent to an ec:MarketingBrand, ec:PublicationChannel, ec:PublicationPlatform, or ec:PublicationService"@en ,
+                        "une propriété objet owl reliant un ec:Agent à un ec:MarketingBrand, ec:PublicationChannel, ec:PublicationPlatform ou ec:PublicationService"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#playsCharacter
+ec:playsCharacter rdf:type owl:ObjectProperty ;
+                  dcterms:description "A character played by a person. The relationship implies that the person has intellectual rights to the performance of the character."@en ,
+                                      "Un personnage interprété par une personne. La relation implique que la personne détient les droits de propriété intellectuelle sur l'interprétation du personnage."@fr ;
+                  rdfs:label "Interprète un personnage"@fr ,
+                             "Plays character"@en ;
+                  skos:definition "an owl:ObjectProperty relating an ec:Involvement to an ec:Character"@en ,
+                                  "une propriété d’objet owl reliant un ec:Involvement à un ec:Character"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#playsOut
+ec:playsOut rdf:type owl:ObjectProperty ;
+            dcterms:description "Describes the Essence used in a PublicationEvent."@en ,
+                                "Décrit l'Essence utilisée dans un PublicationEvent."@fr ;
+            rdfs:label "Essence"@en ,
+                       "Essence"@fr ;
+            skos:definition "an owl:ObjectProperty relating an ec:PublicationEvent to an ec:Essence"@en ,
+                            "une propriété objet owl reliant un ec:PublicationEvent à un ec:Essence"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#portrays
+ec:portrays rdf:type owl:ObjectProperty ;
+            dcterms:description "An animal that appears as a character other than itself."@en ,
+                                "Un animal qui apparaît comme un personnage autre que lui-même."@fr ;
+            rdfs:label "Portrays"@en ,
+                       "Représente"@fr ;
+            skos:definition "an owl:ObjectProperty relating an ec:Animal to an ec:Character"@en ,
+                            "une propriété objet owl reliant un ec:Animal à un ec:Character"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#promotes
+ec:promotes rdf:type owl:ObjectProperty ;
+            dcterms:description "Le contenu promeut un autre contenu."@fr ,
+                                "The content promotes some other content."@en ;
+            rdfs:label "Promeut"@fr ,
+                       "Promotes"@en ;
+            skos:definition "an owl:ObjectProperty relating an ec:EditorialWork to an ec:EditorialGroup or ec:EditorialWork"@en ,
+                            "une owl:ObjectProperty reliant un ec:EditorialWork à un ec:EditorialGroup ou ec:EditorialWork"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#publishes
+ec:publishes rdf:type owl:ObjectProperty ;
+             dcterms:description "L'objet éditorial associé à un événement de publication."@fr ,
+                                 "The editorial object associated with a PublicationEvent."@en ;
+             rdfs:label "Editorial object"@en ,
+                        "Objet éditorial"@fr ;
+             skos:definition "an owl:ObjectProperty relating an ec:PublicationEvent to an ec:EditorialObject"@en ,
+                             "une propriété objet owl reliant un ec:PublicationEvent à un ec:EditorialObject"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#references
+ec:references rdf:type owl:ObjectProperty ;
+              dcterms:description "A related resource that is referenced, cited, or otherwise pointed to by the described resource."@en ,
+                                  "Une ressource connexe qui est référencée, citée ou à laquelle la ressource décrite renvoie d'une autre manière."@fr ;
+              rdfs:label "References"@en ,
+                         "Références"@fr ;
+              skos:definition "an owl:ObjectProperty relating a resource to a referenced resource"@en ,
+                              "une propriété objet owl reliant une ressource à une ressource référencée"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#referencesRule
+ec:referencesRule rdf:type owl:ObjectProperty ;
+                  dcterms:description "A reference to the rule against which an audit report was produced through an associated measure."@en ,
+                                      "Une référence à la règle selon laquelle un rapport d’audit a été produit au moyen d’une mesure associée."@fr ;
+                  rdfs:label "Referenced rule"@en ,
+                             "Règle référencée"@fr ;
+                  skos:definition "an owl:ObjectProperty relating an ec:AuditReport to an ec:Rule"@en ,
+                                  "une propriété d’objet owl:ObjectProperty reliant un ec:AuditReport à un ec:Rule"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#renders
+ec:renders rdf:type owl:ObjectProperty ;
+           dcterms:description "A property that relates a consumption device to the essence it renders."@en ,
+                               "Une propriété qui relie un appareil de consommation à l’essence qu’il restitue."@fr ;
+           rdfs:label "Diffuse"@fr ,
+                      "Renders"@en ;
+           skos:definition "an owl:ObjectProperty relating an ec:ConsumptionDevice to an ec:Essence"@en ,
+                           "une owl:ObjectProperty reliant une ec:ConsumptionDevice à une ec:Essence"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#replaces
+ec:replaces rdf:type owl:ObjectProperty ;
+            dcterms:description "Identifie qu'un actif en remplace un autre."@fr ,
+                                "Identifies that one asset replaces another."@en ;
+            rdfs:label "Remplace"@fr ,
+                       "Replaces"@en ;
+            skos:definition "an owl:ObjectProperty relating an ec:Asset to an ec:Asset"@en ,
+                            "une propriété d'objet owl reliant un ec:Asset à un ec:Asset"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#represents
+ec:represents rdf:type owl:ObjectProperty ;
+              dcterms:description "To establish a relation between an EditorialObject and an Asset."@en ,
+                                  "Établir une relation entre un EditorialObject et un Asset."@fr ;
+              rdfs:label "Actif lié"@fr ,
+                         "Related asset"@en ;
+              skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:Asset"@en ,
+                              "une propriété objet owl reliant un ec:EditorialObject à un ec:Asset"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#requires
+ec:requires rdf:type owl:ObjectProperty ;
+            dcterms:description "Indicates a dependency between an EditorialObject and the resource or object it requires."@en ,
+                                "Indique une dépendance entre un EditorialObject et la ressource ou l’objet qu’il requiert."@fr ;
+            rdfs:label "Nécessite"@fr ,
+                       "Requires"@en ;
+            skos:definition "an owl:ObjectProperty relating an ec:EditorialObject to an ec:MediaResource"@en ,
+                            "une propriété objet owl reliant un ec:EditorialObject à un ec:MediaResource"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#requiresLicence
+ec:requiresLicence rdf:type owl:ObjectProperty ;
+                   dcterms:description "La ec:ConsumptionLicence requise par une ec:ConsumptionEvent."@fr ,
+                                       "The ConsumptionLicence required by a ConsumptionEvent."@en ;
+                   rdfs:label "Licence requise"@fr ,
+                              "Required licence"@en ;
+                   skos:definition "an owl:ObjectProperty relating an ec:ConsumptionEvent to an ec:ConsumptionLicence"@en ,
+                                   "une propriété d’objet owl reliant un ec:ConsumptionEvent à un ec:ConsumptionLicence"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#resultsIn
+ec:resultsIn rdf:type owl:ObjectProperty ;
+             dcterms:description "A link between a ResonanceEvent and a ConsumptionEvent."@en ,
+                                 "Un lien entre un ResonanceEvent et un ConsumptionEvent."@fr ;
+             rdfs:label "Resonance event"@en ,
+                        "Événement de résonance"@fr ;
+             skos:definition "an owl:ObjectProperty relating a ec:ConsumptionEvent to a ec:ResonanceEvent"@en ,
+                             "une owl:ObjectProperty reliant une ec:ConsumptionEvent à une ec:ResonanceEvent"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#supportsConsumptionDeviceProfile
+ec:supportsConsumptionDeviceProfile rdf:type owl:ObjectProperty ;
+                                    dcterms:description "Le profil d’un dispositif de consommation."@fr ,
+                                                        "The profile of a consumption device."@en ;
+                                    rdfs:label "Device profile"@en ,
+                                               "Profil de périphérique"@fr ;
+                                    skos:definition "an owl:ObjectProperty relating an ec:PublicationPlatform to an ec:ConsumptionDeviceProfile"@en ,
+                                                    "une propriété objet owl reliant ec:PublicationPlatform à ec:ConsumptionDeviceProfile"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#transports
+ec:transports rdf:type owl:ObjectProperty ;
+              dcterms:description "A connection through which a publication service can be transported to a consumption device. For example, it may be a cable receiver, an FM receiver, a website, or an application used to access a service."@en ,
+                                  "Une connexion par laquelle un service de publication peut être acheminé vers un dispositif de consommation. Par exemple, il peut s’agir d’un récepteur câblé, d’un récepteur FM, d’un site web ou d’une application utilisée pour accéder à un service."@fr ;
+              rdfs:label "Transports"@en ,
+                         "Transports"@fr ;
+              skos:definition "an owl:ObjectProperty relating an ec:PublicationChannel to an ec:PublicationService"@en ,
+                              "une owl:ObjectProperty reliant ec:PublicationChannel à ec:PublicationService"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#usesConsumptionDevice
+ec:usesConsumptionDevice rdf:type owl:ObjectProperty ;
+                         dcterms:description "Les dispositifs de consommation utilisés par un consommateur."@fr ,
+                                             "The Consumption devices used by a Consumer."@en ;
+                         rdfs:label "Consumption device"@en ,
+                                    "Dispositif de consommation"@fr ;
+                         skos:definition "an owl:ObjectProperty relating an ec:Consumer to an ec:ConsumptionDevice"@en ,
+                                         "une propriété objet owl reliant un ec:Consumer à un ec:ConsumptionDevice"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#usesMeasure
+ec:usesMeasure rdf:type owl:ObjectProperty ;
+               dcterms:description "La mesure associée à une tâche d’audit."@fr ,
+                                   "The measure associated with an audit job."@en ;
+               rdfs:label "Mesure liée"@fr ,
+                          "Related measure"@en ;
+               skos:definition "an owl:ObjectProperty relating an ec:AuditJob to an ec:Measure"@en ,
+                               "une propriété objet owl reliant un ec:AuditJob à un ec:Measure"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#usesProductionDevice
+ec:usesProductionDevice rdf:type owl:ObjectProperty ;
+                        dcterms:description "A device used in a ProductionJob to create or process a MediaResource."@en ,
+                                            "Un dispositif utilisé dans un ProductionJob pour créer ou traiter une MediaResource."@fr ;
+                        rdfs:label "Dispositif de production"@fr ,
+                                   "Production device"@en ;
+                        skos:definition "an owl:ObjectProperty relating an ec:ProductionJob to an ec:ProductionDevice"@en ,
+                                        "une propriété d’objet owl reliant un ec:ProductionJob à un ec:ProductionDevice"@fr .
+
+
+###  http://www.w3.org/2000/01/rdf-schema#related
+rdfs:related rdf:type owl:ObjectProperty .
+
+
+###  http://www.w3.org/2006/time#hasTRS
+time:hasTRS rdf:type owl:ObjectProperty ;
+            dcterms:description "The temporal reference system used by a temporal position or extent description."@en ;
+            rdfs:label "Has TRS"@en .
+
+
+###  http://www.w3.org/ns/ma-ont#hasPermissions
+<http://www.w3.org/ns/ma-ont#hasPermissions> rdf:type owl:ObjectProperty ;
+                                             dcterms:description "To set permissions as defined in the W3C Media Ontology (ma-ont)."@en ;
+                                             rdfs:label "Permissions"@en ;
+                                             skos:prefLabel "Permissions"^^xsd:string .
+
+
+###  https://rdf-vocabulary.ddialliance.org/xkos/after
+xkos:after rdf:type owl:ObjectProperty ;
+           rdfs:subPropertyOf xkos:temporal ;
+           rdfs:label "after"@en .
+
+
+###  https://rdf-vocabulary.ddialliance.org/xkos/before
+xkos:before rdf:type owl:ObjectProperty ;
+            rdfs:subPropertyOf xkos:temporal ;
+            rdfs:label "before"@en .
+
+
+###  https://rdf-vocabulary.ddialliance.org/xkos/next
+xkos:next rdf:type owl:ObjectProperty ;
+          rdfs:subPropertyOf xkos:succeeds ;
+          rdfs:label "next"@en .
+
+
+###  https://rdf-vocabulary.ddialliance.org/xkos/precedes
+xkos:precedes rdf:type owl:ObjectProperty ;
+              rdfs:subPropertyOf xkos:sequential ;
+              rdfs:label "precedes"@en .
+
+
+###  https://rdf-vocabulary.ddialliance.org/xkos/previous
+xkos:previous rdf:type owl:ObjectProperty ;
+              rdfs:subPropertyOf xkos:precedes ;
+              rdfs:label "previous"@en .
+
+
+###  https://rdf-vocabulary.ddialliance.org/xkos/sequential
+xkos:sequential rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf skos:related ;
+                rdfs:label "sequential"@en .
+
+
+###  https://rdf-vocabulary.ddialliance.org/xkos/succeeds
+xkos:succeeds rdf:type owl:ObjectProperty ;
+              rdfs:subPropertyOf xkos:sequential ;
+              rdfs:label "succeeds"@en .
+
+
+###  https://rdf-vocabulary.ddialliance.org/xkos/temporal
+xkos:temporal rdf:type owl:ObjectProperty ;
+              rdfs:subPropertyOf xkos:sequential ;
+              rdfs:label "temporal"@en .
+
+
+#################################################################
+#    Data properties
+#################################################################
+
+###  http://purl.org/dc/elements/1.1/source
+dc:source rdf:type owl:DatatypeProperty ;
+          rdfs:range rdfs:Literal ;
+          dcterms:description "To identify a Resource as the source of another Resource."@en ;
+          rdfs:label "Source"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#DID
+ec:DID rdf:type owl:DatatypeProperty ;
+       rdfs:range xsd:integer ;
+       dcterms:description "Le mot Data Identifier (ainsi que le SDID, s’il est utilisé) indique le type de données accessoires auxquelles le paquet correspond."@fr ,
+                           "The Data Identifier word (along with the SDID, if used), indicates the type of ancillary data that the packet corresponds to."@en ;
+       rdfs:label "Data identifier word"@en ,
+                  "Mot d’identifiant de données"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#SDID
+ec:SDID rdf:type owl:DatatypeProperty ;
+        rdfs:range xsd:integer ;
+        dcterms:description "Mot de repérage des données secondaires pour les données auxiliaires. Identifiant du mode d’envoi. Identifiant indiquant le moment de transmission des sous-titres codés."@fr ,
+                            "Secondary data identification word for ancillary data. Send mode identifier. An identifier which indicates the transmission timing for closed caption data."@en ;
+        rdfs:label "Identifiant du mode d'envoi"@fr ,
+                   "Send mode identifier"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#abstract
+ec:abstract rdf:type owl:DatatypeProperty ;
+            rdfs:subPropertyOf ec:contentDescription ;
+            rdfs:range rdfs:Literal ;
+            dcterms:description "An abstract summarizing the content."@en ,
+                                "Un résumé qui synthétise le contenu."@fr ;
+            rdfs:label "Abstract"@en ,
+                       "Résumé"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#age
+ec:age rdf:type owl:DatatypeProperty ;
+       rdfs:range xsd:integer ;
+       dcterms:description "L'âge en années d'un Contact/Personne."@fr ,
+                           "The age in years of a Contact/Person."@en ;
+       rdfs:label "Age"@en ,
+                  "Âge"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#agentDbpedia
+ec:agentDbpedia rdf:type owl:DatatypeProperty ;
+                rdfs:subPropertyOf ec:agentLinkedData ;
+                rdfs:range xsd:anyURI ;
+                dcterms:description "A link to a DBPedia page."@en ,
+                                    "Un lien vers une page DBPedia."@fr ;
+                rdfs:label "Dbpedia"@en ,
+                           "Dbpedia"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#agentEmailAddress
+ec:agentEmailAddress rdf:type owl:DatatypeProperty ;
+                     rdfs:range xsd:string ;
+                     dcterms:description "L’adresse électronique d’un Agent."@fr ,
+                                         "The email address of an Agent."@en ;
+                     rdfs:label "Courriel"@fr ,
+                                "Email"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#agentFacebook
+ec:agentFacebook rdf:type owl:DatatypeProperty ;
+                 rdfs:subPropertyOf ec:agentSocialMedia ;
+                 rdfs:range xsd:anyURI ;
+                 dcterms:description "Links to an Agent's Facebook page or profile as a URI."@en ,
+                                     "Renvoie un lien vers la page ou le profil Facebook d’un Agent sous forme d’URI."@fr ;
+                 rdfs:label "Facebook"@en ,
+                            "Facebook"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#agentFee
+ec:agentFee rdf:type owl:DatatypeProperty ;
+            rdfs:range rdfs:Literal ;
+            dcterms:description "Les honoraires d’un agent."@fr ,
+                                "The fee of an Agent."@en ;
+            rdfs:label "Agent fee"@en ,
+                       "Frais d'agent"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#agentFlickr
+ec:agentFlickr rdf:type owl:DatatypeProperty ;
+               rdfs:subPropertyOf ec:agentSocialMedia ;
+               rdfs:range xsd:anyURI ;
+               dcterms:description "Liens vers le compte Flickr d’un Agent."@fr ,
+                                   "Links to an Agent's Flickr account."@en ;
+               rdfs:label "Flickr"@en ,
+                          "Flickr"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#agentImdb
+ec:agentImdb rdf:type owl:DatatypeProperty ;
+             rdfs:subPropertyOf ec:agentLinkedData ;
+             rdfs:range xsd:anyURI ;
+             dcterms:description "A link to an imdb page."@en ,
+                                 "Un lien vers une page IMDb."@fr ;
+             rdfs:label "IMDB"@en ,
+                        "IMDB"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#agentInstagram
+ec:agentInstagram rdf:type owl:DatatypeProperty ;
+                  rdfs:subPropertyOf ec:agentSocialMedia ;
+                  rdfs:range xsd:anyURI ;
+                  dcterms:description "Lien vers l’URI du compte Instagram d’un Agent."@fr ,
+                                      "Links to an Agent’s Instagram account URI."@en ;
+                  rdfs:label "Instagram"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#agentLinkedData
+ec:agentLinkedData rdf:type owl:DatatypeProperty ;
+                   rdfs:range xsd:anyURI ;
+                   dcterms:description "A link to linked data for the agent, expressed as a URL or URI."@en ,
+                                       "Un lien vers des données liées pour l’agent, exprimé sous la forme d’une URL ou d’une URI."@fr ;
+                   rdfs:label "Agent linked data"@en ,
+                              "Données liées de l’agent"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#agentLinkedIn
+ec:agentLinkedIn rdf:type owl:DatatypeProperty ;
+                 rdfs:subPropertyOf ec:agentSocialMedia ;
+                 rdfs:range xsd:anyURI ;
+                 dcterms:description "Liens vers le profil LinkedIn d’un Agent."@fr ,
+                                     "Links to an Agent's LinkedIn profile."@en ;
+                 rdfs:label "LinkedIn profile"@en ,
+                            "Profil LinkedIn"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#agentMobileTelephoneNumber
+ec:agentMobileTelephoneNumber rdf:type owl:DatatypeProperty ;
+                              rdfs:subPropertyOf ec:agentTelephoneNumber ;
+                              rdfs:range xsd:string ;
+                              dcterms:description "Le numéro de téléphone mobile d’un Agent (Contact/Personne ou Organisation)."@fr ,
+                                                  "The mobile telephone number of an Agent (Contact/Person or Organisation)."@en ;
+                              rdfs:label "Mobile"@en ,
+                                         "Mobile"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#agentPreviousName
+ec:agentPreviousName rdf:type owl:DatatypeProperty ;
+                     rdfs:range rdfs:Literal ;
+                     dcterms:description "Le nom précédent d’un Agent."@fr ,
+                                         "The previous name of an Agent."@en ;
+                     rdfs:label "Nom précédent"@fr ,
+                                "Previous name"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#agentRelatedInformationLink
+ec:agentRelatedInformationLink rdf:type owl:DatatypeProperty ;
+                               rdfs:subPropertyOf ec:agentRelatedLink ;
+                               rdfs:range xsd:anyURI ;
+                               dcterms:description "A link to a web resource containing information related to an Agent (Contact/Person or Organisation)."@en ,
+                                                   "Un lien vers une ressource web contenant des informations relatives à un agent (contact/personne ou organisation)."@fr ;
+                               rdfs:label "Lien d'information liée"@fr ,
+                                          "Related information link"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#agentRelatedLink
+ec:agentRelatedLink rdf:type owl:DatatypeProperty ;
+                    rdfs:range xsd:anyURI ;
+                    dcterms:description "A link to a web resource related to an Agent."@en ,
+                                        "Un lien vers une ressource web liée à un Agent."@fr ;
+                    rdfs:label "Lien associé"@fr ,
+                               "Related link"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#agentRelatedPressLink
+ec:agentRelatedPressLink rdf:type owl:DatatypeProperty ;
+                         rdfs:subPropertyOf ec:agentRelatedLink ;
+                         rdfs:range xsd:anyURI ;
+                         dcterms:description "A link to a web resource containing information related to an Agent (Contact/Person or Organisation)."@en ,
+                                             "Un lien vers une ressource web contenant des informations relatives à un agent (contact/personne ou organisation)."@fr ;
+                         rdfs:label "Lien de presse associé"@fr ,
+                                    "Related press link"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#agentSocialMedia
+ec:agentSocialMedia rdf:type owl:DatatypeProperty ;
+                    rdfs:range xsd:anyURI ;
+                    dcterms:description "Liens vers les médias sociaux d’un Agent."@fr ,
+                                        "Links to an Agent's social media."@en ;
+                    rdfs:label "Médias sociaux"@fr ,
+                               "Social media"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#agentTelephoneNumber
+ec:agentTelephoneNumber rdf:type owl:DatatypeProperty ;
+                        rdfs:range xsd:string ;
+                        dcterms:description "Le numéro de téléphone d’un Agent (Contact/Personne ou Organisation)."@fr ,
+                                            "The telephone number of an Agent (Contact/Person or Organisation)."@en ;
+                        rdfs:label "Telephone"@en ,
+                                   "Téléphone"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#agentTwitter
+ec:agentTwitter rdf:type owl:DatatypeProperty ;
+                rdfs:subPropertyOf ec:agentSocialMedia ;
+                rdfs:range xsd:anyURI ;
+                dcterms:description "Links to an Agent’s Twitter account URL."@en ,
+                                    "Renvoie vers l’URL du compte Twitter d’un Agent."@fr ;
+                rdfs:label "Twitter"@en ,
+                           "Twitter"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#agentWebHomepage
+ec:agentWebHomepage rdf:type owl:DatatypeProperty ;
+                    rdfs:range xsd:anyURI ;
+                    dcterms:description "L’adresse web d’un Agent (Contact/Personne ou Organisation)."@fr ,
+                                        "The webpage address of an Agent (Contact/Person or Organisation)."@en ;
+                    rdfs:label "Homepage"@en ,
+                               "Page d'accueil"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#agentWikidata
+ec:agentWikidata rdf:type owl:DatatypeProperty ;
+                 rdfs:subPropertyOf ec:agentLinkedData ;
+                 rdfs:range xsd:anyURI ;
+                 dcterms:description "A link to a wikidata page."@en ,
+                                     "Un lien vers une page Wikidata."@fr ;
+                 rdfs:label "Wikidata"@en ,
+                            "Wikidata"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#agentWikipedia
+ec:agentWikipedia rdf:type owl:DatatypeProperty ;
+                  rdfs:subPropertyOf ec:agentSocialMedia ;
+                  rdfs:range xsd:anyURI ;
+                  dcterms:description "Liens vers la page Wikipedia d’un Agent."@fr ,
+                                      "Links to an Agent's Wikipedia page."@en ;
+                  rdfs:label "Wikipedia"@en ,
+                             "Wikipedia"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#animalCharacterName
+ec:animalCharacterName rdf:type owl:DatatypeProperty ;
+                       rdfs:range rdfs:Literal ;
+                       dcterms:description "Le nom de personnage fictif associé à un animal."@fr ,
+                                           "The fictitious character name associated with an animal."@en ;
+                       rdfs:label "Animal character name"@en ,
+                                  "Nom du personnage animal"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#animalCode
+ec:animalCode rdf:type owl:DatatypeProperty ;
+              rdfs:range rdfs:Literal ;
+              dcterms:description "Le code associé à un animal."@fr ,
+                                  "The code associated with an animal."@en ;
+              rdfs:label "Animal code"@en ,
+                         "Code animal"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#animalPassport
+ec:animalPassport rdf:type owl:DatatypeProperty ;
+                  rdfs:range rdfs:Literal ;
+                  dcterms:description "Répliquer le passeport d'un animal."@fr ,
+                                      "To replicate the passport of an animal."@en ;
+                  rdfs:label "Animal passport"@en ,
+                             "Passeport animal"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#annotationConfidence
+ec:annotationConfidence rdf:type owl:DatatypeProperty ;
+                        rdfs:range rdfs:Literal ;
+                        dcterms:description "Estimer la confiance dans une annotation."@fr ,
+                                            "To estimate the confidence in an Annotation."@en ;
+                        rdfs:label "Annotation confidence"@en ,
+                                   "Confiance de l’annotation"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#annotationPurpose
+ec:annotationPurpose rdf:type owl:DatatypeProperty ;
+                     rdfs:range rdfs:Literal ;
+                     dcterms:description "La finalité associée à une annotation."@fr ,
+                                         "The purpose associated with an annotation."@en ;
+                     rdfs:label "Annotation purpose"@en ,
+                                "Objet de l'annotation"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#annotationSaliency
+ec:annotationSaliency rdf:type owl:DatatypeProperty ;
+                      rdfs:range rdfs:Literal ;
+                      dcterms:description "Estimer la saillance d’une annotation."@fr ,
+                                          "To estimate the saliency of an Annotation."@en ;
+                      rdfs:label "Annotation saliency"@en ,
+                                 "Salience de l’annotation"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#artefactAvailability
+ec:artefactAvailability rdf:type owl:DatatypeProperty ;
+                        rdfs:range xsd:boolean ;
+                        dcterms:description "Pour signaler la disponibilité d’un Artefact."@fr ,
+                                            "To flag the availability of an Artefact."@en ;
+                        rdfs:label "Artefact availability flag"@en ,
+                                   "Indicateur de disponibilité d’artefact"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#artefactBoxHeight
+ec:artefactBoxHeight rdf:type owl:DatatypeProperty ;
+                     rdfs:range xsd:nonNegativeInteger ;
+                     dcterms:description "La hauteur de la boîte contenant l’artefact."@fr ,
+                                         "The height of the box containing the Artefact."@en ;
+                     rdfs:label "Artefact box height"@en ,
+                                "Hauteur de la boîte d’artefact"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#artefactBoxTopLeftCornerLineNumber
+ec:artefactBoxTopLeftCornerLineNumber rdf:type owl:DatatypeProperty ;
+                                      rdfs:range xsd:nonNegativeInteger ;
+                                      dcterms:description "Les coordonnées sur un axe vertical de la position du coin supérieur gauche de la boîte contenant l’artefact."@fr ,
+                                                          "The coordinates on a vertical axis of the position of the top left corner of the box containing the Artefact."@en ;
+                                      rdfs:label "Artefact box top left corner Y position"@en ,
+                                                 "Position Y du coin supérieur gauche de la boîte de l’artefact"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#artefactBoxTopLeftCornerPixelNumber
+ec:artefactBoxTopLeftCornerPixelNumber rdf:type owl:DatatypeProperty ;
+                                       rdfs:range xsd:nonNegativeInteger ;
+                                       dcterms:description "Les coordonnées sur un axe horizontal de la position du coin supérieur gauche de la boîte contenant l’artefact."@fr ,
+                                                           "The coordinates on an horizontal axis of the position of the top left corner of the box containing the Artefact."@en ;
+                                       rdfs:label "Artefact box top left corner X position"@en ,
+                                                  "Position X du coin supérieur gauche de la boîte de l'artefact"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#artefactBoxWidth
+ec:artefactBoxWidth rdf:type owl:DatatypeProperty ;
+                    rdfs:range xsd:nonNegativeInteger ;
+                    dcterms:description "La largeur de la boîte contenant l’artefact."@fr ,
+                                        "The width of the box containing the Artefact."@en ;
+                    rdfs:label "Artefact box width"@en ,
+                               "Largeur de la boîte d’artefact"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#artefactBrand
+ec:artefactBrand rdf:type owl:DatatypeProperty ;
+                 rdfs:range rdfs:Literal ;
+                 dcterms:description "La marque d’un artefact."@fr ,
+                                     "The brand of an artefact."@en ;
+                 rdfs:label "Artefact brand"@en ,
+                            "Marque de l’artefact"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#artefactColour
+ec:artefactColour rdf:type owl:DatatypeProperty ;
+                  rdfs:range rdfs:Literal ;
+                  dcterms:description "La couleur ou les couleurs d'un artefact."@fr ,
+                                      "The colour or colours of an artefact."@en ;
+                  rdfs:label "Artefact colour(s)"@en ,
+                             "Couleur(s) de l'artefact"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#artefactComment
+ec:artefactComment rdf:type owl:DatatypeProperty ;
+                   rdfs:range rdfs:Literal ;
+                   dcterms:description "A contextual comment about an Artefact."@en ,
+                                       "Un commentaire contextuel sur un artefact."@fr ;
+                   rdfs:label "Artefact comment"@en ,
+                              "Commentaire d’artefact"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#artefactModel
+ec:artefactModel rdf:type owl:DatatypeProperty ;
+                 rdfs:range rdfs:Literal ;
+                 dcterms:description "Le modèle associé à un Artefact."@fr ,
+                                     "The model associated with an Artefact."@en ;
+                 rdfs:label "Artefact model"@en ,
+                            "Modèle d’artefact"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#artefactPeriod
+ec:artefactPeriod rdf:type owl:DatatypeProperty ;
+                  rdfs:range rdfs:Literal ;
+                  dcterms:description "La période associée à un artefact."@fr ,
+                                      "The period associated with an Artefact."@en ;
+                  rdfs:label "Artefact period"@en ,
+                             "Période de l’artefact"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#artefactPriceAmount
+ec:artefactPriceAmount rdf:type owl:DatatypeProperty ;
+                       rdfs:range rdfs:Literal ;
+                       dcterms:description "Le montant du prix associé à un artefact."@fr ,
+                                           "The price amount associated with an Artefact."@en ;
+                       rdfs:label "Artefact price"@en ,
+                                  "Prix de l’artefact"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#artefactReference
+ec:artefactReference rdf:type owl:DatatypeProperty ;
+                     rdfs:range xsd:anyURI ;
+                     dcterms:description "A reference identifying the Artefact, expressed as a URI."@en ,
+                                         "Une référence identifiant l’Artefact, exprimée sous forme d’URI."@fr ;
+                     rdfs:label "Artefact reference"@en ,
+                                "Référence d’artefact"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#artefactStyle
+ec:artefactStyle rdf:type owl:DatatypeProperty ;
+                 rdfs:range rdfs:Literal ;
+                 dcterms:description "Le style associé à un Artefact."@fr ,
+                                     "The style associated with an Artefact."@en ;
+                 rdfs:label "Artefact style"@en ,
+                            "Style de l'artefact"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#artefactUsageHistory
+ec:artefactUsageHistory rdf:type owl:DatatypeProperty ;
+                        rdfs:range rdfs:Literal ;
+                        dcterms:description "Information about the usage history of an artefact."@en ,
+                                            "Informations sur l'historique d'utilisation d'un artefact."@fr ;
+                        rdfs:label "Artefact usage history"@en ,
+                                   "Historique d'utilisation de l'artefact"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#artefactWebsite
+ec:artefactWebsite rdf:type owl:DatatypeProperty ;
+                   rdfs:range xsd:anyURI ;
+                   dcterms:description "A website with more information about the artefact."@en ,
+                                       "Un site web contenant davantage d'informations sur l'artefact."@fr ;
+                   rdfs:label "Artefact website"@en ,
+                              "Site web de l’artefact"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#aspectRatio
+ec:aspectRatio rdf:type owl:DatatypeProperty ;
+               rdfs:range xsd:string ;
+               dcterms:description "Le rapport d’aspect associé à la ressource média ou à l’image."@fr ,
+                                   "The aspect ratio associated with the media resource or picture."@en ;
+               rdfs:label "Aspect ratio"@en ,
+                          "Rapport hauteur/largeur"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#assetValue
+ec:assetValue rdf:type owl:DatatypeProperty ;
+              dcterms:description "La valeur estimée ou réelle d’un actif."@fr ,
+                                  "The estimated or actual value of an asset."@en ;
+              rdfs:label "Asset value"@en ,
+                         "Valeur de l’actif"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#audienceAgeHigh
+ec:audienceAgeHigh rdf:type owl:DatatypeProperty ;
+                   dcterms:description "L’âge maximal d’un public."@fr ,
+                                       "The maximum age of an Audience."@en ;
+                   rdfs:label "Audience age high"@en ,
+                              "Âge maximal du public"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#audienceAgeLow
+ec:audienceAgeLow rdf:type owl:DatatypeProperty ;
+                  dcterms:description "L’âge minimum d’un public."@fr ,
+                                      "The minimum age of an Audience."@en ;
+                  rdfs:label "Audience age low"@en ,
+                             "Âge du public faible"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#audienceCount
+ec:audienceCount rdf:type owl:DatatypeProperty ;
+                 dcterms:description "La portée de l’audience en nombre ou en pourcentage."@fr ,
+                                     "The Audience reach in numbers or percent."@en ;
+                 rdfs:label "Audience number"@en ,
+                            "Nombre d’audience"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#audienceInterest
+ec:audienceInterest rdf:type owl:DatatypeProperty ;
+                    dcterms:description "Les points d’intérêt d’un public."@fr ,
+                                        "The points of interest of an Audience."@en ;
+                    rdfs:label "Audience interest"@en ,
+                               "Intérêt de l'audience"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#audioBitRate
+ec:audioBitRate rdf:type owl:DatatypeProperty ;
+                rdfs:range xsd:nonNegativeInteger ;
+                dcterms:description "Le débit binaire numérique du composant audio, exprimé sous forme d'entier non négatif."@fr ,
+                                    "The numerical bitrate of the audio component, expressed as a non-negative integer."@en ;
+                rdfs:label "Audio bitrate"@en ,
+                           "Débit binaire audio"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#audioBitRateMax
+ec:audioBitRateMax rdf:type owl:DatatypeProperty ;
+                   rdfs:range xsd:nonNegativeInteger ;
+                   dcterms:description "Le débit binaire audio maximal."@fr ,
+                                       "The max audio bitrate."@en ;
+                   rdfs:label "Audio bitrate max"@en ,
+                              "Bitrate audio max"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#audioBitRateMode
+ec:audioBitRateMode rdf:type owl:DatatypeProperty ;
+                    rdfs:range rdfs:Literal ;
+                    dcterms:description "Le mode de débit audio."@fr ,
+                                        "The audio bitrate mode."@en ;
+                    rdfs:label "Audio bitrate mode"@en ,
+                               "Mode de débit binaire audio"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#audioEncodingLevel
+ec:audioEncodingLevel rdf:type owl:DatatypeProperty ;
+                      rdfs:subPropertyOf ec:encodingLevel ;
+                      rdfs:range rdfs:Literal ;
+                      dcterms:description "Le niveau d’encodage tel que défini dans les spécifications."@fr ,
+                                          "The encoding level as defined in specifications."@en ;
+                      rdfs:label "Audio encoding level"@en ,
+                                 "Niveau d'encodage audio"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#audioEncodingProfile
+ec:audioEncodingProfile rdf:type owl:DatatypeProperty ;
+                        rdfs:subPropertyOf ec:encodingProfile ;
+                        rdfs:range rdfs:Literal ;
+                        dcterms:description "Le profil d’encodage tel que défini dans les spécifications."@fr ,
+                                            "The encoding profile as defined in specifications."@en ;
+                        rdfs:label "Audio encoding profile"@en ,
+                                   "Profil d’encodage audio"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#audioTrackConfiguration
+ec:audioTrackConfiguration rdf:type owl:DatatypeProperty ;
+                           rdfs:range rdfs:Literal ;
+                           dcterms:description "La configuration des pistes audio contenues dans la MediaResource."@fr ,
+                                               "The configuration of audio tracks contained in the MediaResource."@en ;
+                           rdfs:label "Audio track configuration"@en ,
+                                      "Configuration des pistes audio"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#audioTrackNumber
+ec:audioTrackNumber rdf:type owl:DatatypeProperty ;
+                    rdfs:range xsd:nonNegativeInteger ;
+                    dcterms:description "Le numéro de piste audio utilisé pour distinguer une piste d’une autre dans une ressource multimédia."@fr ,
+                                        "The audio track number used to distinguish one track from another in a media resource."@en ;
+                    rdfs:label "Audio track number"@en ,
+                               "Numéro de piste audio"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#auditReportResults
+ec:auditReportResults rdf:type owl:DatatypeProperty ;
+                      dcterms:description "Les résultats combinés d’un ou de plusieurs travaux d’audit."@fr ,
+                                          "The combined results of one or more audit jobs."@en ;
+                      rdfs:label "Audit report results"@en ,
+                                 "Résultats du rapport d'audit"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#awardCeremony
+ec:awardCeremony rdf:type owl:DatatypeProperty ;
+                 rdfs:range rdfs:Literal ;
+                 dcterms:description "Le nom de la cérémonie de remise du prix."@fr ,
+                                     "The award ceremony name."@en ;
+                 rdfs:label "Award ceremony"@en ,
+                            "Cérémonie de remise de prix"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#bitDepth
+ec:bitDepth rdf:type owl:DatatypeProperty ;
+            rdfs:range xsd:nonNegativeInteger ;
+            dcterms:description "La profondeur en bits à laquelle la ressource multimédia a été encodée."@fr ,
+                                "The bit depth at which the media resource has been encoded."@en ;
+            rdfs:label "Bit depth"@en ,
+                       "Profondeur de bits"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#bitRate
+ec:bitRate rdf:type owl:DatatypeProperty ;
+           rdfs:range xsd:nonNegativeInteger ;
+           dcterms:description "Le débit binaire auquel la MediaResource peut être lue, en bits par seconde. Utilisez le débit binaire actuel s’il est constant, ou le débit binaire moyen s’il est variable."@fr ,
+                               "The bitrate at which the MediaResource can be played, in bits per second. Use the current bitrate if constant, or the average bitrate if variable."@en ;
+           rdfs:label "Bit rate"@en ,
+                      "Débit binaire"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#bitRateMax
+ec:bitRateMax rdf:type owl:DatatypeProperty ;
+              rdfs:range xsd:nonNegativeInteger ;
+              dcterms:description "Le débit binaire maximal lorsqu'il est variable, en bits par seconde."@fr ,
+                                  "The maximum bitrate when variable, in bits per second."@en ;
+              rdfs:label "Débit binaire maximal"@fr ,
+                         "Maximum bitrate"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#bitRateMode
+ec:bitRateMode rdf:type owl:DatatypeProperty ;
+               rdfs:range rdfs:Literal ;
+               dcterms:description "A flag to indicate if the bit rate is fixed or variable."@en ,
+                                   "Indique si le débit binaire est fixe ou variable."@fr ;
+               rdfs:label "Bitrate mode"@en ,
+                          "Mode de débit binaire"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#bitRateOverall
+ec:bitRateOverall rdf:type owl:DatatypeProperty ;
+                  rdfs:range xsd:nonNegativeInteger ;
+                  dcterms:description "Le débit binaire global auquel la MediaResource peut être lue, en bits par seconde. Utilisez le débit binaire courant s’il est constant, et le débit binaire moyen s’il est variable."@fr ,
+                                      "The overall bitrate at which the MediaResource can be played, in bits per second. Use the current bitrate if constant, and the average bitrate if variable."@en ;
+                  rdfs:label "Débit binaire global"@fr ,
+                             "Overall bitrate"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#bookmark
+ec:bookmark rdf:type owl:DatatypeProperty ;
+            rdfs:subPropertyOf ec:contentDescription ;
+            rdfs:range rdfs:Literal ;
+            dcterms:description "A bookmark value associated with an editorial object."@en ,
+                                "Une valeur de signet associée à un objet éditorial."@fr ;
+            rdfs:label "Bookmark"@en ,
+                       "Signet"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#characterEndIndex
+ec:characterEndIndex rdf:type owl:DatatypeProperty ;
+                     rdfs:range xsd:integer ;
+                     dcterms:description "L’indice du dernier caractère de la portion de texte à laquelle l’annotation s’applique."@fr ,
+                                         "The end character index of the portion of text to which the annotation applies."@en ;
+                     rdfs:label "Annotation character start index"@en ,
+                                "Indice de début du caractère d’annotation"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#characterStartIndex
+ec:characterStartIndex rdf:type owl:DatatypeProperty ;
+                       rdfs:range xsd:integer ;
+                       dcterms:description "L’indice du caractère de début de la portion de texte à laquelle l’annotation s’applique."@fr ,
+                                           "The start character index of the portion of text to which the annotation applies."@en ;
+                       rdfs:label "Annotation text character start index"@en ,
+                                  "Indice de début du caractère du texte d’annotation"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#codecFamily
+ec:codecFamily rdf:type owl:DatatypeProperty ;
+               rdfs:range rdfs:Literal ;
+               dcterms:description "La famille de produits du codec."@fr ,
+                                   "The product family of the codec."@en ;
+               rdfs:label "Codec family"@en ,
+                          "Famille de codec"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#codecVersion
+ec:codecVersion rdf:type owl:DatatypeProperty ;
+                rdfs:range rdfs:Literal ;
+                dcterms:description "La version du codec."@fr ,
+                                    "The version of the codec."@en ;
+                rdfs:label "Codec version"@en ,
+                           "Version du codec"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#comments
+ec:comments rdf:type owl:DatatypeProperty ;
+            rdfs:subPropertyOf ec:contentDescription ;
+            rdfs:range rdfs:Literal ;
+            dcterms:description "A comment associated with the editorial object."@en ,
+                                "Un commentaire associé à l’objet éditorial."@fr ;
+            rdfs:label "Commentaires"@fr ,
+                       "Comments"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#consumptionDeviceBrand
+ec:consumptionDeviceBrand rdf:type owl:DatatypeProperty ;
+                          dcterms:description "La marque d’un ec:ConsumptionDevice."@fr ,
+                                              "The brand of a ConsumptionDevice."@en ;
+                          rdfs:label "Consumption device brand"@en ,
+                                     "Marque du dispositif de consommation"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#consumptionDeviceBrowser
+ec:consumptionDeviceBrowser rdf:type owl:DatatypeProperty ;
+                            dcterms:description "Le navigateur compatible avec un ec:ConsumptionDevice."@fr ,
+                                                "The browser compatible with a ConsumptionDevice."@en ;
+                            rdfs:label "Consumption device browser"@en ,
+                                       "Navigateur de dispositif de consommation"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#consumptionDeviceModel
+ec:consumptionDeviceModel rdf:type owl:DatatypeProperty ;
+                          dcterms:description "Le modèle d’un ConsumptionDevice."@fr ,
+                                              "The model of a ConsumptionDevice."@en ;
+                          rdfs:label "Consumption device model"@en ,
+                                     "Modèle du dispositif de consommation"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#consumptionDeviceOS
+ec:consumptionDeviceOS rdf:type owl:DatatypeProperty ;
+                       dcterms:description "Le système d’exploitation d’un ConsumptionDevice."@fr ,
+                                           "The operating system of a ConsumptionDevice."@en ;
+                       rdfs:label "Consumption device OS"@en ,
+                                  "Système d’exploitation du dispositif de consommation"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#consumptionLicenceText
+ec:consumptionLicenceText rdf:type owl:DatatypeProperty ;
+                          dcterms:description "Les conditions d’une ConsumptionLicence."@fr ,
+                                              "The terms of a ConsumptionLicence."@en ;
+                          rdfs:label "Consumption licence"@en ,
+                                     "Licence de consommation"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#contentDescription
+ec:contentDescription rdf:type owl:DatatypeProperty ;
+                      rdfs:range rdfs:Literal ;
+                      dcterms:description "Cela peut être spécialisé en utilisant des sous-propriétés, comme celles définies dans https://github.com/ebu/ebu_cs/blob/main/metadata/cs/ebu_DescriptionTypeCodeCS.xml, mises en œuvre à titre d’exemples tels que « summary » ou « script »."@fr ,
+                                          "This can be specialized by using sub-properties like defined in https://github.com/ebu/ebu_cs/blob/main/metadata/cs/ebu_DescriptionTypeCodeCS.xml implemented as examples such as 'summary' or 'script'."@en ;
+                      rdfs:isDefinedBy <dc:description> ;
+                      rdfs:label "Content description"@en ,
+                                 "Description du contenu"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#contractCostAmount
+ec:contractCostAmount rdf:type owl:DatatypeProperty ;
+                      dcterms:description "Le montant du ContractCost."@fr ,
+                                          "The amount of the ContractCost."@en ;
+                      rdfs:label "Cost amount"@en ,
+                                 "Montant du coût"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#costumeSizeInformation
+ec:costumeSizeInformation rdf:type owl:DatatypeProperty ;
+                          rdfs:range rdfs:Literal ;
+                          dcterms:description "Rassembler toutes les informations disponibles utiles pour déterminer la taille d’un costume."@fr ,
+                                              "To collect all information available useful to determine the size of a Costume."@en ;
+                          rdfs:label "Costume size information"@en ,
+                                     "Informations sur la taille du costume"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#costumeTexture
+ec:costumeTexture rdf:type owl:DatatypeProperty ;
+                  rdfs:range rdfs:Literal ;
+                  dcterms:description "Plage : une chaîne de caractères ou un code de Concept d’un vocabulaire, par exemple Getty. Permet de définir la texture d’un Costume."@fr ,
+                                      "Range: a string or a Concept code from a vocabulary, e.g. Getty To define the texture of a Costume."@en ;
+                  rdfs:label "Costume texture"@en ,
+                             "Texture de costume"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#day
+ec:day rdf:type owl:DatatypeProperty ;
+       rdfs:range xsd:integer ;
+       dcterms:description "Le composant jour d’une valeur de date ou de date-heure, exprimé comme un entier."@fr ,
+                           "The day component of a date or date-time value, expressed as an integer."@en ;
+       rdfs:label "Day"@en ,
+                  "Jour"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#description
+ec:description rdf:type owl:DatatypeProperty ;
+               rdfs:range rdfs:Literal ;
+               dcterms:description "A summary of the resource."@en ,
+                                   "Un résumé de la ressource."@fr ;
+               rdfs:label "Description"@en ,
+                          "Description"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#dimensions
+ec:dimensions rdf:type owl:DatatypeProperty ;
+              rdfs:range rdfs:Literal ;
+              dcterms:description "Describes the physical dimensions of a MediaResource, with units of measure concatenated to become part of the value."@en ,
+                                  "Décrit les dimensions physiques d’une MediaResource, avec les unités de mesure concaténées pour faire partie de la valeur."@fr ;
+              rdfs:label "Dimensions"@en ,
+                         "Dimensions"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#displayOrder
+ec:displayOrder rdf:type owl:DatatypeProperty ;
+                rdfs:range rdfs:Literal ;
+                dcterms:description "L'ordre dans lequel un Agent apparaît dans une scène."@fr ,
+                                    "The order in which an Agent appears in a scene."@en ;
+                rdfs:label "Display order"@en ,
+                           "Ordre d’affichage"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#editUnit
+ec:editUnit rdf:type owl:DatatypeProperty ;
+            rdfs:range xsd:long ;
+            dcterms:description "L’unité de montage est par exemple l’inverse du taux d’échantillonnage audio ou du taux d’images vidéo."@fr ,
+                                "The edit unit is e.g. the inverse of the audio sample rate or video frame rate."@en ;
+            rdfs:label "Edit unit"@en ,
+                       "Unité de montage"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#editUnitNumbering
+ec:editUnitNumbering rdf:type owl:DatatypeProperty ;
+                     rdfs:range xsd:long ;
+                     dcterms:description "Temps exprimé comme le nombre d’unités de montage ou d’échantillons."@fr ,
+                                         "Time expressed as the number of edit units or samples."@en ;
+                     rdfs:label "Edit unit numbering"@en ,
+                                "Numérotation des unités de montage"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#education
+ec:education rdf:type owl:DatatypeProperty ;
+             rdfs:range rdfs:Literal ;
+             dcterms:description "Information about a person's education."@en ,
+                                 "Informations sur l’éducation d’une personne."@fr ;
+             rdfs:label "Education"@en ,
+                        "Éducation"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#encodingLevel
+ec:encodingLevel rdf:type owl:DatatypeProperty ;
+                 rdfs:range rdfs:Literal ;
+                 dcterms:description "Le niveau d’encodage associé à une ressource média."@fr ,
+                                     "The encoding level associated with a media resource."@en ;
+                 rdfs:label "Encoding level"@en ,
+                            "Niveau d'encodage"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#encodingProfile
+ec:encodingProfile rdf:type owl:DatatypeProperty ;
+                   rdfs:range rdfs:Literal ;
+                   dcterms:description "Le profil d’encodage tel que défini dans les spécifications."@fr ,
+                                       "The encoding profile as defined in specifications."@en ;
+                   rdfs:label "Encoding profile"@en ,
+                              "Profil d'encodage"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#episodeNumber
+ec:episodeNumber rdf:type owl:DatatypeProperty ;
+                 rdfs:range xsd:integer ;
+                 dcterms:description "Le numéro entier d’épisode attribué à un Programme."@fr ,
+                                     "The integer episode number assigned to a Programme."@en ;
+                 rdfs:label "Episode number"@en ,
+                            "Numéro d’épisode"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#episodeNumberInSeason
+ec:episodeNumberInSeason rdf:type owl:DatatypeProperty ;
+                         rdfs:range xsd:integer ;
+                         dcterms:description "Le numéro de l’épisode dans une saison."@fr ,
+                                             "The Episode Number in a season."@en ;
+                         rdfs:label "Episode number in season"@en ,
+                                    "Numéro d’épisode dans la saison"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#episodeNumberInSerial
+ec:episodeNumberInSerial rdf:type owl:DatatypeProperty ;
+                         rdfs:range xsd:integer ;
+                         dcterms:description "An integer giving the episode number of a programme within a serial."@en ,
+                                             "Un entier indiquant le numéro d’épisode d’un programme au sein d’un serial."@fr ;
+                         rdfs:label "Episode number of serial"@en ,
+                                    "Numéro d'épisode du serial"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#episodeNumberInSeries
+ec:episodeNumberInSeries rdf:type owl:DatatypeProperty ;
+                         rdfs:range xsd:integer ;
+                         dcterms:description "Le numéro d’épisode dans une série."@fr ,
+                                             "The Episode Number in a series."@en ;
+                         rdfs:label "Episode number in series"@en ,
+                                    "Numéro d'épisode dans la série"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#equivalentTime
+ec:equivalentTime rdf:type owl:DatatypeProperty ;
+                  rdfs:range xsd:float ;
+                  dc:description "Notation of time in seconds compares different ways to denote time, like timecode or sample count."@en ;
+                  dcterms:description "A numeric value indicating the equivalent time for a timeline point."@en ,
+                                      "Une valeur numérique indiquant le temps équivalent pour un point de chronologie."@fr ;
+                  rdfs:label "Equivalent time"@en ,
+                             "Temps équivalent"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#familyInformation
+ec:familyInformation rdf:type owl:DatatypeProperty ;
+                     rdfs:range rdfs:Literal ;
+                     dcterms:description "Information about a person's family."@en ,
+                                         "Informations sur la famille d’une personne."@fr ;
+                     rdfs:label "Family information"@en ,
+                                "Informations familiales"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#familyName
+ec:familyName rdf:type owl:DatatypeProperty ;
+              rdfs:range rdfs:Literal ;
+              dcterms:description "Le nom de famille d’une personne."@fr ,
+                                  "The family name of a Person."@en ;
+              rdfs:label "Family name"@en ,
+                         "Nom de famille"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#fileName
+ec:fileName rdf:type owl:DatatypeProperty ,
+                     owl:FunctionalProperty ;
+            rdfs:range xsd:string ;
+            dcterms:description "Le nom du fichier contenant la ressource."@fr ,
+                                "The name of the file containing the Resource."@en ;
+            rdfs:label "File name"@en ,
+                       "Nom du fichier"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#fileSize
+ec:fileSize rdf:type owl:DatatypeProperty ;
+            rdfs:range xsd:nonNegativeInteger ;
+            dcterms:description "Fournit la taille d’une Resource en octets."@fr ,
+                                "Provides the size of a Resource in bytes."@en ;
+            rdfs:label "File size"@en ,
+                       "Taille du fichier"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#firstShowing
+ec:firstShowing rdf:type owl:DatatypeProperty ,
+                         owl:FunctionalProperty ;
+                rdfs:range xsd:boolean ;
+                dcterms:description "Indiquer qu’il s’agit d’un événement de publication en première diffusion."@fr ,
+                                    "To flag this is a first showing PublicationEvent."@en ;
+                rdfs:label "First showing flag"@en ,
+                           "Indicateur de première diffusion"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#firstShowingThisService
+ec:firstShowingThisService rdf:type owl:DatatypeProperty ,
+                                    owl:FunctionalProperty ;
+                           rdfs:range xsd:boolean ;
+                           dcterms:description "Pour signaler qu’il s’agit d’un PublicationEvent de première diffusion sur ce service."@fr ,
+                                               "To flag this is a first showing PublicationEvent on this service."@en ;
+                           rdfs:label "First showing on service flag"@en ,
+                                      "Indicateur de première diffusion sur service"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#folksonomy
+ec:folksonomy rdf:type owl:DatatypeProperty ;
+              rdfs:range rdfs:Literal ;
+              dcterms:description "Fournit une description, un tag ou une étiquette générés par les utilisateurs ou le public pour le contenu de la ressource."@fr ,
+                                  "Provides a user/audience-generated description, tag, or label for resource content."@en ;
+              rdfs:label "Folksonomie"@fr ,
+                         "Folksonomy"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#foodCategory
+ec:foodCategory rdf:type owl:DatatypeProperty ;
+                rdfs:range rdfs:Literal ;
+                dcterms:description "A category of food."@en ,
+                                    "Une catégorie d’aliments."@fr ;
+                rdfs:label "Catégorie alimentaire"@fr ,
+                           "Food category"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#foodIngredient
+ec:foodIngredient rdf:type owl:DatatypeProperty ;
+                  rdfs:range rdfs:Literal ;
+                  dcterms:description "Les ingrédients alimentaires ou les aliments."@fr ,
+                                      "The Food ingredients or Food items."@en ;
+                  rdfs:label "Food ingredient"@en ,
+                             "Ingrédient alimentaire"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#formatId
+ec:formatId rdf:type owl:DatatypeProperty ;
+            rdfs:range [ rdf:type rdfs:Datatype ;
+                         owl:unionOf ( xsd:anyURI
+                                       xsd:string
+                                     )
+                       ] ;
+            dcterms:description "An Id attributed to a Format."@en ,
+                                "Un identifiant attribué à un format."@fr ;
+            rdfs:label "Format id"@en ,
+                       "Id de format"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#frameHeight
+ec:frameHeight rdf:type owl:DatatypeProperty ;
+               rdfs:subPropertyOf ec:height ;
+               rdfs:range xsd:integer ;
+               dcterms:description "La hauteur d'une image vidéo."@fr ,
+                                   "The height of a video frame."@en ;
+               rdfs:label "Frame height"@en ,
+                          "Hauteur de cadre"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#frameHeightUnit
+ec:frameHeightUnit rdf:type owl:DatatypeProperty ;
+                   rdfs:subPropertyOf ec:heightUnit ;
+                   rdfs:range rdfs:Literal ;
+                   dcterms:description "L’unité utilisée pour mesurer la hauteur d’une image."@fr ,
+                                       "The unit used to measure the height of a frame."@en ;
+                   rdfs:label "Frame height unit"@en ,
+                              "Unité de hauteur de cadre"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#frameRate
+ec:frameRate rdf:type owl:DatatypeProperty ;
+             rdfs:range rdfs:Literal ;
+             dcterms:description "L’unité utilisée pour exprimer la fréquence d’image d’une MediaResource en images/seconde."@fr ,
+                                 "The unit used to express the frame rate of a MediaResource in frames/second."@en ;
+             rdfs:label "Frame rate"@en ,
+                        "Fréquence d'images"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#frameSizeUnit
+ec:frameSizeUnit rdf:type owl:DatatypeProperty ;
+                 rdfs:range rdfs:Literal ;
+                 dcterms:description "L’unité utilisée pour exprimer la largeur ou la hauteur de l’image. L’unité par défaut est « pixel »."@fr ,
+                                     "The unit used to express the frame width or height. The unit by default is 'pixel'."@en ;
+                 rdfs:label "Frame size unit"@en ,
+                            "Unité de taille d’image"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#frameWidth
+ec:frameWidth rdf:type owl:DatatypeProperty ;
+              rdfs:subPropertyOf ec:width ;
+              rdfs:range xsd:integer ;
+              dcterms:description "La largeur d’une image vidéo."@fr ,
+                                  "The width of a video frame."@en ;
+              rdfs:label "Frame width"@en ,
+                         "Largeur de cadre"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#frameWidthUnit
+ec:frameWidthUnit rdf:type owl:DatatypeProperty ;
+                  rdfs:subPropertyOf ec:widthUnit ;
+                  rdfs:range rdfs:Literal ;
+                  dcterms:description "L’unité utilisée pour mesurer la largeur d’une image."@fr ,
+                                      "The unit used to measure the width of a frame."@en ;
+                  rdfs:label "Frame width unit"@en ,
+                             "Unité de largeur d'image"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#free
+ec:free rdf:type owl:DatatypeProperty ,
+                 owl:FunctionalProperty ;
+        rdfs:range xsd:boolean ;
+        dcterms:description "A flag to indicate that the access to the PublicationEvent is 'free'."@en ,
+                            "Indique que l’accès à l’événement de publication est « gratuit »."@fr ;
+        rdfs:label "Accès gratuit"@fr ,
+                   "Free access"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#gender
+ec:gender rdf:type owl:DatatypeProperty ;
+          rdfs:range rdfs:Literal ;
+          dcterms:description "Le genre d’une Personne, par exemple masculin ou féminin."@fr ,
+                              "The gender of a Person e.g. male or female."@en ;
+          rdfs:label "Gender"@en ,
+                     "Sexe"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#givenName
+ec:givenName rdf:type owl:DatatypeProperty ;
+             rdfs:range rdfs:Literal ;
+             dcterms:description "Le prénom d’une personne."@fr ,
+                                 "The given name of a Person."@en ;
+             rdfs:label "Given name"@en ,
+                        "Prénom"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hashValue
+ec:hashValue rdf:type owl:DatatypeProperty ;
+             rdfs:range xsd:string ;
+             dcterms:description "La valeur de hachage associée à une Resource. Il existe différentes méthodes et algorithmes pour calculer des valeurs de hachage, qui peuvent être définis comme des sous-propriétés."@fr ,
+                                 "The hash value associated with a Resource. There are different methods / algorithms to calculate hash values, which can be defined as sub-properties."@en ;
+             rdfs:label "Code de hachage"@fr ,
+                        "Hash code"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#height
+ec:height rdf:type owl:DatatypeProperty ;
+          rdfs:range xsd:integer ;
+          dcterms:description "La hauteur d’un, par exemple, cadre vidéo, généralement exprimée en nombre de lignes, ou la hauteur d’une image/photo exprimée en millimètres, ou autre."@fr ,
+                              "The height of e.g. a video frame typically expressed as a number of lines or the height of a picture/image expressed in millimeters or else."@en ;
+          rdfs:label "Hauteur"@fr ,
+                     "Height"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#heightUnit
+ec:heightUnit rdf:type owl:DatatypeProperty ;
+              rdfs:range rdfs:Literal ;
+              dcterms:description "L’unité utilisée pour exprimer la hauteur."@fr ,
+                                  "The unit used to express height."@en ;
+              rdfs:label "Height unit"@en ,
+                         "Unité de hauteur"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#highlights
+ec:highlights rdf:type owl:DatatypeProperty ;
+              rdfs:subPropertyOf ec:contentDescription ;
+              rdfs:range rdfs:Literal ;
+              dcterms:description "Fournit des points saillants pour un objet éditorial sous forme de description concise du contenu."@fr ,
+                                  "Provides highlights for an editorial object as a concise content description."@en ;
+              rdfs:label "Highlights"@en ,
+                         "Points forts"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#hobbies
+ec:hobbies rdf:type owl:DatatypeProperty ;
+           rdfs:range rdfs:Literal ;
+           dcterms:description "Les loisirs d’une personne."@fr ,
+                               "The hobbies of a Person."@en ;
+           rdfs:label "Hobbies"@en ,
+                      "Passe-temps"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#iFrameSize
+ec:iFrameSize rdf:type owl:DatatypeProperty ;
+              rdfs:range xsd:int ;
+              dcterms:description "La distance entre 2 I-frames, également appelée taille du GOP."@fr ,
+                                  "The distance between 2 I-frames also known as the gop size."@en ;
+              rdfs:label "I-frame/GOP size"@en ,
+                         "Taille de l’I-frame/GOP"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#identifierValue
+ec:identifierValue rdf:type owl:DatatypeProperty ;
+                   rdfs:range rdfs:Literal ;
+                   dcterms:description "La valeur associée à un identifiant. Elle peut être une chaîne ou une anyURI."@fr ,
+                                       "The value associated with an identifier. It may be a string or anyURI."@en ;
+                   rdfs:label "Identifier value"@en ,
+                              "Valeur d'identifiant"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#inchesPerSecond
+ec:inchesPerSecond rdf:type owl:DatatypeProperty ;
+                   rdfs:subPropertyOf ec:playbackSpeed ;
+                   rdfs:range xsd:double ;
+                   dcterms:description "Identifie le nombre de pouces par seconde auquel une bande audio analogique doit être lue pour une consommation humaine."@fr ,
+                                       "Identifies the inches per second at which an analog audio tape should be played back for human consumption."@en ;
+                   rdfs:label "Inches per second"@en ,
+                              "Pouces par seconde"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#internetConnectivity
+ec:internetConnectivity rdf:type owl:DatatypeProperty ,
+                                 owl:FunctionalProperty ;
+                        dcterms:description "Indicates whether the service requires Internet connectivity."@en ,
+                                            "Indique si le service nécessite une connexion Internet."@fr ;
+                        rdfs:label "Connectivité Internet"@fr ,
+                                   "Internet connectivity"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#isoDuration
+ec:isoDuration rdf:type owl:DatatypeProperty ;
+               rdfs:range xsd:string ;
+               dcterms:description "A duration expressed as a string formatted as ISO8601 ie PT3M23S."@en ,
+                                   "Une durée exprimée sous forme de chaîne au format ISO 8601, par exemple PT3M23S."@fr ;
+               rdfs:label "Durée ISO"@fr ,
+                          "ISO duration"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#lineNumber
+ec:lineNumber rdf:type owl:DatatypeProperty ;
+              rdfs:range xsd:integer ;
+              dcterms:description "Le numéro de la ligne sur laquelle les données auxiliaires sont transportées dans le domaine numérique."@fr ,
+                                  "The number of the line on which ancillary data is carried in the digital domain."@en ;
+              rdfs:label "Line number"@en ,
+                         "Numéro de ligne"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#live
+ec:live rdf:type owl:DatatypeProperty ,
+                 owl:FunctionalProperty ;
+        rdfs:range xsd:boolean ;
+        dcterms:description "A flag to signal that content is live."@en ,
+                            "Drapeau indiquant que le contenu est en direct."@fr ;
+        rdfs:label "En direct"@fr ,
+                   "Live"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#locationAddressApartmentNumber
+ec:locationAddressApartmentNumber rdf:type owl:DatatypeProperty ;
+                                  rdfs:range xsd:string ;
+                                  dcterms:description "Le numéro identifiant un appartement dans une maison."@fr ,
+                                                      "The number identifying an apartment in a house."@en ;
+                                  rdfs:label "Apartment number"@en ,
+                                             "Numéro d'appartement"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#locationAddressArea
+ec:locationAddressArea rdf:type owl:DatatypeProperty ;
+                       rdfs:range rdfs:Literal ;
+                       dcterms:description "La partie de l’adresse correspondant à la zone associée à un lieu."@fr ,
+                                           "The area part of an address associated with a location."@en ;
+                       rdfs:label "Area"@en ,
+                                  "Zone"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#locationAddressCountry
+ec:locationAddressCountry rdf:type owl:DatatypeProperty ;
+                          rdfs:range rdfs:Literal ;
+                          dcterms:description "Le nom du pays ou le code pays pour l’emplacement."@fr ,
+                                              "The country name or country code for the location."@en ;
+                          rdfs:label "Country"@en ,
+                                     "Pays"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#locationAddressHouseNumber
+ec:locationAddressHouseNumber rdf:type owl:DatatypeProperty ;
+                              rdfs:range xsd:string ;
+                              dcterms:description "Le numéro attribué à la maison ou à une entrée dans une rue."@fr ,
+                                                  "The number given to the house or an entrance in a street."@en ;
+                              rdfs:label "House number"@en ,
+                                         "Numéro de maison"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#locationAddressMunicipality
+ec:locationAddressMunicipality rdf:type owl:DatatypeProperty ;
+                               rdfs:range rdfs:Literal ;
+                               dcterms:description "Fournit le nom d’une ville, d’un village, etc."@fr ,
+                                                   "Provides the name of a city, village, etc."@en ;
+                               rdfs:label "Municipality"@en ,
+                                          "Municipalité"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#locationAddressPostalCode
+ec:locationAddressPostalCode rdf:type owl:DatatypeProperty ;
+                             rdfs:range rdfs:Literal ;
+                             dcterms:description "Le code postal associé à un lieu."@fr ,
+                                                 "The postal code associated with a location."@en ;
+                             rdfs:label "Code postal"@fr ,
+                                        "Postal code"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#locationAddressStreetName
+ec:locationAddressStreetName rdf:type owl:DatatypeProperty ;
+                             rdfs:range rdfs:Literal ;
+                             dcterms:description "Le nom de la rue, de la place ou de l’îlot dans une adresse."@fr ,
+                                                 "The name of the street, square or block in an address."@en ;
+                             rdfs:label "Nom de rue"@fr ,
+                                        "Street name"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#locationAltitude
+ec:locationAltitude rdf:type owl:DatatypeProperty ;
+                    rdfs:range xsd:float ;
+                    dcterms:description "L'altitude d'une Location en mètres."@fr ,
+                                        "The altitude of a Location in meters."@en ;
+                    rdfs:label "Altitude"@en ,
+                               "Altitude"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#locationCoordinateSystemName
+ec:locationCoordinateSystemName rdf:type owl:DatatypeProperty ;
+                                rdfs:range rdfs:Literal ;
+                                dcterms:description "Le nom du système de coordonnées GPS utilisé pour un emplacement."@fr ,
+                                                    "The name of the GPS coordinate system used for a location."@en ;
+                                rdfs:label "Coordinate system"@en ,
+                                           "Système de coordonnées"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#locationLatitude
+ec:locationLatitude rdf:type owl:DatatypeProperty ;
+                    rdfs:range xsd:float ;
+                    dcterms:description "La latitude de l'emplacement."@fr ,
+                                        "The latitude of the Location."@en ;
+                    rdfs:label "Latitude"@en ,
+                               "Latitude"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#locationLongitude
+ec:locationLongitude rdf:type owl:DatatypeProperty ;
+                     rdfs:range xsd:float ;
+                     dcterms:description "La longitude de la Location."@fr ,
+                                         "The longitude of the Location."@en ;
+                     rdfs:label "Longitude"@en ,
+                                "Longitude"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#locatorTargetInformation
+ec:locatorTargetInformation rdf:type owl:DatatypeProperty ;
+                            rdfs:range rdfs:Literal ;
+                            dcterms:description "Information on the locator target."@en ,
+                                                "Informations sur la cible du localisateur."@fr ;
+                            rdfs:label "Informations sur la cible du localisateur"@fr ,
+                                       "Locator target information"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#log
+ec:log rdf:type owl:DatatypeProperty ;
+       rdfs:subPropertyOf ec:contentDescription ;
+       rdfs:range rdfs:Literal ;
+       dcterms:description "Consigner tout le contenu selon des règles et critères prédéfinis, sous forme d’une séquence neutre de descriptions textuelles (éventuellement horodatées)."@fr ,
+                           "To log everything in the content following predefined rules and criteria, as a neutral sequence of (possibly timed) textual descriptions."@en ;
+       rdfs:label "Journal"@fr ,
+                  "Log"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#loudnessIntegratedLoudness
+ec:loudnessIntegratedLoudness rdf:type owl:DatatypeProperty ;
+                              rdfs:range xsd:float ;
+                              dcterms:description "La valeur de la loudness intégrée mesurée au niveau de AudioProgramme ou de AudioContent."@fr ,
+                                                  "The value for integrated loudness measured at AudioProgramme or AudioContent level."@en ;
+                              rdfs:label "Integrated loudness"@en ,
+                                         "Loudness intégré"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#loudnessMaxMomentary
+ec:loudnessMaxMomentary rdf:type owl:DatatypeProperty ;
+                        rdfs:range xsd:float ;
+                        dcterms:description "La valeur du maximum de loudness momentané mesurée au niveau d’AudioProgramme ou d’AudioContent."@fr ,
+                                            "The value for maximum momentary loudness measured at AudioProgramme or AudioContent level."@en ;
+                        rdfs:label "Loudness maximale momentanée"@fr ,
+                                   "Max momentary loudness"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#loudnessMaxShortTerm
+ec:loudnessMaxShortTerm rdf:type owl:DatatypeProperty ;
+                        rdfs:range xsd:float ;
+                        dcterms:description "La valeur du maximum de l’intensité sonore à court terme mesurée au niveau d’AudioProgramme ou d’AudioContent."@fr ,
+                                            "The value for maximum max short term loudness measured at AudioProgramme or AudioContent level."@en ;
+                        rdfs:label "Max short term loudness"@en ,
+                                   "Niveau sonore maximal à court terme"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#loudnessMaxTruepeak
+ec:loudnessMaxTruepeak rdf:type owl:DatatypeProperty ;
+                       rdfs:range xsd:float ;
+                       dcterms:description "La valeur de la loudness maximale en true peak mesurée au niveau de AudioProgramme ou de AudioContent."@fr ,
+                                           "The value for maximum true peak loudness measured at AudioProgramme or AudioContent level."@en ;
+                       rdfs:label "Loudness crête maximale vraie"@fr ,
+                                  "Max true peak loudness"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#loudnessMethod
+ec:loudnessMethod rdf:type owl:DatatypeProperty ;
+                  rdfs:range rdfs:Literal ;
+                  dcterms:description "La méthode de mesure de la sonie au niveau d’AudioProgramme ou d’AudioContent."@fr ,
+                                      "The method for loudness measurement at AudioProgramme or AudioContent level."@en ;
+                  rdfs:label "Loudness method"@en ,
+                             "Méthode de loudness"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#loudnessRange
+ec:loudnessRange rdf:type owl:DatatypeProperty ;
+                 rdfs:range xsd:float ;
+                 dcterms:description "La plage de loudness mesurée au niveau d’AudioProgramme ou d’AudioContent."@fr ,
+                                     "The loudness range measured at AudioProgramme or AudioContent level."@en ;
+                 rdfs:label "Loudness range"@en ,
+                            "Plage de loudness"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#maritalStatus
+ec:maritalStatus rdf:type owl:DatatypeProperty ;
+                 rdfs:range rdfs:Literal ;
+                 dcterms:description "L'état matrimonial associé à une personne."@fr ,
+                                     "The marital status associated with a person."@en ;
+                 rdfs:label "Marital status"@en ,
+                            "État matrimonial"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#measureValue
+ec:measureValue rdf:type owl:DatatypeProperty ;
+                dcterms:description "La valeur de la mesure sous forme de littéral."@fr ,
+                                    "The value of the Measure as a literal."@en ;
+                rdfs:label "Measure value"@en ,
+                           "Valeur de mesure"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#measureValueMax
+ec:measureValueMax rdf:type owl:DatatypeProperty ;
+                   dcterms:description "La valeur maximale d’une Measure, le cas échéant."@fr ,
+                                       "The maximum value of a Measure when applicable."@en ;
+                   rdfs:label "Measure maximum value"@en ,
+                              "Valeur maximale de mesure"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#measureValueMin
+ec:measureValueMin rdf:type owl:DatatypeProperty ;
+                   dcterms:description "La valeur minimale d’une Measure, le cas échéant."@fr ,
+                                       "The minimum value of a Measure, when applicable."@en ;
+                   rdfs:label "Measure minimum value"@en ,
+                              "Valeur minimale de mesure"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#microphone
+ec:microphone rdf:type owl:DatatypeProperty ,
+                       owl:FunctionalProperty ;
+              dcterms:description "Indicates whether the consumption device profile requires a microphone."@en ,
+                                  "Indique si le profil du périphérique de consommation nécessite un microphone."@fr ;
+              rdfs:label "Microphone"@en ,
+                         "Microphone"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#midRollAdAllowed
+ec:midRollAdAllowed rdf:type owl:DatatypeProperty ,
+                             owl:FunctionalProperty ;
+                    rdfs:range xsd:boolean ;
+                    dcterms:description "A flag to indicate whether it is allowed to insert ad breaks in mid-roll."@en ,
+                                        "Un indicateur permettant de préciser s’il est autorisé d’insérer des coupures publicitaires en milieu de diffusion."@fr ;
+                    rdfs:label "Autorisation des publicités en mid-roll"@fr ,
+                               "Midroll ad allowed"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#middleName
+ec:middleName rdf:type owl:DatatypeProperty ;
+              rdfs:range rdfs:Literal ;
+              dcterms:description "One or more middle names associated with a Person."@en ,
+                                  "Un ou plusieurs deuxièmes prénoms associés à une Personne."@fr ;
+              rdfs:label "Deuxième prénom"@fr ,
+                         "Middle name"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#month
+ec:month rdf:type owl:DatatypeProperty ;
+         rdfs:range xsd:integer ;
+         dcterms:description "An integer representing the month of the year."@en ,
+                             "Un entier représentant le mois de l’année."@fr ;
+         rdfs:label "Mois"@fr ,
+                    "Month"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#name
+ec:name rdf:type owl:DatatypeProperty ;
+        rdfs:range rdfs:Literal ;
+        dcterms:description "La désignation de la ressource."@fr ,
+                            "The designation of the resource."@en ;
+        rdfs:label "Name"@en ,
+                   "Nom"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#nickName
+ec:nickName rdf:type owl:DatatypeProperty ;
+            rdfs:range rdfs:Literal ;
+            dcterms:description "Le surnom d'une Personne."@fr ,
+                                "The nickname of a Person."@en ;
+            rdfs:label "Nickname"@en ,
+                       "Surnom"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#noiseFilter
+ec:noiseFilter rdf:type owl:DatatypeProperty ,
+                        owl:FunctionalProperty ;
+               rdfs:range xsd:boolean ;
+               dcterms:description "A flag to signal that a noise filter has been used."@en ,
+                                   "Un indicateur signalant qu’un filtre de bruit a été utilisé."@fr ;
+               rdfs:label "Filtre de bruit"@fr ,
+                          "Noise filter"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#notRated
+ec:notRated rdf:type owl:DatatypeProperty ;
+            rdfs:range xsd:boolean ;
+            dcterms:description "A flag to indicate that the EditorialObject has not been rated."@en ,
+                                "Un indicateur permettant de signaler que l’EditorialObject n’a pas été noté."@fr ;
+            rdfs:label "Non évalué"@fr ,
+                       "Not rated"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#occupation
+ec:occupation rdf:type owl:DatatypeProperty ;
+              rdfs:range rdfs:Literal ;
+              dcterms:description "Le nom du métier ou de la profession d’une personne."@fr ,
+                                  "The job / occupation name of a Person."@en ;
+              rdfs:label "Occupation"@en ,
+                         "Occupation"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#officeEmailAddress
+ec:officeEmailAddress rdf:type owl:DatatypeProperty ;
+                      rdfs:subPropertyOf ec:agentEmailAddress ;
+                      rdfs:range xsd:string ;
+                      dcterms:description "L’adresse e-mail professionnelle ou de bureau d’une Personne."@fr ,
+                                          "The professional or office email address of a Person."@en ;
+                      rdfs:label "Courriel professionnel"@fr ,
+                                 "Office email"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#officeMobileTelephoneNumber
+ec:officeMobileTelephoneNumber rdf:type owl:DatatypeProperty ;
+                               rdfs:subPropertyOf ec:agentTelephoneNumber ;
+                               rdfs:range xsd:string ;
+                               dcterms:description "Le numéro de téléphone mobile professionnel d’une personne."@fr ,
+                                                   "The office mobile telephone number of a Person."@en ;
+                               rdfs:label "Telephone (office)"@en ,
+                                          "Téléphone (bureau)"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#officeTelephoneNumber
+ec:officeTelephoneNumber rdf:type owl:DatatypeProperty ;
+                         rdfs:subPropertyOf ec:agentTelephoneNumber ;
+                         rdfs:range xsd:string ;
+                         dcterms:description "Le numéro de téléphone professionnel d’une Personne."@fr ,
+                                             "The office telephone number of a Person."@en ;
+                         rdfs:label "Telephone (office)"@en ,
+                                    "Téléphone (bureau)"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#onStagePositionCoordinateX
+ec:onStagePositionCoordinateX rdf:type owl:DatatypeProperty ;
+                              dcterms:description "Les coordonnées x dans un espace de coordonnées spatiales à trois axes."@fr ,
+                                                  "The x coordinates within a 3 axis spatial coordinates space."@en ;
+                              rdfs:label "Coordonnée X"@fr ,
+                                         "X coordinate"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#onStagePositionCoordinateY
+ec:onStagePositionCoordinateY rdf:type owl:DatatypeProperty ;
+                              dcterms:description "Les coordonnées y dans un espace de coordonnées spatiales à trois axes."@fr ,
+                                                  "The y coordinates within a 3 axis spatial coordinates space."@en ;
+                              rdfs:label "Coordonnée Y"@fr ,
+                                         "Y coordinate"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#onStagePositionCoordinateZ
+ec:onStagePositionCoordinateZ rdf:type owl:DatatypeProperty ;
+                              dcterms:description "Les coordonnées z dans un espace de coordonnées spatiales à 3 axes."@fr ,
+                                                  "The z coordinates within a 3 axis spatial coordinates space."@en ;
+                              rdfs:label "Coordonnée Z"@fr ,
+                                         "Z coordinate"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#onStagePositionCoordinatesReferencePoint
+ec:onStagePositionCoordinatesReferencePoint rdf:type owl:DatatypeProperty ;
+                                            dcterms:description "Le point de référence utilisé pour définir un ensemble de coordonnées pour une position sur scène."@fr ,
+                                                                "The reference point used to define a set of coordinates for a position on stage."@en ;
+                                            rdfs:label "On stage position coordinates reference point"@en ,
+                                                       "Point de référence des coordonnées de position sur scène"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#orderedFlag
+ec:orderedFlag rdf:type owl:DatatypeProperty ,
+                        owl:FunctionalProperty ;
+               rdfs:range xsd:boolean ;
+               dcterms:description "A flag to indicate that a EditorialObject is member of an ordered group or is an ordered group (e.g. Series)."@en ,
+                                   "Indique qu’un EditorialObject est membre d’un groupe ordonné ou qu’il constitue un groupe ordonné (par exemple une série)."@fr ;
+               rdfs:label "Ordered"@en ,
+                          "Ordonné"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#orientation
+ec:orientation rdf:type owl:DatatypeProperty ;
+               rdfs:range rdfs:Literal ;
+               dcterms:description "L’orientation d’un Document ou d’une Image, c’est-à-dire paysage ou portrait."@fr ,
+                                   "The orientation of a Document or an Image i.e. landscape or portrait."@en ;
+               rdfs:label "Orientation"@en ,
+                          "Orientation"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#packageByteSize
+ec:packageByteSize rdf:type owl:DatatypeProperty ;
+                   rdfs:range xsd:long ;
+                   dcterms:description "La taille d’un paquet multimédia en octets."@fr ,
+                                       "The size of a media package in Bytes."@en ;
+                   rdfs:label "Package size (in bytes)"@en ,
+                              "Taille du paquet (en octets)"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#packageName
+ec:packageName rdf:type owl:DatatypeProperty ;
+               rdfs:range rdfs:Literal ;
+               dcterms:description "Le nom d’un paquet média en octets."@fr ,
+                                   "The name of a media package in Bytes."@en ;
+               rdfs:label "Nom du package"@fr ,
+                          "Package name"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#partTotalNumber
+ec:partTotalNumber rdf:type owl:DatatypeProperty ;
+                   rdfs:range xsd:integer ;
+                   dcterms:description "Le nombre total de Parts associées à un EditorialObject."@fr ,
+                                       "The total number of Parts associated with an EditorialObject."@en ;
+                   rdfs:label "Nombre total de parties"@fr ,
+                              "Part total number"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#period
+ec:period rdf:type owl:DatatypeProperty ;
+          rdfs:range rdfs:Literal ;
+          dcterms:description "La période de temps pendant laquelle un événement a eu lieu."@fr ,
+                              "The period of time during which an Event has occurred."@en ;
+          rdfs:label "Period"@en ,
+                     "Période"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#personHeight
+ec:personHeight rdf:type owl:DatatypeProperty ;
+                rdfs:range rdfs:Literal ;
+                dcterms:description "La taille d’une personne."@fr ,
+                                    "The height of a person."@en ;
+                rdfs:label "Hauteur de la personne"@fr ,
+                           "Person height"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#personWeight
+ec:personWeight rdf:type owl:DatatypeProperty ;
+                rdfs:range rdfs:Literal ;
+                dcterms:description "Le poids d’une personne."@fr ,
+                                    "The weight of a person."@en ;
+                rdfs:label "Person weight"@en ,
+                           "Poids de la personne"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#playbackSpeed
+ec:playbackSpeed rdf:type owl:DatatypeProperty ;
+                 rdfs:range xsd:double ;
+                 dcterms:description "Identifie le débit d’unités par rapport au temps auquel la ressource doit être lue pour la consommation humaine. Si l’unité de mesure est connue, utilisez les sous-propriétés framesPerSecond ou inchesPerSecond."@fr ,
+                                     "Identifies the rate of units against time at which the resource should be played back for human consumption. If the unit of measure is known, use sub-properties framesPerSecond or inchesPerSecond."@en ;
+                 rdfs:label "Playback speed"@en ,
+                            "Vitesse de lecture"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#playlist
+ec:playlist rdf:type owl:DatatypeProperty ;
+            rdfs:subPropertyOf ec:contentDescription ;
+            rdfs:range rdfs:Literal ;
+            dcterms:description "A playlist associated with the editorial object."@en ,
+                                "Une playlist associée à l'objet éditorial."@fr ;
+            rdfs:label "Liste de lecture"@fr ,
+                       "Playlist"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#position
+ec:position rdf:type owl:DatatypeProperty ;
+            rdfs:range rdfs:Literal ;
+            dcterms:description "La position d’un EditorialObject au sein d’un groupe ordonné."@fr ,
+                                "The position of an EditorialObject within an ordered group."@en ;
+            rdfs:label "Position"@en ,
+                       "Position"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#privateEmailAddress
+ec:privateEmailAddress rdf:type owl:DatatypeProperty ;
+                       rdfs:subPropertyOf ec:agentEmailAddress ;
+                       rdfs:range xsd:string ;
+                       dcterms:description "L’adresse e-mail privée d’une Personne."@fr ,
+                                           "The private email address of a Person."@en ;
+                       rdfs:label "Email privé"@fr ,
+                                  "Private email"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#privateHomepage
+ec:privateHomepage rdf:type owl:DatatypeProperty ;
+                   rdfs:subPropertyOf ec:agentWebHomepage ;
+                   rdfs:range xsd:anyURI ;
+                   dcterms:description "La page d’accueil web privée d’une Personne."@fr ,
+                                       "The private web homepage of a Person."@en ;
+                   rdfs:label "Homepage (private)"@en ,
+                              "Page d’accueil (privée)"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#privateMobileTelephoneNumber
+ec:privateMobileTelephoneNumber rdf:type owl:DatatypeProperty ;
+                                rdfs:subPropertyOf ec:agentTelephoneNumber ;
+                                rdfs:range xsd:string ;
+                                dcterms:description "Le numéro de téléphone mobile privé d’une Personne."@fr ,
+                                                    "The private mobile telephone number of a Person."@en ;
+                                rdfs:label "Telephone (private)"@en ,
+                                           "Téléphone (privé)"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#privateTelephoneNumber
+ec:privateTelephoneNumber rdf:type owl:DatatypeProperty ;
+                          rdfs:subPropertyOf ec:agentTelephoneNumber ;
+                          rdfs:range xsd:string ;
+                          dcterms:description "Le numéro de téléphone privé associé à une Personne."@fr ,
+                                              "The private telephone number associated with a Person."@en ;
+                          rdfs:label "Telephone (private)"@en ,
+                                     "Téléphone (privé)"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#productionSynopsis
+ec:productionSynopsis rdf:type owl:DatatypeProperty ;
+                      rdfs:subPropertyOf ec:contentDescription ;
+                      rdfs:range rdfs:Literal ;
+                      dcterms:description "A synopsis or summary provided by the producer at the time of production."@en ,
+                                          "Un synopsis ou un résumé fourni par le producteur au moment de la production."@fr ;
+                      rdfs:label "Production synopsis"@en ,
+                                 "Synopsis de production"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#promotionalInformation
+ec:promotionalInformation rdf:type owl:DatatypeProperty ;
+                          rdfs:subPropertyOf ec:contentDescription ;
+                          rdfs:range rdfs:Literal ;
+                          dcterms:description "Informations promotionnelles textuelles associées au contenu."@fr ,
+                                              "Textual promotional information associated with the content."@en ;
+                          rdfs:label "Informations promotionnelles"@fr ,
+                                     "Promotional information"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#pubStatus
+ec:pubStatus rdf:type owl:DatatypeProperty ;
+             rdfs:subPropertyOf ec:contentDescription ;
+             rdfs:range rdfs:Literal ;
+             dcterms:description "Le statut de publication associé à l’objet éditorial."@fr ,
+                                 "The publication status associated with the editorial object."@en ;
+             rdfs:label "Publication status"@en ,
+                        "Statut de publication"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#publicationPlanTitle
+ec:publicationPlanTitle rdf:type owl:DatatypeProperty ;
+                        dcterms:description "A title associated with a publication plan. It is a literal value used to name or identify the publication plan."@en ,
+                                            "Un titre associé à un plan de publication. Il s’agit d’une valeur littérale utilisée pour nommer ou identifier le plan de publication."@fr ;
+                        rdfs:label "Publication plan title"@en ,
+                                   "Titre du plan de publication"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#publishingEventsLeft
+ec:publishingEventsLeft rdf:type owl:DatatypeProperty ;
+                        dcterms:description "Le nombre d'événements de publication restants."@fr ,
+                                            "The number of publishing events remaining."@en ;
+                        rdfs:label "Publishing events left"@en ,
+                                   "Événements de publication restants"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#radioTuner
+ec:radioTuner rdf:type owl:DatatypeProperty ,
+                       owl:FunctionalProperty ;
+              dcterms:description "Indique si le service nécessite un tuner radio."@fr ,
+                                  "Whether the service requires a radio tuner."@en ;
+              rdfs:label "Radio tuner"@en ,
+                         "Tuner radio"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ratingScaleMax
+ec:ratingScaleMax rdf:type owl:DatatypeProperty ;
+                  rdfs:range rdfs:Literal ;
+                  dcterms:description "La valeur maximale de l’échelle utilisée pour la notation."@fr ,
+                                      "The maximum value of the scale used for the Rating."@en ;
+                  rdfs:label "Rating scale (top value)"@en ,
+                             "Échelle de notation (valeur maximale)"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ratingScaleMin
+ec:ratingScaleMin rdf:type owl:DatatypeProperty ;
+                  rdfs:range rdfs:Literal ;
+                  dcterms:description "La valeur minimale de l'échelle utilisée pour évaluer une MediaResource."@fr ,
+                                      "The minimum value of the scale used for rating a MediaResource."@en ;
+                  rdfs:label "Rating scale (min. value)"@en ,
+                             "Échelle de notation (valeur min.)"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ratingSystemEnvironment
+ec:ratingSystemEnvironment rdf:type owl:DatatypeProperty ;
+                           rdfs:range rdfs:Literal ;
+                           dcterms:description "L’environnement dans lequel la classification s’applique."@fr ,
+                                               "The environment in which the rating applies."@en ;
+                           rdfs:label "Environnement de notation"@fr ,
+                                      "Rating environment"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ratingSystemName
+ec:ratingSystemName rdf:type owl:DatatypeProperty ;
+                    rdfs:range rdfs:Literal ;
+                    dcterms:description "Le nom du système de notation."@fr ,
+                                        "The name of the rating system."@en ;
+                    rdfs:label "Rating system"@en ,
+                               "Système de notation"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ratingValue
+ec:ratingValue rdf:type owl:DatatypeProperty ;
+               rdfs:range rdfs:Literal ;
+               dcterms:description "La valeur en texte libre d’une évaluation définie dans un schéma de classification des évaluations."@fr ,
+                                   "The free-text value of a rating defined in a rating classification scheme."@en ;
+               rdfs:label "Rating"@en ,
+                          "Évaluation"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#readyForPublication
+ec:readyForPublication rdf:type owl:DatatypeProperty ;
+                       rdfs:range xsd:boolean ;
+                       dcterms:description "A flag to indicate that the resource/essence is ready for publication."@en ,
+                                           "Indique que la ressource/l’essence est prête à être publiée."@fr ;
+                       rdfs:label "Prêt pour publication"@fr ,
+                                  "Ready for publication"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#reason
+ec:reason rdf:type owl:DatatypeProperty ;
+          rdfs:range rdfs:Literal ;
+          dcterms:description "A reason given for a rating."@en ,
+                              "Une raison donnée pour une évaluation."@fr ;
+          rdfs:label "Raison"@fr ,
+                     "Reason"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#regionDelimX
+ec:regionDelimX rdf:type owl:DatatypeProperty ;
+                rdfs:range xsd:integer ;
+                dcterms:description "La coordonnée de l’axe x du coin supérieur gauche d’une zone. Si elle est présente avec regionDelimy, la définition de la zone est complétée par les valeurs associées de la hauteur et de la largeur."@fr ,
+                                    "The x-axis coordinate of the top-left corner of a zone. If present with regionDelimy, the zone definition is complemented by the associated values of the height and width."@en ;
+                rdfs:label "Délimiteur de région (axe x)"@fr ,
+                           "Region delimiter (x-axis)"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#regionDelimY
+ec:regionDelimY rdf:type owl:DatatypeProperty ;
+                rdfs:range xsd:integer ;
+                dcterms:description "La coordonnée de l’axe y du coin inférieur droit d’une zone. Si elle est présente avec regionDelimX, la définition de la zone est complétée par les valeurs associées de la hauteur et de la largeur."@fr ,
+                                    "The y-axis coordinate of the bottom right corner of a zone. If present with regionDelimX, the zone definition is complemented by the associated values of the height and width."@en ;
+                rdfs:label "Délimiteur de région (axe y)"@fr ,
+                           "Region delimiter (y-axis)"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#relationOrderedGroupFlag
+ec:relationOrderedGroupFlag rdf:type owl:DatatypeProperty ;
+                            rdfs:range xsd:boolean ;
+                            dcterms:description "A boolean to define if a Relation is defined within and ordered group."@en ,
+                                                "Un booléen permettant d’indiquer si une relation est définie au sein d’un groupe ordonné."@fr ;
+                            rdfs:label "Indicateur de groupe ordonné de relation"@fr ,
+                                       "Relation ordered group flag"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#relationRunningOrderNumber
+ec:relationRunningOrderNumber rdf:type owl:DatatypeProperty ;
+                              rdfs:range xsd:integer ;
+                              dcterms:description "Le numéro d’ordre dans une liste."@fr ,
+                                                  "The order number in a list."@en ;
+                              rdfs:label "Numéro d'ordre de relation"@fr ,
+                                         "Relation running order number"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#relationTotalNumberOfGroupMembers
+ec:relationTotalNumberOfGroupMembers rdf:type owl:DatatypeProperty ;
+                                     rdfs:range xsd:integer ;
+                                     dcterms:description "Nombre total de membres du groupe dans une Relation."@fr ,
+                                                         "Total number of group members in a Relation."@en ;
+                                     rdfs:label "Nombre total de membres du groupe"@fr ,
+                                                "Total number of group members"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#resolution
+ec:resolution rdf:type owl:DatatypeProperty ;
+              rdfs:range rdfs:Literal ;
+              dcterms:description "La résolution d’un objet éditorial, comme une vidéo ou une image."@fr ,
+                                  "The resolution of an editorial object, such as a video or image."@en ;
+              rdfs:label "Resolution"@en ,
+                         "Résolution"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#rightsClearanceFlag
+ec:rightsClearanceFlag rdf:type owl:DatatypeProperty ,
+                                owl:FunctionalProperty ;
+                       rdfs:range xsd:boolean ;
+                       dcterms:description "A flag to indicate that rights have been cleared."@en ,
+                                           "Un indicateur pour signaler que les droits ont été очищés."@fr ;
+                       rdfs:label "Indicateur de validation des droits"@fr ,
+                                  "Rights clearance flag"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#rightsExpression
+ec:rightsExpression rdf:type owl:DatatypeProperty ;
+                    rdfs:range rdfs:Literal ;
+                    dcterms:description "L’expression des droits associés à la ressource."@fr ,
+                                        "The expression of rights associated with the resource."@en ;
+                    rdfs:label "Droits"@fr ,
+                               "Rights"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#rightsLink
+ec:rightsLink rdf:type owl:DatatypeProperty ;
+              rdfs:range xsd:anyURI ;
+              dcterms:description "A link to e.g. a webpage where an expression of the rights can be found and consulted."@en ,
+                                  "Un lien vers, par exemple, une page web où une expression des droits peut être trouvée et consultée."@fr ;
+              rdfs:label "Ressource web des droits"@fr ,
+                         "Rights web resource"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#rightsUsageRestrictions
+ec:rightsUsageRestrictions rdf:type owl:DatatypeProperty ;
+                           dcterms:description "Specifies a set of usage restrictions."@en ,
+                                               "Spécifie un ensemble de restrictions d’utilisation."@fr ;
+                           rdfs:label "Restrictions d'utilisation"@fr ,
+                                      "Usage restrictions"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ruleStatement
+ec:ruleStatement rdf:type owl:DatatypeProperty ;
+                 dcterms:description "A statement associated with a Rule."@en ,
+                                     "Une déclaration associée à une règle."@fr ;
+                 rdfs:label "Rule statement"@en ,
+                            "Énoncé de règle"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#salutationTitle
+ec:salutationTitle rdf:type owl:DatatypeProperty ;
+                   rdfs:range rdfs:Literal ;
+                   dcterms:description "A salutation title such as Mr, Ms, Dr, or Prof."@en ,
+                                       "Un titre de civilité tel que M., Mme, Dr ou Prof."@fr ;
+                   rdfs:label "Salutation title"@en ,
+                              "Titre de civilité"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#sampleRate
+ec:sampleRate rdf:type owl:DatatypeProperty ;
+              rdfs:range xsd:integer ;
+              dcterms:description "La fréquence à laquelle l’audio est échantillonné par seconde. Aussi appelée fréquence d’échantillonnage."@fr ,
+                                  "The frequency at which audio is sampled per second. Also called sampling rate."@en ;
+              rdfs:label "Sample rate"@en ,
+                         "Taux d’échantillonnage"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#sampleSize
+ec:sampleSize rdf:type owl:DatatypeProperty ;
+              rdfs:range xsd:integer ;
+              dcterms:description "La taille d’un échantillon audio en bits. Aussi appelée profondeur de bits."@fr ,
+                                  "The size of an audio sample in bits. Also called bit depth."@en ;
+              rdfs:label "Sample size"@en ,
+                         "Taille d’échantillon"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#sampleType
+ec:sampleType rdf:type owl:DatatypeProperty ;
+              rdfs:range rdfs:Literal ;
+              dcterms:description "Le type d’échantillon audio."@fr ,
+                                  "The type of audio sample."@en ;
+              rdfs:label "Sample type"@en ,
+                         "Type d'échantillon"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#scanningFormat
+ec:scanningFormat rdf:type owl:DatatypeProperty ;
+                  rdfs:range rdfs:Literal ;
+                  dcterms:description "Le format de balayage d’une ressource média. Pour la vidéo, les deux valeurs principales sont « entrelacé » ou « progressif »."@fr ,
+                                      "The scanning format of a media resource. For video, the two main values are \"interlaced\" or \"progressive\"."@en ;
+                  rdfs:label "Format de balayage"@fr ,
+                             "Scanning format"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#script
+ec:script rdf:type owl:DatatypeProperty ;
+          rdfs:subPropertyOf ec:contentDescription ;
+          rdfs:range rdfs:Literal ;
+          dcterms:description "Le contenu du script associé à un objet éditorial."@fr ,
+                              "The script content associated with an editorial object."@en ;
+          rdfs:label "Script"@en ,
+                     "Scénario"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#seasonNumber
+ec:seasonNumber rdf:type owl:DatatypeProperty ;
+                rdfs:range xsd:integer ;
+                dcterms:description "Le numéro de saison associé à l’œuvre."@fr ,
+                                    "The season number associated with the work."@en ;
+                rdfs:label "Numéro de saison"@fr ,
+                           "Season number"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#segmentNumber
+ec:segmentNumber rdf:type owl:DatatypeProperty ;
+                 rdfs:range xsd:integer ;
+                 dcterms:description "Le numéro associé à un segment parmi plusieurs."@fr ,
+                                     "The number associated with a segment as one among many."@en ;
+                 rdfs:label "Numéro de segment"@fr ,
+                            "Segment number"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#shotLog
+ec:shotLog rdf:type owl:DatatypeProperty ;
+           rdfs:subPropertyOf ec:contentDescription ;
+           rdfs:range rdfs:Literal ;
+           dcterms:description "Fournit une description plan par plan d’une MediaResource."@fr ,
+                               "Provides a shot-by-shot description of a MediaResource."@en ;
+           rdfs:label "Journal des plans"@fr ,
+                      "Shot log"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#soundOutput
+ec:soundOutput rdf:type owl:DatatypeProperty ,
+                        owl:FunctionalProperty ;
+               dcterms:description "A flag to indicate if the Service requires a sound output."@en ,
+                                   "Un indicateur permettant de préciser si le service nécessite une sortie sonore."@fr ;
+               rdfs:label "Sortie audio"@fr ,
+                          "Sound output"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#suffix
+ec:suffix rdf:type owl:DatatypeProperty ;
+          rdfs:range rdfs:Literal ;
+          dcterms:description "Le suffixe associé au nom d’une personne, comme Jr."@fr ,
+                              "The suffix associated with a person's name, such as Jr."@en ;
+          rdfs:label "Suffix"@en ,
+                     "Suffixe"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#summary
+ec:summary rdf:type owl:DatatypeProperty ;
+           rdfs:subPropertyOf ec:contentDescription ;
+           rdfs:range rdfs:Literal ;
+           dcterms:description "A summary of the content."@en ,
+                               "Un résumé du contenu."@fr ;
+           rdfs:label "Résumé"@fr ,
+                      "Summary"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#synopsis
+ec:synopsis rdf:type owl:DatatypeProperty ;
+            rdfs:subPropertyOf ec:contentDescription ;
+            rdfs:range rdfs:Literal ;
+            dcterms:description "A summary of the content."@en ,
+                                "Un résumé du contenu."@fr ;
+            rdfs:label "Synopsis"@en ,
+                       "Synopsis"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#tableOfContent
+ec:tableOfContent rdf:type owl:DatatypeProperty ;
+                  rdfs:subPropertyOf ec:contentDescription ;
+                  rdfs:range rdfs:Literal ;
+                  dcterms:description "La table des matières de l'objet éditorial."@fr ,
+                                      "The table of content for the editorial object."@en ;
+                  rdfs:label "Table des contenus"@fr ,
+                             "Table of content"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#tag
+ec:tag rdf:type owl:DatatypeProperty ;
+       rdfs:subPropertyOf ec:contentDescription ;
+       rdfs:range rdfs:Literal ;
+       dcterms:description "A tag value associated with an editorial object."@en ,
+                           "Une valeur de balise associée à un objet éditorial."@fr ;
+       rdfs:label "Balise"@fr ,
+                  "Tag"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#targetAudienceSystem
+ec:targetAudienceSystem rdf:type owl:DatatypeProperty ;
+                        rdfs:range rdfs:Literal ;
+                        dcterms:description "Le système utilisé pour fournir un public cible."@fr ,
+                                            "The system used to provide a target audience."@en ;
+                        rdfs:label "Système d’audience cible"@fr ,
+                                   "Target audience system"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#textInput
+ec:textInput rdf:type owl:DatatypeProperty ,
+                      owl:FunctionalProperty ;
+             dcterms:description "Indicates whether a consumption device profile requires text input capability."@en ,
+                                 "Indique si un profil de dispositif de consommation requiert la capacité de saisie de texte."@fr ;
+             rdfs:label "Capacité de saisie de texte"@fr ,
+                        "Text input capability"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#textLineBoxHeight
+ec:textLineBoxHeight rdf:type owl:DatatypeProperty ;
+                     rdfs:range xsd:nonNegativeInteger ;
+                     dcterms:description "La hauteur de la zone de texte contenant le TextLine."@fr ,
+                                         "The height of the text box containing the TextLine."@en ;
+                     rdfs:label "Hauteur de la boîte de ligne de texte"@fr ,
+                                "Text line box height"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#textLineBoxTopLeftCornerLineNumber
+ec:textLineBoxTopLeftCornerLineNumber rdf:type owl:DatatypeProperty ;
+                                      rdfs:range xsd:nonNegativeInteger ;
+                                      dcterms:description "Les coordonnées sur un axe vertical de la position du coin supérieur gauche de la boîte de texte contenant la TextLine."@fr ,
+                                                          "The coordinates on a vertical axis of the position of the top left corner of the text box containing the TextLine."@en ;
+                                      rdfs:label "Position Y du coin supérieur gauche de la boîte de ligne de texte"@fr ,
+                                                 "Text line box top left corner Y position"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#textLineBoxTopLeftCornerPixelNumber
+ec:textLineBoxTopLeftCornerPixelNumber rdf:type owl:DatatypeProperty ;
+                                       rdfs:range xsd:nonNegativeInteger ;
+                                       dcterms:description "Les coordonnées sur un axe horizontal de la position du coin supérieur gauche de la boîte de texte contenant le TextLine."@fr ,
+                                                           "The coordinates on an horizontal axis of the position of the top left corner of the text box containing the TextLine."@en ;
+                                       rdfs:label "Position X du coin supérieur gauche de la boîte de ligne de texte"@fr ,
+                                                  "Text line box top left corner X position"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#textLineBoxWidth
+ec:textLineBoxWidth rdf:type owl:DatatypeProperty ;
+                    rdfs:range xsd:nonNegativeInteger ;
+                    dcterms:description "La largeur de la zone de texte contenant la TextLine."@fr ,
+                                        "The width of the text box containing the TextLine."@en ;
+                    rdfs:label "Largeur de la boîte de ligne de texte"@fr ,
+                               "Text line box width"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#textLineContent
+ec:textLineContent rdf:type owl:DatatypeProperty ;
+                   rdfs:range rdfs:Literal ;
+                   dcterms:description "Le contenu d’une ligne de texte."@fr ,
+                                       "The content of a text line."@en ;
+                   rdfs:label "Ligne de texte"@fr ,
+                              "Text line"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#textLineOrder
+ec:textLineOrder rdf:type owl:DatatypeProperty ;
+                 rdfs:range rdfs:Literal ;
+                 dcterms:description "L’ordre dans lequel une ligne de texte peut être trouvée, par exemple dans une scène."@fr ,
+                                     "The order in which a text line can be found e.g. in a scene."@en ;
+                 rdfs:label "Ordre des lignes de texte"@fr ,
+                            "Text line order"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#timeOfDay
+ec:timeOfDay rdf:type owl:DatatypeProperty ;
+             rdfs:range xsd:time ;
+             dcterms:description "A time expressed as a normal time of day."@en ,
+                                 "Une heure exprimée comme une heure normale de la journée."@fr ;
+             rdfs:label "Heure de la journée"@fr ,
+                        "Time of day"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#timecodeExpression
+ec:timecodeExpression rdf:type owl:DatatypeProperty ;
+                      rdfs:range xsd:string ;
+                      dcterms:description "A time expressed as timecode."@en ,
+                                          "Un temps exprimé en timecode."@fr ;
+                      rdfs:label "Expression de timecode"@fr ,
+                                 "Timecode expression"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#timeshift
+ec:timeshift rdf:type owl:DatatypeProperty ,
+                      owl:FunctionalProperty ;
+             dcterms:description "A flag to indicate if the Service requires timeshift support."@en ,
+                                 "Une indication pour signaler si le service nécessite la prise en charge du timeshift."@fr ;
+             rdfs:label "Support du timeshift"@fr ,
+                        "Timeshift support"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#title
+ec:title rdf:type owl:DatatypeProperty ;
+         rdfs:range rdfs:Literal ;
+         dcterms:description "Specifies the title or name given to the resource. A root for the definition of sub-properties defining ebucore titles of different types. The ebucore title type can be used to define sub-properties to optionally refine the category of the title. All values of the EBU title status classification scheme (https://github.com/ebu/ebu_cs/blob/main/metadata/cs/ebu_TitleStatusCodeCS.xml) are candidate sub-properties of the title property as implemented for an example with alternativeTitle."@en ,
+                             "Spécifie le titre ou le nom attribué à la ressource. Racine pour la définition de sous-propriétés définissant les titres ebucore de différents types. Le type de titre ebucore peut être utilisé pour définir des sous-propriétés afin de préciser éventuellement la catégorie du titre. Toutes les valeurs du schéma de classification du statut de titre de l'EBU (https://github.com/ebu/ebu_cs/blob/main/metadata/cs/ebu_TitleStatusCodeCS.xml) sont des sous-propriétés candidates de la propriété title, comme l'illustre l'exemple alternativeTitle."@fr ;
+         rdfs:label "Title"@en ,
+                    "Titre"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#totalNumberOfAudioChannels
+ec:totalNumberOfAudioChannels rdf:type owl:DatatypeProperty ;
+                              rdfs:range xsd:nonNegativeInteger ;
+                              dcterms:description "Le nombre total de canaux audio contenus dans la ressource média."@fr ,
+                                                  "The total number of audio channels contained in the MediaResource."@en ;
+                              rdfs:label "Nombre de canal audio"@fr ,
+                                         "Number of audio channel"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#totalNumberOfAudioTracks
+ec:totalNumberOfAudioTracks rdf:type owl:DatatypeProperty ;
+                            rdfs:range xsd:integer ;
+                            dcterms:description "Le nombre total de pistes audio dans une ressource multimédia."@fr ,
+                                                "The total number of audio tracks in a media resource."@en ;
+                            rdfs:label "Nombre de pistes audio"@fr ,
+                                       "Number of audio tracks"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#totalNumberOfEpisodes
+ec:totalNumberOfEpisodes rdf:type owl:DatatypeProperty ;
+                         rdfs:range xsd:integer ;
+                         dcterms:description "Le nombre total d’épisodes associés à une série ou à une saison."@fr ,
+                                             "The total number of episodes associated with a series or season."@en ;
+                         rdfs:label "Nombre total d'épisodes"@fr ,
+                                    "Total number of episodes"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#totalNumberOfGroupMembers
+ec:totalNumberOfGroupMembers rdf:type owl:DatatypeProperty ;
+                             rdfs:range xsd:integer ;
+                             dcterms:description "Le nombre total de membres dans un groupe."@fr ,
+                                                 "The total number of members in a group."@en ;
+                             rdfs:label "Nombre total de membres du groupe"@fr ,
+                                        "Total number of group members"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#totalNumberOfVideoTracks
+ec:totalNumberOfVideoTracks rdf:type owl:DatatypeProperty ;
+                            rdfs:range xsd:integer ;
+                            dcterms:description "Le nombre total de pistes vidéo dans la ressource multimédia."@fr ,
+                                                "The total number of video tracks in the media resource."@en ;
+                            rdfs:label "Nombre de pistes vidéo"@fr ,
+                                       "Number of video tracks"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#username
+ec:username rdf:type owl:DatatypeProperty ;
+            rdfs:range rdfs:Literal ;
+            dcterms:description "Le nom d’utilisateur par lequel une Personne est connue, par exemple lors de l’attribution d’une valeur de notation."@fr ,
+                                "The username by which a Person is known e.g. when attributing a rating value."@en ;
+            rdfs:label "Nom d'utilisateur"@fr ,
+                       "Username"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#version
+ec:version rdf:type owl:DatatypeProperty ;
+           rdfs:range rdfs:Literal ;
+           dcterms:description "La version actuelle d’un EditorialObject."@fr ,
+                               "The current version of an EditorialObject."@en ;
+           rdfs:label "Version"@en ,
+                      "Version"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#videoBitRate
+ec:videoBitRate rdf:type owl:DatatypeProperty ;
+                rdfs:range xsd:nonNegativeInteger ;
+                dcterms:description "Le débit vidéo. Indiquer le débit auquel la ressource média peut être lue, en bits/seconde. Débit actuel s’il est constant, et débit moyen s’il est variable."@fr ,
+                                    "The video bitrate. To provide the bitrate at which the MediaResource can be played in bits/second. Current bitrate if constant, and average bitrate if variable."@en ;
+                rdfs:label "Débit vidéo"@fr ,
+                           "Video bitrate"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#videoBitRateMax
+ec:videoBitRateMax rdf:type owl:DatatypeProperty ;
+                   rdfs:range xsd:nonNegativeInteger ;
+                   dcterms:description "Le débit binaire vidéo maximal."@fr ,
+                                       "The maximum video bitrate."@en ;
+                   rdfs:label "Débit binaire vidéo max"@fr ,
+                              "Video bitrate max"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#videoBitRateMode
+ec:videoBitRateMode rdf:type owl:DatatypeProperty ;
+                    rdfs:range rdfs:Literal ;
+                    dcterms:description "Le mode de débit binaire vidéo."@fr ,
+                                        "The video bitrate mode."@en ;
+                    rdfs:label "Mode de débit binaire vidéo"@fr ,
+                               "Video bitrate mode"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#videoDisplay
+ec:videoDisplay rdf:type owl:DatatypeProperty ,
+                         owl:FunctionalProperty ;
+                dcterms:description "A flag to indicate if the Service requires a video display."@en ,
+                                    "Un indicateur permettant de signaler si le service nécessite un affichage vidéo."@fr ;
+                rdfs:label "Affichage vidéo"@fr ,
+                           "Video display"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#videoEncodingLevel
+ec:videoEncodingLevel rdf:type owl:DatatypeProperty ;
+                      rdfs:subPropertyOf ec:encodingLevel ;
+                      rdfs:range rdfs:Literal ;
+                      dcterms:description "Le niveau d'encodage tel que défini dans les spécifications."@fr ,
+                                          "The encoding level as defined in specifications."@en ;
+                      rdfs:label "Niveau d'encodage vidéo"@fr ,
+                                 "Video encoding level"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#videoEncodingProfile
+ec:videoEncodingProfile rdf:type owl:DatatypeProperty ;
+                        rdfs:subPropertyOf ec:encodingProfile ;
+                        rdfs:range rdfs:Literal ;
+                        dcterms:description "Le niveau d'encodage tel que défini dans les spécifications."@fr ,
+                                            "The encoding level as defined in specifications."@en ;
+                        rdfs:label "Profil d’encodage vidéo"@fr ,
+                                   "Video encoding profile"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#videoTrackNumber
+ec:videoTrackNumber rdf:type owl:DatatypeProperty ;
+                    rdfs:range xsd:nonNegativeInteger ;
+                    dcterms:description "Le nombre utilisé pour identifier une piste vidéo parmi plusieurs pistes dans une ressource multimédia."@fr ,
+                                        "The number used to identify a video track among multiple tracks in a media resource."@en ;
+                    rdfs:label "Numéro de piste vidéo"@fr ,
+                               "Video track number"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#webcam
+ec:webcam rdf:type owl:DatatypeProperty ,
+                   owl:FunctionalProperty ;
+          dcterms:description "A flag to indicate if the Service requires a webcam."@en ,
+                              "Un indicateur pour signaler si le service nécessite une webcam."@fr ;
+          rdfs:label "Webcam"@en ,
+                     "Webcam"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#width
+ec:width rdf:type owl:DatatypeProperty ;
+         rdfs:range xsd:integer ;
+         dcterms:description "La largeur, par exemple celle d’une image vidéo, généralement exprimée en nombre de pixels, ou celle d’une image ou d’une photo en millimètres."@fr ,
+                             "The width of e.g. a video frame typically expressed as a number of pixels, or picture/image in millimeters."@en ;
+         rdfs:label "Largeur"@fr ,
+                    "Width"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#widthUnit
+ec:widthUnit rdf:type owl:DatatypeProperty ;
+             rdfs:range rdfs:Literal ;
+             dcterms:description "L’unité utilisée pour mesurer une largeur, par exemple en pixels, en nombre de lignes, en millimètres, ou autre."@fr ,
+                                 "The unit used to measure a width e.g. in pixels or number of lines or millimeters or else."@en ;
+             rdfs:label "Unité de largeur"@fr ,
+                        "Width unit"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#wordCount
+ec:wordCount rdf:type owl:DatatypeProperty ;
+             rdfs:range xsd:integer ;
+             dcterms:description "Le nombre de mots contenus dans un document."@fr ,
+                                 "The number of words contained in a document."@en ;
+             rdfs:label "Nombre de mots"@fr ,
+                        "Word count"@en .
+
+
+###  http://www.w3.org/2006/time#day
+time:day rdf:type owl:DatatypeProperty ;
+         rdfs:range xsd:gDay ;
+         rdfs:label "day"@en .
+
+
+###  http://www.w3.org/2006/time#inXSDDateTimeStamp
+time:inXSDDateTimeStamp rdf:type owl:DatatypeProperty ;
+                        rdfs:range xsd:dateTimeStamp .
+
+
+###  http://www.w3.org/2006/time#month
+time:month rdf:type owl:DatatypeProperty ;
+           rdfs:range xsd:gMonth ;
+           rdfs:label "month"@en .
+
+
+###  http://www.w3.org/2006/time#year
+time:year rdf:type owl:DatatypeProperty ;
+          rdfs:range xsd:gYear ;
+          rdfs:label "year"@en .
+
+
+#################################################################
+#    Classes
+#################################################################
+
+###  http://purl.org/dc/elements/1.1/Agent
+dc:Agent rdf:type owl:Class ;
+         dcterms:description "A resource that acts or has the power to act."@en ;
+         rdfs:label "Agent"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AccessConditions
+ec:AccessConditions rdf:type owl:Class ;
+                    rdfs:subClassOf ec:Rights ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasGeoBlockingBlacklist ;
+                                      owl:allValuesFrom skos:Concept
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasGeoBlockingWhitelist ;
+                                      owl:allValuesFrom skos:Concept
+                                    ] ;
+                    dcterms:description "Les conditions selon lesquelles l’accès au contenu ou sa publication est accordé."@fr ,
+                                        "The requirements under which access to content or its publication is granted."@en ;
+                    rdfs:label "Access conditions"@en ,
+                               "Conditions d'accès"@fr ;
+                    skos:definition "a ec:Rights that define the requirements under which access to an ec:Asset or a ec:PublicationEvent is granted"@en ,
+                                    "une ec:Rights qui définit les exigences selon lesquelles l'accès à un ec:Asset ou à un ec:PublicationEvent est accordé"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Account
+ec:Account rdf:type owl:Class ;
+           rdfs:subClassOf [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:hasConsumptionContract ;
+                             owl:allValuesFrom ec:Contract
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:hasIdentifier ;
+                             owl:allValuesFrom ec:Identifier
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:hasObjectType ;
+                             owl:allValuesFrom skos:Concept
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:hasRelatedAccount ;
+                             owl:allValuesFrom ec:Account
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:holdsLicence ;
+                             owl:allValuesFrom ec:ConsumptionLicence
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:description ;
+                             owl:allValuesFrom rdfs:Literal
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:name ;
+                             owl:allValuesFrom rdfs:Literal
+                           ] ;
+           dcterms:description "A registration Account to a Service. Account information can vary from one Service to another. Such information covers e.g. a (nick)name, a login, an age, sex, domains of interest or more."@en ,
+                               "Un compte d’inscription à un service. Les informations du compte peuvent varier d’un service à l’autre. Elles couvrent par exemple un nom (ou pseudonyme), un identifiant de connexion, un âge, le sexe, des domaines d’intérêt ou davantage."@fr ;
+           rdfs:label "Account"@en ,
+                      "Compte"@fr ;
+           skos:definition "a registration identity for a media service"@en ,
+                           "une identité d’enregistrement pour un service multimédia"@fr ;
+           skos:example """- a registered user to access netflix
+- a registered family with nicknames and devices to access a VOD service"""@en ,
+                        """- un utilisateur enregistré pour accéder à Netflix
+- une famille enregistrée avec des pseudonymes et des appareils pour accéder à un service VOD"""@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Action
+ec:Action rdf:type owl:Class ;
+          rdfs:subClassOf [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasIdentifier ;
+                            owl:allValuesFrom ec:Identifier
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasObjectType ;
+                            owl:allValuesFrom skos:Concept
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasRelatedAgent ;
+                            owl:allValuesFrom ec:Agent
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasRelatedScene ;
+                            owl:allValuesFrom ec:Scene
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasStart ;
+                            owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                            owl:onClass ec:TimelinePoint
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasEnd ;
+                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                            owl:onClass ec:TimelinePoint
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:description ;
+                            owl:allValuesFrom rdfs:Literal
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:name ;
+                            owl:allValuesFrom rdfs:Literal
+                          ] ;
+          dcterms:description "An entry from a list of actions, often used to create log entries about something happening along the timeline of content, eg. a goal scored in a football game."@en ,
+                              "Une entrée d’une liste d’actions, souvent utilisée pour créer des entrées de journal au sujet d’un événement survenant au fil chronologique du contenu, par exemple un but marqué lors d’un match de football."@fr ;
+          rdfs:label "Action"@en ,
+                     "Action"@fr ;
+          skos:definition "a skos:Concept classifying an action that happens in the course of an event or some content"@en ,
+                          "un skos:Concept classifiant une action qui se produit au cours d’un événement ou d’un contenu"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ActionType
+ec:ActionType rdf:type owl:Class ;
+              rdfs:subClassOf skos:Concept ;
+              dcterms:description "An entry from a list of actions, often used to create log entries about something happening along the timeline of content, eg. a goal scored in a football game."@en ,
+                                  "Une entrée d’une liste d’actions, souvent utilisée pour créer des enregistrements de journal sur un événement survenant au fil du contenu, par exemple un but marqué lors d’un match de football."@fr ;
+              rdfs:label "Action type"@en ,
+                         "Type d’action"@fr ;
+              skos:definition "a skos:Concept classifying an action that happens in the course of an event or some content"@en ,
+                              "un skos:Concept classifiant une action qui se produit au cours d'un événement ou d'un contenu"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ActiveFormatDescriptorCode
+ec:ActiveFormatDescriptorCode rdf:type owl:Class ;
+                              rdfs:subClassOf ec:Format ;
+                              dcterms:description "An entry from the classification of aspect ratios of a media resource on display."@en ,
+                                                  "Une entrée de la classification des rapports d’aspect d’une ressource multimédia à l’écran."@fr ;
+                              rdfs:label "Active format descriptor code"@en ,
+                                         "Code du descripteur de format actif"@fr ;
+                              skos:definition "a ec:Format classifying the aspect ratio of a ec:MediaResource when displayed"@en ,
+                                              "un ec:Format classant le rapport d'aspect d'une ec:MediaResource lorsqu'elle est affichée"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Affiliation
+ec:Affiliation rdf:type owl:Class ;
+               rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                 owl:onProperty ec:hasIdentifier ;
+                                 owl:allValuesFrom ec:Identifier
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty ec:hasObjectType ;
+                                 owl:allValuesFrom skos:Concept
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty ec:isAffiliatedTo ;
+                                 owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                 owl:onClass ec:Organisation
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty ec:hasEndDateTime ;
+                                 owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                 owl:onClass time:Instant
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty ec:hasStartDateTime ;
+                                 owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                 owl:onClass time:Instant
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty ec:description ;
+                                 owl:allValuesFrom rdfs:Literal
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty ec:name ;
+                                 owl:allValuesFrom rdfs:Literal
+                               ] ;
+               dcterms:description "An Organisation to which a Contact is affiliated (with period of validity)."@en ,
+                                   "Une organisation à laquelle un contact est affilié (avec période de validité)."@fr ;
+               rdfs:label "Affiliation"@en ,
+                          "Affiliation"@fr ;
+               skos:definition "an association of a Person to an Organisation for a period of time"@en ,
+                               "une association d'une Personne à une Organisation pendant une période de temps"@fr ;
+               skos:example """- a person's employment with the BBC from hiring to retirement
+- the hosting of a BBC weekly radio show on a radio channel over 8 years"""@en ,
+                            """- l'emploi d'une personne à la BBC, de l'embauche à la retraite
+- l'animation d'une émission de radio hebdomadaire de la BBC sur une chaîne radio pendant plus de 8 ans"""@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Agent
+ec:Agent rdf:type owl:Class ;
+         rdfs:subClassOf dc:Agent ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasAgentBiography ;
+                           owl:allValuesFrom ec:Biography
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasAgentCountryOfResidence ;
+                           owl:allValuesFrom ec:CountryCode
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasAgentLanguage ;
+                           owl:allValuesFrom ec:Language
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasAgentMember ;
+                           owl:allValuesFrom ec:Agent
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasAgentNationality ;
+                           owl:allValuesFrom ec:CountryCode
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasAgentPlaceOfResidence ;
+                           owl:allValuesFrom ec:Location
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasAssociatedArtefact ;
+                           owl:allValuesFrom ec:Artefact
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasCharacter ;
+                           owl:allValuesFrom ec:Character
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasContact ;
+                           owl:allValuesFrom ec:Contact
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasGroupMember ;
+                           owl:allValuesFrom ec:Agent
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasIdentifier ;
+                           owl:allValuesFrom ec:Identifier
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasObjectType ;
+                           owl:allValuesFrom skos:Concept
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasRelatedAgent ;
+                           owl:allValuesFrom ec:Agent
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasRelatedPicture ;
+                           owl:allValuesFrom ec:Picture
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:holdsAward ;
+                           owl:allValuesFrom ec:Award
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:agentDbpedia ;
+                           owl:allValuesFrom xsd:anyURI
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:agentEmailAddress ;
+                           owl:allValuesFrom xsd:string
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:agentFacebook ;
+                           owl:allValuesFrom xsd:anyURI
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:agentFee ;
+                           owl:allValuesFrom rdfs:Literal
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:agentFlickr ;
+                           owl:allValuesFrom xsd:anyURI
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:agentImdb ;
+                           owl:allValuesFrom xsd:anyURI
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:agentInstagram ;
+                           owl:allValuesFrom xsd:anyURI
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:agentLinkedData ;
+                           owl:allValuesFrom xsd:anyURI
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:agentLinkedIn ;
+                           owl:allValuesFrom xsd:anyURI
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:agentMobileTelephoneNumber ;
+                           owl:allValuesFrom xsd:string
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:agentPreviousName ;
+                           owl:allValuesFrom rdfs:Literal
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:agentRelatedInformationLink ;
+                           owl:allValuesFrom xsd:anyURI
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:agentRelatedLink ;
+                           owl:allValuesFrom xsd:anyURI
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:agentRelatedPressLink ;
+                           owl:allValuesFrom xsd:anyURI
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:agentSocialMedia ;
+                           owl:allValuesFrom xsd:anyURI
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:agentTelephoneNumber ;
+                           owl:allValuesFrom xsd:string
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:agentTwitter ;
+                           owl:allValuesFrom xsd:anyURI
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:agentWebHomepage ;
+                           owl:allValuesFrom xsd:anyURI
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:agentWikidata ;
+                           owl:allValuesFrom xsd:anyURI
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:agentWikipedia ;
+                           owl:allValuesFrom xsd:anyURI
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:description ;
+                           owl:allValuesFrom rdfs:Literal
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:name ;
+                           owl:allValuesFrom rdfs:Literal
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:nickName ;
+                           owl:allValuesFrom rdfs:Literal
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:displayOrder ;
+                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                         ] ;
+         dcterms:description "An «Agent» is either a Contact/Person or Organisation to which is associated a Role corresponding to the contribution the «Agent» brings to the realisation of a MediaResource or EditorialObject."@en ,
+                             "Un «Agent» est soit un Contact/Personne soit une Organisation, auquel est associé un Rôle correspondant à la contribution que l’«Agent» apporte à la réalisation d’une MediaResource ou d’un EditorialObject."@fr ;
+         rdfs:label "Agent"@en ,
+                    "Agent"@fr ;
+         skos:definition "an entity performing an activity in the media business"@en ,
+                         "une entité qui exerce une activité dans le secteur des médias"@fr ;
+         skos:example """- a film director
+- a camera woman
+- a sound engineer
+- an actress
+- an author
+- a publishing media enterprise
+- a content providing enterprise
+- a distribution network enterprise
+- a consumption device manufacturing enterprise"""@en ,
+                      """- un réalisateur
+- une cadreuse
+- une ingénieure du son
+- une actrice
+- un auteur
+- une entreprise de médias éditoriaux
+- une entreprise de fourniture de contenus
+- une entreprise de réseau de distribution
+- une entreprise de fabrication d’appareils de lecture"""@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AlternativeTitle
+ec:AlternativeTitle rdf:type owl:Class ;
+                    rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasIdentifier ;
+                                      owl:allValuesFrom ec:Identifier
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasObjectType ;
+                                      owl:allValuesFrom skos:Concept
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasEndDateTime ;
+                                      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                      owl:onClass time:Instant
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasStartDateTime ;
+                                      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                      owl:onClass time:Instant
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:title ;
+                                      owl:someValuesFrom rdfs:Literal
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:description ;
+                                      owl:allValuesFrom rdfs:Literal
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:name ;
+                                      owl:allValuesFrom rdfs:Literal
+                                    ] ;
+                    dcterms:description "A title is a name for a piece or a group of content."@en ,
+                                        "Un titre est un nom donné à une œuvre ou à un ensemble de contenus."@fr ;
+                    rdfs:label "Alternative title"@en ,
+                               "Titre alternatif"@fr ;
+                    skos:definition "a name of a certain type given to an ec:EditorialObject"@en ,
+                                    "un nom d’un certain type donné à un ec:EditorialObject"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AncillaryData
+ec:AncillaryData rdf:type owl:Class ;
+                 rdfs:subClassOf ec:DataTrack ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasWrappingType ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass ec:WrappingType
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:DID ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onDataRange xsd:integer
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:SDID ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onDataRange xsd:integer
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:lineNumber ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onDataRange xsd:integer
+                                 ] ;
+                 dcterms:description "A track containing supplemental data that accompanies video or audio content."@en ,
+                                     "Une piste contenant des données supplémentaires qui accompagnent un contenu vidéo ou audio."@fr ;
+                 rdfs:label "Ancillary data"@en ,
+                            "Données auxiliaires"@fr ;
+                 skos:definition "a ec:DataTrack of data of a supplemental nature"@en ,
+                                 "une ec:DataTrack de données de nature complémentaire"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AncillaryDataFormat
+ec:AncillaryDataFormat rdf:type owl:Class ;
+                       rdfs:subClassOf ec:DataFormat ;
+                       dcterms:description "An entry from the classification of structure schemes for data that supplement audio, video, or images, e.g., legacy data that used to be carried in vertical blanking intervals of video broadcast signals."@en ,
+                                           "Une entrée de la classification des schémas de structure pour des données qui complètent l’audio, la vidéo ou les images, par exemple des données héritées qui étaient autrefois transportées dans les intervalles de suppression verticale des signaux de diffusion vidéo."@fr ;
+                       rdfs:label "Ancillary data format"@en ,
+                                  "Format de données auxiliaires"@fr ;
+                       skos:definition "a ec:DataFormat classifying the structure of supplemental data"@en ,
+                                       "une classe ec:DataFormat classifiant la structure des données supplémentaires"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Animal
+ec:Animal rdf:type owl:Class ;
+          rdfs:subClassOf [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasAnimalBreedCode ;
+                            owl:allValuesFrom ec:AnimalBreedCode
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasAnimalColourCode ;
+                            owl:allValuesFrom ec:AnimalColourCode
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasAnimalGroom ;
+                            owl:allValuesFrom ec:Agent
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasAnimalRole ;
+                            owl:allValuesFrom ec:Involvement
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasIdentifier ;
+                            owl:allValuesFrom ec:Identifier
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasObjectType ;
+                            owl:allValuesFrom skos:Concept
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasOwner ;
+                            owl:allValuesFrom ec:Agent
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:portrays ;
+                            owl:allValuesFrom ec:Character
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasDateOfBirth ;
+                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                            owl:onClass time:Instant
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasDateOfDeath ;
+                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                            owl:onClass time:Instant
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:description ;
+                            owl:allValuesFrom rdfs:Literal
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:name ;
+                            owl:allValuesFrom rdfs:Literal
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:animalCharacterName ;
+                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:animalCode ;
+                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:animalPassport ;
+                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:gender ;
+                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                          ] ;
+          dcterms:description "An animal that is related to or depicted in a piece of work."@en ,
+                              "Un animal qui est lié à une œuvre ou qui y est représenté."@fr ;
+          rdfs:label "Animal"@en ,
+                     "Animal"@fr ;
+          skos:definition "an animal with a role in ec:Involvement"@en ,
+                          "un animal ayant un rôle dans ec:Involvement"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AnimalBreedCode
+ec:AnimalBreedCode rdf:type owl:Class ;
+                   rdfs:subClassOf skos:Concept ;
+                   dcterms:description "An entry from the breed classification of animals."@en ,
+                                       "Une entrée de la classification des races animales."@fr ;
+                   rdfs:label "Animal breed code"@en ,
+                              "Code de race animale"@fr ;
+                   skos:definition "a skos:Concept classifying an ec:Animal by their breed"@en ,
+                                   "un skos:Concept classifiant un ec:Animal selon sa race"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AnimalColourCode
+ec:AnimalColourCode rdf:type owl:Class ;
+                    rdfs:subClassOf skos:Concept ;
+                    dcterms:description "An entry from the colour classification of animals."@en ,
+                                        "Une entrée de la classification des couleurs des animaux."@fr ;
+                    rdfs:label "Animal colour code"@en ,
+                               "Code de couleur des animaux"@fr ;
+                    skos:definition "a skos:Concept classifying an ec:Animal by their colour"@en ,
+                                    "un skos:Concept classifiant un ec:Animal par leur couleur"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Annotation
+ec:Annotation rdf:type owl:Class ;
+              rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:hasAnnotationAgent ;
+                                owl:allValuesFrom ec:Agent
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:hasAnnotationTarget ;
+                                owl:allValuesFrom owl:Thing
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:hasIdentifier ;
+                                owl:allValuesFrom ec:Identifier
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:hasObjectType ;
+                                owl:allValuesFrom skos:Concept
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:hasRelatedAgent ;
+                                owl:allValuesFrom ec:Agent
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:hasRelatedArtefact ;
+                                owl:allValuesFrom ec:Artefact
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:hasRelatedEvent ;
+                                owl:allValuesFrom ec:Event
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:hasAnnotationCurationDateTime ;
+                                owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                owl:onClass time:Instant
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:hasAuthor ;
+                                owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                owl:onClass ec:Agent
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:hasLocation ;
+                                owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                owl:onClass ec:Location
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:isAnnotatedMediaResource ;
+                                owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                owl:onClass ec:MediaResource
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:description ;
+                                owl:allValuesFrom rdfs:Literal
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:name ;
+                                owl:allValuesFrom rdfs:Literal
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:annotationConfidence ;
+                                owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:annotationPurpose ;
+                                owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:annotationSaliency ;
+                                owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                              ] ;
+              dcterms:description "Annotations are meaningful terms that are associated with things. Things that are annotated with the same terms are implicitly associated."@en ,
+                                  "Les annotations sont des termes significatifs associés à des choses. Les choses annotées avec les mêmes termes sont implicitement associées."@fr ;
+              rdfs:label "Annotation"@en ,
+                         "Annotation"@fr ;
+              skos:definition "a string that is assigned to owl:Thing for implicit association amongst them"@en ,
+                              "une chaîne assignée à owl:Thing pour une association implicite entre elles"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AnnotationType
+ec:AnnotationType rdf:type owl:Class ;
+                  rdfs:subClassOf skos:Concept ;
+                  dcterms:description "An entry from the classification of annotations."@en ,
+                                      "Une entrée de la classification des annotations."@fr ;
+                  rdfs:label "Annotation type"@en ,
+                             "Type d’annotation"@fr ;
+                  skos:definition "a skos:Concept classifying an ec:Annotation"@en ,
+                                  "un skos:Concept classifiant une ec:Annotation"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Artefact
+ec:Artefact rdf:type owl:Class ;
+            rdfs:subClassOf [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasArtefactBuyer ;
+                              owl:allValuesFrom ec:Agent
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasArtefactOwner ;
+                              owl:allValuesFrom ec:Agent
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasArtefactRelatedLocation ;
+                              owl:allValuesFrom ec:Location
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasArtefactRelatedPhysicalResource ;
+                              owl:allValuesFrom ec:PhysicalResource
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasArtefactRetailer ;
+                              owl:allValuesFrom ec:Agent
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasArtefactSupplier ;
+                              owl:allValuesFrom ec:Agent
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasCreator ;
+                              owl:allValuesFrom ec:Involvement
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasIdentifier ;
+                              owl:allValuesFrom ec:Identifier
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasObjectType ;
+                              owl:allValuesFrom skos:Concept
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasRelatedAgent ;
+                              owl:allValuesFrom ec:Agent
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasRelatedEditorialObject ;
+                              owl:allValuesFrom ec:EditorialObject
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasRelatedResource ;
+                              owl:allValuesFrom ec:Resource
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasArtefactDateOfPurchase ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onClass time:Instant
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasArtefactDateOfSale ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onClass time:Instant
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasArtefactPriceCurrency ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onClass ec:CurrencyCode
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasLocation ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onClass ec:Location
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:artefactAvailability ;
+                              owl:allValuesFrom rdfs:Literal
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:artefactBrand ;
+                              owl:allValuesFrom rdfs:Literal
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:artefactColour ;
+                              owl:allValuesFrom rdfs:Literal
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:artefactComment ;
+                              owl:allValuesFrom rdfs:Literal
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:artefactModel ;
+                              owl:allValuesFrom rdfs:Literal
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:artefactPeriod ;
+                              owl:allValuesFrom rdfs:Literal
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:artefactPriceAmount ;
+                              owl:allValuesFrom rdfs:Literal
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:artefactReference ;
+                              owl:allValuesFrom xsd:anyURI
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:artefactStyle ;
+                              owl:allValuesFrom rdfs:Literal
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:artefactUsageHistory ;
+                              owl:allValuesFrom rdfs:Literal
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:artefactWebsite ;
+                              owl:allValuesFrom xsd:anyURI
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:description ;
+                              owl:allValuesFrom rdfs:Literal
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:name ;
+                              owl:allValuesFrom rdfs:Literal
+                            ] ;
+            dcterms:description "Quelque chose utilisé pendant une production, souvent visible ou audible, et choisi délibérément pour sa valeur dans le contenu obtenu, comme des costumes, des objets ou des produits."@fr ,
+                                "Something used during a production, often visible or audible and deliberately chosen for its value to the resulting content, such as costumes, objects, or products."@en ;
+            rdfs:label "Artefact"@en ,
+                       "Artefact"@fr ;
+            skos:definition "an object made or modified by a human being, typically one of cultural or historical interest; used in a ec:ProductionJob, often visible or audible, and deliberately chosen for its value to the resulting ec:EditorialObject"@en ,
+                            "un objet fabriqué ou modifié par un être humain, généralement d’intérêt culturel ou historique ; utilisé dans un ec:ProductionJob, souvent visible ou audible, et délibérément choisi pour sa valeur pour l’ec:EditorialObject résultant"@fr ;
+            skos:example """- les costumes et les accessoires d’un film
+- le décor non dynamique, les chaises, la table dans un talk-show"""@fr ,
+                         """- the costumes and props in a movie
+- the non-dynamic backdrop, chairs, table in a talk show"""@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ArtefactType
+ec:ArtefactType rdf:type owl:Class ;
+                rdfs:subClassOf skos:Concept ;
+                dcterms:description "An entry from the classification of media production artefacts."@en ,
+                                    "Une entrée de la classification des artefacts de production médiatique."@fr ;
+                rdfs:label "Artefact type"@en ,
+                           "Type d’artefact"@fr ;
+                skos:definition "a skos:Concept classifying an ec:Artefact"@en ,
+                                "un skos:Concept classifiant un ec:Artefact"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Article
+ec:Article rdf:type owl:Class ;
+           rdfs:subClassOf ec:EditorialWork ;
+           dcterms:description "A work consisting of text, graphics, sometimes video or audio, and created for publication on websites, blogs, etc., or other platforms similar to the more traditional paper-based publications."@en ,
+                               "Une œuvre composée de texte, de graphiques, parfois de vidéo ou d’audio, et créée pour être publiée sur des sites web, des blogs, etc., ou sur d’autres plateformes similaires aux publications plus traditionnelles sur support papier."@fr ;
+           rdfs:label "Article"@en ,
+                      "Article"@fr ;
+           skos:definition "an ec:EditorialWork consisting of text, graphics, sometimes video or audio, created for publication on websites, blogs, et al., or other platforms similar to the more traditional paper-based publications"@en ,
+                           "un ec:EditorialWork constitué de texte, de graphiques, parfois de vidéo ou d'audio, créé pour publication sur des sites web, des blogs, et al., ou d'autres plateformes similaires aux publications traditionnelles sur papier"@fr ;
+           skos:example "- a news article on BBC's website"@en ,
+                        "- un article de presse sur le site Web de la BBC"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Asset
+ec:Asset rdf:type owl:Class ;
+         rdfs:subClassOf [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:derivedTo ;
+                           owl:allValuesFrom ec:Asset
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasAccessConditions ;
+                           owl:allValuesFrom ec:AccessConditions
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasAssetValue ;
+                           owl:allValuesFrom ec:AssetValue
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasChild ;
+                           owl:allValuesFrom ec:Asset
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasContact ;
+                           owl:allValuesFrom ec:Contact
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasCopyright ;
+                           owl:allValuesFrom ec:Copyright
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasCoverageRestrictions ;
+                           owl:allValuesFrom ec:CoverageRestrictions
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasCreativeCommons ;
+                           owl:allValuesFrom ec:CreativeCommons
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasDisclaimer ;
+                           owl:allValuesFrom ec:Disclaimer
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasExploitationIssues ;
+                           owl:allValuesFrom ec:ExploitationIssues
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasIPRRestrictions ;
+                           owl:allValuesFrom ec:IPRRestrictions
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasIdentifier ;
+                           owl:allValuesFrom ec:Identifier
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasLicensing ;
+                           owl:allValuesFrom ec:Licensing
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasParticipatingAgent ;
+                           owl:allValuesFrom ec:Agent
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasRelatedArtefact ;
+                           owl:allValuesFrom ec:Artefact
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasRelatedAsset ;
+                           owl:allValuesFrom ec:Asset
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasRelatedAuditReport ;
+                           owl:allValuesFrom ec:AuditReport
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasRelatedEditorialObject ;
+                           owl:allValuesFrom ec:EditorialObject
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasRelatedPicture ;
+                           owl:allValuesFrom ec:Picture
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasRelatedRecord ;
+                           owl:allValuesFrom ec:Record
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasRelatedResource ;
+                           owl:allValuesFrom ec:Resource
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasRights ;
+                           owl:allValuesFrom ec:Rights
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasRightsClearance ;
+                           owl:allValuesFrom ec:RightsClearance
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasUsageRestrictions ;
+                           owl:allValuesFrom ec:UsageRestrictions
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasUsageRights ;
+                           owl:allValuesFrom ec:UsageRights
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:isDerivedFrom ;
+                           owl:allValuesFrom ec:Asset
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:isReplacedBy ;
+                           owl:allValuesFrom ec:Asset
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:replaces ;
+                           owl:allValuesFrom ec:Asset
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasDateArchived ;
+                           owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                           owl:onClass time:Instant
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasDateCreated ;
+                           owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                           owl:onClass time:Instant
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasDateDeleted ;
+                           owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                           owl:onClass time:Instant
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasDateDistributed ;
+                           owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                           owl:onClass time:Instant
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasDateLicenseEnd ;
+                           owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                           owl:onClass time:Instant
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasDateLicensedStart ;
+                           owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                           owl:onClass time:Instant
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasDateModified ;
+                           owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                           owl:onClass time:Instant
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasDateProduced ;
+                           owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                           owl:onClass time:Instant
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasDateReleased ;
+                           owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                           owl:onClass time:Instant
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasObjectType ;
+                           owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                           owl:onClass skos:Concept
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:isChildOf ;
+                           owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                           owl:onClass ec:Asset
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:description ;
+                           owl:allValuesFrom rdfs:Literal
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:name ;
+                           owl:allValuesFrom rdfs:Literal
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:orderedFlag ;
+                           owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                           owl:onDataRange xsd:boolean
+                         ] ;
+         owl:disjointWith ec:Rating ;
+         dcterms:description "Assets are abstractions of audio, audiovisual, or bibliographical media objects. They serve to describe the value and the associated rights of the media object."@en ,
+                             "Les assets sont des abstractions d’objets médiatiques audio, audiovisuels ou bibliographiques. Ils servent à décrire la valeur et les droits associés de l’objet média."@fr ;
+         rdfs:label "Actif"@fr ,
+                    "Asset"@en ;
+         skos:definition "a piece of content that represents an ec:AssetValue in the context of the owner's business and may carry ec:Rights"@en ,
+                         "une pièce de contenu qui représente une ec:AssetValue dans le contexte de l’activité du propriétaire et peut porter des ec:Rights"@fr ;
+         skos:example """- a film on tape in the archive
+- a digital audio recording with associated author's right and copyright
+- a book
+- a collection of books"""@en ,
+                      """- un film sur bande dans les archives
+- un enregistrement audio numérique avec le droit d'auteur et les droits d'auteur associés
+- un livre
+- une collection de livres"""@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AssetType
+ec:AssetType rdf:type owl:Class ;
+             rdfs:subClassOf skos:Concept ;
+             dcterms:description "An entry from the classification of media assets."@en ,
+                                 "Une entrée de la classification des actifs multimédias."@fr ;
+             rdfs:label "Asset type"@en ,
+                        "Type de ressource"@fr ;
+             skos:definition "a skos:Concept classifying an ec:Asset"@en ,
+                             "un skos:Concept classifiant un ec:Asset"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AssetValue
+ec:AssetValue rdf:type owl:Class ;
+              rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:hasAssetValueCurrency ;
+                                owl:allValuesFrom skos:Concept
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:hasIdentifier ;
+                                owl:allValuesFrom ec:Identifier
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:hasObjectType ;
+                                owl:allValuesFrom skos:Concept
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:assetValue ;
+                                owl:allValuesFrom xsd:decimal
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:description ;
+                                owl:allValuesFrom rdfs:Literal
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:name ;
+                                owl:allValuesFrom rdfs:Literal
+                              ] ;
+              dcterms:description "La valeur d'un actif exprimée sous forme d'un montant d'argent, d'une description de la valeur ou d'une expression ou d'un type non financier."@fr ,
+                                  "The value of an asset expressed as an amount of money, a description of the value or a non-financial expression or type."@en ;
+              rdfs:label "Asset value"@en ,
+                         "Valeur d'actif"@fr ;
+              skos:definition "a financial or intrinsic value of an ec:Asset"@en ,
+                              "une valeur financière ou intrinsèque d’un ec:Asset"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Atmosphere
+ec:Atmosphere rdf:type owl:Class ;
+              rdfs:subClassOf ec:Type ;
+              dcterms:description "A list of entries to classify the atmosphere represented in some content."@en ,
+                                  "Une liste d’entrées permettant de classer l’atmosphère représentée dans un contenu donné."@fr ;
+              rdfs:label "Atmosphere"@en ,
+                         "Atmosphère"@fr ;
+              skos:definition "a ec:Type that lists classifications of the atmosphere of the content"@en ,
+                              "un ec:Type qui liste les classifications de l’atmosphère du contenu"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Audience
+ec:Audience rdf:type owl:Class ;
+            rdfs:subClassOf [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:excludesAudience ;
+                              owl:allValuesFrom ec:Audience
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasIdentifier ;
+                              owl:allValuesFrom ec:Identifier
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasObjectType ;
+                              owl:allValuesFrom skos:Concept
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:includesAudience ;
+                              owl:allValuesFrom ec:Audience
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:audienceAgeHigh ;
+                              owl:allValuesFrom xsd:integer
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:audienceAgeLow ;
+                              owl:allValuesFrom xsd:integer
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:audienceCount ;
+                              owl:allValuesFrom rdfs:Literal
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:audienceInterest ;
+                              owl:allValuesFrom rdfs:Literal
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:description ;
+                              owl:allValuesFrom rdfs:Literal
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:name ;
+                              owl:allValuesFrom rdfs:Literal
+                            ] ;
+            dcterms:description "A group of potential media consumers clustered by age, interest, social categories, or similar. Audience descriptions are used to characterize the intended or observed population for editorial or service analysis."@en ,
+                                "Un groupe de consommateurs potentiels de médias regroupés par âge, centres d'intérêt, catégories sociales ou similaires. Les descriptions d'audience servent à caractériser la population visée ou observée pour l'analyse éditoriale ou de service."@fr ;
+            rdfs:label "Audience"@en ,
+                       "Audience"@fr ;
+            skos:definition "a group of potential media consumers clustered by age, interest, social categories, or similar"@en ,
+                            "un groupe de consommateurs potentiels de médias regroupés par âge, intérêt, catégories sociales ou similaires"@fr ;
+            skos:example """- 14 à 29 ans
+- jeunes des zones rurales
+- hommes de plus de 70 ans
+- personnes orientées vers la culture
+- personnes orientées vers le divertissement
+- parents d’enfants scolarisés
+- hommes de moins de 25 ans peu instruits
+- jeunes personnes progressistes"""@fr ,
+                         """- age 14 to 29
+- rural youth
+- males over 70
+- culture oriented people
+- fun oriented people
+- school kid's parents
+- low educated males under 25
+- young progressive people"""@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AudienceLevel
+ec:AudienceLevel rdf:type owl:Class ;
+                 rdfs:subClassOf ec:Rating ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:targetAudienceSystem ;
+                                   owl:allValuesFrom rdfs:Literal
+                                 ] ;
+                 dcterms:description "L’évaluation de la conformité d’un contenu à un public cible défini par un système de public cible."@fr ,
+                                     "The rating of the conformity of some content to an intended audience defined by a target audience system."@en ;
+                 rdfs:label "Public cible"@fr ,
+                            "Target audience"@en ;
+                 skos:definition "a ec:Rating for the conformity of the ec:EditorialObject to an intended ec:Audience"@en ,
+                                 "une ec:Rating de la conformité de l’ec:EditorialObject à un ec:Audience prévu"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AudienceRating
+ec:AudienceRating rdf:type owl:Class ;
+                  rdfs:subClassOf ec:Rating ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:hasAudienceScoreRecordingTechnique ;
+                                    owl:allValuesFrom skos:Concept
+                                  ] ;
+                  dcterms:description "Le niveau d’adéquation pour un public défini selon une norme, par exemple comme http://en.wikipedia.org/wiki/Motion_picture_rating_system."@fr ,
+                                      "The level of appropriateness for a defined audience according to a standard, e.g. like http://en.wikipedia.org/wiki/Motion_picture_rating_system."@en ;
+                  rdfs:label "Audience du public"@fr ,
+                             "Audience rating"@en ;
+                  skos:definition "a ec:Rating expressing the appropriateness for a defined ec:Audience"@en ,
+                                  "une ec:Rating exprimant l'adéquation pour une ec:Audience définie"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AudienceScoreRecordingTechnique
+ec:AudienceScoreRecordingTechnique rdf:type owl:Class ;
+                                   rdfs:subClassOf skos:Concept ;
+                                   dcterms:description "An entry from the classification of techniques used to measure audience score."@en ,
+                                                       "Une entrée de la classification des techniques utilisées pour mesurer un score d’audience."@fr ;
+                                   rdfs:label "Audience score recording technique"@en ,
+                                              "Technique d'enregistrement du score d'audience"@fr ;
+                                   skos:definition "a skos:Concept classifying the technique used to measure an audience score"@en ,
+                                                   "un skos:Concept classant la technique utilisée pour mesurer un score d’audience"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AudioChannelFunction
+ec:AudioChannelFunction rdf:type owl:Class ;
+                        rdfs:subClassOf skos:Concept ;
+                        dcterms:description "An entry from the classification of functions of an audio channel."@en ,
+                                            "Une entrée de la classification des fonctions d’un canal audio."@fr ;
+                        rdfs:label "Audio channel function"@en ,
+                                   "Fonction du canal audio"@fr ;
+                        skos:definition "a skos:Concept classifying the function of audio channel"@en ,
+                                        "un skos:Concept classifiant la fonction d’un canal audio"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AudioChannelPurpose
+ec:AudioChannelPurpose rdf:type owl:Class ;
+                       rdfs:subClassOf skos:Concept ;
+                       dcterms:description "An entry from the classification of purposes of an audio channel."@en ,
+                                           "Une entrée de la classification des finalités d’un canal audio."@fr ;
+                       rdfs:label "Audio channel purpose"@en ,
+                                  "Finalité du canal audio"@fr ;
+                       skos:definition "a skos:Concept classifying the purpose of an audio channel"@en ,
+                                       "un skos:Concept classifiant la finalité d'un canal audio"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AudioCodec
+ec:AudioCodec rdf:type owl:Class ;
+              rdfs:subClassOf ec:Codec ;
+              dcterms:description "Le codec utilisé dans la production de contenu audio."@fr ,
+                                  "The codec used in the production of audio content."@en ;
+              rdfs:label "Audio codec"@en ,
+                         "Codec audio"@fr ;
+              skos:definition "a ec:Codec used in the production of an audio stream, file or track"@en ,
+                              "un ec:Codec utilisé dans la production d'un flux audio, d'un fichier ou d'une piste"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AudioContent
+ec:AudioContent rdf:type owl:Class ;
+                rdfs:subClassOf ec:EditorialSegment ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty ec:loudnessIntegratedLoudness ;
+                                  owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                  owl:onDataRange xsd:float
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty ec:loudnessMaxMomentary ;
+                                  owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                  owl:onDataRange xsd:float
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty ec:loudnessMaxShortTerm ;
+                                  owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                  owl:onDataRange xsd:float
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty ec:loudnessMaxTruepeak ;
+                                  owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                  owl:onDataRange xsd:float
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty ec:loudnessRange ;
+                                  owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                  owl:onDataRange xsd:float
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty ec:loudnessMethod ;
+                                  owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                ] ;
+                dcterms:description "A segment of a programme with its descriptive metadata according to the EBU R128 loudness standard and its set of loudness parameters. This notion of a segment will often, but not always, encompass the entire timeline."@en ,
+                                    "Un segment d’un programme avec ses métadonnées descriptives selon la norme de loudness EBU R128 et son ensemble de paramètres de loudness. Cette notion de segment englobe souvent, mais pas toujours, l’ensemble de la chronologie."@fr ;
+                rdfs:label "Audio content"@en ,
+                           "Contenu audio"@fr ;
+                skos:definition "a ec:EditorialSegment of audio signals that are described according to the EBU R128 loudness standard"@en ,
+                                "un ec:EditorialSegment de signaux audio décrits selon la norme de loudness EBU R128"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AudioContentType
+ec:AudioContentType rdf:type owl:Class ;
+                    rdfs:subClassOf skos:Concept ;
+                    dcterms:description "An entry from the classification of types of audio content according to the loudness standard."@en ,
+                                        "Une entrée de la classification des types de contenu audio selon la norme de loudness."@fr ;
+                    rdfs:label "Audio content type"@en ,
+                               "Type de contenu audio"@fr ;
+                    skos:definition "a skos:Concept classifying the type of ec:AudioContent"@en ,
+                                    "un skos:Concept classifiant le type de ec:AudioContent"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AudioDescription
+ec:AudioDescription rdf:type owl:Class ;
+                    rdfs:subClassOf ec:AudioTrack ;
+                    dcterms:description "An audio track describing the visible scenes for visually impaired viewers."@en ,
+                                        "Une piste audio décrivant les scènes visibles pour les spectateurs malvoyants."@fr ;
+                    rdfs:label "Audio description"@en ,
+                               "Audio-description"@fr ;
+                    skos:definition "a ec:AudioTrack describing the visible scenes on the screen for the visually impaired"@en ,
+                                    "une ec:AudioTrack décrivant les scènes visibles à l’écran pour les personnes malvoyantes"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AudioEncodingFormat
+ec:AudioEncodingFormat rdf:type owl:Class ;
+                       rdfs:subClassOf ec:EncodingFormat ;
+                       dcterms:description "An entry from the classification of transformations that produce digital audio resources from audio signals."@en ,
+                                           "Une entrée de la classification des transformations qui produisent des ressources audio numériques à partir de signaux audio."@fr ;
+                       rdfs:label "Audio encoding format"@en ,
+                                  "Format d'encodage audio"@fr ;
+                       skos:definition "a ec:EncodingFormat classifying the transformation from an audio signal to audio data in a ec;MediaResource"@en ,
+                                       "une ec:EncodingFormat classant la transformation d’un signal audio en données audio dans un ec;MediaResource"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AudioFormat
+ec:AudioFormat rdf:type owl:Class ;
+               rdfs:subClassOf ec:Format ;
+               dcterms:description "An entry from the classification of audio formats."@en ,
+                                   "Une entrée de la classification des formats audio."@fr ;
+               rdfs:label "Audio format"@en ,
+                          "Format audio"@fr ;
+               skos:definition "a ec:Format classifying the encoding format used for audio information"@en ,
+                               "un ec:Format classant le format d'encodage utilisé pour les informations audio"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AudioObject
+ec:AudioObject rdf:type owl:Class ;
+               rdfs:subClassOf ec:MediaResource ;
+               dcterms:description "A media resource in the form of an object in reference to the Audio Definition Model (ADM)."@en ,
+                                   "Une ressource multimédia sous la forme d’un objet, en référence au modèle de définition audio (ADM)."@fr ;
+               rdfs:label "Audio object"@en ,
+                          "Objet audio"@fr ;
+               skos:definition "a ec:MediaResource in the form of an object in reference to the Audio Definition Model (ADM)"@en ,
+                               "une ec:MediaResource sous la forme d’un objet en référence au Audio Definition Model (ADM)"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AudioProgramme
+ec:AudioProgramme rdf:type owl:Class ;
+                  rdfs:subClassOf ec:EditorialWork ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:loudnessIntegratedLoudness ;
+                                    owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                    owl:onDataRange xsd:float
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:loudnessMaxMomentary ;
+                                    owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                    owl:onDataRange xsd:float
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:loudnessMaxShortTerm ;
+                                    owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                    owl:onDataRange xsd:float
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:loudnessMaxTruepeak ;
+                                    owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                    owl:onDataRange xsd:float
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:loudnessRange ;
+                                    owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                    owl:onDataRange xsd:float
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:loudnessMethod ;
+                                    owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                  ] ;
+                  dcterms:description "A whole programme with its descriptive metadata according to the EBU R128 loudness standard and its set of loudness parameters."@en ,
+                                      "Un programme complet avec ses métadonnées descriptives conformément à la norme de loudness EBU R128 et son ensemble de paramètres de loudness."@fr ;
+                  rdfs:isDefinedBy <https://tech.ebu.ch/docs/r/r128.pdf> ;
+                  rdfs:label "Audio programme"@en ,
+                             "Programme audio"@fr ;
+                  skos:definition "an ec:EditorialWork of audio signals that are described according to the EBU R128 loudness standard"@en ,
+                                  "un ec:EditorialWork de signaux audio décrits selon la norme de loudness EBU R128"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AudioProgrammeType
+ec:AudioProgrammeType rdf:type owl:Class ;
+                      rdfs:subClassOf skos:Concept ;
+                      dcterms:description "An entry from the classification of types of audio programmes as used for measuring loudness in a finished production."@en ,
+                                          "Une entrée de la classification des types de programmes audio utilisée pour mesurer la sonie dans une production terminée."@fr ;
+                      rdfs:label "Audio programme type"@en ,
+                                 "Type de programme audio"@fr ;
+                      skos:definition "a skos:Concept classifying the type of ec:AudioProgrammet"@en ,
+                                      "un skos:Concept classifiant le type de ec:AudioProgrammet"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AudioStream
+ec:AudioStream rdf:type owl:Class ;
+               rdfs:subClassOf ec:Stream ;
+               dcterms:description "A data stream containing a decidable audio signal, e.g. PCM, Dolby E. It is composed of one or more AudioTracks."@en ,
+                                   "Un flux de données contenant un signal audio décodable, par exemple PCM, Dolby E. Il est composé d'une ou plusieurs AudioTracks."@fr ;
+               rdfs:label "Audio stream"@en ,
+                          "Flux audio"@fr ;
+               skos:definition "a ec:Stream with encoded audio"@en ,
+                               "un ec:Stream avec audio encodé"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AudioTrack
+ec:AudioTrack rdf:type owl:Class ;
+              rdfs:subClassOf ec:Track ;
+              dcterms:description "A track that contains encoded audio signals and defines a component of an audio stream."@en ,
+                                  "Une piste qui contient des signaux audio encodés et constitue un composant d’un flux audio."@fr ;
+              rdfs:label "Audio track"@en ,
+                         "Piste audio"@fr ;
+              skos:definition "a ec:Track containing encoded audio signal and forming part of an ech:AudioStream"@en ,
+                              "un ec:Track contenant un signal audio encodé et faisant partie d’un ech:AudioStream"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AudioTrackPurpose
+ec:AudioTrackPurpose rdf:type owl:Class ;
+                     rdfs:subClassOf skos:Concept ;
+                     dcterms:description "An entry from the classification of purposes of an audio track."@en ,
+                                         "Une entrée de la classification des finalités d'une piste audio."@fr ;
+                     rdfs:label "Audio track purpose"@en ,
+                                "Finalité de la piste audio"@fr ;
+                     skos:definition "a skos:Concept classifying the purpose of an ec:AudioTrack"@en ,
+                                     "un skos:Concept classant la finalité d’un ec:AudioTrack"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AuditJob
+ec:AuditJob rdf:type owl:Class ;
+            rdfs:subClassOf ec:ProductionJob ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasAuditJobRelatedAuditReport ;
+                              owl:allValuesFrom ec:AuditReport
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:usesMeasure ;
+                              owl:allValuesFrom ec:Measure
+                            ] ;
+            dcterms:description "L’évaluation de la conformité est effectuée par rapport à une Measure associée à une Rule via un AuditJob."@fr ,
+                                "The assessment of compliance is made against a Measure associated with a Rule via an AuditJob."@en ;
+            rdfs:label "Audit job"@en ,
+                       "Travail d'audit"@fr ;
+            skos:definition "an assessment of compliance against a Measure"@en ,
+                            "une évaluation de la conformité par rapport à une Measure"@fr ;
+            skos:example """- measuring the maximum volume level in the audio track of a video file
+- measuring the share of speaker time in a debate of the candidates before an election
+- measuring the share of male/females experts across all programmes of a publication service"""@en ,
+                         """- mesurer le niveau volumique maximal dans la piste audio d'un fichier vidéo
+- mesurer la part de temps de parole d'un candidat dans un débat des candidats avant une élection
+- mesurer la part d'experts masculins/féminins dans l'ensemble des programmes d'un service de publication"""@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AuditReport
+ec:AuditReport rdf:type owl:Class ;
+               rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                 owl:onProperty ec:hasApprover ;
+                                 owl:allValuesFrom ec:Agent
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty ec:hasAuditReportDate ;
+                                 owl:allValuesFrom time:Instant
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty ec:hasIdentifier ;
+                                 owl:allValuesFrom ec:Identifier
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty ec:hasObjectType ;
+                                 owl:allValuesFrom skos:Concept
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty ec:hasRelatedAuditJob ;
+                                 owl:allValuesFrom ec:AuditJob
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty ec:hasRelatedResource ;
+                                 owl:allValuesFrom ec:Resource
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty ec:referencesRule ;
+                                 owl:allValuesFrom ec:Rule
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty ec:auditReportResults ;
+                                 owl:allValuesFrom rdfs:Literal
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty ec:description ;
+                                 owl:allValuesFrom rdfs:Literal
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty ec:name ;
+                                 owl:allValuesFrom rdfs:Literal
+                               ] ;
+               dcterms:description "An AuditReport aggregates results from related AuditJob."@en ,
+                                   "Un AuditReport agrège les résultats des AuditJob associés."@fr ;
+               rdfs:label "Audit report"@en ,
+                          "Rapport d'audit"@fr ;
+               skos:definition "a report on aggregated results from auditing"@en ,
+                               "un rapport sur les résultats agrégés de l'audit"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Award
+ec:Award rdf:type owl:Class ;
+         rdfs:subClassOf [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasIdentifier ;
+                           owl:allValuesFrom ec:Identifier
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasLogo ;
+                           owl:allValuesFrom ec:Logo
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasObjectType ;
+                           owl:allValuesFrom skos:Concept
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasRelatedAgent ;
+                           owl:allValuesFrom ec:Agent
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasRelatedEvent ;
+                           owl:allValuesFrom ec:Event
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:isAwardedTo ;
+                           owl:allValuesFrom ec:Agent
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasAwardDate ;
+                           owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                           owl:onClass time:Instant
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:description ;
+                           owl:allValuesFrom rdfs:Literal
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:name ;
+                           owl:allValuesFrom rdfs:Literal
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:awardCeremony ;
+                           owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                         ] ;
+         dcterms:description "A prize, such as money, or something else, for something that somebody has done."@en ,
+                             "Un prix, par exemple une somme d’argent, ou autre chose, pour quelque chose qu’une personne a fait."@fr ;
+         rdfs:label "Award"@en ,
+                    "Prix"@fr ;
+         skos:definition "a financial or symbolic prize given to an ec:Agent to honor an outstanding performance, achievement or contribution"@en ,
+                         "un prix financier ou symbolique remis à un ec:Agent pour honorer une performance, une réussite ou une contribution exceptionnelles"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#AwardType
+ec:AwardType rdf:type owl:Class ;
+             rdfs:subClassOf skos:Concept ;
+             dcterms:description "An entry from the classification of award types."@en ,
+                                 "Une entrée de la classification des types de récompenses."@fr ;
+             rdfs:label "Award type"@en ,
+                        "Type de récompense"@fr ;
+             skos:definition "a skos:Concept classifying the type of ec:Award"@en ,
+                             "un skos:Concept classifiant le type de ec:Award"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#BibliographicalObject
+ec:BibliographicalObject rdf:type owl:Class ;
+                         rdfs:subClassOf ec:Asset ,
+                                         [ rdf:type owl:Restriction ;
+                                           owl:onProperty ec:references ;
+                                           owl:allValuesFrom ec:BibliographicalObject
+                                         ] ,
+                                         [ rdf:type owl:Restriction ;
+                                           owl:onProperty ec:references ;
+                                           owl:allValuesFrom ec:EditorialObject
+                                         ] ;
+                         dcterms:description "A written piece of work."@en ,
+                                             "Une œuvre écrite."@fr ;
+                         rdfs:label "Bibliographical object"@en ,
+                                    "Objet bibliographique"@fr ;
+                         skos:definition "a ec:Asset consisting of text"@en ,
+                                         "un ec:Asset constitué de texte"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Biography
+ec:Biography rdf:type owl:Class ;
+             rdfs:subClassOf ec:BibliographicalObject ;
+             dcterms:description "A book about the life of a person."@en ,
+                                 "Un livre sur la vie d’une personne."@fr ;
+             rdfs:label "Biographie"@fr ,
+                        "Biography"@en ;
+             skos:definition "a ec:BibliographicalObject about the life of a ec:Person"@en ,
+                             "un ec:BibliographicalObject sur la vie d'un ec:Person"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Campaign
+ec:Campaign rdf:type owl:Class ;
+            rdfs:subClassOf [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasConsumptionCount ;
+                              owl:allValuesFrom ec:Audience
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasIdentifier ;
+                              owl:allValuesFrom ec:Identifier
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasInputResonance ;
+                              owl:allValuesFrom ec:ResonanceCount
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasObjectType ;
+                              owl:allValuesFrom skos:Concept
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasPublicationPlan ;
+                              owl:allValuesFrom ec:PublicationPlan
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasTargetAudience ;
+                              owl:allValuesFrom ec:Audience
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:description ;
+                              owl:allValuesFrom rdfs:Literal
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:title ;
+                              owl:allValuesFrom rdfs:Literal
+                            ] ;
+            dcterms:description "A Campaign defines a strategy for publishing content (EditorialObjects and related Resources/MediaResources/Essences) to a targeted Audience according to a PublicationPlan. Campaign strategies can be adapted taking into account the analysis of the Resonance of related ConsumptionEvents (e.g. likes, downloads, etc.). Campaigns can apply to a variety of broadcasting strategies e.g. advertising campaigns, promotional campaigns or else."@en ,
+                                "Une Campaign définit une stratégie de publication de contenu (EditorialObjects et Resources/MediaResources/Essences associées) vers un Audience ciblé selon un PublicationPlan. Les stratégies de Campaign peuvent être adaptées en tenant compte de l’analyse de la Resonance des ConsumptionEvents associés (par exemple les likes, les téléchargements, etc.). Les Campaigns peuvent s’appliquer à विविध types de stratégies de diffusion, par exemple des campagnes publicitaires, des campagnes promotionnelles ou autres."@fr ;
+            rdfs:label "Campagne"@fr ,
+                       "Campaign"@en ;
+            skos:definition "a strategy for coordinated publishing effort towards a target audience"@en ,
+                            "une stratégie de publication coordonnée vers un public cible"@fr ;
+            skos:example """- an advertisement effort for a product, by publishing a set of videos at a time and on a channel, when and where the target audience can be effectively reached
+- an announcement of the journalistic coverage of an upcoming government election from many different perspectives and for a variety of target audiences published on several channels of linear TV, linear radio, social media, podcast portals, etc."""@en ,
+                         """- une action publicitaire pour un produit, en publiant un ensemble de vidéos en même temps et sur une chaîne, lorsque et où le public cible peut être atteint efficacement
+- une annonce du traitement journalistique d’une prochaine élection gouvernementale sous de multiples angles et pour विविध publics cibles, publiée sur plusieurs chaînes de télévision linéaire, de radio linéaire, sur les réseaux sociaux, sur des portails de podcasts, etc."""@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#CampaignPackage
+ec:CampaignPackage rdf:type owl:Class ;
+                   rdfs:subClassOf ec:EditorialGroup ;
+                   dcterms:description "A package of promotional content to advertise a product, a service, an event or similar in various ways but in a coordinated effort."@en ,
+                                       "Un ensemble de contenus promotionnels destinés à faire la publicité d’un produit, d’un service, d’un événement ou d’un élément similaire, de manière coordonnée."@fr ;
+                   rdfs:label "Campaign package"@en ,
+                              "Pack campagne"@fr ;
+                   skos:definition "an ec:EditorialGroup whose members are brought together to advertise a product, a service, an event, or similar in various ways but in a coordinated effort"@en ,
+                                   "un ec:EditorialGroup dont les membres sont réunis pour faire la promotion d'un produit, d'un service, d'un événement ou similaire de diverses manières mais dans un effort coordonné"@fr ;
+                   skos:example """- a set of different ads for one product
+- a set of different trailers for a film"""@en ,
+                                """- un ensemble de différentes publicités pour un produit
+- un ensemble de différentes bandes-annonces pour un film"""@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Captioning
+ec:Captioning rdf:type owl:Class ;
+              rdfs:subClassOf ec:Track ;
+              dcterms:description "A track containing text from transcribed dialogues or a description of the audio for the hard of hearing."@en ,
+                                  "Une piste contenant du texte issu de dialogues transcrits ou une description de l’audio pour les malentendants."@fr ;
+              rdfs:label "Captioning"@en ,
+                         "Sous-titrage"@fr ;
+              skos:definition "a ec:Track containing text from transcribed dialogues or description of the audio for the hard of hearing"@en ,
+                              "un ec:Track contenant du texte provenant de dialogues transcrits ou une description de l'audio pour les malentendants"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#CaptioningFormat
+ec:CaptioningFormat rdf:type owl:Class ;
+                    rdfs:subClassOf ec:DataFormat ;
+                    dcterms:description "An entry from the classification of structure schemes for captioning data, mainly used for transcription."@en ,
+                                        "Une entrée de la classification des schémas de structure pour les données de sous-titrage, principalement utilisée pour la transcription."@fr ;
+                    rdfs:label "Captioning format"@en ,
+                               "Format de sous-titrage"@fr ;
+                    skos:definition "a ec:DataFormat classifying the structure of captioning data from transcriptions"@en ,
+                                    "une ec:DataFormat classifiant la structure des données de sous-titrage issues de transcriptions"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#CastMember
+ec:CastMember rdf:type owl:Class ;
+              rdfs:subClassOf ec:Person ;
+              dcterms:description "A cast member performs a role or acts as a character in a screenplay."@en ,
+                                  "Un membre de la distribution interprète un rôle ou incarne un personnage dans un scénario."@fr ;
+              rdfs:label "Cast member"@en ,
+                         "Membre de la distribution"@fr ;
+              skos:definition "a ec:Person that is a member of the cast of a fictional piece of work"@en ,
+                              "une ec:Personne qui est membre de la distribution d’une œuvre fictive"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Character
+ec:Character rdf:type owl:Class ;
+             rdfs:subClassOf ec:Person ,
+                             [ rdf:type owl:Restriction ;
+                               owl:onProperty ec:hasEmbodyingArtefact ;
+                               owl:allValuesFrom ec:Artefact
+                             ] ,
+                             [ rdf:type owl:Restriction ;
+                               owl:onProperty ec:isAnimatedBy ;
+                               owl:allValuesFrom ec:Person
+                             ] ,
+                             [ rdf:type owl:Restriction ;
+                               owl:onProperty ec:isPlayedBy ;
+                               owl:allValuesFrom ec:Involvement
+                             ] ,
+                             [ rdf:type owl:Restriction ;
+                               owl:onProperty ec:isPortrayedBy ;
+                               owl:allValuesFrom ec:Animal
+                             ] ,
+                             [ rdf:type owl:Restriction ;
+                               owl:onProperty ec:hasFictitiousPerson ;
+                               owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                               owl:onClass ec:Person
+                             ] ;
+             dcterms:description "A character is played by an actor in a screenplay or drama."@en ,
+                                 "Un personnage est joué par un acteur dans un scénario ou une pièce de théâtre."@fr ;
+             rdfs:label "Character"@en ,
+                        "Personnage"@fr ;
+             skos:definition "a fictitious ec:Person in a screenplay or drama"@en ,
+                             "un ec:Person fictif dans un scénario ou un drame"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#CityCode
+ec:CityCode rdf:type owl:Class ;
+            rdfs:subClassOf skos:Concept ;
+            dcterms:description "An entry from the postal codes of cities."@en ,
+                                "Une entrée des codes postaux des villes."@fr ;
+            rdfs:label "City code"@en ,
+                       "Code de ville"@fr ;
+            skos:definition "a skos:Concept classifying cities by their postal codes"@en ,
+                            "un skos:Concept classifiant les villes par leurs codes postaux"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ClosedCaptions
+ec:ClosedCaptions rdf:type owl:Class ;
+                  rdfs:subClassOf ec:Captioning ;
+                  dcterms:description "A captioning that exists in a media resource of its own, outside of video, i.e. it can be turned on or off at any time."@en ,
+                                      "Un sous-titrage qui existe dans une ressource multimédia propre, en dehors de la vidéo, c’est-à-dire qu’il peut être activé ou désactivé à tout moment."@fr ;
+                  rdfs:label "Closed caption"@en ,
+                             "Sous-titrage codé"@fr ;
+                  skos:definition "a ec:Captioning that exists in a ec:MediaResource of its own, outside of video"@en ,
+                                  "un ec:Captioning qui existe dans une ec:MediaResource propre, en dehors de la vidéo"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ClosedSigning
+ec:ClosedSigning rdf:type owl:Class ;
+                 rdfs:subClassOf ec:Signing ;
+                 dcterms:description "A signing that is provided as a separate media resource, separate from the video or audio content, i.e., it can be turned on or off at any time."@en ,
+                                     "Un sous-titrage ou un système de signes fourni comme une ressource média distincte, séparée du contenu vidéo ou audio, c’est-à-dire qu’il peut être activé ou désactivé à tout moment."@fr ;
+                 rdfs:label "Closed signing"@en ,
+                            "Signage fermée"@fr ;
+                 skos:definition "a ec:Signing that exists in a ec:MediaResource of its own, outside of video"@en ,
+                                 "un ec:Signing qui existe dans une ec:MediaResource qui lui est propre, en dehors de la vidéo"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ClosedSubtitling
+ec:ClosedSubtitling rdf:type owl:Class ;
+                    rdfs:subClassOf ec:Subtitling ;
+                    dcterms:description "A subtitling that is carried in its own media resource, besides media resources for audio and/or video. Subtitling can be turned on or off."@en ,
+                                        "Un sous-titrage transporté dans sa propre ressource multimédia, en plus des ressources multimédias pour l'audio et/ou la vidéo. Le sous-titrage peut être activé ou désactivé."@fr ;
+                    rdfs:label "Closed subtitling"@en ,
+                               "Sous-titrage fermé"@fr ;
+                    skos:definition "a ec:Subtitling that exists in a ec:MediaResource of its own, outside of video"@en ,
+                                    "un ec:Subtitling qui existe dans une ec:MediaResource qui lui est propre, en dehors de la vidéo"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Codec
+ec:Codec rdf:type owl:Class ;
+         rdfs:subClassOf [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasCodecVendor ;
+                           owl:allValuesFrom ec:Agent
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasIdentifier ;
+                           owl:allValuesFrom ec:Identifier
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasObjectType ;
+                           owl:allValuesFrom skos:Concept
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:codecFamily ;
+                           owl:allValuesFrom rdfs:Literal
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:codecVersion ;
+                           owl:allValuesFrom rdfs:Literal
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:description ;
+                           owl:allValuesFrom rdfs:Literal
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:name ;
+                           owl:allValuesFrom rdfs:Literal
+                         ] ;
+         dcterms:description "La technique utilisée pour encoder et décoder des informations photo, vidéo ou audio en fichiers ou en flux."@fr ,
+                             "The technique used to encode and decode photo, video, or audio information into files or streams."@en ;
+         rdfs:label "Codec"@en ,
+                    "Codec"@fr ;
+         skos:definition "a coding/decoding technique used in the production of a ec:MediaResource"@en ,
+                         "une technique de codage/décodage utilisée dans la production d’une ec:MediaResource"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Collection
+ec:Collection rdf:type owl:Class ;
+              rdfs:subClassOf ec:EditorialGroup ;
+              dcterms:description "A group of content of many types. Grouping is done according to a concept or intention. In the world of archives, a collection corresponds to all items belonging to an individual/collector."@en ,
+                                  "Un groupe de contenus de nombreux types. Le regroupement est effectué selon un concept ou une intention. Dans le monde des archives, une collection correspond à l’ensemble des éléments appartenant à un individu ou à un collecteur."@fr ;
+              rdfs:label "Collection"@en ,
+                         "Collection"@fr ;
+              skos:definition "an ec:EditorialGroup that can group content of any type"@en ,
+                              "un ec:EditorialGroup pouvant regrouper des contenus de tout type"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ColourSpace
+ec:ColourSpace rdf:type owl:Class ;
+               rdfs:subClassOf ec:Format ;
+               dcterms:description "An entry from the classification of colour spaces for videos."@en ,
+                                   "Une entrée de la classification des espaces colorimétriques pour les vidéos."@fr ;
+               rdfs:label "Colour space"@en ,
+                          "Espace couleur"@fr ;
+               skos:definition "a ec:Format classifying the colour space of a video"@en ,
+                               "un ec:Format classant l’espace colorimétrique d’une vidéo"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#CommercialCode
+ec:CommercialCode rdf:type owl:Class ;
+                  rdfs:subClassOf ec:Type ;
+                  dcterms:description "A list of entries to classify commercial content, e.g. EBU's classification scheme on Commerciality Type."@en ,
+                                      "Une liste d’entrées permettant de classer les contenus commerciaux, par exemple le schéma de classification d’EBU sur le type de commercialité."@fr ;
+                  rdfs:label "Code commercial"@fr ,
+                             "Commercial code"@en ;
+                  skos:definition "a ec:Type that lists types of commercial content"@en ,
+                                  "un ec:Type qui répertorie les types de contenu commercial"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Component
+ec:Component rdf:type owl:Class ;
+             rdfs:subClassOf ec:MediaResource ;
+             dcterms:description "A media resource that is an ingredient of another media resource e.g. audio track, data track or similar."@en ,
+                                 "Une ressource multimédia qui est un composant d'une autre ressource multimédia, par exemple une piste audio, une piste de données ou similaire."@fr ;
+             rdfs:label "Component"@en ,
+                        "Composant"@fr ;
+             skos:definition "a ec:MediaResource that is an ingredient of another ec:MediaResource"@en ,
+                             "un ec:MediaResource qui est un ingrédient d'un autre ec:MediaResource"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Consumer
+ec:Consumer rdf:type owl:Class ;
+            rdfs:subClassOf ec:Person ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:belongsToAudience ;
+                              owl:allValuesFrom ec:Audience
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasAssociatedConsumptionEvent ;
+                              owl:allValuesFrom ec:ConsumptionEvent
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasRegistration ;
+                              owl:allValuesFrom ec:Account
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:usesConsumptionDevice ;
+                              owl:allValuesFrom ec:ConsumptionDevice
+                            ] ;
+            dcterms:description "A person consuming a media service."@en ,
+                                "Une personne qui consomme un service média."@fr ;
+            rdfs:label "Consommateur"@fr ,
+                       "Consumer"@en ;
+            skos:definition "a ec:Person consuming a media service"@en ,
+                            "une ec:Person consommant un service média"@fr ;
+            skos:example """- a radio listener
+- a video stream viewer"""@en ,
+                         """- un auditeur radio
+- un téléspectateur de flux vidéo"""@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ConsumptionCount
+ec:ConsumptionCount rdf:type owl:Class ;
+                    rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasAudience ;
+                                      owl:allValuesFrom ec:Audience
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasConsumptionEvent ;
+                                      owl:allValuesFrom ec:ConsumptionEvent
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasIdentifier ;
+                                      owl:allValuesFrom ec:Identifier
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasObjectType ;
+                                      owl:allValuesFrom skos:Concept
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasEnd ;
+                                      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                      owl:onClass ec:TimelinePoint
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasEndDateTime ;
+                                      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                      owl:onClass time:Instant
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasStart ;
+                                      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                      owl:onClass ec:TimelinePoint
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasStartDateTime ;
+                                      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                      owl:onClass time:Instant
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:audienceCount ;
+                                      owl:allValuesFrom rdfs:Literal
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:description ;
+                                      owl:allValuesFrom rdfs:Literal
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:name ;
+                                      owl:allValuesFrom rdfs:Literal
+                                    ] ;
+                    dcterms:description "A count of consumption events aggregated by one or more attributed properties, e.g. start time, end time, duration, publication event, service, platform, channel, device, account, consumer, resonance event, essence (stream or file), content, content genre, serial/series/season, and so on. Consumption counts are used to answer analytical questions and to compare answers over periods of time. Standardized counts (\"consumptions on our platform in July\") can be defined as subclasses and be stored and reused for comparison."@en ,
+                                        "Un décompte des événements de consommation agrégé selon une ou plusieurs propriétés attribuées, par exemple l’heure de début, l’heure de fin, la durée, l’événement de publication, le service, la plateforme, le canal, l’appareil, le compte, le consommateur, l’événement de résonance, l’essence (flux ou fichier), le contenu, le genre de contenu, la série/collection/saison, et ainsi de suite. Les décomptes de consommation sont utilisés pour répondre à des questions analytiques et pour comparer les réponses sur des périodes de temps. Des décomptes normalisés (« consommations sur notre plateforme en juillet ») peuvent être définis comme sous-classes et être stockés puis réutilisés à des fins de comparaison."@fr ;
+                    rdfs:label "Consumption count"@en ,
+                               "Nombre de consommations"@fr ;
+                    skos:definition "a count of ec:ConsumptionEvents aggregated by one or more attributed properties"@en ,
+                                    "un décompte de ec:ConsumptionEvents agrégé selon une ou plusieurs propriétés attribuées"@fr ;
+                    skos:example """- a 46% market share of French viewers for the football world cup final 2022
+- a 72% market share of French viewers aged 14 to 29 for the football world cup final 2022
+- 18.7 million live stream views of the funeral of former pope Benedict in Europe
+- 36973 views of the youtube-video \"Tom Hanks had an ICONIC chat with the Queen\" from BBC's \"The One Show\" 6 months after publishing
+- 2080 attendees at Stuttgart Liederhalle for a live concert of SWR's symphonic orchestra on April 8, 2022"""@en ,
+                                 """- une part de marché de 46 % des téléspectateurs français pour la finale de la Coupe du monde de football 2022
+- une part de marché de 72 % des téléspectateurs français âgés de 14 à 29 ans pour la finale de la Coupe du monde de football 2022
+- 18,7 millions de vues en direct du funérailles de l'ancien pape Benoît en Europe
+- 36 973 vues de la vidéo YouTube « Tom Hanks had an ICONIC chat with the Queen » de « The One Show » de la BBC, 6 mois après sa publication
+- 2 080 participants au Stuttgart Liederhalle pour un concert en direct de l'orchestre symphonique de SWR le 8 avril 2022"""@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ConsumptionDevice
+ec:ConsumptionDevice rdf:type owl:Class ;
+                     rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                       owl:onProperty ec:compliesWith ;
+                                       owl:allValuesFrom ec:ConsumptionDeviceProfile
+                                     ] ,
+                                     [ rdf:type owl:Restriction ;
+                                       owl:onProperty ec:hasConsumptionDeviceManufacturer ;
+                                       owl:allValuesFrom ec:Agent
+                                     ] ,
+                                     [ rdf:type owl:Restriction ;
+                                       owl:onProperty ec:hasIdentifier ;
+                                       owl:allValuesFrom ec:Identifier
+                                     ] ,
+                                     [ rdf:type owl:Restriction ;
+                                       owl:onProperty ec:hasObjectType ;
+                                       owl:allValuesFrom skos:Concept
+                                     ] ,
+                                     [ rdf:type owl:Restriction ;
+                                       owl:onProperty ec:renders ;
+                                       owl:allValuesFrom ec:Essence
+                                     ] ,
+                                     [ rdf:type owl:Restriction ;
+                                       owl:onProperty ec:consumptionDeviceBrand ;
+                                       owl:allValuesFrom xsd:string
+                                     ] ,
+                                     [ rdf:type owl:Restriction ;
+                                       owl:onProperty ec:consumptionDeviceBrowser ;
+                                       owl:allValuesFrom xsd:string
+                                     ] ,
+                                     [ rdf:type owl:Restriction ;
+                                       owl:onProperty ec:consumptionDeviceModel ;
+                                       owl:allValuesFrom xsd:string
+                                     ] ,
+                                     [ rdf:type owl:Restriction ;
+                                       owl:onProperty ec:consumptionDeviceOS ;
+                                       owl:allValuesFrom xsd:string
+                                     ] ,
+                                     [ rdf:type owl:Restriction ;
+                                       owl:onProperty ec:description ;
+                                       owl:allValuesFrom rdfs:Literal
+                                     ] ,
+                                     [ rdf:type owl:Restriction ;
+                                       owl:onProperty ec:name ;
+                                       owl:allValuesFrom rdfs:Literal
+                                     ] ;
+                     dcterms:description "A device for consuming a media service, such as a television, set-top box, or other playback endpoint used to access media content."@en ,
+                                         "Un dispositif permettant de consommer un service multimédia, comme un téléviseur, un décodeur ou un autre terminal de lecture utilisé pour accéder au contenu multimédia."@fr ;
+                     rdfs:label "Consumption device"@en ,
+                                "Dispositif de consommation"@fr ;
+                     skos:definition "a device for consuming a media service"@en ,
+                                     "un dispositif pour consommer un service multimédia"@fr ;
+                     skos:example """- a smartphone
+- a smart TV
+- a fm radio set
+- a beamer fed with a media signal and projecting onto a screen"""@en ,
+                                  """- un smartphone
+- une smart TV
+- un récepteur radio FM
+- un vidéoprojecteur alimenté par un signal média et projetant sur un écran"""@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ConsumptionDeviceProfile
+ec:ConsumptionDeviceProfile rdf:type owl:Class ;
+                            rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                              owl:onProperty ec:canAccessPublicationChannel ;
+                                              owl:allValuesFrom ec:PublicationChannel
+                                            ] ,
+                                            [ rdf:type owl:Restriction ;
+                                              owl:onProperty ec:canAccessPublicationPlatform ;
+                                              owl:allValuesFrom ec:PublicationPlatform
+                                            ] ,
+                                            [ rdf:type owl:Restriction ;
+                                              owl:onProperty ec:hasGeoLocation ;
+                                              owl:allValuesFrom ec:Location
+                                            ] ,
+                                            [ rdf:type owl:Restriction ;
+                                              owl:onProperty ec:hasIdentifier ;
+                                              owl:allValuesFrom ec:Identifier
+                                            ] ,
+                                            [ rdf:type owl:Restriction ;
+                                              owl:onProperty ec:hasObjectType ;
+                                              owl:allValuesFrom skos:Concept
+                                            ] ,
+                                            [ rdf:type owl:Restriction ;
+                                              owl:onProperty ec:description ;
+                                              owl:allValuesFrom rdfs:Literal
+                                            ] ,
+                                            [ rdf:type owl:Restriction ;
+                                              owl:onProperty ec:name ;
+                                              owl:allValuesFrom rdfs:Literal
+                                            ] ,
+                                            [ rdf:type owl:Restriction ;
+                                              owl:onProperty ec:internetConnectivity ;
+                                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                              owl:onDataRange xsd:boolean
+                                            ] ,
+                                            [ rdf:type owl:Restriction ;
+                                              owl:onProperty ec:microphone ;
+                                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                              owl:onDataRange xsd:boolean
+                                            ] ,
+                                            [ rdf:type owl:Restriction ;
+                                              owl:onProperty ec:radioTuner ;
+                                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                              owl:onDataRange xsd:boolean
+                                            ] ,
+                                            [ rdf:type owl:Restriction ;
+                                              owl:onProperty ec:soundOutput ;
+                                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                              owl:onDataRange xsd:boolean
+                                            ] ,
+                                            [ rdf:type owl:Restriction ;
+                                              owl:onProperty ec:textInput ;
+                                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                              owl:onDataRange xsd:boolean
+                                            ] ,
+                                            [ rdf:type owl:Restriction ;
+                                              owl:onProperty ec:timeshift ;
+                                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                              owl:onDataRange xsd:boolean
+                                            ] ,
+                                            [ rdf:type owl:Restriction ;
+                                              owl:onProperty ec:videoDisplay ;
+                                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                              owl:onDataRange xsd:boolean
+                                            ] ,
+                                            [ rdf:type owl:Restriction ;
+                                              owl:onProperty ec:webcam ;
+                                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                              owl:onDataRange xsd:boolean
+                                            ] ;
+                            dcterms:description "A set of characteristic properties to classify a consumption device, for example manufacturer, model, operating system, screen size, etc."@en ,
+                                                "Un ensemble de propriétés caractéristiques permettant de classer un appareil de consommation, par exemple le fabricant, le modèle, le système d’exploitation, la taille de l’écran, etc."@fr ;
+                            rdfs:label "Consumption device profile"@en ,
+                                       "Profil du dispositif de consommation"@fr ;
+                            skos:definition "a set of properties that allow classification of a ec:ConsumptionDevice"@en ,
+                                            "un ensemble de propriétés permettant de classer un ec:ConsumptionDevice"@fr ;
+                            skos:example """- an Apple smartphone with iOS version > 16
+- a smart TV with screen 50' to 60' and HDR support
+- a VR headset"""@en ,
+                                         """- un smartphone Apple avec une version d’iOS > 16
+- une Smart TV avec un écran de 50' à 60' et prise en charge HDR
+- un casque de réalité virtuelle"""@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ConsumptionEvent
+ec:ConsumptionEvent rdf:type owl:Class ;
+                    rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:consumesEssence ;
+                                      owl:allValuesFrom ec:Essence
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasConsumer ;
+                                      owl:allValuesFrom ec:Consumer
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasConsumptionEventResumePoint ;
+                                      owl:allValuesFrom ec:TimelinePoint
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasDevice ;
+                                      owl:allValuesFrom ec:ConsumptionDevice
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasIdentifier ;
+                                      owl:allValuesFrom ec:Identifier
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasObjectType ;
+                                      owl:allValuesFrom skos:Concept
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasRelatedConsumptionEvent ;
+                                      owl:allValuesFrom ec:ConsumptionEvent
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasRelatedPublicationEvent ;
+                                      owl:allValuesFrom ec:PublicationEvent
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:occursIn ;
+                                      owl:allValuesFrom ec:PublicationChannel
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:occursIn ;
+                                      owl:allValuesFrom ec:PublicationService
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:occursOn ;
+                                      owl:allValuesFrom ec:PublicationPlatform
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:requiresLicence ;
+                                      owl:allValuesFrom ec:ConsumptionLicence
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:resultsIn ;
+                                      owl:allValuesFrom ec:ResonanceEvent
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:accountingTo ;
+                                      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                      owl:onClass ec:Account
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasEnd ;
+                                      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                      owl:onClass ec:TimelinePoint
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasEndDateTime ;
+                                      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                      owl:onClass time:Instant
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasStart ;
+                                      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                      owl:onClass ec:TimelinePoint
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasStartDateTime ;
+                                      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                      owl:onClass time:Instant
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:description ;
+                                      owl:allValuesFrom rdfs:Literal
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:name ;
+                                      owl:allValuesFrom rdfs:Literal
+                                    ] ;
+                    dcterms:description "A location and time span during which consumers of a media service use a device to read, watch or listen to some content that was published within that media service. E.g. a woman watching the latest video of BBC News on YouTube on her smartphone or a family watching a skiing competition during the winter Olympics live on their big screen at home."@en ,
+                                        "Une période et un lieu pendant lesquels les consommateurs d’un service médiatique utilisent un appareil pour lire, regarder ou écouter un contenu publié au sein de ce service médiatique. Par exemple, une femme regardant la dernière vidéo de BBC News sur YouTube sur son smartphone ou une famille regardant en direct, sur grand écran à la maison, une compétition de ski pendant les Jeux olympiques d’hiver."@fr ;
+                    rdfs:label "Consumption event"@en ,
+                               "Événement de consommation"@fr ;
+                    skos:definition "an event of a ec:Consumer using a ec:Device to consume an ec:EditorialObject that was published in a ec:PublicationEvent within a ec:MediaService"@en ,
+                                    "un événement d’un ec:Consumer utilisant un ec:Device pour consommer un ec:EditorialObject publié dans un ec:PublicationEvent au sein d’un ec:MediaService"@fr ;
+                    skos:example """- a person watching a news show on linear tv
+- a family listening to linear radio while having breakfast at home
+- a couple on their living room couch streaming a movie from a VoD service"""@en ,
+                                 """- une personne regardant une émission d’actualités à la télévision linéaire
+- une famille écoutant la radio linéaire pendant le petit-déjeuner à la maison
+- un couple sur le canapé de son salon regardant en streaming un film depuis un service de VoD"""@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ConsumptionLicence
+ec:ConsumptionLicence rdf:type owl:Class ;
+                      rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:coversConsumptionDevice ;
+                                        owl:allValuesFrom ec:ConsumptionDevice
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:hasIdentifier ;
+                                        owl:allValuesFrom ec:Identifier
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:hasObjectType ;
+                                        owl:allValuesFrom skos:Concept
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:hasConsumptionLicenceLink ;
+                                        owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                        owl:onClass ec:Contract
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:description ;
+                                        owl:allValuesFrom rdfs:Literal
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:name ;
+                                        owl:allValuesFrom rdfs:Literal
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:consumptionLicenceText ;
+                                        owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                      ] ;
+                      dcterms:description "A permit attributed to a consumer defines the terms of content consumption within a media service. E.g., the licence is verified by a mechanism often located in the device, referred to as DRM (Digital Rights Management). Age-restricted content can be consumed only after the consumer verifies their age."@en ,
+                                          "Un permis attribué à un consommateur définit les conditions de consommation du contenu au sein d’un service média. Par exemple, la licence est vérifiée par un mécanisme souvent situé dans l’appareil, appelé DRM (Digital Rights Management). Le contenu soumis à une restriction d’âge ne peut être consommé qu’après vérification de l’âge du consommateur."@fr ;
+                      rdfs:label "Consumption licence"@en ,
+                                 "Licence de consommation"@fr ;
+                      skos:definition "a permit attributed to a ec:Consumer that defines the terms of use for a ec:PublicationService or a ec:PublicationEvent of an ec:EditorialObject"@en ,
+                                      "un permis attribué à un ec:Consumer qui définit les conditions d’utilisation d’un ec:PublicationService ou d’un ec:PublicationEvent d’un ec:EditorialObject"@fr ;
+                      skos:example """- a subscription to unlimited streaming from spotify, encompassing 3 devices
+- a 3 month test subscription to a VoD service
+- the entitlement to consume free-to-air broadcast services as the resident of a country"""@en ,
+                                   """- un abonnement au streaming illimité sur Spotify, couvrant 3 appareils
+- un abonnement d'essai de 3 mois à un service de VoD
+- le droit de consommer des services de diffusion en clair en tant que résident d'un pays"""@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Contact
+ec:Contact rdf:type owl:Class ;
+           rdfs:subClassOf ec:Person ;
+           dcterms:description "A person's name and address details through which a connection can be established, often to an organisation or a business the person belongs to."@en ,
+                               "Les nom et adresse d’une personne, par lesquels il est possible d’établir un contact, souvent auprès d’une organisation ou d’une entreprise à laquelle la personne appartient."@fr ;
+           rdfs:label "Contact"@en ,
+                      "Contact"@fr ;
+           skos:definition "a ec:Person that is fully described by its address details"@en ,
+                           "un ec:Personne entièrement décrite par ses coordonnées d'adresse"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ContainerCodec
+ec:ContainerCodec rdf:type owl:Class ;
+                  rdfs:subClassOf ec:Codec ;
+                  dcterms:description "Le codec utilisé pour la production d’un conteneur de contenu."@fr ,
+                                      "The codec used in the production of a content container."@en ;
+                  rdfs:label "Codec de conteneur"@fr ,
+                             "Container codec"@en ;
+                  skos:definition "a ec:Codec used in the production of a container of ec:MediaResources"@en ,
+                                  "un ec:Codec utilisé dans la production d'un conteneur de ec:MediaResources"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ContainerEncodingFormat
+ec:ContainerEncodingFormat rdf:type owl:Class ;
+                           rdfs:subClassOf ec:EncodingFormat ;
+                           dcterms:description "An entry from the classification of transformations that produce digital audio resources from audio signals."@en ,
+                                               "Une entrée de la classification des transformations qui produisent des ressources audio numériques à partir de signaux audio."@fr ;
+                           rdfs:label "Container encoding format"@en ,
+                                      "Format d’encodage du conteneur"@fr ;
+                           skos:definition "a ec:EncodingFormat classifying the transformation from source data into a container that is a ec;MediaResource"@en ,
+                                           "une classe ec:EncodingFormat classifiant la transformation des données स्रोत?"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ContainerFormat
+ec:ContainerFormat rdf:type owl:Class ;
+                   rdfs:subClassOf ec:Format ;
+                   dcterms:description "An entry from the classification of packing schemes for a collection of files or streams with encoded audio, video, image or data information packed in a single file that serves as a container."@en ,
+                                       "Une entrée de la classification des schémas d’empaquetage pour un ensemble de fichiers ou de flux contenant des informations audio, vidéo, image ou de données encodées, regroupées dans un seul fichier servant de conteneur."@fr ;
+                   rdfs:label "Container format"@en ,
+                              "Format de conteneur"@fr ;
+                   skos:definition "a ec:Format classifying the packing scheme of a file containing a set of encoded audio, video, image and/or data streams"@en ,
+                                   "une ec:Format classant le schéma d’empaquetage d’un fichier contenant un ensemble de flux audio, vidéo, image et/ou de données encodés"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ContainerMimeType
+ec:ContainerMimeType rdf:type owl:Class ;
+                     rdfs:subClassOf ec:Format ;
+                     dcterms:description "An entry from the classification of Internet media types. See also: http://www.iana.org/assignments/media-types/application/index.html."@en ,
+                                         "Une entrée de la classification des types de médias Internet. Voir aussi : http://www.iana.org/assignments/media-types/application/index.html."@fr ;
+                     rdfs:label "Container mime type"@en ,
+                                "Type MIME du conteneur"@fr ;
+                     skos:definition "a ec:Format classifying the structure of a file as its Internet media type"@en ,
+                                     "une ec:Format classant la structure d'un fichier selon son type de média Internet"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ContentAlert
+ec:ContentAlert rdf:type owl:Class ;
+                rdfs:subClassOf ec:Type ;
+                dcterms:description "A list of entries to classify the type of alerting for some content."@en ,
+                                    "Une liste d'entrées permettant de classifier le type d'alerte pour un contenu donné."@fr ;
+                rdfs:label "Alerte de contenu"@fr ,
+                           "Content alert"@en ;
+                skos:definition "a ec:Type that list types of alerting for some content"@en ,
+                                "un ec:Type qui liste les types d’alertes pour un contenu"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ContentEditorialCode
+ec:ContentEditorialCode rdf:type owl:Class ;
+                        rdfs:subClassOf ec:Type ;
+                        dcterms:description "A list of entries to classify some content by an editorial format code, e.g. EBU's classification scheme on Editorial Format Codes."@en ,
+                                            "Une liste d’entrées permettant de classer un contenu selon un code de format éditorial, par exemple le schéma de classification de l’EBU sur les codes de format éditorial."@fr ;
+                        rdfs:label "Code éditorial"@fr ,
+                                   "Editorial code"@en ;
+                        skos:definition "a ec:Type that lists editorial format codes for some content"@en ,
+                                        "un ec:Type qui répertorie des codes de format éditorial pour un contenu"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ContentEditorialFormat
+ec:ContentEditorialFormat rdf:type owl:Class ;
+                          rdfs:subClassOf ec:Type ;
+                          dcterms:description "A list of entries to classify some content by an editorial format."@en ,
+                                              "Une liste d’entrées permettant de classer un contenu selon un format éditorial."@fr ;
+                          rdfs:label "Editorial format"@en ,
+                                     "Format éditorial"@fr ;
+                          skos:definition "a ec:Type that lists editorial formats for some content"@en ,
+                                          "un ec:Type qui liste les formats éditoriaux pour un contenu"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Contract
+ec:Contract rdf:type owl:Class ;
+            rdfs:subClassOf [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasContractLink ;
+                              owl:allValuesFrom ec:Resource
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasContractRelatedCost ;
+                              owl:allValuesFrom ec:ContractCost
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasContractTemplate ;
+                              owl:allValuesFrom ec:Contract
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasContractualParty ;
+                              owl:allValuesFrom ec:Agent
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasIdentifier ;
+                              owl:allValuesFrom ec:Identifier
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasObjectType ;
+                              owl:allValuesFrom skos:Concept
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:description ;
+                              owl:allValuesFrom rdfs:Literal
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:name ;
+                              owl:allValuesFrom rdfs:Literal
+                            ] ;
+            dcterms:description "An agreement between parties or a law concerning the rights and duties in the creation or publication of content. More specific contracts for activities like licensing, buying, ordering, etc., can be defined as subclasses."@en ,
+                                "Un accord entre des parties ou une loi concernant les droits et obligations dans la création ou la publication de contenu. Des contrats plus spécifiques pour des activités telles que l’octroi de licence, l’achat, la commande, etc., peuvent être définis comme des sous-classes."@fr ;
+            rdfs:label "Contract"@en ,
+                       "Contrat"@fr ;
+            skos:definition "an agreement between ec:Agents or a law concerning the rights and duties in the creation or publication of ec:Assets"@en ,
+                            "un accord entre des ec:Agents ou une loi concernant les droits et devoirs dans la création ou la publication de ec:Assets"@fr ;
+            skos:example """- a contract between a PSM and a production company for the delivery of a series
+- a law about copyrights of news articles"""@en ,
+                         """- un contrat entre un PSM et une société de production pour la livraison d’une série
+- une loi sur les droits d’auteur des articles de presse"""@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ContractCost
+ec:ContractCost rdf:type owl:Class ;
+                rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                  owl:onProperty ec:hasContractCostAmountCurrency ;
+                                  owl:allValuesFrom skos:Concept
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty ec:hasIdentifier ;
+                                  owl:allValuesFrom ec:Identifier
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty ec:hasObjectType ;
+                                  owl:allValuesFrom skos:Concept
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty ec:contractCostAmount ;
+                                  owl:allValuesFrom xsd:decimal
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty ec:description ;
+                                  owl:allValuesFrom rdfs:Literal
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty ec:name ;
+                                  owl:allValuesFrom rdfs:Literal
+                                ] ;
+                dcterms:description "Les coûts financiers associés à un contrat."@fr ,
+                                    "The financial costs associated to a contract."@en ;
+                rdfs:label "Contract cost"@en ,
+                           "Coût du contrat"@fr ;
+                skos:definition "a costs associated to an ec:Contract"@en ,
+                                "un coût associé à un ec:Contract"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ContractType
+ec:ContractType rdf:type owl:Class ;
+                rdfs:subClassOf skos:Concept ;
+                dcterms:description "An entry from the classification of types of contracts."@en ,
+                                    "Une entrée de la classification des types de contrats."@fr ;
+                rdfs:label "Contract type"@en ,
+                           "Type de contrat"@fr ;
+                skos:definition "a skos:Concept classifying the type of a ec:Contract"@en ,
+                                "un skos:Concept classant le type d'un ec:Contract"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Copyright
+ec:Copyright rdf:type owl:Class ;
+             rdfs:subClassOf ec:Rights ;
+             dcterms:description "Les conditions dans lesquelles le contenu peut être copié."@fr ,
+                                 "The conditions under which content can be copied."@en ;
+             rdfs:label "Copyright"@en ,
+                        "Droit d’auteur"@fr ;
+             skos:definition "a ec:Rights that define the conditions for copying a ec:MediaResource"@en ,
+                             "un ec:Rights qui définissent les conditions de copie d’un ec:MediaResource"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Costume
+ec:Costume rdf:type owl:Class ;
+           rdfs:subClassOf ec:Artefact ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:hasLogo ;
+                             owl:allValuesFrom ec:Logo
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:hasSticker ;
+                             owl:allValuesFrom ec:Sticker
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:costumeSizeInformation ;
+                             owl:allValuesFrom rdfs:Literal
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:costumeTexture ;
+                             owl:allValuesFrom rdfs:Literal
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:gender ;
+                             owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                           ] ;
+           dcterms:description "A piece of clothing that an actress or actor wears while acting."@en ,
+                               "Une pièce de vêtement qu’un acteur ou une actrice porte en jouant."@fr ;
+           rdfs:label "Costume"@en ,
+                      "Costume"@fr ;
+           skos:definition "an ec:Artefact in the form of a garment that an actress or actor wears while acting"@en ,
+                           "un ec:Artefact sous la forme d’un vêtement qu’une actrice ou un acteur porte en jouant"@fr ;
+           skos:example "- les uniformes portés par l’équipage de Star Trek"@fr ,
+                        "- the uniforms worn by the Star Trek crew"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#CostumeType
+ec:CostumeType rdf:type owl:Class ;
+               rdfs:subClassOf skos:Concept ;
+               dcterms:description "An entry from the classification of types of costumes."@en ,
+                                   "Une entrée de la classification des types de costumes."@fr ;
+               rdfs:label "Costume type"@en ,
+                          "Type de costume"@fr ;
+               skos:definition "a skos:Concept classifying the type of a ec:Costume"@en ,
+                               "un skos:Concept classifiant le type d’un ec:Costume"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#CountryCode
+ec:CountryCode rdf:type owl:Class ;
+               rdfs:subClassOf skos:Concept ;
+               dcterms:description "An entry from the ISO codes of countries."@en ,
+                                   "Une entrée provenant des codes ISO des pays."@fr ;
+               rdfs:label "Code pays"@fr ,
+                          "Country code"@en ;
+               skos:definition "a skos:Concept classifying countries by their ISO codes"@en ,
+                               "un skos:Concept classant les pays selon leurs codes ISO"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#CoverageRestrictions
+ec:CoverageRestrictions rdf:type owl:Class ;
+                        rdfs:subClassOf ec:Rights ;
+                        dcterms:description "Les limitations de publication du contenu, par exemple en termes de durée ou de couverture spatiale."@fr ,
+                                            "The limitations for publishing content, e.g. in terms of time or spatial coverage."@en ;
+                        rdfs:label "Coverage restrictions"@en ,
+                                   "Restrictions de couverture"@fr ;
+                        skos:definition "a ec:Rights that define the limitations for publishing an ec:Asset"@en ,
+                                        "une ec:Rights qui définissent les limitations de publication d'un ec:Asset"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#CreativeCommons
+ec:CreativeCommons rdf:type owl:Class ;
+                   rdfs:subClassOf ec:Rights ;
+                   dcterms:description "A standardized set of licensing conditions edited by a non-profit organisation that authors can choose from to limit the use of their works by others."@en ,
+                                       "Un ensemble standardisé de conditions de licence, élaboré par une organisation à but non lucratif, parmi lesquelles les auteurs peuvent choisir pour limiter l’utilisation de leurs œuvres par des tiers."@fr ;
+                   rdfs:label "Creative Commons"@fr ,
+                              "Creative commons"@en ;
+                   skos:definition "a ec:Rights that is a standardized set of licencing conditions selectable for authors (as ec:RightsHolder) to protect their work"@en ,
+                                   "une ec:Rights qui est un ensemble standardisé de conditions de licence pouvant être choisi par les auteurs (en tant que ec:RightsHolder) pour protéger leur œuvre"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#CrewMember
+ec:CrewMember rdf:type owl:Class ;
+              rdfs:subClassOf ec:Person ;
+              dcterms:description "Crew members work in the production of media resources."@en ,
+                                  "Les membres de l'équipe travaillent à la production de ressources médiatiques."@fr ;
+              rdfs:label "Crew"@en ,
+                         "Équipage"@fr ;
+              skos:definition "a ec:Person who is a member of the workforce in the production of a media resource"@en ,
+                              "une ec:Personne qui fait partie de l’effectif dans la production d’une ressource média"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#CuisineStyle
+ec:CuisineStyle rdf:type owl:Class ;
+                rdfs:subClassOf skos:Concept ;
+                dcterms:description "An entry from the classification of cuisine styles to describe food."@en ,
+                                    "Une entrée de la classification des styles de cuisine pour décrire les aliments."@fr ;
+                rdfs:label "Cuisine style"@en ,
+                           "Style de cuisine"@fr ;
+                skos:definition "a skos:Concept classifying the style of a cuisine to describe ec:Food"@en ,
+                                "un skos:Concept classant le style d’une cuisine pour décrire ec:Food"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#CurrencyCode
+ec:CurrencyCode rdf:type owl:Class ;
+                rdfs:subClassOf skos:Concept ;
+                dcterms:description "An entry from the ISO codes of currencies."@en ,
+                                    "Une entrée des codes ISO des devises."@fr ;
+                rdfs:label "Code de devise"@fr ,
+                           "Currency code"@en ;
+                skos:definition "a skos:Concept classifying currencies by their ISO codes"@en ,
+                                "un skos:Concept classant les devises par leurs codes ISO"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#DataFormat
+ec:DataFormat rdf:type owl:Class ;
+              rdfs:subClassOf ec:Format ;
+              dcterms:description "An entry from the classification of structure schemes for data."@en ,
+                                  "Une entrée de la classification des schémas de structure pour les données."@fr ;
+              rdfs:label "Data format"@en ,
+                         "Format de données"@fr ;
+              skos:definition "a ec:Format classifying the structure of data"@en ,
+                              "un ec:Format classant la structure des données"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#DataTrack
+ec:DataTrack rdf:type owl:Class ;
+             rdfs:subClassOf ec:Track ,
+                             [ rdf:type owl:Restriction ;
+                               owl:onProperty ec:hasDataFormat ;
+                               owl:allValuesFrom ec:DataFormat
+                             ] ;
+             dcterms:description "A track containing data that accompanies video or audio content."@en ,
+                                 "Une piste contenant des données qui accompagnent du contenu vidéo ou audio."@fr ;
+             rdfs:label "Data track"@en ,
+                        "Flux de données"@fr ;
+             skos:definition "a ec:Track containing data accompanying video or audio"@en ,
+                             "un ec:Track contenant des données accompagnant la vidéo ou l’audio"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Department
+ec:Department rdf:type owl:Class ;
+              rdfs:subClassOf ec:Organisation ;
+              dcterms:description "A section in a large organisation, typically built around a business task, like an archive department in a media enterprise."@en ,
+                                  "Une section d’une grande organisation, généralement structurée autour d’une tâche métier, comme un service d’archives dans une entreprise de médias."@fr ;
+              rdfs:label "Department"@en ,
+                         "Département"@fr ;
+              skos:definition "a ec:Organisation that is a substructure within an ec:Organisation"@en ,
+                              "une ec:Organisation qui est une sous-structure au sein d’une ec:Organisation"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#DepictedEvent
+ec:DepictedEvent rdf:type owl:Class ;
+                 rdfs:subClassOf ec:Event ;
+                 dcterms:description "A DepictedEVent is fictitious or historical or other sort of Event that the content of the EditorialObject or resource relates to."@en ,
+                                     "Un DepictedEVent est un événement fictif, historique ou d'un autre type auquel se rapporte le contenu de l'EditorialObject ou de la ressource."@fr ;
+                 rdfs:label "Depicted event"@en ,
+                            "Événement représenté"@fr ;
+                 skos:definition "a ec:Event"@en ,
+                                 "un ec:Event"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Disclaimer
+ec:Disclaimer rdf:type owl:Class ;
+              rdfs:subClassOf ec:Rights ;
+              dcterms:description "A declaration of an intentional giving up of an entitlement, claim, or privilege."@en ,
+                                  "Une déclaration de renonciation intentionnelle à un droit, une créance ou un privilège."@fr ;
+              rdfs:label "Avertissement"@fr ,
+                         "Disclaimer"@en ;
+              skos:definition "a ec:Rights that declares the intentional giving up of an entitlement, claim, or privilege"@en ,
+                              "une ec:Rights qui déclare l’abandon intentionnel d’un droit, d’une revendication ou d’un privilège"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Document
+ec:Document rdf:type owl:Class ;
+            rdfs:subClassOf ec:Resource ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasDocumentFormat ;
+                              owl:allValuesFrom ec:DocumentFormat
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasEncodingFormat ;
+                              owl:allValuesFrom ec:EncodingFormat
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:wordCount ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onDataRange xsd:integer
+                            ] ;
+            dcterms:description "A resource in the form of encoded text and/or graphics, e.g. a HTML webpage with news items; a screenplay as a PDF document."@en ,
+                                "Une ressource sous forme de texte et/ou de graphiques codés, par exemple une page web HTML contenant des articles de presse ; un scénario sous forme de document PDF."@fr ;
+            rdfs:label "Document"@en ,
+                       "Document"@fr ;
+            skos:definition "a ec:Resource in the form of encoded text and/or graphics"@en ,
+                            "un ec:Resource sous forme de texte et/ou de graphiques encodés"@fr ;
+            skos:example """- a text file
+- a paper book
+- a web page or a reusable block thereof"""@en ,
+                         """- un fichier texte
+- un livre papier
+- une page web ou un bloc réutilisable de celle-ci"""@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#DocumentFormat
+ec:DocumentFormat rdf:type owl:Class ;
+                  rdfs:subClassOf ec:Format ;
+                  dcterms:description "An entry from the classification of structure schemes for digital documents."@en ,
+                                      "Une entrée de la classification des schémas de structure pour les documents numériques."@fr ;
+                  rdfs:label "Document format"@en ,
+                             "Format de document"@fr ;
+                  skos:definition "a ec:Format classifying the structure of a ec:Document"@en ,
+                                  "un ec:Format classant la structure d’un ec:Document"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Dopesheet
+ec:Dopesheet rdf:type owl:Class ;
+             rdfs:subClassOf ec:Document ;
+             dcterms:description "A document containing additional information about a news item."@en ,
+                                 "Un document contenant des informations supplémentaires sur un sujet d'actualité."@fr ;
+             rdfs:label "Dopesheet"@en ,
+                        "Feuille de présence"@fr ;
+             skos:definition "a ec:Document containing additional information about a news item"@en ,
+                             "un ec:Document contenant des informations supplémentaires sur un élément d’actualité"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#EditUnitCount
+ec:EditUnitCount rdf:type owl:Class ;
+                 rdfs:subClassOf ec:TimelinePoint ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:editUnit ;
+                                   owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onDataRange xsd:long
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:editUnitNumbering ;
+                                   owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onDataRange xsd:long
+                                 ] ;
+                 dcterms:description "A point in time within the timeline of a content that is expressed in units of frames, samples or time."@en ,
+                                     "Un point dans le temps au sein de la chronologie d'un contenu, exprimé en unités d'images, d'échantillons ou de temps."@fr ;
+                 rdfs:label "Edit unit count"@en ,
+                            "Nombre d’unités de montage"@fr ;
+                 skos:definition "a ec:TimelinePoint expressed in units of frames, samples or times"@en ,
+                                 "un ec:TimelinePoint exprimé en unités de frames, samples ou temps"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#EditorialExtra
+ec:EditorialExtra rdf:type owl:Class ;
+                  rdfs:subClassOf ec:EditorialWork ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:hasProgramme ;
+                                    owl:allValuesFrom ec:Programme
+                                  ] ;
+                  dcterms:description "An optional addition to a main work, created to explain, entertain, advertise, or similar, e.g., a trailer or behind-the-scenes."@en ,
+                                      "Un ajout optionnel à une œuvre principale, ստեղծé pour expliquer, divertir, faire de la publicité ou à des fins similaires, par exemple une bande-annonce ou un aperçu des coulisses."@fr ;
+                  rdfs:label "Editorial extra"@en ,
+                             "Supplément éditorial"@fr ;
+                  skos:definition "an ec:EditorialWork serving as an optional addition to a main ec:EditorialWork created to explain, entertain, advertise or similar"@en ,
+                                  "un ec:EditorialWork servant d’ajout facultatif à un ec:EditorialWork principal, créé pour expliquer, divertir, faire de la publicité ou similaire"@fr ;
+                  skos:example """Contenu supplémentaire pour un film : bande-annonce, making-of, matériel bonus, scènes coupées ...
+
+Coulisses :
+- un contenu éditorial supplémentaire qui raconte des scènes de l’œuvre éditoriale
+- court métrage avec des explications sur les scènes de cascades dans un film d’action
+
+Bonus :
+- un Editorial Extra destiné à enrichir le contenu principal d’une ec:EditorialWork.
+- contenu supplémentaire pour un film à consommer séparément comme enrichissement
+
+Making-of :
+- un EditorialExtra sur la réalisation d’un film ou d’un Programme
+- un film documentaire sur le tournage ou la production d’un film ou d’une œuvre audiovisuelle (film TV, série TV, etc.), voire d’une autre production artistique (p. ex. bande dessinée).
+
+Scènes coupées :
+- un contenu éditorial supplémentaire rassemblant des plans ou des scènes écartés lors de la postproduction, mais qui restent attrayants pour les consommateurs pour le plaisir, la curiosité, etc.
+- un clip contenant une collection de scènes coupées sur un DVD bonus d’un film
+
+Bande-annonce :
+- un Editorial Extra avec une durée promotionnelle typique allant jusqu’à 2 minutes, promouvant un Programme, un Serial ou une Series à paraître ultérieurement
+- une séquence audiovisuelle promouvant un film, une série ou un programme télévisé.
+- un aperçu d’une minute du prochain épisode de la série allemande « Tatort » de dimanche prochain
+- un clip promotionnel pour la finale d’une coupe sportive plus tard ce soir"""@fr ,
+                               """Extra content for a movie: trailer, making of, bonus material, outtakes ...
+
+Behind the scenes:
+- an editorial extra that provides a story about scenes of the EditorialWork
+- short film with explanations on the stunt scenes in an action movie
+
+Bonus:
+- an Editorial Extra intended as an enhancing content of a main EditorialWork.
+- Additional content for a movie to be consumed separately as an enhancement
+
+Making of:
+- an EditorialExtra about the making of a film or a Programme
+- A documentary film about the shooting or production of a film or audiovisual work (TV film, TV series, etc.), or even another artistic production (e.g. comic strip).
+
+Outtakes:
+- an Editorial Extra collecting Shots or Scenes that were sorted out during post-production, but still appeal to consumers for fun, curiosity, etc
+- a clip with a collection of outtakes on a bonus DVD of a film
+
+Trailer:
+-an Editorial Extra with typical promotion length of up to 2 minutes, promoting a Programme, a Serial or a Series to be published in the future
+- An AV sequence promoting a film, series or television programme.
+- a 1-minute-preview for next Sunday's episode of German Series \"Tatort\"
+- a promo-clip for a sports-cup-final later tonight"""@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#EditorialFormat
+ec:EditorialFormat rdf:type owl:Class ;
+                   rdfs:subClassOf ec:EditorialGroup ;
+                   dcterms:description "A set of content with a specific editorial style, content layout, anchor host, etc., to address a target audience. Most often used in the assessment of current offerings or in the development of new offerings."@en ,
+                                       "Un ensemble de contenus présentant un style éditorial spécifique, une mise en page du contenu, un hébergeur d’ancre, etc., pour répondre à un public cible. Le plus souvent utilisé pour l’évaluation des offres existantes ou pour le développement de nouvelles offres."@fr ;
+                   rdfs:label "Format"@en ,
+                              "Format"@fr ;
+                   skos:definition "an ec:EditorialGroup of members with a specific editorial style, content layout, anchor-host, e.g., to address a target audience"@en ,
+                                   "un ec:EditorialGroup de membres avec un style éditorial spécifique, une mise en page du contenu, un anchor-host, par exemple pour s’adresser à un public cible"@fr ;
+                   skos:example """- A game show with a specific host: \"Rudis Raterunde\"
+- A journal show on Asian topics: \"Asia Report\"
+- An evening news program: \"Tagesschau Main Edition at 8:00 PM\"
+- An online-streamed discussion show for young people with live audience members and a commentary feature: \"MixTalk\""""@en ,
+                                """- Une émission-jeu avec un animateur spécifique : « Rudis Raterunde »
+- Une émission de magazine sur des sujets asiatiques : « Asia Report »
+- Un journal télévisé du soir : « Tagesschau Main Edition at 8:00 PM »
+- Une émission de discussion diffusée en ligne pour les jeunes, avec des participants en direct dans le public et une fonction de commentaire : « MixTalk »"""@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#EditorialGroup
+ec:EditorialGroup rdf:type owl:Class ;
+                  rdfs:subClassOf ec:EditorialObject ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:hasEditorialGroup ;
+                                    owl:allValuesFrom ec:EditorialGroup
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:hasMember ;
+                                    owl:allValuesFrom ec:EditorialObject
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:totalNumberOfEpisodes ;
+                                    owl:allValuesFrom xsd:integer
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:totalNumberOfGroupMembers ;
+                                    owl:allValuesFrom xsd:integer
+                                  ] ;
+                  dcterms:description "A set of works aligned by either story continuity, format similarity, a common motto, or similar."@en ,
+                                      "Un ensemble d’œuvres reliées par une continuité narrative, une similarité de format, une devise commune ou d’autres éléments similaires."@fr ;
+                  rdfs:label "Editorial group"@en ,
+                             "Groupe éditorial"@fr ;
+                  skos:definition "a ec:EditorialObject that is a group of ec:EditorialWorks and/or ec:EditorialSegments"@en ,
+                                  "un ec:EditorialObject qui est un groupe de ec:EditorialWorks et/ou de ec:EditorialSegments"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#EditorialObject
+ec:EditorialObject rdf:type owl:Class ;
+                   rdfs:subClassOf ec:Asset ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:approvedBy ;
+                                     owl:allValuesFrom ec:Agent
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:coversEvent ;
+                                     owl:allValuesFrom ec:Event
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:coversLocation ;
+                                     owl:allValuesFrom ec:Location
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:existsAs ;
+                                     owl:allValuesFrom ec:EditorialObject
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasAlternativeTitle ;
+                                     owl:allValuesFrom ec:AlternativeTitle
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasAssociatedProductionJob ;
+                                     owl:allValuesFrom ec:ProductionJob
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasAudioDescription ;
+                                     owl:allValuesFrom ec:AudioDescription
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasBrand ;
+                                     owl:allValuesFrom ec:MarketingBrand
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasCaptioning ;
+                                     owl:allValuesFrom ec:Captioning
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasCastMember ;
+                                     owl:allValuesFrom ec:CastMember
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasCharacter ;
+                                     owl:allValuesFrom ec:Character
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasCommissioningContract ;
+                                     owl:allValuesFrom ec:Contract
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasContentEditorialFormat ;
+                                     owl:allValuesFrom ec:ContentEditorialFormat
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasContributor ;
+                                     owl:allValuesFrom ec:Involvement
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasCoverage ;
+                                     owl:allValuesFrom owl:Thing
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasCreator ;
+                                     owl:allValuesFrom ec:Involvement
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasCrewMember ;
+                                     owl:allValuesFrom ec:CrewMember
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasDubbedLanguage ;
+                                     owl:allValuesFrom ec:Language
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasEditorialFormat ;
+                                     owl:allValuesFrom ec:EditorialFormat
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasEditorialFormatOf ;
+                                     owl:allValuesFrom ec:EditorialObject
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasGenre ;
+                                     owl:allValuesFrom skos:Concept
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasKeyword ;
+                                     owl:allValuesFrom ec:Keyword
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasLanguage ;
+                                     owl:allValuesFrom ec:Language
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasManifestation ;
+                                     owl:allValuesFrom ec:Resource
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasOriginalLanguage ;
+                                     owl:allValuesFrom ec:Language
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasParentEditorialObject ;
+                                     owl:allValuesFrom ec:EditorialObject
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasPart ;
+                                     owl:allValuesFrom ec:EditorialSegment
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasProducer ;
+                                     owl:allValuesFrom ec:Agent
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasPublication ;
+                                     owl:allValuesFrom ec:PublicationEvent
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasPublicationHistory ;
+                                     owl:allValuesFrom ec:PublicationHistory
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasPublisher ;
+                                     owl:allValuesFrom ec:Involvement
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasRating ;
+                                     owl:allValuesFrom ec:Rating
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasRelatedAnimal ;
+                                     owl:allValuesFrom ec:Animal
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasRelatedAudioContent ;
+                                     owl:allValuesFrom ec:AudioContent
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasRelatedAudioProgramme ;
+                                     owl:allValuesFrom ec:AudioProgramme
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasRelatedAward ;
+                                     owl:allValuesFrom ec:Award
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasRelatedEditorialObject ;
+                                     owl:allValuesFrom ec:EditorialObject
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasRelatedEvent ;
+                                     owl:allValuesFrom ec:Event
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasRelatedMediaResource ;
+                                     owl:allValuesFrom ec:MediaResource
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasRelatedTextLine ;
+                                     owl:allValuesFrom ec:TextLine
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasReview ;
+                                     owl:allValuesFrom ec:Review
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasSigning ;
+                                     owl:allValuesFrom ec:Signing
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasSubject ;
+                                     owl:allValuesFrom ec:Subject
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasSubtitling ;
+                                     owl:allValuesFrom ec:Subtitling
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasTargetAudience ;
+                                     owl:allValuesFrom ec:Audience
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasTargetChannel ;
+                                     owl:allValuesFrom ec:PublicationChannel
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasTargetPlatform ;
+                                     owl:allValuesFrom ec:PublicationPlatform
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasTargetService ;
+                                     owl:allValuesFrom ec:PublicationService
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasTheme ;
+                                     owl:allValuesFrom ec:Theme
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasTimelineTrack ;
+                                     owl:allValuesFrom ec:TimelineTrack
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasTopic ;
+                                     owl:allValuesFrom ec:Topic
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasVersion ;
+                                     owl:allValuesFrom ec:EditorialObject
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasVersionType ;
+                                     owl:allValuesFrom skos:Concept
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:isAbout ;
+                                     owl:allValuesFrom ec:Asset
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:isDistributedOn ;
+                                     owl:allValuesFrom ec:PublicationService
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:isExtractOf ;
+                                     owl:allValuesFrom ec:EditorialObject
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:isInstantiatedBy ;
+                                     owl:allValuesFrom ec:MediaResource
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:isMemberOf ;
+                                     owl:allValuesFrom ec:EditorialGroup
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:isRequiredBy ;
+                                     owl:allValuesFrom ec:EditorialObject
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:isTimelineTrackPartOf ;
+                                     owl:allValuesFrom ec:TimelineTrack
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:isVersionOf ;
+                                     owl:allValuesFrom ec:EditorialObject
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:references ;
+                                     owl:allValuesFrom ec:BibliographicalObject
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:references ;
+                                     owl:allValuesFrom ec:EditorialObject
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:represents ;
+                                     owl:allValuesFrom ec:Asset
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:requires ;
+                                     owl:allValuesFrom ec:EditorialObject
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasDateBroadcast ;
+                                     owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                     owl:onClass time:Instant
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasDateIssued ;
+                                     owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                     owl:onClass time:Instant
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasDuration ;
+                                     owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                     owl:onClass ec:TimelinePoint
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasEnd ;
+                                     owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                     owl:onClass ec:TimelinePoint
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasLocation ;
+                                     owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                     owl:onClass ec:Location
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasResourceOffset ;
+                                     owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                     owl:onClass ec:TimelinePoint
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasStart ;
+                                     owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                     owl:onClass ec:TimelinePoint
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:isNextInSequence ;
+                                     owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                     owl:onClass ec:EditorialObject
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:isPreviousInSequence ;
+                                     owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                     owl:onClass ec:EditorialObject
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:title ;
+                                     owl:someValuesFrom rdfs:Literal
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:abstract ;
+                                     owl:allValuesFrom rdfs:Literal
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:bookmark ;
+                                     owl:allValuesFrom rdfs:Literal
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:comments ;
+                                     owl:allValuesFrom rdfs:Literal
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:contentDescription ;
+                                     owl:allValuesFrom rdfs:Literal
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:folksonomy ;
+                                     owl:allValuesFrom rdfs:Literal
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:highlights ;
+                                     owl:allValuesFrom rdfs:Literal
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:log ;
+                                     owl:allValuesFrom rdfs:Literal
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:playlist ;
+                                     owl:allValuesFrom rdfs:Literal
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:productionSynopsis ;
+                                     owl:allValuesFrom rdfs:Literal
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:promotionalInformation ;
+                                     owl:allValuesFrom rdfs:Literal
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:pubStatus ;
+                                     owl:allValuesFrom rdfs:Literal
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:script ;
+                                     owl:allValuesFrom rdfs:Literal
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:shotLog ;
+                                     owl:allValuesFrom rdfs:Literal
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:summary ;
+                                     owl:allValuesFrom rdfs:Literal
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:synopsis ;
+                                     owl:allValuesFrom rdfs:Literal
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:tableOfContent ;
+                                     owl:allValuesFrom rdfs:Literal
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:tag ;
+                                     owl:allValuesFrom rdfs:Literal
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:midRollAdAllowed ;
+                                     owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                     owl:onDataRange xsd:boolean
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:orientation ;
+                                     owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:partTotalNumber ;
+                                     owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                     owl:onDataRange xsd:integer
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:position ;
+                                     owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:resolution ;
+                                     owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                     owl:onDataRange xsd:string
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:rightsClearanceFlag ;
+                                     owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                     owl:onDataRange xsd:boolean
+                                   ] ;
+                   dcterms:description "An EditorialObject collects all the descriptive information about an object to be realised as a single MediaResource or a collection thereof. An «EditorialObject» describes any idea, any story and will be used to transform a concept into an editorial definition of a MediaResource before fabrication (Production Domain) and Distribution (Distribution Domain). An «EditorialObject» is a set of descriptive metadata summarising e.g. editing decisions. An «EditorialObject» can be a group of EditorialObjects. An «EditorialObject» can also be a part of another «EditorialObject», which is defined by its start time and duration. EditorialObjects can be ordered either as groups or as items on a timeline. Examples of simple EditorialObjects: Programme, Item, Shot, Part, etc. Examples of Groups: Brand, Series, Serial, Collection, etc. A simplified use-case: A news broadcast consists of two news items. One news item contains the last ten seconds of a one minute long interview taken from another source (i.e. 50\">60\" ). This could be modelled as follows: • The NewsBroadcast is linked to a MediaResource using the instantiates-property • The NewsItems are linked to the NewsBroadcast using a TimelineTrack. Tech 3351 EBU CCDM 13 • The InterviewPart is linked to the NewsItem using the hasMember-property. Start and Duration are properties within the InterviewPart indicating its appearance within the NewsItem2. • The InterviewPart is linked to its original source using the existsAs-property • The Interview instantiates a MediaResource, which in turn is linked from the MediaResource of the NewsBroadcast using the hasSource-property • Representation of segmentation: TimelineTracks are preferred over hasPart-properties, when a rundown is needed, e.g. for playout."@en ,
+                                       "Un EditorialObject rassemble toutes les informations descriptives sur un objet destiné à être réalisé sous la forme d’une seule MediaResource ou d’un ensemble de MediaResource. Un «EditorialObject» décrit n’importe quelle idée, n’importe quelle histoire, et servira à transformer un concept en une définition éditoriale d’une MediaResource avant sa fabrication (Production Domain) et sa distribution (Distribution Domain). Un «EditorialObject» est un ensemble de métadonnées descriptives résumant par exemple des décisions de montage. Un «EditorialObject» peut être un groupe d’EditorialObject. Un «EditorialObject» peut aussi être une partie d’un autre «EditorialObject», définie par son temps de début et sa durée. Les EditorialObjects peuvent être ordonnés soit en groupes, soit comme des éléments sur une chronologie. Exemples d’EditorialObjects simples : Programme, Item, Shot, Part, etc. Exemples de groupes : Brand, Series, Serial, Collection, etc. Cas d’usage simplifié : un bulletin d’information se compose de deux éléments d’actualité. Un élément d’actualité contient les dix dernières secondes d’une interview d’une minute provenant d’une autre source (c’est-à-dire 50\">60\" ). Cela peut être modélisé comme suit : • Le NewsBroadcast est lié à une MediaResource à l’aide de la propriété instantiates • Les NewsItems sont liés au NewsBroadcast à l’aide d’un TimelineTrack. Tech 3351 EBU CCDM 13 • Le InterviewPart est lié au NewsItem à l’aide de la propriété hasMember. Start et Duration sont des propriétés à l’intérieur de InterviewPart indiquant son apparition dans le NewsItem2. • Le InterviewPart est lié à sa source d’origine à l’aide de la propriété existsAs • Le Interview instantiates une MediaResource, laquelle est à son tour liée à partir de la MediaResource du NewsBroadcast à l’aide de la propriété hasSource • Représentation de la segmentation : les TimelineTracks sont préférés aux propriétés hasPart lorsqu’un rundown est nécessaire, par exemple pour le playout."@fr ;
+                   rdfs:label "Editorial object"@en ,
+                              "Objet éditorial"@fr ;
+                   skos:definition "an Asset in the form of content related information about a MediaResource that may or may not exist"@en ,
+                                   "un Asset sous la forme d’informations liées au contenu concernant une MediaResource qui peut exister ou non"@fr ;
+                   skos:example """- a group of EditorialObjects
+- a single \"work of the mind\", a piece
+- a segment of a \"work of the mind\""""@en ,
+                                """- un groupe d'EditorialObjects
+- une seule « œuvre de l'esprit », une pièce
+- un segment d'une « œuvre de l'esprit »"""@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#EditorialObjectType
+ec:EditorialObjectType rdf:type owl:Class ;
+                       rdfs:subClassOf skos:Concept ;
+                       dcterms:description "An entry from the classification of types of editorial objects."@en ,
+                                           "Une entrée de la classification des types d’objets éditoriaux."@fr ;
+                       rdfs:label "Editorial object type"@en ,
+                                  "Type d'objet éditorial"@fr ;
+                       skos:definition "a skos:Concept classifying the type of a ec:EditorialObject"@en ,
+                                       "un skos:Concept classifiant le type d’un ec:EditorialObject"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#EditorialSegment
+ec:EditorialSegment rdf:type owl:Class ;
+                    rdfs:subClassOf ec:EditorialObject ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:isPartOf ;
+                                      owl:someValuesFrom ec:EditorialObject
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasEditorialGroup ;
+                                      owl:allValuesFrom ec:EditorialGroup
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasEditorialWork ;
+                                      owl:allValuesFrom ec:EditorialWork
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:segmentNumber ;
+                                      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                      owl:onDataRange xsd:integer
+                                    ] ;
+                    dcterms:description "A fraction of a work."@en ,
+                                        "Une fraction d’une œuvre."@fr ;
+                    rdfs:label "Editorial segment"@en ,
+                               "Segment éditorial"@fr ;
+                    skos:definition "an ec:EditorialObject representing a fraction of an ec:EditorialWork"@en ,
+                                    "un ec:EditorialObject représentant une fraction d'un ec:EditorialWork"@fr ;
+                    skos:example """- a scene in a movie
+- a section of an interview
+- an intro of a song
+- a paragraph of a text"""@en ,
+                                 """- une scène dans un film
+- une section d’une interview
+- une introduction d’une chanson
+- un paragraphe d’un texte"""@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#EditorialWork
+ec:EditorialWork rdf:type owl:Class ;
+                 rdfs:subClassOf ec:EditorialObject ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasEditorialGroup ;
+                                   owl:allValuesFrom ec:EditorialGroup
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasEditorialWork ;
+                                   owl:allValuesFrom ec:EditorialWork
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:promotes ;
+                                   owl:allValuesFrom ec:EditorialGroup
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:promotes ;
+                                   owl:allValuesFrom ec:EditorialWork
+                                 ] ;
+                 dcterms:description "Some content that is created for publication and consumption, e.g. a film, an episode of a series, an item in a news show, a web article, a social media post, etc."@en ,
+                                     "Un contenu créé pour être publié et consommé, par exemple un film, un épisode de série, un élément d’un journal télévisé, un article web, une publication sur les réseaux sociaux, etc."@fr ;
+                 rdfs:label "Editorial work"@en ,
+                            "Travail éditorial"@fr ;
+                 skos:definition "an ec:EditorialObject representing a \"work of the mind\", a piece"@en ,
+                                 "un ec:EditorialObject représentant une « œuvre de l’esprit », une pièce"@fr ;
+                 skos:example """- a film based on a playbook
+- a radio drama based on a playbook
+- a news programme with several items
+- an item in a news programme
+- an episode of a series"""@en ,
+                              """- un film basé sur un livre de scénario
+- un drame radiophonique basé sur un livre de scénario
+- une émission d'information comportant plusieurs sujets
+- un sujet dans une émission d'information
+- un épisode d'une série"""@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Emotion
+ec:Emotion rdf:type owl:Class ;
+           rdfs:subClassOf [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:hasIdentifier ;
+                             owl:allValuesFrom ec:Identifier
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:hasObjectType ;
+                             owl:allValuesFrom skos:Concept
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:hasRelatedAgent ;
+                             owl:allValuesFrom ec:Agent
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:hasRelatedScene ;
+                             owl:allValuesFrom ec:Scene
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:hasStart ;
+                             owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                             owl:onClass ec:TimelinePoint
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:hasEnd ;
+                             owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                             owl:onClass ec:TimelinePoint
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:description ;
+                             owl:allValuesFrom rdfs:Literal
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:name ;
+                             owl:allValuesFrom rdfs:Literal
+                           ] ;
+           dcterms:description "A feeling related to an agent or a sequence in some content."@en ,
+                               "Un sentiment lié à un agent ou à une séquence dans un contenu."@fr ;
+           rdfs:label "Emotion"@en ,
+                      "Émotion"@fr ;
+           skos:definition "a feeling related to a ec:Agent or a ec:Scene or a period of time in some content"@en ,
+                           "un sentiment lié à un ec:Agent, à une ec:Scene ou à une période de temps dans un contenu"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#EmotionType
+ec:EmotionType rdf:type owl:Class ;
+               rdfs:subClassOf skos:Concept ;
+               dcterms:description "An entry from the classification of types of emotions."@en ,
+                                   "Une entrée de la classification des types d'émotions."@fr ;
+               rdfs:label "Emotion type"@en ,
+                          "Type d’émotion"@fr ;
+               skos:definition "a skos:Concept classifying the type of an emotion"@en ,
+                               "un skos:Concept classifiant le type d’une émotion"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#EncodingFormat
+ec:EncodingFormat rdf:type owl:Class ;
+                  rdfs:subClassOf ec:Format ;
+                  dcterms:description "An entry from the classification of transformations that produce digital resources such as video, audio, images or documents from source signals or data streams."@en ,
+                                      "Une entrée de la classification des transformations qui produisent des ressources numériques telles que des vidéos, des fichiers audio, des images ou des documents à partir de signaux sources ou de flux de données."@fr ;
+                  rdfs:label "Codage"@fr ,
+                             "Encoding"@en ;
+                  skos:definition "a ec:Format classifying the transformation from a source signal or data to a ec:MediaResource, ec:Picture or ec:Document"@en ,
+                                  "une ec:Format classant la transformation d’un signal source ou de données vers une ec:MediaResource, ec:Picture ou ec:Document"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Essence
+ec:Essence rdf:type owl:Class ;
+           rdfs:subClassOf ec:MediaResource ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:hasRelatedPublicationEvent ;
+                             owl:allValuesFrom ec:PublicationEvent
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:isComposedOf ;
+                             owl:allValuesFrom ec:MediaResource
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:readyForPublication ;
+                             owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                             owl:onDataRange xsd:boolean
+                           ] ;
+           dcterms:description "A media resource in the form of a single file or a file package for play-out or publishing, e.g. an audio file for playout on an audio on demand platform; a MXF container for playout; a video file together with additional language tracks and a subtitle file."@en ,
+                               "Une ressource média sous la forme d’un seul fichier ou d’un paquet de fichiers pour la diffusion ou la publication, par exemple un fichier audio pour la diffusion sur une plateforme audio à la demande ; un conteneur MXF pour la diffusion ; un fichier vidéo accompagné de pistes linguistiques supplémentaires et d’un fichier de sous-titres."@fr ;
+           rdfs:label "Essence"@en ,
+                      "Essence"@fr ;
+           skos:definition "a ec:MediaResource in the form of a single file or a file package for play-out or publishing"@en ,
+                           "une ec:MediaResource sous la forme d’un fichier unique ou d’un paquet de fichiers pour la diffusion ou la publication"@fr ;
+           skos:example """- a mxf file
+- a file package delivered by a camera of a specific brand"""@en ,
+                        """- un fichier mxf
+- un paquet de fichiers livré par une caméra d’une marque spécifique"""@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Event
+ec:Event rdf:type owl:Class ;
+         rdfs:subClassOf [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasIdentifier ;
+                           owl:allValuesFrom ec:Identifier
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasObjectType ;
+                           owl:allValuesFrom skos:Concept
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasRelatedAgent ;
+                           owl:allValuesFrom ec:Agent
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasRelatedArtefact ;
+                           owl:allValuesFrom ec:Artefact
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasRelatedEvent ;
+                           owl:allValuesFrom ec:Event
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasRelatedResource ;
+                           owl:allValuesFrom ec:Resource
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasEndDateTime ;
+                           owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                           owl:onClass time:Instant
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasLocation ;
+                           owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                           owl:onClass ec:Location
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasStartDateTime ;
+                           owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                           owl:onClass time:Instant
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:description ;
+                           owl:allValuesFrom rdfs:Literal
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:name ;
+                           owl:allValuesFrom rdfs:Literal
+                         ] ;
+         dcterms:description "A real or fictional happening that is covered in some content."@en ,
+                             "Un événement réel ou fictif qui est couvert dans un contenu quelconque."@fr ;
+         rdfs:label "Event"@en ,
+                    "Événement"@fr ;
+         skos:definition "a real or fictional happening covered in some content"@en ,
+                         "un événement réel ou fictif couvert dans un contenu"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#EventType
+ec:EventType rdf:type owl:Class ;
+             rdfs:subClassOf skos:Concept ;
+             dcterms:description "An entry from the classification of types of events."@en ,
+                                 "Une entrée de la classification des types d’événements."@fr ;
+             rdfs:label "Event type"@en ,
+                        "Type d’événement"@fr ;
+             skos:definition "a skos:Concept classifying the type of a ec:Event"@en ,
+                             "un skos:Concept classifiant le type d’un ec:Event"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ExclusivityType
+ec:ExclusivityType rdf:type owl:Class ;
+                   rdfs:subClassOf skos:Concept ;
+                   dcterms:description "An entry from a list of types of particularity of rights."@en ,
+                                       "Une entrée d’une liste de types de particularité des droits."@fr ;
+                   rdfs:label "Exclusivity type"@en ,
+                              "Type d’exclusivité"@fr ;
+                   skos:definition "a skos:Concept identifying the type of particularity of rights"@en ,
+                                   "un skos:Concept identifiant le type de particularité des droits"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ExploitationIssues
+ec:ExploitationIssues rdf:type owl:Class ;
+                      rdfs:subClassOf ec:Rights ;
+                      dcterms:description "A potential problem arising from the use of someone else's work."@en ,
+                                          "Un problème potentiel lié à l’utilisation de l’œuvre d’autrui."@fr ;
+                      rdfs:label "Exploitation issues"@en ,
+                                 "Problèmes d’exploitation"@fr ;
+                      skos:definition "a ec:Rights that highlight potential problems in the use of someone else's work"@en ,
+                                      "un ec:Rights qui mettent en évidence des problèmes potentiels dans l’utilisation de l’œuvre d’autrui"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#FictionalEvent
+ec:FictionalEvent rdf:type owl:Class ;
+                  rdfs:subClassOf ec:Event ;
+                  dcterms:description "An event that is not real."@en ,
+                                      "Un événement qui n’est pas réel."@fr ;
+                  rdfs:label "Fictional event"@en ,
+                             "Événement fictif"@fr ;
+                  skos:definition "a ec:Event that is not real"@en ,
+                                  "un ec:Event qui n'est pas réel"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#FictionalLocation
+ec:FictionalLocation rdf:type owl:Class ;
+                     rdfs:subClassOf ec:Location ;
+                     dcterms:description "A location that is not real."@en ,
+                                         "Un lieu qui n’est pas réel."@fr ;
+                     rdfs:label "Fictional location"@en ,
+                                "Lieu fictif"@fr ;
+                     skos:definition "a ec:Location that is not real"@en ,
+                                     "une ec:Location qui n'est pas réelle"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#FictionalOrganisation
+ec:FictionalOrganisation rdf:type owl:Class ;
+                         rdfs:subClassOf ec:Organisation ;
+                         dcterms:description "A non-existent organisation mentioned in a fictional story."@en ,
+                                             "Une organisation inexistante mentionnée dans une histoire fictive."@fr ;
+                         rdfs:label "Fictional organisation"@en ,
+                                    "Organisation fictive"@fr ;
+                         skos:definition "an ec:Organisation that does not exist in reality, but as part of a fiction"@en ,
+                                         "une ec:Organisation qui n’existe pas dans la réalité, mais dans le cadre d’une fiction"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#FileFormat
+ec:FileFormat rdf:type owl:Class ;
+              rdfs:subClassOf ec:Format ;
+              dcterms:description "An entry from the classification of file formats for files with non-audiovisual content."@en ,
+                                  "Une entrée de la classification des formats de fichier pour les fichiers à contenu non audiovisuel."@fr ;
+              rdfs:label "File format"@en ,
+                         "Format de fichier"@fr ;
+              skos:definition "a ec:Format for non-audiovisual resources"@en ,
+                              "un ec:Format pour les ressources non audiovisuelles"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Food
+ec:Food rdf:type owl:Class ;
+        rdfs:subClassOf ec:Artefact ,
+                        [ rdf:type owl:Restriction ;
+                          owl:onProperty ec:hasCuisineOrigin ;
+                          owl:allValuesFrom ec:CountryCode
+                        ] ,
+                        [ rdf:type owl:Restriction ;
+                          owl:onProperty ec:hasCuisineStyle ;
+                          owl:allValuesFrom ec:CuisineStyle
+                        ] ,
+                        [ rdf:type owl:Restriction ;
+                          owl:onProperty ec:hasFoodStyle ;
+                          owl:allValuesFrom ec:FoodStyle
+                        ] ,
+                        [ rdf:type owl:Restriction ;
+                          owl:onProperty ec:foodCategory ;
+                          owl:allValuesFrom rdfs:Literal
+                        ] ,
+                        [ rdf:type owl:Restriction ;
+                          owl:onProperty ec:foodIngredient ;
+                          owl:allValuesFrom rdfs:Literal
+                        ] ;
+        dcterms:description "Des denrées qui sont montrées ou consommées dans une scène, comme une pomme, une bouteille de bière, etc."@fr ,
+                            "Provisions that are shown or consumed in a scene, such as an apple, a bottle of beer, etc."@en ;
+        rdfs:label "Aliment"@fr ,
+                   "Food"@en ;
+        skos:definition "an edible item shown or consumed in a scene of the ec:EditorialObject"@en ,
+                        "un élément comestible montré ou consommé dans une scène de ec:EditorialObject"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#FoodStyle
+ec:FoodStyle rdf:type owl:Class ;
+             rdfs:subClassOf skos:Concept ;
+             dcterms:description "An entry from the classification of food styles."@en ,
+                                 "Une entrée de la classification des styles alimentaires."@fr ;
+             rdfs:label "Food style"@en ,
+                        "Style alimentaire"@fr ;
+             skos:definition "a skos:Concept classifying the style of ec:Food"@en ,
+                             "un skos:Concept classifiant le style de ec:Food"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Format
+ec:Format rdf:type owl:Class ;
+          rdfs:subClassOf skos:Concept ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasFormatId ;
+                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                            owl:onClass ec:Identifier
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasFormatVersionId ;
+                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                            owl:onClass ec:Identifier
+                          ] ;
+          dcterms:description "An entry from the classification of types of formats, that can also be more specific like audio / video / image / document / data and container formats. A format can be globally associated with a resource but more specific formats can also be distinctly associated with a more specific resource."@en ,
+                              "Une entrée de la classification des types de formats, qui peut aussi être plus spécifique comme les formats audio / vidéo / image / document / données et les formats de conteneur. Un format peut être associé globalement à une ressource, mais des formats plus spécifiques peuvent aussi être associés distinctement à une ressource plus précise."@fr ;
+          rdfs:label "Format"@en ,
+                     "Format"@fr ;
+          skos:definition "a skos:Concept classifying the technical format of a ec:Resource"@en ,
+                          "un skos:Concept classant le format technique d’une ec:Resource"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Generation
+ec:Generation rdf:type owl:Class ;
+              rdfs:subClassOf ec:Format ;
+              dcterms:description "An entry from the classification of versions of media resources, e.g. \"master\", \"edit master\" or \"distribution copy\"."@en ,
+                                  "Une entrée de la classification des versions de ressources médiatiques, par exemple « master », « edit master » ou « copie de distribution »."@fr ;
+              rdfs:label "Generation"@en ,
+                         "Génération"@fr ;
+              skos:definition "a ec:Format classifying the version of a ec:MediaResource"@en ,
+                              "une classe ec:Format classant la version d’un ec:MediaResource"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Genre
+ec:Genre rdf:type owl:Class ;
+         rdfs:subClassOf ec:Type ;
+         dcterms:description "A list of entries to classify some content by genre, e.g. EBU's classification scheme on ContentGenre."@en ,
+                             "Une liste d’entrées permettant de classer certains contenus par genre, par exemple le schéma de classification ContentGenre de l’EBU."@fr ;
+         rdfs:label "Genre"@en ,
+                    "Genre"@fr ;
+         skos:definition "a ec:Type that lists editorial genres for some content"@en ,
+                         "un ec:Type qui répertorie les genres éditoriaux pour un contenu"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#IPRRestrictions
+ec:IPRRestrictions rdf:type owl:Class ;
+                   rdfs:subClassOf ec:Rights ;
+                   dcterms:description "A limitation of the use of a work referring to intellectual property legislation or contracts."@en ,
+                                       "Une limitation de l'utilisation d'une œuvre se référant à la législation sur la propriété intellectuelle ou à des contrats."@fr ;
+                   rdfs:label "IPR restrictions"@en ,
+                              "Restrictions IPR"@fr ;
+                   skos:definition "a ec:Rights that limits the use of a work referring to intellectual property legislation or contracts"@en ,
+                                   "une ec:Rights qui limite l’utilisation d’une œuvre se référant à la législation ou à des contrats de propriété intellectuelle"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Identifier
+ec:Identifier rdf:type owl:Class ;
+              rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:hasIssuer ;
+                                owl:allValuesFrom ec:Agent
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:hasObjectType ;
+                                owl:allValuesFrom skos:Concept
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:hasDateCreated ;
+                                owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                owl:onClass time:Instant
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:description ;
+                                owl:allValuesFrom rdfs:Literal
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:name ;
+                                owl:allValuesFrom rdfs:Literal
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:identifierValue ;
+                                owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                owl:onDataRange xsd:string
+                              ] ;
+              dcterms:description "Pour prendre en charge l’utilisation d’identifiants structurés."@fr ,
+                                  "To support the use of structured identifiers."@en ;
+              rdfs:label "Identifiant"@fr ,
+                         "Identifier"@en ;
+              skos:definition "a unique string associated with an entity"@en ,
+                              "une chaîne unique associée à une entité"@fr ;
+              skos:example """- \"ISAN 0000-0001-8947-0000-8-0000-0000-D\" est un identifiant ISAN
+- \"10.5240/EA73-79D7-1B2B-B378-3A73-M\" est un identifiant EIDR pour le film « Blade Runner »"""@fr ,
+                           """- \"ISAN 0000-0001-8947-0000-8-0000-0000-D\" is an ISAN Identifier
+- \"10.5240/EA73-79D7-1B2B-B378-3A73-M\" is an EIDR Identifier for the movie \"Blade Runner\""""@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#IdentifierType
+ec:IdentifierType rdf:type owl:Class ;
+                  rdfs:subClassOf skos:Concept ;
+                  dcterms:description "An entry from the classification of types of identifiers."@en ,
+                                      "Une entrée de la classification des types d'identifiants."@fr ;
+                  rdfs:label "Identifier type"@en ,
+                             "Type d'identifiant"@fr ;
+                  skos:definition "a skos:Concept classifying the type of a ec:Identifier"@en ,
+                                  "un skos:Concept classifiant le type d’un ec:Identifier"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ImageCodec
+ec:ImageCodec rdf:type owl:Class ;
+              rdfs:subClassOf ec:Codec ;
+              dcterms:description "Le codec utilisé pour la production d’images numériques."@fr ,
+                                  "The codec used in the production of digital images."@en ;
+              rdfs:label "Codec d'image"@fr ,
+                         "Image codec"@en ;
+              skos:definition "a ec:Codec used in the production of a file for a photo"@en ,
+                              "un ec:Codec utilisé dans la production d’un fichier pour une photo"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ImageFormat
+ec:ImageFormat rdf:type owl:Class ;
+               rdfs:subClassOf ec:Format ;
+               dcterms:description "An entry from the classification of formats of pictures or media resources, e.g. \"3x4\", \"4x3\" or \"16x9\"."@en ,
+                                   "Une entrée de la classification des formats d’images ou de ressources multimédias, par exemple « 3x4 », « 4x3 » ou « 16x9 »."@fr ;
+               rdfs:label "Format d'image"@fr ,
+                          "Image format"@en ;
+               skos:definition "a ec:Format classifying the relation of length vs. height of a ec:Picture or a ec:MediaResource"@en ,
+                               "un ec:Format classant la relation entre la longueur et la hauteur d'une ec:Picture ou d'une ec:MediaResource"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#IntentionCode
+ec:IntentionCode rdf:type owl:Class ;
+                 rdfs:subClassOf ec:Type ;
+                 dcterms:description "A list of entries to classify the intention for the creation of some content, e.g. EBU's classification scheme of Intention Codes."@en ,
+                                     "Une liste d’entrées permettant de classer l’intention de la création d’un contenu, par exemple le schéma de classification des Intention Codes d’EBU."@fr ;
+                 rdfs:label "Code d’intention"@fr ,
+                            "Intention code"@en ;
+                 skos:definition "a ec:Type that lists intentions for which some content was created"@en ,
+                                 "un ec:Type qui répertorie les intentions pour lesquelles un contenu a été créé"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Involvement
+ec:Involvement rdf:type owl:Class ;
+               rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                 owl:onProperty ec:bringsRights ;
+                                 owl:allValuesFrom ec:Rights
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty ec:hasAgent ;
+                                 owl:allValuesFrom ec:Agent
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty ec:hasAgentOnStagePosition ;
+                                 owl:allValuesFrom ec:OnStagePosition
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty ec:hasAssociatedArtefact ;
+                                 owl:allValuesFrom ec:Artefact
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty ec:hasIdentifier ;
+                                 owl:allValuesFrom ec:Identifier
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty ec:hasObjectType ;
+                                 owl:allValuesFrom skos:Concept
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty ec:hasRelatedArtefact ;
+                                 owl:allValuesFrom ec:Artefact
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty ec:playsCharacter ;
+                                 owl:allValuesFrom ec:Character
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty ec:usesProductionDevice ;
+                                 owl:allValuesFrom ec:ProductionDevice
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty ec:description ;
+                                 owl:allValuesFrom rdfs:Literal
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty ec:name ;
+                                 owl:allValuesFrom rdfs:Literal
+                               ] ;
+               dcterms:description "An agent's participation in the content, e.g., an actress playing a character, a screenwriter, a production company, or a broadcaster holding the publishing rights."@en ,
+                                   "La participation d’un agent au contenu, par exemple une actrice interprétant un personnage, un scénariste, une société de production ou un diffuseur détenant les droits de publication."@fr ;
+               rdfs:label "Implication"@fr ,
+                          "Involvement"@en ;
+               skos:definition "an ec:Agent's participation in an ec:EditorialObject or the creation or publication thereof"@en ,
+                               "la participation d’un ec:Agent dans un ec:EditorialObject ou sa création ou publication"@fr ;
+               skos:example """- authoring a screenplay for a film production
+- directing a movie
+- sound engineering of a talk show
+- creation special effects for a movie"""@en ,
+                            """- rédaction du scénario d’un film
+- réalisation d’un film
+- ingénierie sonore d’un talk-show
+- création d’effets spéciaux pour un film"""@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Item
+ec:Item rdf:type owl:Class ;
+        rdfs:subClassOf ec:EditorialWork ,
+                        [ rdf:type owl:Restriction ;
+                          owl:onProperty ec:hasArticle ;
+                          owl:allValuesFrom ec:Article
+                        ] ,
+                        [ rdf:type owl:Restriction ;
+                          owl:onProperty ec:hasDopesheet ;
+                          owl:allValuesFrom ec:Dopesheet
+                        ] ,
+                        [ rdf:type owl:Restriction ;
+                          owl:onProperty ec:hasPost ;
+                          owl:allValuesFrom ec:Post
+                        ] ,
+                        [ rdf:type owl:Restriction ;
+                          owl:onProperty ec:hasProgramme ;
+                          owl:allValuesFrom ec:Programme
+                        ] ;
+        dcterms:description "Content created to be incorporated into a programme, an article, or a post, e.g., a news item or a short video for social media."@en ,
+                            "Contenu créé pour être intégré dans un programme, un article ou un post, par exemple un sujet d’actualité ou une courte vidéo pour les réseaux sociaux."@fr ;
+        rdfs:label "Article"@fr ,
+                   "Item"@en ;
+        skos:definition "an ec:EditorialWork to be incorporated into a Programme, an Article or a Post"@en ,
+                        "un ec:EditorialWork à incorporer dans un Programme, un Article ou un Post"@fr ;
+        skos:example """- a news item to be incorporated in a news programme
+- a survey-clip to be incorporated in a debate"""@en ,
+                     """- un élément d’actualité à intégrer dans un programme d’actualités
+- un extrait d’enquête à intégrer dans un débat"""@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#KeyCareerEvent
+ec:KeyCareerEvent rdf:type owl:Class ;
+                  rdfs:subClassOf ec:KeyEvent ;
+                  dcterms:description "A significant event for the career of a real or fictional person."@en ,
+                                      "Un événement important dans la carrière d’une personne réelle ou fictive."@fr ;
+                  rdfs:label "Key career event"@en ,
+                             "Événement clé de carrière"@fr ;
+                  skos:definition "a ec:KeyEvent for the career of a ec:Person"@en ,
+                                  "un ec:KeyEvent pour la carrière d’un ec:Person"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#KeyEvent
+ec:KeyEvent rdf:type owl:Class ;
+            rdfs:subClassOf ec:Event ;
+            dcterms:description "A significant event in a person’s career or personal life, or another notable happening covered in content."@en ,
+                                "Un événement important dans la carrière ou la vie personnelle d’une personne, ou tout autre fait marquant couvert par le contenu."@fr ;
+            rdfs:label "Key event"@en ,
+                       "Événement clé"@fr ;
+            skos:definition "a ec:Event that is significant"@en ,
+                            "un ec:Event significatif"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#KeyPersonalEvent
+ec:KeyPersonalEvent rdf:type owl:Class ;
+                    rdfs:subClassOf ec:KeyEvent ;
+                    dcterms:description "A significant event in the personal life of a real or fictional person."@en ,
+                                        "Un événement significatif dans la vie personnelle d’une personne réelle ou fictive."@fr ;
+                    rdfs:label "Key personal event"@en ,
+                               "Événement personnel clé"@fr ;
+                    skos:definition "a ec:KeyEvent in the personal life a ec:Person"@en ,
+                                    "un ec:KeyEvent dans la vie personnelle d’une ec:Person"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Keyframe
+ec:Keyframe rdf:type owl:Class ;
+            rdfs:subClassOf ec:Picture ;
+            dcterms:description "A picture extracted at some point in time from a video, often called a \"frame\", used to represent the surrounding video sequence for easy navigation back and forth along the video timeline."@en ,
+                                "Une image extraite à un moment donné d’une vidéo, souvent appelée « image », utilisée pour représenter la séquence vidéo environnante afin de faciliter la navigation avant et arrière le long de la chronologie de la vidéo."@fr ;
+            rdfs:label "Image clé"@fr ,
+                       "Key frame"@en ;
+            skos:definition "a ec:Picture that is extracted at a point in time from a video and used to visually reference that same point in time"@en ,
+                            "une ec:Picture extraite à un instant donné d'une vidéo et utilisée pour se référer visuellement à ce même instant"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Keyword
+ec:Keyword rdf:type owl:Class ;
+           rdfs:subClassOf skos:Concept ;
+           dcterms:description "An entry from the list of keywords to classify the content of a piece of work."@en ,
+                               "Une entrée de la liste de mots-clés permettant de classer le contenu d’une œuvre."@fr ;
+           rdfs:label "Keyword"@en ,
+                      "Mot-clé"@fr ;
+           skos:definition "a skos:Concept classifying the content of a ec:EditorialObject"@en ,
+                           "un skos:Concept classifiant le contenu d'un ec:EditorialObject"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Language
+ec:Language rdf:type owl:Class ;
+            rdfs:subClassOf skos:Concept ;
+            dcterms:description "An entry from the list of languages related to, e.g. a piece of work, a person or an organisation."@en ,
+                                "Une entrée de la liste des langues associées, par exemple, à une œuvre, une personne ou une organisation."@fr ;
+            rdfs:label "Language"@en ,
+                       "Langue"@fr ;
+            skos:definition "a skos:Concept classifying the language of a ec:EditorialObject or ec:Agent"@en ,
+                            "un skos:Concept classifiant la langue d’un ec:EditorialObject ou d’un ec:Agent"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Licensing
+ec:Licensing rdf:type owl:Class ;
+             rdfs:subClassOf ec:Rights ;
+             dcterms:description "A set of conditions under which the use of a work is granted."@en ,
+                                 "Un ensemble de conditions dans lesquelles l’utilisation d’une œuvre est autorisée."@fr ;
+             rdfs:label "Licensing"@en ,
+                        "Octroi de licence"@fr ;
+             skos:definition "a ec:Rights that defines the conditions under which the use of a work is granted"@en ,
+                             "une ec:Rights qui définit les conditions dans lesquelles l'utilisation d'une œuvre est accordée"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Location
+ec:Location rdf:type owl:Class ;
+            rdfs:subClassOf [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasIdentifier ;
+                              owl:allValuesFrom ec:Identifier
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasLocationCode ;
+                              owl:allValuesFrom ec:LocationCode
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasLocationPicture ;
+                              owl:allValuesFrom ec:Picture
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasObjectType ;
+                              owl:allValuesFrom skos:Concept
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasRelatedArtefact ;
+                              owl:allValuesFrom ec:Artefact
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasRelatedEvent ;
+                              owl:allValuesFrom ec:Event
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasRelatedResource ;
+                              owl:allValuesFrom ec:Resource
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasRegionCode ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onClass ec:RegionCode
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:description ;
+                              owl:allValuesFrom rdfs:Literal
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:locationAddressMunicipality ;
+                              owl:allValuesFrom rdfs:Literal
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:locationAddressPostalCode ;
+                              owl:allValuesFrom rdfs:Literal
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:locationAddressStreetName ;
+                              owl:allValuesFrom rdfs:Literal
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:name ;
+                              owl:allValuesFrom rdfs:Literal
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:locationAddressApartmentNumber ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onDataRange xsd:string
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:locationAddressArea ;
+                              owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:locationAddressCountry ;
+                              owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:locationAddressHouseNumber ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onDataRange xsd:string
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:locationAltitude ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onDataRange xsd:float
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:locationCoordinateSystemName ;
+                              owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:locationLatitude ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onDataRange xsd:float
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:locationLongitude ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onDataRange xsd:float
+                            ] ;
+            dcterms:description "A location related to the media resource, e.g. depicted in the resource (possibly fictional) or where the resource was created (shooting location), e.g. A «Location» is used to define the spatial coverage of the story or recording locations like studios or in the field, associated with the EditorialObjects (or Part of EditorialObjects). Note: a type of location shall be defined as a sub-class of Location."@en ,
+                                "Un lieu lié à la ressource médiatique, par exemple représenté dans la ressource (éventuellement fictif) ou là où la ressource a été créée (lieu de tournage), par exemple, une «Location» est utilisée pour définir la couverture spatiale de l कहानी ou les lieux d’enregistrement comme des studios ou sur le terrain, associés aux EditorialObjects (ou à une partie des EditorialObjects). Note : un type de lieu doit être défini comme une sous-classe de Location."@fr ;
+            rdfs:label "Emplacement"@fr ,
+                       "Location"@en ;
+            skos:definition "a spatial assignment to a media related locatable Thing"@en ,
+                            "une assignation spatiale à une chose localisable liée à un média"@fr ;
+            skos:example """- London as a place where BBC produces news shows
+- London as a place for a screenplay
+- London as a place for the prime minister's public announcement covered in a BBC news show"""@en ,
+                         """- Londres comme lieu où la BBC produit des émissions d'information
+- Londres comme lieu pour un scénario
+- Londres comme lieu de l'annonce publique du Premier ministre, relayée dans une émission d'information de la BBC"""@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#LocationCode
+ec:LocationCode rdf:type owl:Class ;
+                rdfs:subClassOf skos:Concept ;
+                dcterms:description "An entry from a list of codes identifying a location."@en ,
+                                    "Une entrée d’une liste de codes identifiant un lieu."@fr ;
+                rdfs:label "Code de localisation"@fr ,
+                           "Location code"@en ;
+                skos:definition "a skos:Concept identifying a ec:Location"@en ,
+                                "un skos:Concept identifiant un ec:Location"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#LocationType
+ec:LocationType rdf:type owl:Class ;
+                rdfs:subClassOf skos:Concept ;
+                dcterms:description "An entry from a list of types to classify locations."@en ,
+                                    "Une entrée d’une liste de types permettant de classer les lieux."@fr ;
+                rdfs:label "Location type"@en ,
+                           "Type de lieu"@fr ;
+                skos:definition "a skos:Concept classifying the type of a ec:Location"@en ,
+                                "un skos:Concept classifiant le type d'un ec:Location"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Locator
+ec:Locator rdf:type owl:Class ;
+           rdfs:subClassOf [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:hasIdentifier ;
+                             owl:allValuesFrom ec:Identifier
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:hasObjectType ;
+                             owl:allValuesFrom skos:Concept
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:description ;
+                             owl:allValuesFrom rdfs:Literal
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:locatorTargetInformation ;
+                             owl:allValuesFrom rdfs:Literal
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:name ;
+                             owl:allValuesFrom rdfs:Literal
+                           ] ;
+           dcterms:description "A place within a location, e.g. a hall name and number in a large concert building."@en ,
+                               "Un lieu au sein d’un emplacement, par exemple le nom et le numéro d’une salle dans un grand bâtiment de concert."@fr ;
+           rdfs:label "Localisateur"@fr ,
+                      "Locator"@en ;
+           skos:definition "an additional specification of a place subordinate to a ec:Locator"@en ,
+                           "une spécification supplémentaire d’un lieu subordonné à un ec:Locator"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Logo
+ec:Logo rdf:type owl:Class ;
+        rdfs:subClassOf ec:Picture ;
+        dcterms:description "A picture representing an organisation, an award, a brand, a publication platform, a publication channel, a publication service or a rating. This list may be extended in the future."@en ,
+                            "Une image représentant une organisation, un prix, une marque, une plateforme de publication, un canal de publication, un service de publication ou une note. Cette liste pourra être étendue à l'avenir."@fr ;
+        rdfs:label "Logo"@en ,
+                   "Logo"@fr ;
+        skos:definition "a ec:Picture to represent an ec: Organization, a ec:Award, a ec:MarketingBrand, a ec:PublicationPlatform, a ec:PublicationChannel, a ec:PublicationService, or a ec:Rating"@en ,
+                        "une ec:Picture pour représenter une ec:Organization, une ec:Award, une ec:MarketingBrand, une ec:PublicationPlatform, une ec:PublicationChannel, une ec:PublicationService, ou une ec:Rating"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#MarketingBrand
+ec:MarketingBrand rdf:type owl:Class ;
+                  rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:hasIdentifier ;
+                                    owl:allValuesFrom ec:Identifier
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:hasLogo ;
+                                    owl:allValuesFrom ec:Logo
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:isOwnedBy ;
+                                    owl:allValuesFrom ec:Agent
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:description ;
+                                    owl:allValuesFrom rdfs:Literal
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:name ;
+                                    owl:allValuesFrom rdfs:Literal
+                                  ] ;
+                  dcterms:description "A name, often accompanied by a logo, and given to an asset or a publication service or a group thereof to distinguish them from those provided by other manufacturers or merchants."@en ,
+                                      "Un nom, souvent accompagné d’un logo, attribué à un actif ou à un service de publication, ou à un groupe de ceux-ci, afin de les distinguer de ceux fournis par d’autres fabricants ou commerçants."@fr ;
+                  rdfs:label "Brand"@en ,
+                             "Marque"@fr ;
+                  skos:definition "a name, often accompanied by a logo, and given to an ec:Asset or an ec:PublicationService or a group thereof to distinguish them from those provided by other manufacturers or merchants"@en ,
+                                  "un nom, souvent accompagné d’un logo, et attribué à un ec:Asset ou à un ec:PublicationService ou à un groupe de ceux-ci afin de les distinguer de ceux fournis par d’autres fabricants ou marchands"@fr ;
+                  skos:example """- le nom d’une organisation de service public audiovisuel : « BBC »
+- le nom d’une chaîne média : « BBC4 »
+- le nom d’une série : « Downton Abbey »
+- le nom d’un feuilleton : « BBC News »"""@fr ,
+                               """- the name of a PSM organization: \"BBC\"
+- the name of a media channel: \"BBC4\"
+- the name of a series: \"Downton Abbey\"
+- the name of a serial: \"BBC News\""""@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Measure
+ec:Measure rdf:type owl:Class ;
+           rdfs:subClassOf [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:hasIdentifier ;
+                             owl:allValuesFrom ec:Identifier
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:hasObjectType ;
+                             owl:allValuesFrom skos:Concept
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:hasUnit ;
+                             owl:allValuesFrom skos:Concept
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:measures ;
+                             owl:allValuesFrom ec:Rule
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:description ;
+                             owl:allValuesFrom rdfs:Literal
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:measureValue ;
+                             owl:allValuesFrom rdfs:Literal
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:measureValueMax ;
+                             owl:allValuesFrom rdfs:Literal
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:measureValueMin ;
+                             owl:allValuesFrom rdfs:Literal
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:name ;
+                             owl:allValuesFrom rdfs:Literal
+                           ] ;
+           dcterms:description "A Measure associated with a Rule to assess compliance through AuditJobs."@en ,
+                               "Une mesure associée à une règle pour évaluer la conformité via des AuditJobs."@fr ;
+           rdfs:label "Measure"@en ,
+                      "Mesure"@fr ;
+           skos:definition "a act of determining a number and a unit to answer a given question, by counting, comparing, aggregating or calculating"@en ,
+                           "un acte de déterminer un nombre et une unité pour répondre à une question donnée, en comptant, comparant, agrégeant ou calculant"@fr ;
+           skos:example """- determining the volume level of audio track
+- counting the minutes that a speaker has during a debate
+- counting the number of female experts in all programmes of BBC One"""@en ,
+                        """- déterminer le niveau sonore d’une piste audio
+- compter les minutes dont dispose un intervenant lors d’un débat
+- compter le nombre d’expertes dans l’ensemble des programmes de BBC One"""@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#MediaFragment
+ec:MediaFragment rdf:type owl:Class ;
+                 rdfs:subClassOf ec:MediaResource ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:isMediaFragmentOf ;
+                                   owl:allValuesFrom ec:MediaResource
+                                 ] ;
+                 dcterms:description "A media resource that is a temporal or spatial segment of a resource as defined by the Media Fragment URI (http://www.w3.org/2008/WebVideo/Fragments/WD-media-fragments-spec/)."@en ,
+                                     "Une ressource multimédia qui est un segment temporel ou spatial d’une ressource, telle que définie par l’URI Media Fragment (http://www.w3.org/2008/WebVideo/Fragments/WD-media-fragments-spec/)."@fr ;
+                 rdfs:label "Fragment média"@fr ,
+                            "Media fragment"@en ;
+                 skos:definition "a ec:MediaResource that is a temporal or spatial segment of a ec:Resource as defined by the Media Fragment URI (http://www.w3.org/2008/WebVideo/Fragments/WD-media-fragments-spec/)"@en ,
+                                 "un ec:MediaResource qui est un segment temporel ou spatial d'un ec:Resource tel que défini par le Media Fragment URI (http://www.w3.org/2008/WebVideo/Fragments/WD-media-fragments-spec/)"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#MediaResource
+ec:MediaResource rdf:type owl:Class ;
+                 rdfs:subClassOf ec:Resource ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasAudioTrack ;
+                                   owl:allValuesFrom ec:AudioTrack
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasCaptioningSource ;
+                                   owl:allValuesFrom ec:Agent
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasClone ;
+                                   owl:allValuesFrom ec:MediaResource
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasCodec ;
+                                   owl:allValuesFrom ec:Codec
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasDataTrack ;
+                                   owl:allValuesFrom ec:DataTrack
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasDub ;
+                                   owl:allValuesFrom ec:MediaResource
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasEncodingFormat ;
+                                   owl:allValuesFrom ec:EncodingFormat
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasGeneration ;
+                                   owl:allValuesFrom ec:MediaResource
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasMediaFragment ;
+                                   owl:allValuesFrom ec:MediaFragment
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasMedium ;
+                                   owl:allValuesFrom ec:Medium
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasMetadataTrack ;
+                                   owl:allValuesFrom ec:MetadataTrack
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasProductionDevice ;
+                                   owl:allValuesFrom ec:ProductionDevice
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasRelatedAudioObject ;
+                                   owl:allValuesFrom ec:AudioObject
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasRelatedAudioTrack ;
+                                   owl:allValuesFrom ec:AudioTrack
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasRelatedEssence ;
+                                   owl:allValuesFrom ec:Essence
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasStandard ;
+                                   owl:allValuesFrom ec:Standard
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasStorageType ;
+                                   owl:allValuesFrom ec:StorageType
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasSubtitlingFormat ;
+                                   owl:allValuesFrom ec:SubtitlingFormat
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasTimecodeTrack ;
+                                   owl:allValuesFrom ec:TimecodeTrack
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasTrack ;
+                                   owl:allValuesFrom ec:Track
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasVideoTrack ;
+                                   owl:allValuesFrom ec:VideoTrack
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:isMasterOf ;
+                                   owl:allValuesFrom ec:MediaResource
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:isRequiredBy ;
+                                   owl:allValuesFrom ec:MediaResource
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:requires ;
+                                   owl:allValuesFrom ec:MediaResource
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasAncillaryDataFormat ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass ec:AncillaryDataFormat
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasAudioCodec ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass ec:AudioCodec
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasAudioEncodingFormat ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass ec:AudioEncodingFormat
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasCaptioningFormat ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass ec:CaptioningFormat
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasColourSpace ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass ec:ColourSpace
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasContainerCodec ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass ec:ContainerCodec
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasContainerEncodingFormat ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass ec:ContainerEncodingFormat
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasContainerMimeType ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass ec:MimeType
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasDateDigitised ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass time:Instant
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasDateIngested ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass time:Instant
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasDateMigrated ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass time:Instant
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasDateNormalized ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass time:Instant
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasDateTransferred ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass time:Instant
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasDisplayAspectRatio ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass ec:ActiveFormatDescriptorCode
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasFileFormat ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass ec:FileFormat
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasImageCodec ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass ec:ImageCodec
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasImageFormat ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass ec:ImageFormat
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasLocation ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass ec:Location
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasMaster ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass ec:MediaResource
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasMimeType ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass ec:MimeType
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasParentMediaResource ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass ec:MediaResource
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasSource ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass ec:MediaResource
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasVideoCodec ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass ec:VideoCodec
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasVideoEncodingFormat ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass ec:VideoEncodingFormat
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:instantiates ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass ec:EditorialObject
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:isCloneOf ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass ec:MediaResource
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:isDubOf ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass ec:MediaResource
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:isTrackPartOf ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass ec:Track
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:encodingLevel ;
+                                   owl:allValuesFrom rdfs:Literal
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:encodingProfile ;
+                                   owl:allValuesFrom rdfs:Literal
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty dc:source ;
+                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:aspectRatio ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onDataRange xsd:string
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:audioBitRate ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onDataRange xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:audioBitRateMax ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onDataRange xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:audioBitRateMode ;
+                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:audioEncodingLevel ;
+                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:audioEncodingProfile ;
+                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:audioTrackConfiguration ;
+                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:audioTrackNumber ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onDataRange xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:bitDepth ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onDataRange xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:bitRate ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onDataRange xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:bitRateMax ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onDataRange xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:bitRateMode ;
+                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:bitRateOverall ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onDataRange xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:dimensions ;
+                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:frameHeight ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onDataRange xsd:integer
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:frameHeightUnit ;
+                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:frameRate ;
+                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:frameSizeUnit ;
+                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:frameWidth ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onDataRange xsd:integer
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:frameWidthUnit ;
+                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hashValue ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onDataRange xsd:string
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:iFrameSize ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onDataRange xsd:integer
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:inchesPerSecond ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onDataRange xsd:double
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:noiseFilter ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onDataRange xsd:boolean
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:packageByteSize ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onDataRange xsd:long
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:packageName ;
+                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:playbackSpeed ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onDataRange xsd:double
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:regionDelimX ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onDataRange xsd:integer
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:regionDelimY ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onDataRange xsd:integer
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:sampleRate ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onDataRange xsd:integer
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:sampleSize ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onDataRange xsd:integer
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:sampleType ;
+                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:scanningFormat ;
+                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:totalNumberOfAudioChannels ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onDataRange xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:totalNumberOfAudioTracks ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onDataRange xsd:integer
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:totalNumberOfVideoTracks ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onDataRange xsd:integer
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:videoBitRate ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onDataRange xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:videoBitRateMax ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onDataRange xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:videoBitRateMode ;
+                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:videoEncodingLevel ;
+                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:videoEncodingProfile ;
+                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                 ] ;
+                 owl:disjointWith ec:Rating ;
+                 dcterms:description "A resource that comprises encoded audio, video, graphics, data or text."@en ,
+                                     "Une ressource qui comprend de l’audio, de la vidéo, des graphiques, des données ou du texte encodés."@fr ;
+                 rdfs:label "Media resource"@en ,
+                            "Ressource multimédia"@fr ;
+                 skos:definition "a ec:Resource that comprises encoded audio, video, graphics, data or text"@en ,
+                                 "un ec:Resource qui comprend de l'audio, de la vidéo, des graphiques, des données ou du texte encodés"@fr ;
+                 skos:example """- an audio CD
+- an audio track on a CD
+- an audio file
+- a video file
+- a video DVD"""@en ,
+                              """- un CD audio
+- une piste audio sur un CD
+- un fichier audio
+- un fichier vidéo
+- un DVD vidéo"""@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#MediaResourceType
+ec:MediaResourceType rdf:type owl:Class ;
+                     rdfs:subClassOf skos:Concept ;
+                     dcterms:description "An entry from a list of types to classify media resources."@en ,
+                                         "Une entrée d’une liste de types permettant de classer les ressources multimédias."@fr ;
+                     rdfs:label "Media resource type"@en ,
+                                "Type de ressource média"@fr ;
+                     skos:definition "a skos:Concept classifying the type of a ec:MediaResource"@en ,
+                                     "un skos:Concept classifiant le type d’un ec:MediaResource"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#MediaType
+ec:MediaType rdf:type owl:Class ;
+             rdfs:subClassOf ec:Format ;
+             dcterms:description "An entry from the classification of types of media resources, often historic, like phonograph cylinder."@en ,
+                                 "Une entrée de la classification des types de ressources médiatiques, souvent historiques, comme un cylindre de phonographe."@fr ;
+             rdfs:label "Media type"@en ,
+                        "Type de média"@fr ;
+             skos:definition "a ec:Format classifying additional type information about a ec:MediaResource"@en ,
+                             "une ec:Format classant des informations de type supplémentaires sur une ec:MediaResource"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Medium
+ec:Medium rdf:type owl:Class ;
+          rdfs:subClassOf ec:Format ;
+          dcterms:description "An entry from the classification of media that carry media resources, e.g. \"Betamax\", \"DVD\", \"LP\"."@en ,
+                              "Une entrée de la classification des supports qui transportent des ressources multimédias, par exemple « Betamax », « DVD », « LP »."@fr ;
+          rdfs:label "Medium"@en ,
+                     "Moyen"@fr ;
+          skos:definition "a ec:Format classifying the medium carrying a ec:MediaResource"@en ,
+                          "un ec:Format classant le support portant une ec:MediaResource"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#MetadataTrack
+ec:MetadataTrack rdf:type owl:Class ;
+                 rdfs:subClassOf ec:Track ;
+                 dcterms:description "A track containing metadata about the content that it accompanies, e.g. in MXF containers."@en ,
+                                     "Une piste contenant des métadonnées sur le contenu qu’elle accompagne, par exemple dans des conteneurs MXF."@fr ;
+                 rdfs:label "Metadata track"@en ,
+                            "Piste de métadonnées"@fr ;
+                 skos:definition "a ec:Track containing metadata about the content that it accompanies"@en ,
+                                 "un ec:Track contenant des métadonnées sur le contenu qu'il accompagne"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#MimeType
+ec:MimeType rdf:type owl:Class ;
+            rdfs:subClassOf ec:Format ;
+            dcterms:description "An entry from the classification of Internet media types. See also: http://www.iana.org/assignments/media-types/application/index.html."@en ,
+                                "Une entrée de la classification des types de médias Internet. Voir aussi : http://www.iana.org/assignments/media-types/application/index.html."@fr ;
+            rdfs:label "Mime type"@en ,
+                       "Type MIME"@fr ;
+            skos:definition "a ec:Format classifying the structure of a file as its Internet media type"@en ,
+                            "une ec:Format classifiant la structure d’un fichier selon son type MIME Internet"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#NormalPlayTime
+ec:NormalPlayTime rdf:type owl:Class ;
+                  rdfs:subClassOf ec:TimelinePoint ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:isoDuration ;
+                                    owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                    owl:onDataRange xsd:string
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:timeOfDay ;
+                                    owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                    owl:onDataRange xsd:time
+                                  ] ;
+                  dcterms:description "La durée d’un contenu est exprimée sous forme d’un point dans le temps au format ISO."@fr ,
+                                      "The duration of a content is expressed as a point in time in ISO format."@en ;
+                  rdfs:label "Normal play time"@en ,
+                             "Temps de jeu normal"@fr ;
+                  skos:definition "a ec:TimelinePoint representing the duration of a content expressed in ISO Format"@en ,
+                                  "un ec:TimelinePoint représentant la durée d’un contenu exprimée au format ISO"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#OnStagePosition
+ec:OnStagePosition rdf:type owl:Class ;
+                   rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasIdentifier ;
+                                     owl:allValuesFrom ec:Identifier
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasObjectType ;
+                                     owl:allValuesFrom skos:Concept
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasRelatedStage ;
+                                     owl:allValuesFrom ec:Stage
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:description ;
+                                     owl:allValuesFrom rdfs:Literal
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:name ;
+                                     owl:allValuesFrom rdfs:Literal
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:onStagePositionCoordinateX ;
+                                     owl:allValuesFrom xsd:float
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:onStagePositionCoordinateY ;
+                                     owl:allValuesFrom xsd:float
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:onStagePositionCoordinateZ ;
+                                     owl:allValuesFrom xsd:float
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:onStagePositionCoordinatesReferencePoint ;
+                                     owl:allValuesFrom rdfs:Literal
+                                   ] ;
+                   dcterms:description "A position on a specific stage given in coordinates."@en ,
+                                       "Une position sur une scène spécifique donnée en coordonnées."@fr ;
+                   rdfs:label "On stage position"@en ,
+                              "Position sur scène"@fr ;
+                   skos:definition "a coordinate-based location on a ec:Stage"@en ,
+                                   "une position basée sur des coordonnées sur un ec:Stage"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#OpenCaptions
+ec:OpenCaptions rdf:type owl:Class ;
+                rdfs:subClassOf ec:Captioning ;
+                dcterms:description "A caption that is burnt into the images of a media resource. i.e. it cannot be turned off."@en ,
+                                    "Un sous-titre incrusté dans les images d’une ressource multimédia. Autrement dit, il ne peut pas être désactivé."@fr ;
+                rdfs:label "Open captions"@en ,
+                           "Sous-titres ouverts"@fr ;
+                skos:definition "a ec:Captioning that is burned in the images of a ec:MediaResource"@en ,
+                                "un ec:Captioning intégré dans les images d’une ec:MediaResource"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#OpenSigning
+ec:OpenSigning rdf:type owl:Class ;
+               rdfs:subClassOf ec:Signing ;
+               dcterms:description "A signing that is burned in the images of a media resource."@en ,
+                                   "Un sous-titrage incrusté dans les images d’une ressource multimédia."@fr ;
+               rdfs:label "Open signing"@en ,
+                          "Sous-titrage ouvert"@fr ;
+               skos:definition "a ec:Signing that is burned in the images of a ec:MediaResource and cannot be turned off"@en ,
+                               "un ec:Signing qui est incrusté dans les images d’une ec:MediaResource et qui ne peut pas être désactivé"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#OpenSubtitling
+ec:OpenSubtitling rdf:type owl:Class ;
+                  rdfs:subClassOf ec:Subtitling ;
+                  dcterms:description "A subtitling that is carried in the same media resource as audio and/or video. Subtitling cannot be turned on or off."@en ,
+                                      "Un sous-titrage intégré au même média que l’audio et/ou la vidéo. Le sous-titrage ne peut pas être activé ou désactivé."@fr ;
+                  rdfs:label "Open subtitling"@en ,
+                             "Sous-titrage ouvert"@fr ;
+                  skos:definition "a ec:Subtitling that is burned in the images of a ec:MediaResource"@en ,
+                                  "un ec:Subtitling intégré dans les images d’une ec:MediaResource"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Organisation
+ec:Organisation rdf:type owl:Class ;
+                rdfs:subClassOf ec:Agent ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty ec:hasDepartment ;
+                                  owl:allValuesFrom ec:Department
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty ec:hasLogo ;
+                                  owl:allValuesFrom ec:Logo
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty ec:hasOrganisationStaff ;
+                                  owl:allValuesFrom ec:StaffMember
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty ec:hasStaffMember ;
+                                  owl:allValuesFrom ec:StaffMember
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty ec:hasEndDateTime ;
+                                  owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                  owl:onClass time:Instant
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty ec:hasStartDateTime ;
+                                  owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                  owl:onClass time:Instant
+                                ] ;
+                dcterms:description "An organisation (business, corporation, federation, etc.) or moral agent (government body)."@en ,
+                                    "Une organisation (entreprise, société, fédération, etc.) ou un agent moral (organisme gouvernemental)."@fr ;
+                rdfs:label "Organisation"@en ,
+                           "Organisation"@fr ;
+                skos:definition "an Agent in the form of an administrative and functional structure participating in media related activities"@en ,
+                                "un Agent sous la forme d'une structure administrative et fonctionnelle participant à des activités liées aux médias"@fr ;
+                skos:example """- PSM organisations
+- EBU
+- collecting society
+- film studios
+- cinemas
+- authors' union"""@en ,
+                             """- organisations PSM
+- UER
+- société de gestion collective
+- studios de cinéma
+- cinémas
+- syndicat d'auteurs"""@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#PartType
+ec:PartType rdf:type owl:Class ;
+            rdfs:subClassOf skos:Concept ;
+            dcterms:description "An entry from a list of types to classify media resources."@en ,
+                                "Une entrée d’une liste de types permettant de classer les ressources multimédias."@fr ;
+            rdfs:label "Part type"@en ,
+                       "Type de partie"@fr ;
+            skos:definition "a skos:Concept classifying the type of a ec:MediaResource"@en ,
+                            "un skos:Concept classant le type d’un ec:MediaResource"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Person
+ec:Person rdf:type owl:Class ;
+          rdfs:subClassOf ec:Agent ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasAffiliation ;
+                            owl:allValuesFrom ec:Affiliation
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasIdPicture ;
+                            owl:allValuesFrom ec:Picture
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasKeyCareerEvent ;
+                            owl:allValuesFrom ec:KeyCareerEvent
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasKeyPersonalEvent ;
+                            owl:allValuesFrom ec:KeyPersonalEvent
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasCountryOfBirth ;
+                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                            owl:onClass ec:CountryCode
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasCountryOfDeath ;
+                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                            owl:onClass ec:CountryCode
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasDateOfBirth ;
+                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                            owl:onClass time:Instant
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasDateOfDeath ;
+                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                            owl:onClass time:Instant
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasDateOfRetirement ;
+                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                            owl:onClass time:Instant
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasPlaceOfBirth ;
+                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                            owl:onClass ec:Location
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasPlaceOfDeath ;
+                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                            owl:onClass ec:Location
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:education ;
+                            owl:allValuesFrom rdfs:Literal
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:familyInformation ;
+                            owl:allValuesFrom rdfs:Literal
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:familyName ;
+                            owl:allValuesFrom rdfs:Literal
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:givenName ;
+                            owl:allValuesFrom rdfs:Literal
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hobbies ;
+                            owl:allValuesFrom rdfs:Literal
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:middleName ;
+                            owl:allValuesFrom rdfs:Literal
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:occupation ;
+                            owl:allValuesFrom rdfs:Literal
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:officeEmailAddress ;
+                            owl:allValuesFrom xsd:string
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:officeMobileTelephoneNumber ;
+                            owl:allValuesFrom xsd:string
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:officeTelephoneNumber ;
+                            owl:allValuesFrom xsd:string
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:personWeight ;
+                            owl:allValuesFrom rdfs:Literal
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:privateEmailAddress ;
+                            owl:allValuesFrom xsd:string
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:privateHomepage ;
+                            owl:allValuesFrom xsd:anyURI
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:privateMobileTelephoneNumber ;
+                            owl:allValuesFrom xsd:string
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:privateTelephoneNumber ;
+                            owl:allValuesFrom xsd:string
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:salutationTitle ;
+                            owl:allValuesFrom rdfs:Literal
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:suffix ;
+                            owl:allValuesFrom rdfs:Literal
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:username ;
+                            owl:allValuesFrom rdfs:Literal
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:age ;
+                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                            owl:onDataRange xsd:integer
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:gender ;
+                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:maritalStatus ;
+                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:personHeight ;
+                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                          ] ;
+          dcterms:description "A person who is an individual agent in the media domain."@en ,
+                              "Une personne qui est un agent individuel dans le domaine des médias."@fr ;
+          rdfs:label "Person"@en ,
+                     "Personne"@fr ;
+          skos:definition "an individual Agent"@en ,
+                          "un agent individuel"@fr ;
+          skos:example """- Alfred Hitchcock (director)
+- James Bond (character)
+- Sean Connery (actor)
+- John Ford (pseudonym used by the director John Martin Feeney)"""@en ,
+                       """- Alfred Hitchcock (réalisateur)
+- James Bond (personnage)
+- Sean Connery (acteur)
+- John Ford (pseudonyme utilisé par le réalisateur John Martin Feeney)"""@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#PhysicalResource
+ec:PhysicalResource rdf:type owl:Class ;
+                    rdfs:subClassOf ec:Resource ;
+                    dcterms:description "A tangible resource for the storage and transportation of media content, e.g. a tape."@en ,
+                                        "Une ressource matérielle destinée au stockage et au transport de contenu multimédia, par exemple une bande."@fr ;
+                    rdfs:label "Physical resource"@en ,
+                               "Ressource physique"@fr ;
+                    skos:definition "a tangible ec:Resource for the storage and transportation of media content"@en ,
+                                    "une ec:Resource tangible pour le stockage et le transport de contenu média"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Pictogram
+ec:Pictogram rdf:type owl:Class ;
+             rdfs:subClassOf ec:Picture ;
+             dcterms:description "A picture, often abstracted, simplified or graphical, that represents a concept and aids non-verbal communication."@en ,
+                                 "Une image, souvent abstraite, simplifiée ou graphique, qui représente un concept et facilite la communication non verbale."@fr ;
+             rdfs:label "Pictogram"@en ,
+                        "Pictogramme"@fr ;
+             skos:definition "a ec:Picture, often abstracted, that represents or symbolizes a concept to aid non-verbal communication"@en ,
+                             "un ec:Picture, souvent abstrait, qui représente ou symbolise un concept pour aider à la communication non verbale"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Picture
+ec:Picture rdf:type owl:Class ;
+           rdfs:subClassOf ec:Resource ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:hasEncodingFormat ;
+                             owl:allValuesFrom ec:EncodingFormat
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:hasImageCodec ;
+                             owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                             owl:onClass ec:ImageCodec
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:hasImageFormat ;
+                             owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                             owl:onClass ec:ImageFormat
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:aspectRatio ;
+                             owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                             owl:onDataRange xsd:string
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:frameHeight ;
+                             owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                             owl:onDataRange xsd:integer
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:frameHeightUnit ;
+                             owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:frameWidth ;
+                             owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                             owl:onDataRange xsd:integer
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:frameWidthUnit ;
+                             owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                           ] ;
+           dcterms:description "A photography, a logo, and a pictogram."@en ,
+                               "Une photographie, un logo et un pictogramme."@fr ;
+           rdfs:label "Image"@fr ,
+                      "Picture"@en ;
+           skos:definition "a Resource in the form of an encoded picture"@en ,
+                           "une ressource sous la forme d’une image encodée"@fr ;
+           skos:example """- a JPEG file of a photo, a logo, a graphic, ...
+- a PNG file of a photo, a logo, a graphic, ..."""@en ,
+                        """- un fichier JPEG d’une photo, d’un logo, d’un graphique, ...
+- un fichier PNG d’une photo, d’un logo, d’un graphique, ..."""@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#PictureDisplayFormat
+ec:PictureDisplayFormat rdf:type owl:Class ;
+                        rdfs:subClassOf ec:Format ;
+                        dcterms:description "An entry from the classification of formats that a display can have."@en ,
+                                            "Une entrée de la classification des formats qu'un affichage peut avoir."@fr ;
+                        rdfs:label "Code de format d’affichage d’image"@fr ,
+                                   "Picture display format code"@en ;
+                        skos:definition "a ec:Format classifying the format of a display"@en ,
+                                        "un ec:Format classant le format d’un affichage"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Post
+ec:Post rdf:type owl:Class ;
+        rdfs:subClassOf ec:EditorialWork ;
+        dcterms:description "A combination of text, graphics, sometimes video or audio, created to be published on a social media platform or similar."@en ,
+                            "Une combinaison de texte, de graphiques, parfois de vidéo ou d’audio, créée pour être publiée sur une plateforme de médias sociaux ou similaire."@fr ;
+        rdfs:label "Post"@en ,
+                   "Publication"@fr ;
+        skos:definition "an ec:EditorialWork consisting of text, graphics, sometimes video or audio, created for publication on social media platforms or similar"@en ,
+                        "un ec:EditorialWork constitué de texte, de graphismes, parfois de vidéo ou d’audio, créé pour être publié sur des plateformes de médias sociaux ou similaires"@fr ;
+        skos:example """- a tweet on twitter
+- a post on Facebook
+- a post on Instagram
+- a video-post on Youtube"""@en ,
+                     """- un tweet sur Twitter
+- un post sur Facebook
+- un post sur Instagram
+- une vidéo publiée sur YouTube"""@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ProductionDevice
+ec:ProductionDevice rdf:type owl:Class ;
+                    rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasIdentifier ;
+                                      owl:allValuesFrom ec:Identifier
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasObjectType ;
+                                      owl:allValuesFrom skos:Concept
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasProductionDeviceOnStagePosition ;
+                                      owl:allValuesFrom ec:OnStagePosition
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasUsageContract ;
+                                      owl:allValuesFrom ec:Contract
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:description ;
+                                      owl:allValuesFrom rdfs:Literal
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:name ;
+                                      owl:allValuesFrom rdfs:Literal
+                                    ] ;
+                    dcterms:description "A Device used for creating/processing a MediaResource."@en ,
+                                        "Un dispositif utilisé pour créer ou traiter une MediaResource."@fr ;
+                    rdfs:label "Dispositif de production"@fr ,
+                               "Production device"@en ;
+                    skos:definition "a tool to facilitate activities in a ProductionJob"@en ,
+                                    "un outil pour faciliter les activités dans un ProductionJob"@fr ;
+                    skos:example """- a camera
+- a microphone
+- a video or sound mixer
+- a video or sound editor
+- spot lights
+- a LED wall"""@en ,
+                                 """- une caméra
+- un microphone
+- une console de mixage vidéo ou audio
+- un éditeur vidéo ou audio
+- des projecteurs
+- un mur LED"""@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ProductionJob
+ec:ProductionJob rdf:type owl:Class ;
+                 rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:basedOn ;
+                                   owl:allValuesFrom ec:EditorialObject
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:createsMetadata ;
+                                   owl:allValuesFrom ec:EditorialObject
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasContributor ;
+                                   owl:allValuesFrom ec:Involvement
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasIdentifier ;
+                                   owl:allValuesFrom ec:Identifier
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasInputMediaResource ;
+                                   owl:allValuesFrom ec:MediaResource
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasInputResource ;
+                                   owl:allValuesFrom ec:Resource
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasObjectType ;
+                                   owl:allValuesFrom skos:Concept
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasOutputEssence ;
+                                   owl:allValuesFrom ec:Essence
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasOutputMediaResource ;
+                                   owl:allValuesFrom ec:MediaResource
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasOutputResource ;
+                                   owl:allValuesFrom ec:Resource
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasPreviousRelated ;
+                                   owl:allValuesFrom ec:ProductionJob
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasProductionJobEvent ;
+                                   owl:allValuesFrom ec:Event
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasProductionJobLocation ;
+                                   owl:allValuesFrom ec:Location
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasSubJob ;
+                                   owl:allValuesFrom ec:ProductionJob
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:isOrderedBy ;
+                                   owl:allValuesFrom ec:Contract
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:usesProductionDevice ;
+                                   owl:allValuesFrom ec:ProductionDevice
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasEndDateTime ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass time:Instant
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasStartDateTime ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass time:Instant
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:description ;
+                                   owl:allValuesFrom rdfs:Literal
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:name ;
+                                   owl:allValuesFrom rdfs:Literal
+                                 ] ;
+                 dcterms:description "A job / process to be performed to manipulate/create/modify/store, etc., MediaResources and Essences as defined in an associated EditorialObject. It is ordered by Contract."@en ,
+                                     "Un travail / processus à réaliser pour manipuler/créer/modifier/stockeR, etc., des MediaResources et des Essences tels que définis dans un EditorialObject associé. Il est ordonné par Contract."@fr ;
+                 rdfs:label "Production job"@en ,
+                            "Travail de production"@fr ;
+                 skos:definition "a task or set of tasks to create, modify, manipulate, store, or otherwise process a MediaResource"@en ,
+                                 "une tâche ou un ensemble de tâches pour créer, modifier, manipuler, stocker ou traiter autrement une MediaResource"@fr ;
+                 skos:example """- a live show production for broadcasting
+- filming and editing a news clip
+- an outsourced production of a complete movie"""@en ,
+                              """- une production de spectacle en direct pour la diffusion
+- le tournage et le montage d’un clip d’actualité
+- une production externalisée d’un film complet"""@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ProductionOrder
+ec:ProductionOrder rdf:type owl:Class ;
+                   rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasIdentifier ;
+                                     owl:allValuesFrom ec:Identifier
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasObjectType ;
+                                     owl:allValuesFrom skos:Concept
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasProductionContract ;
+                                     owl:allValuesFrom ec:Contract
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:description ;
+                                     owl:allValuesFrom rdfs:Literal
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:name ;
+                                     owl:allValuesFrom rdfs:Literal
+                                   ] ;
+                   dcterms:description "A formal request for the creation, production, purchase or reuse of media resources, often resulting from a contract with a third party."@en ,
+                                       "Une demande formelle de création, de production, d’achat ou de réutilisation de ressources médias, résultant souvent d’un contrat avec un tiers."@fr ;
+                   rdfs:label "Ordre de production"@fr ,
+                              "Production order"@en ;
+                   skos:definition "a formal request for the creation, production, purchase or reuse of ec:MediaResources often resulting from a ec:Contract"@en ,
+                                   "une demande formelle de création, de production, d’achat ou de réutilisation de ec:MediaResources résultant souvent d’un ec:Contract"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Programme
+ec:Programme rdf:type owl:Class ;
+             rdfs:subClassOf ec:EditorialWork ,
+                             [ rdf:type owl:Restriction ;
+                               owl:onProperty ec:isEpisodeOfSeason ;
+                               owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                               owl:onClass ec:Season
+                             ] ,
+                             [ rdf:type owl:Restriction ;
+                               owl:onProperty ec:isEpisodeOfSerial ;
+                               owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                               owl:onClass ec:Serial
+                             ] ,
+                             [ rdf:type owl:Restriction ;
+                               owl:onProperty ec:isEpisodeOfSeries ;
+                               owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                               owl:onClass ec:Series
+                             ] ,
+                             [ rdf:type owl:Restriction ;
+                               owl:onProperty ec:episodeNumber ;
+                               owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                               owl:onDataRange xsd:integer
+                             ] ,
+                             [ rdf:type owl:Restriction ;
+                               owl:onProperty ec:episodeNumberInSeason ;
+                               owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                               owl:onDataRange xsd:integer
+                             ] ,
+                             [ rdf:type owl:Restriction ;
+                               owl:onProperty ec:episodeNumberInSerial ;
+                               owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                               owl:onDataRange xsd:integer
+                             ] ,
+                             [ rdf:type owl:Restriction ;
+                               owl:onProperty ec:episodeNumberInSeries ;
+                               owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                               owl:onDataRange xsd:integer
+                             ] ;
+             dcterms:description "A stand-alone work or an episode of a serial or a series, created to be published and consumed as a whole."@en ,
+                                 "Une œuvre autonome ou un épisode d’un feuilleton ou d’une série, créée pour être publiée et consommée dans son intégralité."@fr ;
+             rdfs:label "Programme"@en ,
+                        "Programme"@fr ;
+             skos:definition "an ec:EditorialWork as a stand-alone content or an episode of a ec:Serial or ec:Series and created to be published and consumed as a whole"@en ,
+                             "une ec:EditorialWork en tant que contenu autonome ou un épisode d'une ec:Serial ou d'une ec:Series, créé pour être publié et consommé dans son intégralité"@fr ;
+             skos:example """- le film « Titanic »
+- l’épisode 2 « The Blind Banker » de la série « Sherlock », une série policière
+- l’épisode d’aujourd’hui de « BBC News », l’émission d’actualités quotidienne
+- l’épisode 2 « Frozen Worlds » de la série « Our Planet », une série documentaire sur la nature
+- l’épisode de lundi prochain du feuilleton de la BBC « Panorama », un reportage politique"""@fr ,
+                          """- the movie \"Titanic\"
+- the episode 2 \"The Blind Banker\" of the series \"Sherlock\", a detective series
+- today's episode of \"BBC News\", the daily news show serial
+- the episode 2 \"Frozen Worlds\" of the series \"Our Planet\", a nature documentary series
+- next Monday's episode of the BBC serial \"Panorama\", a political report"""@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Promotion
+ec:Promotion rdf:type owl:Class ;
+             rdfs:subClassOf ec:EditorialWork ,
+                             [ rdf:type owl:Restriction ;
+                               owl:onProperty ec:isMemberOf ;
+                               owl:allValuesFrom ec:CampaignPackage
+                             ] ;
+             dcterms:description "An advertisement, e.g. for a car model, an event, a programme, a travel offer or similar."@en ,
+                                 "Une publicité, par exemple pour un modèle de voiture, un événement, un programme, une offre de voyage ou similaire."@fr ;
+             rdfs:label "Promotion"@en ,
+                        "Promotion"@fr ;
+             skos:definition "an ec:EditorialWork for advertising purposes"@en ,
+                             "une ec:EditorialWork à des fins publicitaires"@fr ;
+             skos:example """- an ad for an insurance company
+- a promotion-clip for a PSM, one of its channels, its brands"""@en ,
+                          """- une publicité pour une compagnie d’assurance
+- un clip promotionnel pour une société de service public, l’un de ses canaux, ses marques"""@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Props
+ec:Props rdf:type owl:Class ;
+         rdfs:subClassOf ec:Artefact ;
+         dcterms:description "Some object that is visible or audible in a scene and deliberately chosen for its value to the resulting content, such as a stone, a weapon, a bag, etc."@en ,
+                             "Un objet visible ou audible dans une scène et délibérément choisi pour sa valeur dans le contenu النات, comme une pierre, une arme, un sac, etc."@fr ;
+         rdfs:label "Accessoires"@fr ,
+                    "Props"@en ;
+         skos:definition "an object deliberately chosen to appear in a scene of the ec:EditorialObject"@en ,
+                         "un objet délibérément choisi pour apparaître dans une scène de ec:EditorialObject"@fr ;
+         skos:example """- a car in a movie
+- furniture in a movie
+- a buzzer in a quiz show"""@en ,
+                      """- une voiture dans un film
+- des meubles dans un film
+- un buzzer dans un jeu télévisé"""@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Provenance
+ec:Provenance rdf:type owl:Class ;
+              rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:hasIdentifier ;
+                                owl:allValuesFrom ec:Identifier
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:hasObjectType ;
+                                owl:allValuesFrom skos:Concept
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:hasProvenanceTarget ;
+                                owl:allValuesFrom owl:Thing
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:isAttributedTo ;
+                                owl:allValuesFrom ec:Agent
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:hasDateCreated ;
+                                owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                owl:onClass time:DateTimeDescription
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:hasDateModified ;
+                                owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                owl:onClass time:DateTimeDescription
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:description ;
+                                owl:allValuesFrom rdfs:Literal
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:name ;
+                                owl:allValuesFrom rdfs:Literal
+                              ] ;
+              dcterms:description "Les enregistrements de provenance peuvent identifier l’objet de données dont l’historique est décrit, l’agent auquel il est attribué, ainsi que les dates pertinentes de création ou de modification."@fr ,
+                                  "Provenance records can identify the data object whose history is described, the agent to which it is attributed, and relevant creation or modification dates."@en ;
+              rdfs:label "Provenance"@en ,
+                         "Provenance"@fr ;
+              skos:definition "a set of properties describing the origin and life cycle of a data object"@en ,
+                              "un ensemble de propriétés décrivant l’origine et le cycle de vie d’un objet de données"@fr ;
+              skos:example """- la date de création du data object
+- le système à partir duquel le data object a été initialement récupéré"""@fr ,
+                           """- the creationDate of a data object
+- the system from which the data object was originally retrieved"""@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Pseudonym
+ec:Pseudonym rdf:type owl:Class ;
+             rdfs:subClassOf ec:Person ;
+             dcterms:description "A pseudonym is a fictitious name used by an author, an actor or others, invented to hide the real name, to sound better, to foster associations or similar."@en ,
+                                 "Un pseudonyme est un nom fictif utilisé par un auteur, un acteur ou d’autres personnes, inventé pour masquer le vrai nom, paraître plus harmonieux, susciter des associations ou pour des raisons similaires."@fr ;
+             rdfs:label "Pseudonym"@en ,
+                        "Pseudonyme"@fr ;
+             skos:definition "a fictitious ec:Person mainly described by its name that is used to hide the name of the real ec:Person"@en ,
+                             "une ec:Person fictive décrite principalement par son nom, utilisée pour cacher le nom de la vraie ec:Person"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#PublicationChannel
+ec:PublicationChannel rdf:type owl:Class ;
+                      rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:accountingTo ;
+                                        owl:allValuesFrom ec:Account
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:hasConsumptionCount ;
+                                        owl:allValuesFrom ec:Audience
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:hasIdentifier ;
+                                        owl:allValuesFrom ec:Identifier
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:hasLogo ;
+                                        owl:allValuesFrom ec:Logo
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:hasObjectType ;
+                                        owl:allValuesFrom skos:Concept
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:hasRelatedPublicationChannel ;
+                                        owl:allValuesFrom ec:PublicationChannel
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:hasTargetAudience ;
+                                        owl:allValuesFrom ec:Audience
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:isOperatedBy ;
+                                        owl:allValuesFrom ec:PublicationService
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:isOwnedBy ;
+                                        owl:allValuesFrom ec:Agent
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:transports ;
+                                        owl:allValuesFrom ec:PublicationService
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:hasEndDateTime ;
+                                        owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                        owl:onClass time:Instant
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:hasStartDateTime ;
+                                        owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                        owl:onClass time:Instant
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:description ;
+                                        owl:allValuesFrom rdfs:Literal
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:name ;
+                                        owl:allValuesFrom rdfs:Literal
+                                      ] ;
+                      dcterms:description "A connection through which a consumption device can consume a service, e.g. a cable receiver for linear services on a cable network, an FM receiver for linear audio services, the YouTube.com webpage or the YouTube application on Android for the VoD service YouTube, the BBC iPlayer App on LG Smart-TVs for BBC's VoD, event streaming and live streaming services."@en ,
+                                          "Une connexion par laquelle un appareil de consommation peut consommer un service, par exemple un récepteur câble pour des services linéaires sur un réseau câblé, un récepteur FM pour des services audio linéaires, la page web YouTube.com ou l'application YouTube sur Android pour le service de vidéo à la demande YouTube, l'application BBC iPlayer sur les téléviseurs intelligents LG pour les services de vidéo à la demande, de diffusion d'événements et de diffusion en direct de la BBC."@fr ;
+                      rdfs:label "Canal de publication"@fr ,
+                                 "Publication channel"@en ;
+                      skos:definition "a connection through which a ec:ConsumptionDevice can consume ec:PublicationServices"@en ,
+                                      "une connexion par laquelle un ec:ConsumptionDevice peut consommer des ec:PublicationServices"@fr ;
+                      skos:example """- le canal DVB-S à 10714 MHz H sur le satellite Astra 2E pour le service vidéo linéaire \"BBC One HD\"
+- le canal DVB-T E23 à Londres/Chrystal Palace pour le service vidéo linéaire \"BBC One London\"
+- le flux vidéo en direct \"BBC One\" dans BBC iPlayer
+- le canal @bbcradio1 sur youtube pour le service vidéo à la demande \"BBC Radio 1 visual radio\"
+- le canal @elonmusk sur twitter pour un service textuel social \"Elon Musk's Tweets\""""@fr ,
+                                   """- the DVB-S channel at 10714 MHz H on the Astra 2E satellite for the linear video service \"BBC One HD\"
+- the DVB-T channel E23 in London/Chrystal Palace for the linear video service \"BBC One London\"
+- the live video stream \"BBC One\" within the BBC iPlayer
+- the channel @bbcradio1 on youtube for the on demand video service \"BBC Radio 1 visual radio\"
+- the channel @elonmusk on twitter for a social text service \"Elon Musk's Tweets\""""@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#PublicationChannelType
+ec:PublicationChannelType rdf:type owl:Class ;
+                          rdfs:subClassOf skos:Concept ;
+                          dcterms:description "An entry from a list of types to classify publication channels."@en ,
+                                              "Une entrée d’une liste de types permettant de classer les canaux de publication."@fr ;
+                          rdfs:label "Publication channel type"@en ,
+                                     "Type de canal de publication"@fr ;
+                          skos:definition "a skos:Concept classifying the type of a ec:PublicationChannel"@en ,
+                                          "un skos:Concept classant le type d’un ec:PublicationChannel"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#PublicationEvent
+ec:PublicationEvent rdf:type owl:Class ;
+                    rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasAccessConditions ;
+                                      owl:allValuesFrom ec:AccessConditions
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasAlternativeTitle ;
+                                      owl:allValuesFrom ec:AlternativeTitle
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasConsumptionCount ;
+                                      owl:allValuesFrom ec:ConsumptionCount
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasCoverageRestrictions ;
+                                      owl:allValuesFrom ec:CoverageRestrictions
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasIdentifier ;
+                                      owl:allValuesFrom ec:Identifier
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasObjectType ;
+                                      owl:allValuesFrom skos:Concept
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasPublicationChannel ;
+                                      owl:allValuesFrom ec:PublicationChannel
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasPublicationEvent ;
+                                      owl:allValuesFrom ec:PublicationEvent
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasPublicationMedium ;
+                                      owl:allValuesFrom ec:PublicationMedium
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasPublicationRegion ;
+                                      owl:allValuesFrom ec:Location
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasRestrictedAudience ;
+                                      owl:allValuesFrom ec:Audience
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasRights ;
+                                      owl:allValuesFrom ec:Rights
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasTargetAudience ;
+                                      owl:allValuesFrom ec:Audience
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasUsageRestrictions ;
+                                      owl:allValuesFrom ec:UsageRestrictions
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:isOfferedBy ;
+                                      owl:allValuesFrom ec:PublicationService
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:playsOut ;
+                                      owl:allValuesFrom ec:Essence
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:publishes ;
+                                      owl:allValuesFrom ec:EditorialObject
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasStartDateTime ;
+                                      owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                      owl:onClass time:Instant
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasDuration ;
+                                      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                      owl:onClass ec:TimelinePoint
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasEndDateTime ;
+                                      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                      owl:onClass time:DateTimeDescription
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:hasScheduleDate ;
+                                      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                      owl:onClass time:Instant
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:title ;
+                                      owl:someValuesFrom rdfs:Literal
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:abstract ;
+                                      owl:allValuesFrom rdfs:Literal
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:description ;
+                                      owl:allValuesFrom rdfs:Literal
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:name ;
+                                      owl:allValuesFrom rdfs:Literal
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:firstShowing ;
+                                      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                      owl:onDataRange xsd:boolean
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:firstShowingThisService ;
+                                      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                      owl:onDataRange xsd:boolean
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:free ;
+                                      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                      owl:onDataRange xsd:boolean
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty ec:live ;
+                                      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                      owl:onDataRange xsd:boolean
+                                    ] ;
+                    owl:disjointWith ec:Rating ;
+                    dcterms:description "Le moment ou la période ainsi que le service média au sein desquels le contenu est rendu techniquement accessible aux appareils des consommateurs, par exemple la diffusion d’une émission d’actualités programmée, le téléversement d’un documentaire sur une plateforme de VoD ou la publication d’un mème sur Instagram."@fr ,
+                                        "The time or time span and the media service within which the content is made technically accessible for devices of consumers, e.g. broadcasting a scheduled news show, uploading a documentary to a VoD platform, posting a meme on Instagram."@en ;
+                    rdfs:label "Publication event"@en ,
+                               "Événement de publication"@fr ;
+                    skos:definition "a time or time span and the ec:PublicationService within which an ec:Essence is made technically accessible for ec:ConsumptionDevices of ec:Consumers"@en ,
+                                    "un temps ou un intervalle de temps et le ec:PublicationService dans lequel une ec:Essence est rendue techniquement accessible aux ec:ConsumptionDevices des ec:Consumers"@fr ;
+                    skos:example """- la diffusion de la finale de la Coupe du monde de football 2022 dans un service vidéo en direct par satellite par la BBC en Grande-Bretagne
+- la publication du texte d’Elon Musk « Next I'm buying Coca Cola to put the cocaine back in » sur Twitter, le 27 avril 2022, sur son compte @elonmusk"""@fr ,
+                                 """- the broadcasting of the football world cup final 2022 in a live video service over satellite by the BBC in Great Britain
+- the posting of Elon Musk's text \"Next I'm buying Coca Cola to put the cocaine back in\" on twitter, April 27, 2022, in his channel @elonmusk"""@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#PublicationEventType
+ec:PublicationEventType rdf:type owl:Class ;
+                        rdfs:subClassOf skos:Concept ;
+                        dcterms:description "An entry from a list of types to classify publication events."@en ,
+                                            "Une entrée d’une liste de types permettant de classer les événements de publication."@fr ;
+                        rdfs:label "Publication event type"@en ,
+                                   "Type d’événement de publication"@fr ;
+                        skos:definition "a skos:Concept classifying the type of a ec:PublicationEvent"@en ,
+                                        "un skos:Concept classifiant le type d’un ec:PublicationEvent"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#PublicationHistory
+ec:PublicationHistory rdf:type owl:Class ;
+                      rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:hasPublicationEvent ;
+                                        owl:someValuesFrom ec:PublicationEvent
+                                      ] ;
+                      dcterms:description "A collection of publication events of the content."@en ,
+                                          "Une collection d’événements de publication du contenu."@fr ;
+                      rdfs:label "Historique de publication"@fr ,
+                                 "Publication history"@en ;
+                      skos:definition "a collection of ec:PublicationEvents of an ec:EditorialObject"@en ,
+                                      "une collection d'ec:PublicationEvents d'un ec:EditorialObject"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#PublicationLog
+ec:PublicationLog rdf:type owl:Class ;
+                  rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:hasResourceOffset ;
+                                    owl:someValuesFrom ec:TimelinePoint
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:hasStartDateTime ;
+                                    owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                    owl:onClass time:Instant
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:logs ;
+                                    owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                    owl:onClass ec:PublicationEvent
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:hasEndDateTime ;
+                                    owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                    owl:onClass time:Instant
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:hasObjectType ;
+                                    owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                    owl:onClass skos:Concept
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:description ;
+                                    owl:allValuesFrom rdfs:Literal
+                                  ] ;
+                  dcterms:description "A collection of consecutive publication events of a service."@en ,
+                                      "Une collection d’événements de publication consécutifs d’un service."@fr ;
+                  rdfs:label "Journal de publication"@fr ,
+                             "Publication log"@en ;
+                  skos:definition "a collection of consecutive ec:PublicationEvents of a ec:PublicationService"@en ,
+                                  "une collection d’ec:PublicationEvents consécutifs d’un ec:PublicationService"@fr ;
+                  skos:example """- le « as run log » d’un système de diffusion TV linéaire pour une journée complète
+- le « as run log » d’un système de diffusion radio linéaire pour la matinée"""@fr ,
+                               """- the \"as run log\" of a linear TV playout system for a full day
+- the \"as run log\" of a linear radio playout system for the morning"""@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#PublicationMedium
+ec:PublicationMedium rdf:type owl:Class ;
+                     rdfs:subClassOf skos:Concept ;
+                     dcterms:description "An entry from a list of types to classify the publication medium, e.g. radio, tv, internet, online, streaming."@en ,
+                                         "Une entrée d’une liste de types permettant de classer le support de publication, par exemple radio, télévision, internet, en ligne, diffusion en continu."@fr ;
+                     rdfs:label "Média de publication"@fr ,
+                                "Publication medium"@en ;
+                     skos:definition "a skos:Concept classifying the type of a ec:PublicationMedium"@en ,
+                                     "un skos:Concept classifiant le type d’un ec:PublicationMedium"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#PublicationPlan
+ec:PublicationPlan rdf:type owl:Class ;
+                   rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasPublicationEvent ;
+                                     owl:someValuesFrom ec:PublicationEvent
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasAsset ;
+                                     owl:allValuesFrom ec:Asset
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasAssociatedProductionOrder ;
+                                     owl:allValuesFrom ec:ProductionOrder
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasBusinessContract ;
+                                     owl:allValuesFrom ec:Contract
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasIdentifier ;
+                                     owl:allValuesFrom ec:Identifier
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasObjectType ;
+                                     owl:allValuesFrom skos:Concept
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasPublicationPlanMember ;
+                                     owl:allValuesFrom ec:PublicationPlan
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasStakeholder ;
+                                     owl:allValuesFrom ec:Agent
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:isMemberOf ;
+                                     owl:allValuesFrom ec:PublicationPlan
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasEndDateTime ;
+                                     owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                     owl:onClass time:Instant
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasPublicationPlanStatus ;
+                                     owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                     owl:onClass skos:Collection
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:hasStartDateTime ;
+                                     owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                     owl:onClass time:Instant
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:description ;
+                                     owl:allValuesFrom rdfs:Literal
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:name ;
+                                     owl:allValuesFrom rdfs:Literal
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty ec:publicationPlanTitle ;
+                                     owl:allValuesFrom rdfs:Literal
+                                   ] ;
+                   dcterms:description "A collection of scheduled publication events related to a targeted audience (e.g. a list of publications for sports lovers), promotion material for a content (e.g. a campaign of several commercials for a product), a time span in a media service (e.g. a full day's programme in a linear service), or other useful criteria."@en ,
+                                       "Une collection d’événements de publication planifiés liés à un public ciblé (par exemple, une liste de publications pour les amateurs de sport), à du matériel promotionnel pour un contenu (par exemple, une campagne de plusieurs publicités pour un produit), à une période dans un service média (par exemple, la programmation d’une journée entière dans un service linéaire), ou à d’autres critères utiles."@fr ;
+                   rdfs:label "Plan de publication"@fr ,
+                              "Publication plan"@en ;
+                   skos:definition "a collection of scheduled ec:PublicationEvents related to a targeted ec:Audience, promotion material for an ec:EditorialObject, a time span in a ec:PublicationService or other useful criteria"@en ,
+                                   "une collection d'ec:PublicationEvents programmés liés à un ec:Audience ciblé, du matériel promotionnel pour un ec:EditorialObject, une période dans un ec:PublicationService ou d'autres critères utiles"@fr ;
+                   skos:example """- la date, l’heure et le canal prévus pour la publication d’un film
+- les dates, heures et canaux prévus pour la publication des épisodes d’une série
+- le calendrier prévu pour un canal au cours d’une journée
+- les dates, heures et canaux prévus pour une collection de contenus sur un thème commun"""@fr ,
+                                """- the planned date, time and channel for the publication of a movie
+- the planned dates, times and channels for the publication of the episodes of a serial
+- the planned schedule for a channel during one day
+- the planned dates, times and channels for a collection of content about a common theme"""@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#PublicationPlanType
+ec:PublicationPlanType rdf:type owl:Class ;
+                       rdfs:subClassOf skos:Concept ;
+                       dcterms:description "An entry from a list of types to classify the publication plan, like daily, monthly, yearly."@en ,
+                                           "Une entrée d’une liste de types permettant de classer le plan de publication, comme quotidien, mensuel, annuel."@fr ;
+                       rdfs:label "Publication plan type"@en ,
+                                  "Type de plan de publication"@fr ;
+                       skos:definition "a skos:Concept classifying the type of a ec:PublicationPlan"@en ,
+                                       "un skos:Concept classifiant le type d’un ec:PublicationPlan"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#PublicationPlatform
+ec:PublicationPlatform rdf:type owl:Class ;
+                       rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                         owl:onProperty ec:accountingTo ;
+                                         owl:allValuesFrom ec:Account
+                                       ] ,
+                                       [ rdf:type owl:Restriction ;
+                                         owl:onProperty ec:hasConsumptionCount ;
+                                         owl:allValuesFrom ec:Audience
+                                       ] ,
+                                       [ rdf:type owl:Restriction ;
+                                         owl:onProperty ec:hasIdentifier ;
+                                         owl:allValuesFrom ec:Identifier
+                                       ] ,
+                                       [ rdf:type owl:Restriction ;
+                                         owl:onProperty ec:hasLogo ;
+                                         owl:allValuesFrom ec:Logo
+                                       ] ,
+                                       [ rdf:type owl:Restriction ;
+                                         owl:onProperty ec:hasObjectType ;
+                                         owl:allValuesFrom skos:Concept
+                                       ] ,
+                                       [ rdf:type owl:Restriction ;
+                                         owl:onProperty ec:hasPublicationChannel ;
+                                         owl:allValuesFrom ec:PublicationChannel
+                                       ] ,
+                                       [ rdf:type owl:Restriction ;
+                                         owl:onProperty ec:hasRelatedPublicationService ;
+                                         owl:allValuesFrom ec:PublicationService
+                                       ] ,
+                                       [ rdf:type owl:Restriction ;
+                                         owl:onProperty ec:hasTargetAudience ;
+                                         owl:allValuesFrom ec:Audience
+                                       ] ,
+                                       [ rdf:type owl:Restriction ;
+                                         owl:onProperty ec:isOwnedBy ;
+                                         owl:allValuesFrom ec:Agent
+                                       ] ,
+                                       [ rdf:type owl:Restriction ;
+                                         owl:onProperty ec:offers ;
+                                         owl:allValuesFrom ec:PublicationService
+                                       ] ,
+                                       [ rdf:type owl:Restriction ;
+                                         owl:onProperty ec:supportsConsumptionDeviceProfile ;
+                                         owl:allValuesFrom ec:ConsumptionDeviceProfile
+                                       ] ,
+                                       [ rdf:type owl:Restriction ;
+                                         owl:onProperty ec:hasEndDateTime ;
+                                         owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                         owl:onClass time:Instant
+                                       ] ,
+                                       [ rdf:type owl:Restriction ;
+                                         owl:onProperty ec:hasStartDateTime ;
+                                         owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                         owl:onClass time:Instant
+                                       ] ,
+                                       [ rdf:type owl:Restriction ;
+                                         owl:onProperty ec:description ;
+                                         owl:allValuesFrom rdfs:Literal
+                                       ] ,
+                                       [ rdf:type owl:Restriction ;
+                                         owl:onProperty ec:name ;
+                                         owl:allValuesFrom rdfs:Literal
+                                       ] ;
+                       dcterms:description "A facility that distributes media services so that devices can access them through a channel, e.g. a satellite network distributes a video broadcast service so that a TV-set can access it through a satellite receiver; a VoD platform distributes a non-linear service so that a tablet can access it through an application. Platforms can be uni- or bidirectional. Platforms support a range of services and channels. The choices are limited by technology or by negotiation between the media service provider and the platform provider."@en ,
+                                           "Un établissement qui distribue des services médiatiques afin que des appareils puissent y accéder via un canal, par exemple un réseau satellite distribue un service de diffusion vidéo afin qu’un téléviseur puisse y accéder via un récepteur satellite ; une plateforme de vidéo à la demande (VoD) distribue un service non linéaire afin qu’une tablette puisse y accéder via une application. Les plateformes peuvent être unidirectionnelles ou bidirectionnelles. Elles prennent en charge une gamme de services et de canaux. Les choix sont limités par la technologie ou par la négociation entre le fournisseur de services médiatiques et le fournisseur de plateforme."@fr ;
+                       rdfs:label "Plateforme de publication"@fr ,
+                                  "Publication platform"@en ;
+                       skos:definition "a facility that distributes ec:PublicationServices so that ec:ConsumptionDevices can access them through ec:PublicationChannels"@en ,
+                                       "une installation qui distribue des ec:PublicationServices afin que des ec:ConsumptionDevices puissent y accéder via des ec:PublicationChannels"@fr ;
+                       skos:example """- la plateforme de diffusion DVB-S d’Eutelsat
+- la plateforme de vidéo à la demande YouTube
+- tous les serveurs accessibles via des protocoles Internet et proposant / recevant du contenu encodé en HTML ou similaire
+- Fortnite, Decentraland ou Roblox en tant que métavers"""@fr ,
+                                    """- the Eutelsat DVB-S broadcasting platform
+- the youtube video on demand platform
+- all servers accessible via internet protocols and offering / taking content encoded in HTML or similar
+- Fortnite, Decentraland or Roblox as metaverses"""@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#PublicationService
+ec:PublicationService rdf:type owl:Class ;
+                      rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:accountingTo ;
+                                        owl:allValuesFrom ec:Account
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:hasBrand ;
+                                        owl:allValuesFrom ec:MarketingBrand
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:hasConsumptionCount ;
+                                        owl:allValuesFrom ec:Audience
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:hasIdentifier ;
+                                        owl:allValuesFrom ec:Identifier
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:hasLogo ;
+                                        owl:allValuesFrom ec:Logo
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:hasObjectType ;
+                                        owl:allValuesFrom skos:Concept
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:hasRelatedPublicationService ;
+                                        owl:allValuesFrom ec:PublicationService
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:hasServiceGenre ;
+                                        owl:allValuesFrom skos:Concept
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:hasTargetAudience ;
+                                        owl:allValuesFrom ec:Audience
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:isOwnedBy ;
+                                        owl:allValuesFrom ec:Agent
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:hasEndDateTime ;
+                                        owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                        owl:onClass time:Instant
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:hasStartDateTime ;
+                                        owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                        owl:onClass time:Instant
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:description ;
+                                        owl:allValuesFrom rdfs:Literal
+                                      ] ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty ec:name ;
+                                        owl:allValuesFrom rdfs:Literal
+                                      ] ;
+                      dcterms:description "A named media offering provided by a publisher, distributed by a platform and made accessible through a channel for devices to allow people to consume the service, e.g. a linear audio service distributed via FM; a non-linear video streaming service distributed via a PSM's own VoD platform; a YouTube channel distributed via the YouTube platform."@en ,
+                                          "Une offre médiatique nommée fournie par un éditeur, distribuée par une plateforme et rendue accessible via un canal pour des appareils afin de permettre aux personnes de consommer le service, par exemple un service audio linéaire distribué via la FM ; un service de streaming vidéo non linéaire distribué via la propre plateforme de vidéo à la demande d’un PSM ; une chaîne YouTube distribuée via la plateforme YouTube."@fr ;
+                      rdfs:label "Publication service"@en ,
+                                 "Service de publication"@fr ;
+                      skos:definition "a named media offering provided by a publishing ec:Agent, distributed by a ec:PublicationPlatform and made accessible through ec:PublicationChannels for ec:ConsumptionDevices to allow ec:Consumers to consume the service"@en ,
+                                      "une offre médiatique nommée fournie par un Agent ec:publishing, distribuée par une ec:PublicationPlatform et rendue accessible via des ec:PublicationChannels pour des ec:ConsumptionDevices afin de permettre aux ec:Consumers de consommer le service"@fr ;
+                      skos:example """- le service vidéo linéaire nommé « BBC One »
+- le service de vidéo à la demande de Netflix"""@fr ,
+                                   """- the linear video service named \"BBC One\"
+- the video on demand service of Netflix"""@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Rating
+ec:Rating rdf:type owl:Class ;
+          rdfs:subClassOf [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasIdentifier ;
+                            owl:allValuesFrom ec:Identifier
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasLogo ;
+                            owl:allValuesFrom ec:Logo
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasObjectType ;
+                            owl:allValuesFrom skos:Concept
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasPictogram ;
+                            owl:allValuesFrom ec:Picture
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasTerritoryExcludes ;
+                            owl:allValuesFrom ec:CountryCode
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasTerritoryIncludes ;
+                            owl:allValuesFrom ec:CountryCode
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasRatingProvider ;
+                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                            owl:onClass ec:Agent
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:description ;
+                            owl:allValuesFrom rdfs:Literal
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:name ;
+                            owl:allValuesFrom rdfs:Literal
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:reason ;
+                            owl:allValuesFrom rdfs:Literal
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:ratingValue ;
+                            owl:cardinality "1"^^xsd:nonNegativeInteger
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:notRated ;
+                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                            owl:onDataRange xsd:boolean
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:ratingScaleMax ;
+                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:ratingScaleMin ;
+                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:ratingSystemEnvironment ;
+                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:ratingSystemName ;
+                            owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                          ] ;
+          dcterms:description "An evaluation of some content to judge the level of conformity with the applied criteria."@en ,
+                              "Une évaluation d’un contenu visant à juger le niveau de conformité aux critères appliqués."@fr ;
+          rdfs:label "Rating"@en ,
+                     "Évaluation"@fr ;
+          skos:definition "an evaluation of a ec:EditorialObject based on explainable criteria to judge the level of conformity"@en ,
+                          "une évaluation d’un ec:EditorialObject fondée sur des critères explicables afin de juger le niveau de conformité"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Record
+ec:Record rdf:type owl:Class ;
+          rdfs:subClassOf ec:BibliographicalObject ;
+          dcterms:description "A written account of something that is kept for future reading or use."@en ,
+                              "Un compte rendu écrit de quelque chose qui est conservé pour une lecture ou une utilisation ultérieure."@fr ;
+          rdfs:label "Document"@fr ,
+                     "Record"@en ;
+          skos:definition "a ec:BibliographicalObject about something happening that is kept for later use"@en ,
+                          "un ec:BibliographicalObject sur quelque chose qui se passe et qui est conservé pour une utilisation ultérieure"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#RegionCode
+ec:RegionCode rdf:type owl:Class ;
+              rdfs:subClassOf skos:Concept ;
+              dcterms:description "An entry from a list of codes identifying regions of locations."@en ,
+                                  "Une entrée d’une liste de codes identifiant les régions des lieux."@fr ;
+              rdfs:label "Code de région"@fr ,
+                         "Region code"@en ;
+              skos:definition "a skos:Concept identifying the region of a ec:Location"@en ,
+                              "un skos:Concept identifiant la région d’une ec:Location"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Relation
+ec:Relation rdf:type owl:Class ;
+            rdfs:subClassOf [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasIdentifier ;
+                              owl:allValuesFrom ec:Identifier
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasObjectType ;
+                              owl:allValuesFrom skos:Concept
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasRelationLink ;
+                              owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasRelationSource ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onClass ec:Agent
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:description ;
+                              owl:allValuesFrom rdfs:Literal
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:name ;
+                              owl:allValuesFrom rdfs:Literal
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:relationOrderedGroupFlag ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onDataRange xsd:boolean
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:relationRunningOrderNumber ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onDataRange xsd:integer
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:relationTotalNumberOfGroupMembers ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onDataRange xsd:integer
+                            ] ;
+            dcterms:description "A link between a person or organisation and a thing. The link can be classified, named, grouped and numbered."@en ,
+                                "Un lien entre une personne ou une organisation et une chose. Le lien peut être classé, nommé, regroupé et numéroté."@fr ;
+            rdfs:label "Relation"@en ,
+                       "Relation"@fr ;
+            skos:definition "a link between a ec:Agent and a owl:Thing"@en ,
+                            "un lien entre un ec:Agent et un owl:Thing"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#RelationType
+ec:RelationType rdf:type owl:Class ;
+                rdfs:subClassOf skos:Concept ;
+                dcterms:description "An entry from a list of types to classify a relation."@en ,
+                                    "Une entrée d’une liste de types pour classer une relation."@fr ;
+                rdfs:label "Relation type"@en ,
+                           "Type de relation"@fr ;
+                skos:definition "a skos:Concept identifying the type of a ec:Relation"@en ,
+                                "un skos:Concept identifiant le type d'une ec:Relation"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Reminder
+ec:Reminder rdf:type owl:Class ;
+            rdfs:subClassOf ec:EditorialWork ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasPromotion ;
+                              owl:allValuesFrom ec:Promotion
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:isMemberOf ;
+                              owl:allValuesFrom ec:CampaignPackage
+                            ] ;
+            dcterms:description "A content that refers to previous promotion created to remind the consumer of the advertised object."@en ,
+                                "Un contenu qui fait référence à une promotion précédente, créé pour rappeler au consommateur l'objet publicisé."@fr ;
+            rdfs:label "Rappel"@fr ,
+                       "Reminder"@en ;
+            skos:definition "an ec:EditorialWork that reminds a consumer of previous ec:Promotion"@en ,
+                            "un ec:EditorialWork qui rappelle un consommateur d’une ec:Promotion précédente"@fr ;
+            skos:example "- a 4 second repetition of the logo and the jingle of an insurance company, minutes after a 15 second advertisement"@en ,
+                         "- une répétition de 4 secondes du logo et du jingle d'une compagnie d'assurance, quelques minutes après une publicité de 15 secondes"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ResonanceCount
+ec:ResonanceCount rdf:type owl:Class ;
+                  rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:compilesResonanceEvents ;
+                                    owl:allValuesFrom ec:ResonanceEvent
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:hasIdentifier ;
+                                    owl:allValuesFrom ec:Identifier
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:hasLocator ;
+                                    owl:allValuesFrom ec:Locator
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:hasMeasurementAgent ;
+                                    owl:allValuesFrom ec:Agent
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:hasObjectType ;
+                                    owl:allValuesFrom skos:Concept
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:description ;
+                                    owl:allValuesFrom rdfs:Literal
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:name ;
+                                    owl:allValuesFrom rdfs:Literal
+                                  ] ;
+                  dcterms:description "L’agrégation d’événements de résonance, souvent sur une période donnée, pour indiquer la performance d’un événement de publication, d’un service ou d’un contenu, par exemple la part de marché pour l’événement en direct \"UEFA Champions League Final 2025\" diffusé sur des plateformes DVB par rapport à un flux en direct sur une plateforme de distribution à large bande ; le nombre de commentaires positifs par rapport aux commentaires négatifs sur une publication Instagram au cours du premier jour suivant la publication."@fr ,
+                                      "The aggregation of resonance events, often within a time span, to indicate performance of a publication event, a service or content, e.g. market share for he live event \"UEFA Champions League Final 2025\" broadcast on DVB platforms compared to live stream on broadband distribution platform; the number of positive vs. negative comments on an instagram post within the first day of the publication."@en ;
+                  rdfs:label "Resonance"@en ,
+                             "Résonance"@fr ;
+                  skos:definition "an aggregation of ec:ResonanceEvents, often within a time span, to indicate performance of a ec:PublicationEvent, a ec:PublicationService or an ec:EditorialObject"@en ,
+                                  "une agrégation de ec:ResonanceEvents, souvent sur une période donnée, pour indiquer la réalisation d'un ec:PublicationEvent, d'un ec:PublicationService ou d'un ec:EditorialObject"@fr ;
+                  skos:example """- market share of viewers on a sports live broadcast
+- weekly page impressions of a news website
+- number of daily unique users on a news website
+- number of likes on an instagram post
+- number of views of a movie from a VOD portal"""@en ,
+                               """- part de marché des téléspectateurs lors d’une retransmission sportive en direct
+- impressions de pages hebdomadaires d’un site web d’actualité
+- nombre d’utilisateurs uniques quotidiens d’un site web d’actualité
+- nombre de mentions J’aime sur une publication Instagram
+- nombre de vues d’un film depuis un portail VOD"""@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ResonanceEvent
+ec:ResonanceEvent rdf:type owl:Class ;
+                  rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:references ;
+                                    owl:someValuesFrom ec:ConsumptionEvent
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:references ;
+                                    owl:someValuesFrom ec:EditorialObject
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:references ;
+                                    owl:someValuesFrom ec:PublicationChannel
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:references ;
+                                    owl:someValuesFrom ec:PublicationEvent
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:references ;
+                                    owl:someValuesFrom ec:PublicationPlatform
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:references ;
+                                    owl:someValuesFrom ec:PublicationService
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:hasAssociatedConsumer ;
+                                    owl:allValuesFrom ec:Consumer
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:hasIdentifier ;
+                                    owl:allValuesFrom ec:Identifier
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:hasLocator ;
+                                    owl:allValuesFrom ec:Locator
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:description ;
+                                    owl:allValuesFrom rdfs:Literal
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:name ;
+                                    owl:allValuesFrom rdfs:Literal
+                                  ] ;
+                  dcterms:description "A countable or noticeable consumption-related action by a consumer during or after a consumption, e.g. a click on \"play\" or on \"pause\", likes, comments, votes, tweets, preferences, downloads. Resonance events are linked by content consumption. They represent raw data that need to be aggregated (e.g., summed)."@en ,
+                                      "Une action liée à la consommation, comptable ou perceptible, effectuée par un consommateur pendant ou après une consommation, par exemple un clic sur « play » ou sur « pause », des likes, des commentaires, des votes, des tweets, des préférences, des téléchargements. Les événements de résonance sont liés par la consommation de contenu. Ils représentent des données brutes qui doivent être agrégées (par exemple, additionnées)."@fr ;
+                  rdfs:label "Resonance event"@en ,
+                             "Événement de résonance"@fr ;
+                  skos:definition "a countable or noticeable consumption-related action by a ec:Consumer during or after a ec:ConsumptionEvent"@en ,
+                                  "une action liée à la consommation, comptable ou notable, effectuée par un ec:Consumer pendant ou après un ec:ConsumptionEvent"@fr ;
+                  skos:example """- turning off the TV set
+- switching to another radio channel
+- pausing the playback of a video from a VOD portal
+- searching for content on a VOD portal
+- liking, sharing or commenting a twitter post
+- commenting a video on youtube
+- calling the PSM's program hotline by phone to complain
+- rating a radio show in the radio station's app"""@en ,
+                               """- éteindre le téléviseur
+- passer à une autre chaîne radio
+- mettre en pause la lecture d’une vidéo sur un portail VOD
+- rechercher du contenu sur un portail VOD
+- aimer, partager ou commenter une publication Twitter
+- commenter une vidéo sur YouTube
+- appeler par téléphone la ligne de programmation du PSM pour se plaindre
+- noter une émission de radio dans l’application de la station de radio"""@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Resource
+ec:Resource rdf:type owl:Class ;
+            rdfs:subClassOf [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasAncillaryData ;
+                              owl:allValuesFrom ec:AncillaryData
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasFormat ;
+                              owl:allValuesFrom ec:Format
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasIdentifier ;
+                              owl:allValuesFrom ec:Identifier
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasLocator ;
+                              owl:allValuesFrom ec:Locator
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasObjectType ;
+                              owl:allValuesFrom skos:Concept
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasRelatedMediaFragment ;
+                              owl:allValuesFrom ec:MediaFragment
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasStorageId ;
+                              owl:allValuesFrom ec:Identifier
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasStorageType ;
+                              owl:allValuesFrom skos:Concept
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:isCommissionedBy ;
+                              owl:allValuesFrom ec:Contract
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasDateDeleted ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onClass time:Instant
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasDateValidated ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onClass time:Instant
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:description ;
+                              owl:allValuesFrom rdfs:Literal
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:name ;
+                              owl:allValuesFrom rdfs:Literal
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:fileName ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onDataRange xsd:string
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:fileSize ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onDataRange xsd:double
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:resolution ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onDataRange xsd:string
+                            ] ;
+            dcterms:description "A tangible or digital thing that is used or referred to in a media-related workflow, e.g. a document, an image, or similar. It often has a locator indicating from where it can be retrieved."@en ,
+                                "Une chose tangible ou numérique utilisée ou mentionnée dans un flux de travail lié aux médias, par exemple un document, une image ou un élément similaire. Elle comporte souvent un localisateur indiquant d’où elle peut être récupérée."@fr ;
+            rdfs:label "Resource"@en ,
+                       "Ressource"@fr ;
+            skos:definition "a tangible or digital ec:Thing that is used or referred to in a media-related workflow"@en ,
+                            "une ec:Thing tangible ou numérique utilisée ou mentionnée dans un flux de travail lié aux médias"@fr ;
+            skos:example """- a paper document
+- a digital document
+- a digital picture
+- a vinyl record
+- an audio CD
+- an audio tape
+- a video tape
+- a film dvd"""@en ,
+                         """- un document papier
+- un document numérique
+- une image numérique
+- un disque vinyle
+- un CD audio
+- une cassette audio
+- une cassette vidéo
+- un DVD de film"""@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ResourceType
+ec:ResourceType rdf:type owl:Class ;
+                rdfs:subClassOf skos:Concept ;
+                dcterms:description "An entry from a list of types to classify a relation."@en ,
+                                    "Une entrée d’une liste de types permettant de classer une relation."@fr ;
+                rdfs:label "Resource type"@en ,
+                           "Type de ressource"@fr ;
+                skos:definition "a skos:Concept identifying the type of a ec:Resource"@en ,
+                                "un skos:Concept identifiant le type d'une ec:Resource"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Review
+ec:Review rdf:type owl:Class ;
+          rdfs:subClassOf ec:Item ;
+          dcterms:description "An audio or audio-visual report, in which somebody gives their opinion of a play, film, etc."@en ,
+                              "Un reportage audio ou audiovisuel dans lequel quelqu’un donne son opinion sur une pièce, un film, etc."@fr ;
+          rdfs:label "Examen"@fr ,
+                     "Review"@en ;
+          skos:definition "a ec:Item in which somebody gives their opinion about an ec:EditorialObject"@en ,
+                          "un ec:Item dans lequel quelqu’un donne son opinion sur un ec:EditorialObject"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Rights
+ec:Rights rdf:type owl:Class ;
+          rdfs:subClassOf [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:applyTo ;
+                            owl:allValuesFrom ec:Asset
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasContact ;
+                            owl:allValuesFrom ec:Contact
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasIdentifier ;
+                            owl:allValuesFrom ec:Identifier
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasObjectType ;
+                            owl:allValuesFrom skos:Concept
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasRightsHolder ;
+                            owl:allValuesFrom ec:Agent
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasRightsTargetService ;
+                            owl:allValuesFrom ec:PublicationService
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasRightsTerritoryExcludes ;
+                            owl:allValuesFrom ec:CountryCode
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasRightsTerritoryIncludes ;
+                            owl:allValuesFrom ec:CountryCode
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:originatesFrom ;
+                            owl:allValuesFrom ec:Contract
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasDuration ;
+                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                            owl:onClass ec:TimelinePoint
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasEndDateTime ;
+                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                            owl:onClass time:Instant
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasStartDateTime ;
+                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                            owl:onClass time:Instant
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:description ;
+                            owl:allValuesFrom rdfs:Literal
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:name ;
+                            owl:allValuesFrom rdfs:Literal
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:publishingEventsLeft ;
+                            owl:allValuesFrom xsd:integer
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:rightsExpression ;
+                            owl:allValuesFrom rdfs:Literal
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:rightsLink ;
+                            owl:allValuesFrom xsd:anyURI
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:rightsUsageRestrictions ;
+                            owl:allValuesFrom rdfs:Literal
+                          ] ;
+          dcterms:description "Le droit des titulaires de droits d'utiliser ou de publier des œuvres, tel que défini par la législation sur la propriété intellectuelle ou par des contrats."@fr ,
+                              "The entitlement of rights holders to use or publish works as defined by intellectual property legislation or by contracts."@en ;
+          rdfs:label "Droits"@fr ,
+                     "Rights"@en ;
+          skos:definition "an entitlement of a ec:RightsHolder to use or publish an ec:Asset according to a ec:Contract"@en ,
+                          "un droit pour un ec:RightsHolder d’utiliser ou de publier un ec:Asset conformément à un ec:Contract"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#RightsClearance
+ec:RightsClearance rdf:type owl:Class ;
+                   rdfs:subClassOf ec:Rights ;
+                   dcterms:description "A grant to use the work in any way, issued by the organisation that checked all possible limitations and concluded that there are none."@en ,
+                                       "Une autorisation d’utiliser l’œuvre de quelque manière que ce soit, délivrée par l’organisation qui a vérifié toutes les limitations possibles et a conclu qu’il n’y en a aucune."@fr ;
+                   rdfs:label "Autorisation des droits"@fr ,
+                              "Rights clearance"@en ;
+                   skos:definition "a ec:Rights that allows all uses of the work to the organisation that has checked all possible limitations"@en ,
+                                   "une ec:Rights qui permet tous les usages de l’œuvre à l’organisation qui a vérifié toutes les limitations possibles"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#RightsType
+ec:RightsType rdf:type owl:Class ;
+              rdfs:subClassOf skos:Concept ;
+              dcterms:description "An entry from a list of types to classify rights."@en ,
+                                  "Une entrée d’une liste de types pour classer les droits."@fr ;
+              rdfs:label "Rights type"@en ,
+                         "Type de droits"@fr ;
+              skos:definition "a skos:Concept identifying the type of a ec:Rights"@en ,
+                              "un skos:Concept identifiant le type d’un ec:Rights"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Rule
+ec:Rule rdf:type owl:Class ;
+        rdfs:subClassOf [ rdf:type owl:Restriction ;
+                          owl:onProperty ec:hasIdentifier ;
+                          owl:allValuesFrom ec:Identifier
+                        ] ,
+                        [ rdf:type owl:Restriction ;
+                          owl:onProperty ec:hasObjectType ;
+                          owl:allValuesFrom skos:Concept
+                        ] ,
+                        [ rdf:type owl:Restriction ;
+                          owl:onProperty ec:hasPriority ;
+                          owl:allValuesFrom skos:Concept
+                        ] ,
+                        [ rdf:type owl:Restriction ;
+                          owl:onProperty ec:hasRelatedRule ;
+                          owl:allValuesFrom ec:Rule
+                        ] ,
+                        [ rdf:type owl:Restriction ;
+                          owl:onProperty ec:isDefinedBy ;
+                          owl:allValuesFrom ec:Contract
+                        ] ,
+                        [ rdf:type owl:Restriction ;
+                          owl:onProperty ec:description ;
+                          owl:allValuesFrom rdfs:Literal
+                        ] ,
+                        [ rdf:type owl:Restriction ;
+                          owl:onProperty ec:name ;
+                          owl:allValuesFrom rdfs:Literal
+                        ] ,
+                        [ rdf:type owl:Restriction ;
+                          owl:onProperty ec:ruleStatement ;
+                          owl:allValuesFrom rdfs:Literal
+                        ] ;
+        dcterms:description "A Rule defined from legal, technical or editorial, or regulatory requirements."@en ,
+                            "Une règle définie à partir d’exigences juridiques, techniques, éditoriales ou réglementaires."@fr ;
+        rdfs:label "Rule"@en ,
+                   "Règle"@fr ;
+        skos:definition "a legal, regulatory, technical or editorial guideline"@en ,
+                        "une ligne directrice juridique, réglementaire, technique ou éditoriale"@fr ;
+        skos:example """- audio track volume level must be below 0dB
+- speaker time in a debate between two candidates must be equal
+- the share of male/female experts in all programmes of BBC One should be 50% each"""@en ,
+                     """- le niveau du volume de la piste audio doit être inférieur à 0 dB
+- le temps de parole des intervenants dans un débat entre deux candidats doit être égal
+- la part d'experts masculins/féminins dans tous les programmes de BBC One doit être de 50 % chacun"""@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Scene
+ec:Scene rdf:type owl:Class ;
+         rdfs:subClassOf ec:EditorialSegment ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasProgramme ;
+                           owl:allValuesFrom ec:Programme
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasShot ;
+                           owl:allValuesFrom ec:Shot
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasTake ;
+                           owl:allValuesFrom ec:Take
+                         ] ;
+         owl:disjointWith ec:Shot ,
+                          ec:Take ;
+         dcterms:description "A (usually small) part of a story that is filmed or recorded without a leap in time or location to represent a continuous action."@en ,
+                             "Une partie (généralement petite) d'une histoire qui est filmée ou enregistrée sans saut dans le temps ou le lieu afin de représenter une action continue."@fr ;
+         rdfs:label "Scene"@en ,
+                    "Scène"@fr ;
+         skos:definition "an ec:EditorialSegment that contains a small part of a story without leaps in time or location"@en ,
+                         "un ec:EditorialSegment qui contient une petite partie d'une histoire sans sauts dans le temps ou le lieu"@fr ;
+         skos:example "- le dernier adieu de Humphrey Bogart et Ingrid Bergman à l’aéroport de Casablanca dans le film du même nom."@fr ,
+                      "- the final goodbye of Humphrey Bogart and Ingrid Bergman at the airport of Casablanca in the equally named film."@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Season
+ec:Season rdf:type owl:Class ;
+          rdfs:subClassOf ec:EditorialGroup ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasEpisode ;
+                            owl:someValuesFrom ec:Programme
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasSerial ;
+                            owl:allValuesFrom ec:Serial
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:isSeasonOf ;
+                            owl:allValuesFrom ec:Series
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:seasonNumber ;
+                            owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                            owl:onDataRange xsd:integer
+                          ] ;
+          dcterms:description "A group of works that is produced within one production effort, like episodes 1 to 6 for a new fictional series. Alternatively, grouping can be done by time span, such as all comedy shows by a host in one fiscal year."@en ,
+                              "Un groupe d’œuvres produit dans le cadre d’un même effort de production, comme les épisodes 1 à 6 d’une nouvelle série de fiction. Le regroupement peut aussi se faire selon une période, par exemple tous les spectacles comiques d’un animateur au cours d’un même exercice fiscal."@fr ;
+          rdfs:label "Saison"@fr ,
+                     "Season"@en ;
+          skos:definition "an ec:EditorialGroup that contains episodes of ec:Series or ec:Serial, usually due to a common production effort or a common production time"@en ,
+                          "un ec:EditorialGroup qui contient des épisodes de ec:Series ou de ec:Serial, généralement en raison d’un effort de production commun ou d’une période de production commune"@fr ;
+          skos:example """- les 216 épisodes de 2018 de la série de la BBC « EastEnder »
+- la saison 1 avec 8 épisodes de la série allemande « Babylon Berlin »"""@fr ,
+                       """- the 216 episodes of 2018 of BBC series \"EastEnder\"
+- season 1 with 8 episodes of German serial \"Babylon Berlin\""""@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Serial
+ec:Serial rdf:type owl:Class ;
+          rdfs:subClassOf ec:EditorialGroup ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasEpisode ;
+                            owl:someValuesFrom ec:Programme
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasSeason ;
+                            owl:allValuesFrom ec:Season
+                          ] ;
+          dcterms:description "A group of works that usually sum up sequentially to a common story, like chapters in a novel."@en ,
+                              "Un groupe d’œuvres qui s’enchaînent généralement pour former un récit commun, comme des chapitres dans un roman."@fr ;
+          rdfs:label "Serial"@en ,
+                     "Série"@fr ;
+          skos:definition "an ec:EditorialGroup telling a whole story in parts, each continuing the preceding part"@en ,
+                          "un ec:EditorialGroup qui raconte une histoire entière en parties, chacune poursuivant la partie précédente"@fr ;
+          skos:example "- German serial \"Babylon Berlin\" with several seasons"@en ,
+                       "- Série allemande « Babylon Berlin » avec plusieurs saisons"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Series
+ec:Series rdf:type owl:Class ;
+          rdfs:subClassOf ec:EditorialGroup ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasEpisode ;
+                            owl:someValuesFrom ec:Programme
+                          ] ,
+                          [ rdf:type owl:Restriction ;
+                            owl:onProperty ec:hasSeason ;
+                            owl:allValuesFrom ec:Season
+                          ] ;
+          dcterms:description "A group of works that are usually grouped by characters (e.g. talk show host) or topics (e.g. sports, news, ...) or publication scheme (weekly), but not by a sequential story."@en ,
+                              "Un groupe d’œuvres généralement regroupées par des personnages (par exemple, l’animateur d’un talk-show), par des sujets (par exemple, sport, actualités, ...) ou selon un schéma de publication (hebdomadaire), mais pas selon une histoire séquentielle."@fr ;
+          rdfs:label "Series"@en ,
+                     "Série"@fr ;
+          skos:definition "an ec:EditorialGroup of Programmes, that are grouped by characters or topics or publication scheme, but not by a sequential story"@en ,
+                          "un ec:EditorialGroup de Programmes, regroupés par personnages ou par sujets ou par schéma de publication, mais pas par une histoire séquentielle"@fr ;
+          skos:example """- ABC serial \"Friends\"
+- BBC's daily news programme \"BBC News\"
+- ARD's Sunday night drama \"Tatort\""""@en ,
+                       """- Série télévisée ABC « Friends »
+- Programme d’actualités quotidien de la BBC « BBC News »
+- Drame du dimanche soir de l’ARD « Tatort »"""@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#ServiceType
+ec:ServiceType rdf:type owl:Class ;
+               rdfs:subClassOf skos:Concept ;
+               dcterms:description "An entry from a list of types to classify a publication service."@en ,
+                                   "Une entrée d’une liste de types permettant de classer un service de publication."@fr ;
+               rdfs:label "Service type"@en ,
+                          "Type de service"@fr ;
+               skos:definition "a skos:Concept identifying the type of a ec:PublicationService"@en ,
+                               "un skos:Concept identifiant le type d’une ec:PublicationService"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Shot
+ec:Shot rdf:type owl:Class ;
+        rdfs:subClassOf ec:EditorialSegment ,
+                        [ rdf:type owl:Restriction ;
+                          owl:onProperty ec:hasScene ;
+                          owl:allValuesFrom ec:Scene
+                        ] ,
+                        [ rdf:type owl:Restriction ;
+                          owl:onProperty ec:hasTake ;
+                          owl:allValuesFrom ec:Take
+                        ] ;
+        owl:disjointWith ec:Take ;
+        dcterms:description "A video sequence filmed continuously by one camera."@en ,
+                            "Une séquence vidéo filmée en continu par une seule caméra."@fr ;
+        rdfs:label "Plan"@fr ,
+                   "Shot"@en ;
+        skos:definition "an ec:EditorialSegment filmed with one camera without interruption"@en ,
+                        "un ec:EditorialSegment filmé avec une seule caméra sans interruption"@fr ;
+        skos:example "- a part of the final Scene of \"Casablanca\" showing Humphrey Bogart from behind while watching Ingrid Bergman and Paul Henreid walking to the plane, filmed from one camera without interruption"@en ,
+                     "- une partie de la scène finale de « Casablanca » montrant Humphrey Bogart de dos alors qu'il regarde Ingrid Bergman et Paul Henreid marcher vers l'avion, filmée par une seule caméra sans interruption"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#SignLanguageCode
+ec:SignLanguageCode rdf:type owl:Class ;
+                    rdfs:subClassOf skos:Concept ;
+                    dcterms:description "An entry from a list of codes to identify a sign language."@en ,
+                                        "Une entrée d'une liste de codes permettant d'identifier une langue des signes."@fr ;
+                    rdfs:label "Code de langue des signes"@fr ,
+                               "Sign language code"@en ;
+                    skos:definition "a skos:Concept identifying the code of a sign language"@en ,
+                                    "un skos:Concept identifiant le code d'une langue des signes"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Signing
+ec:Signing rdf:type owl:Class ;
+           rdfs:subClassOf ec:Track ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:hasSigningFormat ;
+                             owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                             owl:onClass ec:SigningFormat
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty ec:hasSigningSource ;
+                             owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                             owl:onClass ec:Agent
+                           ] ;
+           dcterms:description "A track containing sign language."@en ,
+                               "Une piste contenant la langue des signes."@fr ;
+           rdfs:label "Signing"@en ,
+                      "Sous-titrage en langue des signes"@fr ;
+           skos:definition "a ec:Track containing sign language for deaf and hard of hearing"@en ,
+                           "un ec:Track contenant la langue des signes pour les sourds et malentendants"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#SigningFormat
+ec:SigningFormat rdf:type owl:Class ;
+                 rdfs:subClassOf skos:Concept ;
+                 dcterms:description "An entry from a list of formats to identify the sign language interpretation in audiovisual media, e.g. in-vision/inset, full-screen, overlay, avatar."@en ,
+                                     "Une entrée d’une liste de formats permettant d’identifier l’interprétation en langue des signes dans les médias audiovisuels, par exemple en incrustation à l’écran, plein écran, superposition, avatar."@fr ;
+                 rdfs:label "Format de sous-titrage"@fr ,
+                            "Signing format"@en ;
+                 skos:definition "a skos:Concept identifying the format of sign language interpretation"@en ,
+                                 "un skos:Concept identifiant le format de l’interprétation en langue des signes"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#StaffMember
+ec:StaffMember rdf:type owl:Class ;
+               rdfs:subClassOf ec:Person ;
+               dcterms:description "A member of staff is a person in a company's workforce."@en ,
+                                   "Un membre du personnel est une personne faisant partie de l'effectif d'une entreprise."@fr ;
+               rdfs:label "Membre du personnel"@fr ,
+                          "Staff member"@en ;
+               skos:definition "a ec:Person who is a member of the workforce in a company"@en ,
+                               "une ec:Personne qui est membre du personnel d'une entreprise"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Stage
+ec:Stage rdf:type owl:Class ;
+         rdfs:subClassOf [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasLocator ;
+                           owl:allValuesFrom ec:Locator
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasObjectType ;
+                           owl:allValuesFrom skos:Concept
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasStageLocation ;
+                           owl:allValuesFrom ec:Location
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:description ;
+                           owl:allValuesFrom rdfs:Literal
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:name ;
+                           owl:allValuesFrom rdfs:Literal
+                         ] ;
+         dcterms:description "A space for the performing arts, such as a theatre, a concert hall or a film studio."@en ,
+                             "Un espace dédié aux arts du spectacle, comme un théâtre, une salle de concert ou un studio de cinéma."@fr ;
+         rdfs:label "Scène"@fr ,
+                    "Stage"@en ;
+         skos:definition "a space for the performing arts"@en ,
+                         "un espace pour les arts de la scène"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Standard
+ec:Standard rdf:type owl:Class ;
+            rdfs:subClassOf ec:Format ;
+            dcterms:description "An entry from the classification of video standards for media resources, i.e. NTSC or PAL."@en ,
+                                "Une entrée de la classification des normes vidéo pour les ressources multimédias, par exemple NTSC ou PAL."@fr ;
+            rdfs:label "Standard"@en ,
+                       "Standard"@fr ;
+            skos:definition "a ec:Format classifying the video standard of a ec:MediaResource"@en ,
+                            "un ec:Format classant la norme vidéo d'un ec:MediaResource"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Sticker
+ec:Sticker rdf:type owl:Class ;
+           rdfs:subClassOf ec:Picture ;
+           dcterms:description "A picture that is attached to a piece of clothing worn by an actor."@en ,
+                               "Une image attachée à un vêtement porté par un acteur."@fr ;
+           rdfs:label "Autocollant"@fr ,
+                      "Sticker"@en ;
+           skos:definition "a ec:Picture that is attached to a ec:Costume"@en ,
+                           "une ec:Picture attachée à un ec:Costume"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#StorageType
+ec:StorageType rdf:type owl:Class ;
+               rdfs:subClassOf skos:Concept ;
+               dcterms:description "An entry from a list of types to classify a storage."@en ,
+                                   "Une entrée d’une liste de types permettant de classer un stockage."@fr ;
+               rdfs:label "Storage type"@en ,
+                          "Type de stockage"@fr ;
+               skos:definition "a skos:Concept identifying the type of storage"@en ,
+                               "un skos:Concept identifiant le type de stockage"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Stream
+ec:Stream rdf:type owl:Class ;
+          rdfs:subClassOf ec:Component ;
+          dcterms:description "A component of a media resource in the form of a continuous flow of bits."@en ,
+                              "Un composant d’une ressource média sous la forme d’un flux continu de bits."@fr ;
+          rdfs:label "Flux"@fr ,
+                     "Stream"@en ;
+          skos:definition "a ec:Component in the form of a continuous flow of bits"@en ,
+                          "un ec:Component sous la forme d’un flux continu de bits"@fr ;
+          skos:example """- an audio stream from an audio on demand service
+- a video stream from a video on demand service"""@en ,
+                       """- un flux audio provenant d’un service de vidéo à la demande
+- un flux vidéo provenant d’un service de vidéo à la demande"""@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Subject
+ec:Subject rdf:type owl:Class ;
+           rdfs:subClassOf skos:Concept ;
+           dcterms:description "An entry from the list of subjects to classify the content of a piece of work."@en ,
+                               "Une entrée de la liste des sujets permettant de classer le contenu d’une œuvre."@fr ;
+           rdfs:label "Subject"@en ,
+                      "Sujet"@fr ;
+           skos:definition "a skos:Concept classifying the topic covered by a ec:EditorialObject"@en ,
+                           "un skos:Concept classifiant le sujet couvert par un ec:EditorialObject"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Subtitling
+ec:Subtitling rdf:type owl:Class ;
+              rdfs:subClassOf ec:Track ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:hasSubtitlingSource ;
+                                owl:allValuesFrom ec:Agent
+                              ] ;
+              dcterms:description "A track containing subtitles in some languages."@en ,
+                                  "Une piste contenant des sous-titres dans certaines langues."@fr ;
+              rdfs:label "Sous-titrage"@fr ,
+                         "Subtitling"@en ;
+              skos:definition "a ec:Track containing subtitles in some language"@en ,
+                              "un ec:Track contenant des sous-titres dans une langue quelconque"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#SubtitlingFormat
+ec:SubtitlingFormat rdf:type owl:Class ;
+                    rdfs:subClassOf ec:DataFormat ;
+                    dcterms:description "An entry from the classification of structure schemes for subtitling data, mainly used for translations."@en ,
+                                        "Une entrée de la classification des schémas de structure pour les données de sous-titrage, principalement utilisée pour les traductions."@fr ;
+                    rdfs:label "Format de sous-titrage"@fr ,
+                               "Subtitling format"@en ;
+                    skos:definition "a ec:DataFormat classifying the structure of subtitling data"@en ,
+                                    "une ec:DataFormat classant la structure des données de sous-titrage"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Take
+ec:Take rdf:type owl:Class ;
+        rdfs:subClassOf ec:EditorialSegment ,
+                        [ rdf:type owl:Restriction ;
+                          owl:onProperty ec:hasScene ;
+                          owl:allValuesFrom ec:Scene
+                        ] ;
+        dcterms:description "A shot or a scene filmed repeatedly to provide a choice of takes and allow to select the best fit during post-production."@en ,
+                            "Une prise ou une scène filmée à plusieurs reprises afin d'offrir un choix de prises et de permettre de sélectionner la plus adaptée en postproduction."@fr ;
+        rdfs:label "Prise"@fr ,
+                   "Take"@en ;
+        skos:definition "a ec:Shot or a ec:Scene filmed or recorded repeatedly to provide a choice of Takes"@en ,
+                        "un ec:Shot ou une ec:Scene filmé ou enregistré plusieurs fois pour offrir un choix de Takes"@fr ;
+        skos:example "- an EditorialWork consists of selected Takes, while discarded Takes sometimes are published as \"outtakes\", for which examples can be easily found in the web"@en ,
+                     "- une EditorialWork consiste en des Takes sélectionnés, tandis que les Takes écartés sont parfois publiés comme « outtakes », dont on peut facilement trouver des exemples sur le web"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Team
+ec:Team rdf:type owl:Class ;
+        rdfs:subClassOf ec:Organisation ,
+                        [ rdf:type owl:Restriction ;
+                          owl:onProperty ec:hasTeamMember ;
+                          owl:allValuesFrom ec:Person
+                        ] ;
+        dcterms:description "A number of people working together, often in different roles, toward a common goal, such as conducting a project, operating a service, executing a process, or similar."@en ,
+                            "Un groupe de personnes travaillant ensemble, souvent dans des rôles différents, vers un objectif commun, par exemple la conduite d’un projet, l’exploitation d’un service, l’exécution d’un processus ou autre chose de similaire."@fr ;
+        rdfs:label "Team"@en ,
+                   "Équipe"@fr ;
+        skos:definition "a ec:Organisation consisting of ec:Persons as members"@en ,
+                        "une ec:Organisation composée de ec:Persons en tant que membres"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Template
+ec:Template rdf:type owl:Class ;
+            rdfs:subClassOf ec:Essence ;
+            dcterms:description "An essence in the form of a template for essences with all associated technical parameters."@en ,
+                                "Une essence sous la forme d’un modèle pour des essences avec tous les paramètres techniques associés."@fr ;
+            rdfs:label "Modèle"@fr ,
+                       "Template"@en ;
+            skos:definition "an ec:Essence in the form of a template for ec:Essences with all associated technical parameters"@en ,
+                            "une ec:Essence sous la forme d’un modèle pour des ec:Essences avec tous les paramètres techniques associés"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#TerritoryCode
+ec:TerritoryCode rdf:type owl:Class ;
+                 rdfs:subClassOf skos:Concept ;
+                 dcterms:description "An entry from a list of codes identifying territories, e.g. by their UN Code."@en ,
+                                     "Une entrée d’une liste de codes identifiant des territoires, par exemple selon leur code ONU."@fr ;
+                 rdfs:label "Code de territoire"@fr ,
+                            "Territory code"@en ;
+                 skos:definition "a skos:Concept identifying a territory"@en ,
+                                 "un skos:Concept identifiant un territoire"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#TextAnnotation
+ec:TextAnnotation rdf:type owl:Class ;
+                  rdfs:subClassOf ec:Annotation ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:characterEndIndex ;
+                                    owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                    owl:onDataRange xsd:integer
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty ec:characterStartIndex ;
+                                    owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                    owl:onDataRange xsd:integer
+                                  ] ;
+                  dcterms:description "A text annotation adds description, context, comments, or similar to a thing."@en ,
+                                      "Une annotation textuelle ajoute une description, un contexte, des commentaires ou des éléments similaires à une chose."@fr ;
+                  rdfs:label "Annotation textuelle"@fr ,
+                             "Text annotation"@en ;
+                  skos:definition "a ec:Annotation containing text or portions of texts"@en ,
+                                  "une ec:Annotation contenant du texte ou des portions de textes"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#TextLine
+ec:TextLine rdf:type owl:Class ;
+            rdfs:subClassOf [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasIdentifier ;
+                              owl:allValuesFrom ec:Identifier
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasRelatedAgent ;
+                              owl:allValuesFrom ec:Agent
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasRelatedCharacter ;
+                              owl:allValuesFrom ec:Character
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasRelatedScene ;
+                              owl:allValuesFrom ec:Scene
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasEnd ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onClass ec:TimelinePoint
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasObjectType ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onClass skos:Concept
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasStart ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onClass ec:TimelinePoint
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:hasTextLineSource ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onClass ec:Agent
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:artefactBoxHeight ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onDataRange xsd:nonNegativeInteger
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:artefactBoxTopLeftCornerLineNumber ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onDataRange xsd:nonNegativeInteger
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:artefactBoxTopLeftCornerPixelNumber ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onDataRange xsd:nonNegativeInteger
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:artefactBoxWidth ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onDataRange xsd:nonNegativeInteger
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:textLineBoxHeight ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onDataRange xsd:nonNegativeInteger
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:textLineBoxTopLeftCornerLineNumber ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onDataRange xsd:nonNegativeInteger
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:textLineBoxTopLeftCornerPixelNumber ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onDataRange xsd:nonNegativeInteger
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:textLineBoxWidth ;
+                              owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onDataRange xsd:nonNegativeInteger
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:textLineContent ;
+                              owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                            ] ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:textLineOrder ;
+                              owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                            ] ;
+            dcterms:description "A line of text that appears within some content on a screen, at a given space and time."@en ,
+                                "Une ligne de texte qui apparaît dans un contenu affiché à l’écran, à un espace et un moment donnés."@fr ;
+            rdfs:label "Ligne de texte"@fr ,
+                       "Text line"@en ;
+            skos:definition "a line of text that is visible in a spatial and timed context together with content"@en ,
+                            "une ligne de texte visible dans un contexte spatial et temporel avec du contenu"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#TextLineType
+ec:TextLineType rdf:type owl:Class ;
+                rdfs:subClassOf skos:Concept ;
+                dcterms:description "An entry from a list of types to classify a text line."@en ,
+                                    "Une entrée d’une liste de types permettant de classer une ligne de texte."@fr ;
+                rdfs:label "Text line type"@en ,
+                           "Type de ligne de texte"@fr ;
+                skos:definition "a skos:Concept identifying the type of a ec:TextLine"@en ,
+                                "un skos:Concept identifiant le type d'un ec:TextLine"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#TextUsageType
+ec:TextUsageType rdf:type owl:Class ;
+                 rdfs:subClassOf skos:Concept ;
+                 dcterms:description "An entry from a list of types to classify the usage of a text."@en ,
+                                     "Une entrée d’une liste de types permettant de classer l’usage d’un texte."@fr ;
+                 rdfs:label "Text usage type"@en ,
+                            "Type d'utilisation du texte"@fr ;
+                 skos:definition "a skos:Concept identifying the type of usage of text"@en ,
+                                 "un skos:Concept identifiant le type d’usage d’un texte"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Theme
+ec:Theme rdf:type owl:Class ;
+         rdfs:subClassOf skos:Concept ;
+         dcterms:description "An entry from the list of themes to associate with of a piece of work."@en ,
+                             "Une entrée de la liste des thèmes à associer à une œuvre."@fr ;
+         rdfs:label "Theme"@en ,
+                    "Thème"@fr ;
+         skos:definition "a skos:Concept classifying the theme associated with a ec:Asset"@en ,
+                         "un skos:Concept classifiant le thème associé à un ec:Asset"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Thumbnail
+ec:Thumbnail rdf:type owl:Class ;
+             rdfs:subClassOf ec:Picture ;
+             dcterms:description "A low-resolution picture to save computing and storage resources in user interfaces, e.g. on small-screen devices for consumption."@en ,
+                                 "Une image basse résolution permettant d’économiser des ressources de calcul et de stockage dans les interfaces utilisateur, par exemple sur des appareils à petit écran pour la consultation."@fr ;
+             rdfs:label "Thumbnail"@en ,
+                        "Vignette"@fr ;
+             skos:definition "a ec:Picture in a low resolution instantiation to save computing and storage resources in user interfaces"@en ,
+                             "une ec:Picture en instanciation à faible résolution pour économiser les ressources de calcul et de stockage dans les interfaces utilisateur"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#TimeCode
+ec:TimeCode rdf:type owl:Class ;
+            rdfs:subClassOf ec:TimelinePoint ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty ec:timecodeExpression ;
+                              owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                              owl:onDataRange xsd:string
+                            ] ;
+            dcterms:description "A point in time within the timeline of a content that is expressed as a timecode."@en ,
+                                "Un point dans le temps au sein de la chronologie d’un contenu, exprimé sous forme de code temporel."@fr ;
+            rdfs:label "Code temporel"@fr ,
+                       "Time code"@en ;
+            skos:definition "a ec:TimelinePoint expressed in a timecode expression"@en ,
+                            "un ec:TimelinePoint exprimé dans une expression de timecode"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#TimeCodeDropFrame
+ec:TimeCodeDropFrame rdf:type owl:Class ;
+                     rdfs:subClassOf ec:TimelinePoint ,
+                                     [ rdf:type owl:Restriction ;
+                                       owl:onProperty ec:timecodeExpression ;
+                                       owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                       owl:onDataRange xsd:string
+                                     ] ;
+                     dcterms:description "A point in time within the timeline of a content that is expressed as a timecode with dropframe."@en ,
+                                         "Un point dans le temps au sein de la chronologie d’un contenu, exprimé sous la forme d’un timecode avec dropframe."@fr ;
+                     rdfs:label "Code temporel avec drop-frame"@fr ,
+                                "Time code with dropframe"@en ;
+                     skos:definition "a ec:TimelinePoint expressed in a timecode expression with dropframe"@en ,
+                                     "un ec:TimelinePoint exprimé dans une expression de timecode avec dropframe"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#TimecodeTrack
+ec:TimecodeTrack rdf:type owl:Class ;
+                 rdfs:subClassOf ec:Track ;
+                 dcterms:description "A track containing timecode information."@en ,
+                                     "Une piste contenant des informations de timecode."@fr ;
+                 rdfs:label "Piste de timecode"@fr ,
+                            "Timecode track"@en ;
+                 skos:definition "a ec:Track containing timecode information"@en ,
+                                 "un ec:Track contenant des informations de timecode"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#TimedTextAuthoringTechnique
+ec:TimedTextAuthoringTechnique rdf:type owl:Class ;
+                               rdfs:subClassOf ec:Format ;
+                               dcterms:description "An entry from the classification of techniques for the representation of timed text for media resources."@en ,
+                                                   "Une entrée de la classification des techniques de représentation des textes temporisés pour des ressources média."@fr ;
+                               rdfs:label "Technique de création de texte synchronisé"@fr ,
+                                          "Timed text authoring technique"@en ;
+                               skos:definition "a ec:Format classifying the technique to represent time related text for a ec:MediaResource"@en ,
+                                               "un ec:Format classifiant la technique de représentation du texte synchronisé pour un ec:MediaResource"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#TimedTextContentType
+ec:TimedTextContentType rdf:type owl:Class ;
+                        rdfs:subClassOf ec:Format ;
+                        dcterms:description "An entry from the classification of types of timed text for media resources."@en ,
+                                            "Une entrée de la classification des types de texte temporisé pour les ressources multimédias."@fr ;
+                        rdfs:label "Timed text content type"@en ,
+                                   "Type de contenu de texte horodaté"@fr ;
+                        skos:definition "a ec:Format classifying the type of timed text for a ec:MediaResource"@en ,
+                                        "un ec:Format classant le type de texte synchronisé pour une ec:MediaResource"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#TimedTextSubtitleTargetFormat
+ec:TimedTextSubtitleTargetFormat rdf:type owl:Class ;
+                                 rdfs:subClassOf ec:Format ;
+                                 dcterms:description "An entry from the classification of types of timed text subtitles for media resources."@en ,
+                                                     "Une entrée de la classification des types de sous-titres en texte temporel pour les ressources multimédias."@fr ;
+                                 rdfs:label "Format cible des sous-titres en texte synchronisé"@fr ,
+                                            "Timed text subtitle target format"@en ;
+                                 skos:definition "a ec:Format classifying the format of timed text subtitles for a ec:MediaResource"@en ,
+                                                 "un ec:Format classant le format des sous-titres en texte temporel pour une ec:MediaResource"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#TimelinePoint
+ec:TimelinePoint rdf:type owl:Class ;
+                 rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:equivalentTime ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onDataRange xsd:float
+                                 ] ;
+                 dc:description "A precise time point  of a media resource"@en ;
+                 dcterms:description "A point in time within the timeline of a content, typically used to mark a specific event, position, or segment boundary in media timing metadata."@en ,
+                                     "Un point dans le temps au sein de la chronologie d’un contenu, généralement utilisé pour marquer un événement spécifique, une position ou une frontière de segment dans les métadonnées de synchronisation des médias."@fr ;
+                 rdfs:label "Point chronologique"@fr ,
+                            "Timeline point"@en ;
+                 skos:definition "a point in time within the timeline of a content"@en ,
+                                 "un point temporel dans la chronologie d’un contenu"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#TimelineTrack
+ec:TimelineTrack rdf:type owl:Class ;
+                 rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasIdentifier ;
+                                   owl:allValuesFrom ec:Identifier
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasTimelineTrackPart ;
+                                   owl:allValuesFrom ec:EditorialObject
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasDuration ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass ec:TimelinePoint
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasObjectType ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass skos:Concept
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:description ;
+                                   owl:allValuesFrom rdfs:Literal
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:name ;
+                                   owl:allValuesFrom rdfs:Literal
+                                 ] ;
+                 dcterms:description "A temporal scale used as a reference to express the sequence in time for a set of content."@en ,
+                                     "Une échelle temporelle utilisée comme référence pour exprimer la séquence dans le temps d’un ensemble de contenus."@fr ;
+                 rdfs:label "Piste chronologique"@fr ,
+                            "Timeline track"@en ;
+                 skos:definition "a temporal scale used as a reference to express the sequence in time of a set of ec:EditorialObjects"@en ,
+                                 "une échelle temporelle utilisée comme référence pour exprimer la séquence dans le temps d’un ensemble de ec:EditorialObjects"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#TimelineTrackType
+ec:TimelineTrackType rdf:type owl:Class ;
+                     rdfs:subClassOf skos:Concept ;
+                     dcterms:description "An entry from a list of types to classify timeline tracks."@en ,
+                                         "Une entrée d’une liste de types permettant de classer les pistes de chronologie."@fr ;
+                     rdfs:label "Timeline track type"@en ,
+                                "Type de piste chronologique"@fr ;
+                     skos:definition "a skos:Concept identifying the type of a ec:TimelineTrack"@en ,
+                                     "un skos:Concept identifiant le type d'un ec:TimelineTrack"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Topic
+ec:Topic rdf:type owl:Class ;
+         rdfs:subClassOf skos:Concept ;
+         dcterms:description "An entry from the list of topics to classify the content of a piece of work."@en ,
+                             "Une entrée de la liste des sujets servant à classer le contenu d’une œuvre."@fr ;
+         rdfs:label "Sujet"@fr ,
+                    "Topic"@en ;
+         skos:definition "a skos:Concept classifying a topic covered in a ec:EditorialObject"@en ,
+                         "un skos:Concept classifiant un sujet couvert dans un ec:EditorialObject"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Track
+ec:Track rdf:type owl:Class ;
+         rdfs:subClassOf ec:MediaResource ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasTrackPart ;
+                           owl:allValuesFrom ec:MediaResource
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasTrackPurpose ;
+                           owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                           owl:onClass ec:TrackPurpose
+                         ] ,
+                         [ rdf:type owl:Restriction ;
+                           owl:onProperty ec:hasTrackType ;
+                           owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                           owl:onClass ec:TrackType
+                         ] ;
+         dcterms:description "E.g. audio, video, timecode and/or data Tracks forming the MediaResource."@en ,
+                             "Par exemple, des pistes audio, vidéo, de timecode et/ou de données formant la MediaResource."@fr ;
+         rdfs:label "Piste"@fr ,
+                    "Track"@en ;
+         skos:definition "a MediaResource in the form of time-based elements for audio, video or data (\"track\") comprised in an \"aggregated\" MediaResource"@en ,
+                         "une MediaResource sous forme d’éléments temporels pour l’audio, la vidéo ou des données (« track ») compris dans une MediaResource « agrégée »"@fr ;
+         skos:example "- l’audio dans un fichier vidéo MPEG4"@fr ,
+                      "- the audio in a MPEG4 video file"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#TrackPurpose
+ec:TrackPurpose rdf:type owl:Class ;
+                rdfs:subClassOf skos:Concept ;
+                dcterms:description "An entry from a list of purposes to classify a track."@en ,
+                                    "Une entrée d’une liste de finalités permettant de classer une piste."@fr ;
+                rdfs:label "But de la piste"@fr ,
+                           "Track purpose"@en ;
+                skos:definition "a skos:Concept identifying the purpose of a ec:Track"@en ,
+                                "un skos:Concept identifiant le but d'un ec:Track"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#TrackType
+ec:TrackType rdf:type owl:Class ;
+             rdfs:subClassOf skos:Concept ;
+             dcterms:description "An entry from a list of types to classify a track, e.g. EBU's classification scheme on Track Type."@en ,
+                                 "Une entrée d’une liste de types permettant de classifier une piste, par exemple le schéma de classification d’EBU sur le type de piste."@fr ;
+             rdfs:label "Track type"@en ,
+                        "Type de piste"@fr ;
+             skos:definition "a skos:Concept identifying the type of a ec:Track"@en ,
+                             "un skos:Concept identifiant le type d’un ec:Track"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#Type
+ec:Type rdf:type owl:Class ;
+        rdfs:subClassOf skos:Concept ;
+        dcterms:description "A superclass for classification types of content."@en ,
+                            "Une superclasse pour les types de classification du contenu."@fr ;
+        rdfs:label "Type"@en ,
+                   "Type"@fr ;
+        skos:definition "a skos:Concept representing the superclass for classification types of content"@en ,
+                        "un skos:Concept représentant la superclasse des types de classification du contenu"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#UncertainDate
+ec:UncertainDate rdf:type owl:Class ;
+                 rdfs:subClassOf time:Instant ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasEndDateTime ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass time:Instant
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasObjectType ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass skos:Concept
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:hasStartDateTime ;
+                                   owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                   owl:onClass time:Instant
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:description ;
+                                   owl:allValuesFrom rdfs:Literal
+                                 ] ,
+                                 [ rdf:type owl:Restriction ;
+                                   owl:onProperty ec:period ;
+                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                 ] ;
+                 owl:disjointWith time:DateTimeDescription ;
+                 dcterms:description "A time stamp that is lacking exactness can be expressed by the following scheme: omit information from small to large time units: omit seconds, then minutes, then hours, then days, then months, then years. To express a period of time with lacking exactness, define a start and end time stamp using the described uncertainty scheme."@en ,
+                                     "Un horodatage dépourvu de précision exacte peut être exprimé selon le schéma suivant : omettre les informations des unités de temps de la plus petite à la plus grande : omettre les secondes, puis les minutes, puis les heures, puis les jours, puis les mois, puis les années. Pour exprimer une période de temps dépourvue de précision exacte, définir un horodatage de début et un horodatage de fin en utilisant le schéma d’incertitude décrit."@fr ;
+                 rdfs:label "Date incertaine"@fr ,
+                            "Uncertain date"@en ;
+                 skos:definition "a time:Instant that can express missing exactness of a time stamp or a period of time"@en ,
+                                 "un time:Instant pouvant exprimer l’imprécision d’un horodatage ou d’une période de temps"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#UsageRestrictions
+ec:UsageRestrictions rdf:type owl:Class ;
+                     rdfs:subClassOf ec:Rights ;
+                     dcterms:description "A set of constraints on the use of a work."@en ,
+                                         "Un ensemble de contraintes sur l’utilisation d’une œuvre."@fr ;
+                     rdfs:label "Restrictions d’utilisation"@fr ,
+                                "Usage restrictions"@en ;
+                     skos:definition "a ec:Rights that define the constraints on the use of a work"@en ,
+                                     "une ec:Rights qui définissent les contraintes sur l’utilisation d’une œuvre"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#UsageRights
+ec:UsageRights rdf:type owl:Class ;
+               rdfs:subClassOf ec:Rights ;
+               dcterms:description "A set of entitlements to the use of work."@en ,
+                                   "Un ensemble de droits d’utilisation d’une œuvre."@fr ;
+               rdfs:label "Droits d’utilisation"@fr ,
+                          "Usage rights"@en ;
+               skos:definition "a ec:Rights that define the entitlements in the use of a work"@en ,
+                               "un ec:Rights qui définit les droits d’usage d’une œuvre"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#VideoCodec
+ec:VideoCodec rdf:type owl:Class ;
+              rdfs:subClassOf ec:Codec ;
+              dcterms:description "Le codec utilisé dans la production de contenu vidéo."@fr ,
+                                  "The codec used in the production of video content."@en ;
+              rdfs:label "Codec vidéo"@fr ,
+                         "Video codec"@en ;
+              skos:definition "a ec:Codec used in the production of a video stream, file or track"@en ,
+                              "un ec:Codec utilisé dans la production d’un flux vidéo, d’un fichier ou d’une piste"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#VideoEncodingFormat
+ec:VideoEncodingFormat rdf:type owl:Class ;
+                       rdfs:subClassOf ec:EncodingFormat ;
+                       dcterms:description "An entry from the classification of transformations that produce digital video resources from audio signals."@en ,
+                                           "Une entrée de la classification des transformations qui produisent des ressources vidéo numériques à partir de signaux audio."@fr ;
+                       rdfs:label "Format d'encodage vidéo"@fr ,
+                                  "Video encoding format"@en ;
+                       skos:definition "a ec:EncodingFormat classifying the transformation from a video signal to video data in a ec:MediaResource"@en ,
+                                       "une ec:EncodingFormat classifiant la transformation d'un signal vidéo en données vidéo dans une ec:MediaResource"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#VideoFormat
+ec:VideoFormat rdf:type owl:Class ;
+               rdfs:subClassOf ec:Format ;
+               dcterms:description "An entry from the classification of types of video formats for media resources."@en ,
+                                   "Une entrée de la classification des types de formats vidéo pour les ressources multimédias."@fr ;
+               rdfs:label "Format vidéo"@fr ,
+                          "Video format"@en ;
+               skos:definition "a ec:Format classifying the format of video in a ec:MediaResource"@en ,
+                               "un ec:Format classant le format d’une vidéo dans un ec:MediaResource"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#VideoStream
+ec:VideoStream rdf:type owl:Class ;
+               rdfs:subClassOf ec:Stream ;
+               dcterms:description "A data stream containing a decidable video signal."@en ,
+                                   "Un flux de données contenant un signal vidéo décodable."@fr ;
+               rdfs:label "Flux vidéo"@fr ,
+                          "Video stream"@en ;
+               skos:definition "a ec:Stream with encoded video"@en ,
+                               "un ec:Stream avec vidéo encodée"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#VideoTrack
+ec:VideoTrack rdf:type owl:Class ;
+              rdfs:subClassOf ec:Track ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty ec:videoTrackNumber ;
+                                owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                owl:onDataRange xsd:nonNegativeInteger
+                              ] ;
+              dcterms:description "A track containing video."@en ,
+                                  "Une piste contenant de la vidéo."@fr ;
+              rdfs:label "Piste vidéo"@fr ,
+                         "Video track"@en ;
+              skos:definition "a ec:Track containing video"@en ,
+                              "un ec:Track contenant de la vidéo"@fr .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#WrappingType
+ec:WrappingType rdf:type owl:Class ;
+                rdfs:subClassOf skos:Concept ;
+                dcterms:description "An entry from a list of types for the wrapping, usually of data."@en ,
+                                    "Une entrée d’une liste de types pour l’enveloppement, généralement des données."@fr ;
+                rdfs:label "Type d'emballage"@fr ,
+                           "Wrapping type"@en ;
+                skos:definition "a skos:Concept identifying the type of wrapping"@en ,
+                                "un skos:Concept identifiant le type d’enrobage"@fr .
+
+
+###  http://www.w3.org/2004/02/skos/core#Concept
+skos:Concept rdf:type owl:Class ;
+             dcterms:description "An entry from a list of complementary notions."@en ;
+             rdfs:isDefinedBy <http://www.w3.org/2004/02/skos/core> ;
+             skos:definition "an entity representing a notion or an idea from a knowledge domain"@en .
+
+
+###  http://www.w3.org/2006/time#DateTimeDescription
+time:DateTimeDescription rdf:type owl:Class ;
+                         rdfs:subClassOf time:Instant ,
+                                         [ rdf:type owl:Restriction ;
+                                           owl:onProperty time:day ;
+                                           owl:allValuesFrom xsd:gDay
+                                         ] ,
+                                         [ rdf:type owl:Restriction ;
+                                           owl:onProperty time:month ;
+                                           owl:allValuesFrom xsd:gMonth
+                                         ] ,
+                                         [ rdf:type owl:Restriction ;
+                                           owl:onProperty time:year ;
+                                           owl:allValuesFrom xsd:gYear
+                                         ] ;
+                         dcterms:description "A point in time that is described by year, month, day, hour, minute, second and milliseconds with respect to the Gregorian calendar."@en ;
+                         rdfs:label "Date-time description"@en ;
+                         skos:definition "a time:Instant that can express a date and a time of day with respect ot a time:TRS"@en .
+
+
+###  http://www.w3.org/2006/time#Instant
+time:Instant rdf:type owl:Class ;
+             rdfs:subClassOf [ rdf:type owl:Restriction ;
+                               owl:onProperty time:hasTRS ;
+                               owl:hasValue <http://www.opengis.net/def/uom/ISO-8601/0/Gregorian>
+                             ] ,
+                             [ rdf:type owl:Restriction ;
+                               owl:onProperty time:inXSDDateTimeStamp ;
+                               owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                               owl:onDataRange xsd:dateTimeStamp
+                             ] ;
+             dcterms:description "A point in time."@en ;
+             rdfs:label "Time instant"@en ;
+             skos:definition "a temporal entity with zero extent or duration"@en .
+
+
+###  http://www.w3.org/2006/time#TRS
+time:TRS rdf:type owl:Class ;
+         dcterms:description "A reference system for the specification of points in time with an origin, a direction and a scale, such as a calendar-clock combination, e.g. the Gregorian calendar, or a (possibly hierarchical) ordinal system."@en ;
+         rdfs:label "Temporal reference system"@en ;
+         skos:definition "a reference system for the specification of points in time with an origin, a direction and a scale"@en .
+
+
+#################################################################
+#    Individuals
+#################################################################
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#SOMEPROGRAMME
+ec:SOMEPROGRAMME rdf:type owl:NamedIndividual ,
+                          ec:EditorialObject ;
+                 ec:aspectRatio "16:9" ;
+                 ec:tag "Et merke"@nb ,
+                        "et annet merke (some tag)"@nb .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#abridgedTitle
+ec:abridgedTitle rdf:type owl:NamedIndividual ,
+                          skos:Concept ;
+                 skos:inScheme ec:alternativeTitleTypes ;
+                 skos:prefLabel "Abridged title"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#alternativeTitleTypes
+ec:alternativeTitleTypes rdf:type owl:NamedIndividual ,
+                                  skos:ConceptScheme ;
+                         skos:prefLabel "Alternative title types"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#originalTitle
+ec:originalTitle rdf:type owl:NamedIndividual ,
+                          skos:Concept ;
+                 skos:inScheme ec:alternativeTitleTypes ;
+                 skos:definition "The original title used to identify the work."@en ;
+                 skos:prefLabel "Original title"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#serialTitle
+ec:serialTitle rdf:type owl:NamedIndividual ,
+                        skos:Concept ;
+               skos:inScheme ec:alternativeTitleTypes ;
+               skos:prefLabel "Serial title"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#seriesTitle
+ec:seriesTitle rdf:type owl:NamedIndividual ,
+                        skos:Concept ;
+               skos:inScheme ec:alternativeTitleTypes ;
+               skos:prefLabel "Series title"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#subtitle
+ec:subtitle rdf:type owl:NamedIndividual ,
+                     skos:Concept ;
+            skos:inScheme ec:alternativeTitleTypes ;
+            skos:prefLabel "Subtitle"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#translationTitle
+ec:translationTitle rdf:type owl:NamedIndividual ,
+                             skos:Concept ;
+                    skos:inScheme ec:alternativeTitleTypes ;
+                    skos:prefLabel "Translation title"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#versionTitle
+ec:versionTitle rdf:type owl:NamedIndividual ,
+                         skos:Concept ;
+                skos:inScheme ec:alternativeTitleTypes ;
+                skos:prefLabel "Version title"@en .
+
+
+###  http://www.ebu.ch/metadata/ontologies/ebucoreplus#workingTitle
+ec:workingTitle rdf:type owl:NamedIndividual ,
+                         skos:Concept ;
+                skos:inScheme ec:alternativeTitleTypes ;
+                skos:prefLabel "working title"@en .
+
+
+###  http://www.opengis.net/def/uom/ISO-8601/0/Gregorian
+<http://www.opengis.net/def/uom/ISO-8601/0/Gregorian> rdf:type owl:NamedIndividual .
+
+
+[ owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger
+] .
+
+#################################################################
+#    Annotations
+#################################################################
+
+dcterms:contributor dcterms:description "In the context of EBUCore, reserved for the annotation of RDF properties."@en ;
+                     rdfs:label "Contributor"@en .
+
+
+###  Generated by the OWL API (version 4.5.9.2019-02-01T07:24:44Z) https://github.com/owlcs/owlapi


### PR DESCRIPTION
This PR should be merged before other open PRs that modify `ebucoreplus.owl`.

It re-establishes `ebucoreplus.owl` as the normalized English reference ontology and introduces the derived bilingual distributions from that baseline.

Other ontology PRs touching `ebucoreplus.owl` should be rebased or regenerated on top of this branch or on top of `main` after this PR is merged.

## Main Change 

The main change in this PR is the normalization of the English reference ontology content in `ebucoreplus.owl`.

After the reference ontology was normalized, two bilingual derived distributions were produced from it:

- `ebucoreplus_en_fr.owl` as the English/French distribution
- `ebucoreplus_en_de.owl` as the English/German distribution

## Rule Set Applied

The normalization followed the Annotation Workbench rule families, including in particular:

- structural checks such as required annotations, duplicate annotation values, parse validity, literal typing, empty values, and placeholder values
- label rules covering capitalization, trailing punctuation, article removal, readable labels instead of raw local names, and sentence-case formatting
- skos:definition rules covering the expected `a` / `an` opening, banned openers, trailing punctuation, and exclusion of explanatory or example-like phrasing
- dcterms:description rules covering capitalization, trailing punctuation, removal of legacy ontology phrasing, and minimum explanatory quality
- cross-field consistency checks to avoid normalized duplicates between label, definition, and description
- checks for spelling and domain/range alignment for property definitions and descriptions

## Out of Scope

This PR does not change the ontology model itself.

Classes, properties, restrictions, axioms, identifiers, and non-targeted metadata were preserved. The intent of the change is editorial normalization of annotation content, not semantic remodeling.